### PR TITLE
[FEM.HyperElastic] Remove optimization based on type of matrix in StandardTetrahedralFEMForceField

### DIFF
--- a/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
+++ b/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
@@ -541,7 +541,7 @@ void StandardTetrahedralFEMForceField<DataTypes>::addDForce(const core::Mechanic
 template<class DataTypes>
 void  StandardTetrahedralFEMForceField<DataTypes>::addKToMatrix(sofa::linearalgebra::BaseMatrix * mat, SReal kFact, unsigned int &offset)
 {
-    const unsigned int nbEdges=m_topology->getNbEdges();
+    const sofa::Size nbEdges = m_topology->getNbEdges();
     const type::vector< Edge>& edgeArray=m_topology->getEdges();
 
     const edgeInformationVector& edgeInf = edgeInfo.getValue();


### PR DESCRIPTION
Since https://github.com/sofa-framework/sofa/pull/2281, it is no longer necessary to force the optimization of the matrix assembly based on the type of the matrix using a `dynamic_cast`.
This PR removes it for `StandardTetrahedralFEMForceField`.

It is supported by a [benchmark](https://github.com/alxbilger/SofaBenchmark/blob/main/SofaBenchmarkScenes/src/SofaBenchmarkScenes/fem/StandardTetrahedralFEMForceField.cpp):

Before:

```
--------------------------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------
BM_StandardTetrahedralFEMForceField/32         333 ms          328 ms            2 FPS=97.5238/s MBKBuild=379.033u MBKSolve=6.66173m frame=0.0102539s
BM_StandardTetrahedralFEMForceField/64         664 ms          672 ms            1 FPS=95.2558/s MBKBuild=354.073u MBKSolve=6.62915m frame=0.010498s
BM_StandardTetrahedralFEMForceField/128       1319 ms         1328 ms            1 FPS=96.3765/s MBKBuild=347.671u MBKSolve=6.58216m frame=0.010376s
BM_StandardTetrahedralFEMForceField/256       2583 ms         2578 ms            1 FPS=99.297/s MBKBuild=330.558u MBKSolve=6.43889m frame=0.0100708s
```

After

```
--------------------------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------
BM_StandardTetrahedralFEMForceField/32         321 ms          320 ms            2 FPS=99.9024/s MBKBuild=379.211u MBKSolve=6.43458m frame=0.0100098s
BM_StandardTetrahedralFEMForceField/64         637 ms          641 ms            1 FPS=99.9024/s MBKBuild=361.311u MBKSolve=6.34991m frame=0.0100098s
BM_StandardTetrahedralFEMForceField/128       1287 ms         1281 ms            1 FPS=99.9024/s MBKBuild=349.305u MBKSolve=6.4886m frame=0.0100098s
BM_StandardTetrahedralFEMForceField/256       2548 ms         2547 ms            1 FPS=100.515/s MBKBuild=347.56u MBKSolve=6.35484m frame=9.94873ms
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
