### PR TITLE
[LinearSolver.Direct] LU solver can be templated to CRSMat3x3

### DIFF
--- a/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.cpp
+++ b/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.cpp
@@ -30,10 +30,12 @@ namespace sofa::component::linearsolver::direct
 using namespace sofa::linearalgebra;
 
 int SparseLUSolverClass = core::RegisterObject("Direct linear solver based on Sparse LU factorization, implemented with the CSPARSE library")
-        .add< SparseLUSolver< CompressedRowSparseMatrix<SReal>,FullVector<SReal> > >()
+        .add< SparseLUSolver< CompressedRowSparseMatrix<SReal>, FullVector<SReal> > >()
+        .add< SparseLUSolver< CompressedRowSparseMatrix<type::Mat<3,3,SReal> >,FullVector<SReal> > >()
         ;
 
-template class SOFA_COMPONENT_LINEARSOLVER_DIRECT_API SparseLUSolver< CompressedRowSparseMatrix<SReal>,FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSOLVER_DIRECT_API SparseLUSolver< CompressedRowSparseMatrix<SReal>, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSOLVER_DIRECT_API SparseLUSolver< CompressedRowSparseMatrix<type::Mat<3,3,SReal> >, FullVector<SReal> >;
 
 } // namespace sofa::component::linearsolver::direct
 

--- a/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
+++ b/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
@@ -89,7 +89,7 @@ protected :
         return new SparseLUInvertData<Real>();
     }
 
-    sofa::linearalgebra::CompressedRowSparseMatrix<Real> Mfiltered;
+    std::unique_ptr<sofa::linearalgebra::CompressedRowSparseMatrix<Real> > Mfiltered;
 
 };
 

--- a/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
+++ b/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
@@ -89,6 +89,8 @@ protected :
         return new SparseLUInvertData<Real>();
     }
 
+    sofa::linearalgebra::CompressedRowSparseMatrix<Real> Mfiltered;
+
 };
 
 

--- a/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.inl
+++ b/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.inl
@@ -98,18 +98,21 @@ void SparseLUSolver<TMatrix,TVector,TThreadManager>::invert(Matrix& M)
 {
     SparseLUInvertData<Real> * invertData = (SparseLUInvertData<Real>*) this->getMatrixInvertData(&M);
 
+    Mfiltered.copyNonZeros(M);
+    Mfiltered.compress();
+
     if (invertData->N) cs_nfree(invertData->N);
     if (invertData->tmp) cs_free(invertData->tmp);
-    M.compress();
+
     //build A with M
-    invertData->A.nzmax = M.getColsValue().size();	// maximum number of entries
-    invertData->A.m = M.rowBSize();					// number of rows
-    invertData->A.n = M.colBSize();					// number of columns
-    invertData->A_p = M.getRowBegin();
+    invertData->A.nzmax = Mfiltered.getColsValue().size();	// maximum number of entries
+    invertData->A.m = Mfiltered.rowSize();					// number of rows
+    invertData->A.n = Mfiltered.colSize();					// number of columns
+    invertData->A_p = Mfiltered.getRowBegin();
     invertData->A.p = (int *) &(invertData->A_p[0]);							// column pointers (size n+1) or col indices (size nzmax)
-    invertData->A_i = M.getColsIndex();
+    invertData->A_i = Mfiltered.getColsIndex();
     invertData->A.i = (int *) &(invertData->A_i[0]);							// row indices, size nzmax
-    invertData->A_x = M.getColsValue();
+    invertData->A_x = Mfiltered.getColsValue();
     invertData->A.x = (Real *) &(invertData->A_x[0]);				// numerical values, size nzmax
     invertData->A.nz = -1;							// # of entries in triplet matrix, -1 for compressed-col
     cs_dropzeros( &invertData->A );

--- a/examples/Components/linearsolver/FEMBAR_SparseLUSolver.scn
+++ b/examples/Components/linearsolver/FEMBAR_SparseLUSolver.scn
@@ -2,7 +2,7 @@
 
     <include href="FEMBAR-common.xml"/>
 
-    <SparseLUSolver/>
+    <SparseLUSolver template="CompressedRowSparseMatrixMat3x3d" permutation="None"/>
     <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
 
 </Node>


### PR DESCRIPTION
Matrix assembly can be accelerated if CRS matrices are defined using blocks of 3x3.
This PR makes LU solver compatible with 3x3 blocks.

Benchmark https://github.com/alxbilger/SofaBenchmark/pull/22:

Before

```
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
BM_SparseLUSolver/50/iterations:10              368 ms          370 ms           10 FPS=135.021/s MBKBuild=1.82966m MBKSolve=5.34694m frame=7.40625ms
```

After

```
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
BM_SparseLUSolver/50/iterations:10              371 ms          367 ms           10 FPS=136.17/s MBKBuild=1.81682m MBKSolve=5.41681m frame=7.34375ms
BM_SparseLUSolverMat3x3/50/iterations:10        308 ms          311 ms           10 FPS=160.804/s MBKBuild=529.916u MBKSolve=5.4368m frame=6.21875ms
```

We can observe that the time stays the same for `CompressedRowSparseMatrixd` (no performance loss), and it is faster (MBKBuild timer) for `CompressedRowSparseMatrixd`.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
