### PR TITLE
[FEM.Elastic] Simplify addkToMatrix in TriangularFEMForceFieldOptim

### DIFF
--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.h
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.h
@@ -215,9 +215,6 @@ public:
         computeTriangleRotation(result,x0[t[0]], x0[t[1]], x0[t[2]]);
     }
 
-    template<class MatrixWriter>
-    void addKToMatrixT(const core::MechanicalParams* mparams, MatrixWriter m);
-
     void getTriangleVonMisesStress(Index i, Real& stressValue);
     void getTrianglePrincipalStress(Index i, Real& stressValue, Deriv& stressDirection, Real& stressValue2, Deriv& stressDirection2);
 


### PR DESCRIPTION
Since https://github.com/sofa-framework/sofa/pull/2281, it is no longer necessary to force the optimization of the matrix assembly based on the type of the matrix using a `dynamic_cast`.
In TriangularFEMForceFieldOptim, a mechanism were used in order to hide this cast. It used `BlocMatrixWriter`.
Since this optimization is no longer required, TriangularFEMForceFieldOptim now writes its `addKToMatrix` using the traditional way.

It is supported by a [benchmark](https://github.com/alxbilger/SofaBenchmark/pull/21):

Before:
```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_TriangularFEMForceFieldOptim/32         190 ms          188 ms            4 FPS=170.667/s MBKBuild=561.555u MBKSolve=5.21104m frame=5.85938ms
BM_TriangularFEMForceFieldOptim/64         368 ms          367 ms            2 FPS=174.298/s MBKBuild=526.034u MBKSolve=5.06889m frame=5.7373ms
BM_TriangularFEMForceFieldOptim/128        715 ms          719 ms            1 FPS=178.087/s MBKBuild=509.678u MBKSolve=4.93597m frame=5.61523ms
BM_TriangularFEMForceFieldOptim/256       1259 ms         1266 ms            1 FPS=202.272/s MBKBuild=500.564u MBKSolve=4.28127m frame=4.94385ms
```
After

```

----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_TriangularFEMForceFieldOptim/32         196 ms          195 ms            4 FPS=163.84/s MBKBuild=590.4u MBKSolve=5.34807m frame=6.10352ms
BM_TriangularFEMForceFieldOptim/64         377 ms          375 ms            2 FPS=170.667/s MBKBuild=529.309u MBKSolve=5.19836m frame=5.85938ms
BM_TriangularFEMForceFieldOptim/128        720 ms          703 ms            1 FPS=182.044/s MBKBuild=497.814u MBKSolve=4.9813m frame=5.49316ms
BM_TriangularFEMForceFieldOptim/256       1270 ms         1266 ms            1 FPS=202.272/s MBKBuild=502.338u MBKSolve=4.3129m frame=4.94385ms
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
