### PR TITLE
[SofaCUDA] Fix compilation for SOFA_GPU_CUDA_DOUBLE

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearVelocityConstraint.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearVelocityConstraint.cpp
@@ -43,8 +43,8 @@ int LinearVelocityConstraintCudaClass = core::RegisterObject("Supports GPU-side 
         .add< sofa::component::constraint::projective::LinearVelocityConstraint<CudaVec6fTypes> >()
         .add< sofa::component::constraint::projective::LinearVelocityConstraint<CudaRigid3fTypes> >()
 #ifdef SOFA_GPU_CUDA_DOUBLE
-        .add< component::projectiveconstraintset::LinearVelocityConstraint<CudaVec6dTypes> >()
-        .add< component::projectiveconstraintset::LinearVelocityConstraint<CudaRigid3dTypes> >()
+        .add< sofa::component::constraint::projective::LinearVelocityConstraint<CudaVec6dTypes> >()
+        .add< sofa::component::constraint::projective::LinearVelocityConstraint<CudaRigid3dTypes> >()
 #endif // SOFA_GPU_CUDA_DOUBLE
         ;
 


### PR DESCRIPTION
Broken by https://github.com/sofa-framework/sofa/pull/2790/files#diff-beb90dbb98788df220b4c6b4a57cac3d3a8eeb658515bfe80c3831cc5e94de06



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
