### PR TITLE
[SofaBoundaryCondition] Remove optimization based on type of matrix

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.h
@@ -41,19 +41,6 @@ using sofa::core::MechanicalParams;
 using sofa::defaulttype::Vec3Types;
 using sofa::defaulttype::Rigid3Types;
 
-template<typename DataTypes>
-struct TorsionForceFieldTraits
-{
-	typedef typename DataTypes::Real Real;
-	typedef typename DataTypes::Coord Coord;
-	typedef typename DataTypes::Deriv Deriv;
-	typedef type::vector<Coord> VecCoord;
-	typedef type::vector<Deriv> VecDeriv;
-	enum { deriv_total_size = Coord::total_size };
-	typedef Mat<deriv_total_size, deriv_total_size, Real> MatrixBlock;
-};
-
-
 ///
 ///	\brief TorsionForceField
 ///
@@ -68,13 +55,11 @@ public:
 	SOFA_CLASS(SOFA_TEMPLATE(TorsionForceField,DataTypes),SOFA_TEMPLATE(sofa::core::behavior::ForceField,DataTypes));
 
 	typedef ForceField<DataTypes> Inherit;
-	typedef TorsionForceFieldTraits<DataTypes> Traits;
-	typedef typename Traits::Real Real;
-	typedef typename Traits::Coord Coord;
-	typedef typename Traits::Deriv Deriv;
-	typedef typename Traits::VecCoord VecCoord;
-	typedef typename Traits::VecDeriv VecDeriv;
-	typedef typename Traits::MatrixBlock MatrixBlock;
+	typedef typename DataTypes::Real Real;
+	typedef typename DataTypes::Coord Coord;
+	typedef typename DataTypes::Deriv Deriv;
+	typedef typename DataTypes::VecCoord VecCoord;
+	typedef typename DataTypes::VecDeriv VecDeriv;
 	typedef typename DataTypes::CPos Pos;
 //	typedef TorsionForceFieldUtility<DataTypes> FFUtil;
 	typedef Data<VecCoord> DataVecCoord;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
@@ -105,44 +105,17 @@ void TorsionForceField<DataTypes>::addKToMatrix(linearalgebra::BaseMatrix* matri
 	const VecId& indices = m_indices.getValue();
 	const Real& tau = m_torque.getValue();
 
-	const auto nNodes = indices.size();
-
-	MatrixBlock D;
+	sofa::type::MatNoInit<3,3, Real> D;
 	D(0,0) = 1 - m_u(0)*m_u(0) ;	D(0,1) = -m_u(1)*m_u(0) ;		D(0,2) = -m_u(2)*m_u(0);
 	D(1,0) = -m_u(0)*m_u(1) ;		D(1,1) = 1 - m_u(1)*m_u(1) ;	D(1,2) = -m_u(2)*m_u(1);
 	D(2,0) = -m_u(0)*m_u(2) ;		D(2,1) = -m_u(1)*m_u(2) ;		D(2,2) = 1 - m_u(3)*m_u(3);
 	D *= (tau * kFact);
 
-	if( CompressedRowSparseMatrix<MatrixBlock>* m = dynamic_cast<CompressedRowSparseMatrix<MatrixBlock>*>(matrix) )
+	for (const auto id : indices)
 	{
-
-		for(Size n = 0 ; n < nNodes ; ++n)
-		{
-			PointId id = indices[n];
-			*m->wbloc(id, id, true) += D;
-		}
+		const unsigned int c = offset + Deriv::total_size * id;
+		matrix->add(c, c, D);
 	}
-	else
-	{
-		for(Size n = 0 ; n < nNodes ; ++n)
-		{
-			PointId id = indices[n];
-			const unsigned int c = offset + Deriv::total_size*id;
-
-			matrix->add(c+0, c+0, D(0,0));
-			matrix->add(c+0, c+1, D(0,1));
-			matrix->add(c+0, c+2, D(0,2));
-
-			matrix->add(c+1, c+0, D(1,0));
-			matrix->add(c+1, c+1, D(1,1));
-			matrix->add(c+1, c+2, D(1,2));
-
-			matrix->add(c+2, c+0, D(2,0));
-			matrix->add(c+2, c+1, D(2,1));
-			matrix->add(c+2, c+2, D(2,2));
-		}
-	}
-
 }
 
 template<typename DataTypes>


### PR DESCRIPTION
Since https://github.com/sofa-framework/sofa/pull/2281, it is no longer necessary to force the optimization of the matrix assembly based on the type of the matrix using a dynamic_cast.
This PR removes it for TorsionForceField.

Note that there is no example for this component.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
