### PR TITLE
[SofaCore] Inf fix topo subset indices

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/topology/BaseTopologyData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseTopologyData.h
@@ -113,7 +113,10 @@ public:
     }
 
     /// to handle PointSubsetData
-    void setDataSetArraySize(const Index s) { m_lastElementIndex = s - 1; }
+    void setDataSetArraySize(const Index s) 
+    { 
+        m_lastElementIndex = (s == 0) ? sofa::InvalidID : s-1; 
+    }
 
     /// Return the last element index of the topolgy buffer this Data is linked to. @sa m_lastElementIndex
     Index getLastElementIndex() const { return m_lastElementIndex; }

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyData.inl
@@ -211,6 +211,13 @@ void TopologyData <TopologyElementType, VecT>::remove(const sofa::type::vector<I
     helper::WriteOnlyAccessor<Data< container_type > > data = this;
     if (data.size() > 0)
     {
+        // make sure m_lastElementIndex is up to date before removing
+        this->m_lastElementIndex = data.size() - 1;
+
+        // Loop over the indices to remove. As in topology process when removing elements:
+        // 1- propagate event by calling callback if it has been set.
+        // 2- really remove element using swap + pop_back. 
+        // 3- Update m_lastElementIndex in case it is used in callback while removing several elements
         for (std::size_t i = 0; i < index.size(); ++i)
         {
             if (p_onDestructionCallback)
@@ -235,9 +242,12 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::type::vector<Inde
     const sofa::type::vector< AncestorElem >& ancestorElems)
 {
     std::size_t nbElements = index.size();
-    if (nbElements == 0) return;
+    if (nbElements == 0) 
+        return;
+
     // Using default values
     helper::WriteOnlyAccessor<Data< container_type > > data = this;
+    
     std::size_t i0 = data.size();
     if (i0 != index[0])
     {
@@ -248,19 +258,30 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::type::vector<Inde
             << " while vector size is " << i0;
         i0 = index[0];
     }
+
+
+    // As in topology process when adding elements:
+    // 1- Add new element. Using Data default constructors
+    // 2- Update m_lastElementIndex in case it is used in callback while adding several elements
+    // 3- propagate event by calling callback if it has been set.
     data.resize(i0 + nbElements);
-    this->m_lastElementIndex += sofa::Index(nbElements);
 
     if (p_onCreationCallback)
     {
         for (Index i = 0; i < nbElements; ++i)
         {
-            value_type& t = data[i0 + i];
+            Index newElemId = i0 + i;
+            value_type& t = data[newElemId];
+            this->m_lastElementIndex = newElemId;
 
-            p_onCreationCallback(Index(i0 + i), t, elems[i],
+            p_onCreationCallback(newElemId, t, elems[i],
                 (ancestors.empty() || coefs.empty()) ? s_empty_ancestors : ancestors[i],
                 (ancestors.empty() || coefs.empty()) ? s_empty_coefficients : coefs[i]);
         }
+    }
+    else
+    {
+        this->m_lastElementIndex = data.size() - 1;
     }
 }
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
@@ -56,10 +56,15 @@ public:
     /// Getter of the vector map indices
     sofa::type::vector<Index>& getMap2Elements() { return m_map2Elements; }
 
-    bool getSparseDataStatus() { return m_isConcerned; }
-
-    void activateSparseData() { m_isConcerned = true; }
-    void desactivateSparseData() { m_isConcerned = false; }
+    /** Method to activate/unactivate the @sa m_addNewElements option. To allow this TopologySubsetData to add new elements.
+    * By default @sa m_addNewElements is set to false. 
+    * @param {bool} to change m_addNewElements value. 
+    */
+    void supportNewTopologyElements(bool value) { m_addNewElements = true; }
+    
+    /// Getter to the option @sa m_addNewElements
+    bool isNewTopologyElementsSupported() const { return m_addNewElements; }
+    
 
     /** Method to return the index position of an element inside the vector map @sa m_map2Elements
     * @param {Index} element index of the full Data vector to find in the vector map
@@ -140,8 +145,10 @@ protected:
     /// same size as this SubsetData but contains id of element link to each data[]
     sofa::type::vector<Index> m_map2Elements;
 
-    /// boolen to set subdata as concerne, will allow to add element
-    bool m_isConcerned;
+    /** Boolen to allow this TopologySubsetData to add new elements. If true, for every new Element added in the topology container
+    * linked by this TopologyData, the index of the new element will be added into this TopologySubsetData.
+    */
+    bool m_addNewElements = false;
 };
 
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
@@ -131,9 +131,9 @@ protected:
 
     /**
     * Internal method called at the end of @sa add method to apply internal mechanism, such as updating the map size.
-    * @param nbElements Number of element added
+    * @param dataLastId Index of the last element id in the TopologyData tracked
     */
-    virtual void addPostProcess(sofa::Size nbElements);
+    virtual void addPostProcess(sofa::Index dataLastId);
 
     /**
     * Internal method to update the last element of this Data and/or map when the topology buffer is reduced.

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -81,52 +81,57 @@ void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
     const sofa::type::vector<sofa::type::vector<Index> >& ancestors,
     const sofa::type::vector<sofa::type::vector<SReal> >& coefs)
 {
-    // if no new element are added to this subset. Just update the lastElementIndex for future deletion
-    if (!this->isNewTopologyElementsSupported())
-    {
-        this->m_lastElementIndex += nbElements;
-        return;
-    }
+    sofa::type::vector< TopologyElementType > elems; 
+    elems.resize(nbElements);
 
-    // Using default values
-    container_type& data = *(this->beginEdit());
-
-    Size size = data.size();
-    data.resize(size + nbElements);
-    
-    // Call for specific callback if handler has been set
-    if (this->p_onCreationCallback)
-    {
-        value_type t;
-        for (std::size_t i = 0; i < nbElements; ++i)
-        {
-            if (ancestors.empty() || coefs.empty())
-            {
-                const sofa::type::vector< Index > empty_vecint;
-                const sofa::type::vector< SReal > empty_vecdouble;
-
-                this->p_onCreationCallback(Index(size + i), t, TopologyElementType(), empty_vecint, empty_vecdouble);
-            }
-            else 
-            {
-                this->p_onCreationCallback(Index(size + i), t, TopologyElementType(), ancestors[i], coefs[i]);
-            }
-        }
-    }
-    this->endEdit();
-
-    // update map if needed
-    addPostProcess(nbElements);
+    return this->add(nbElements, elems, ancestors, coefs);    
 }
 
 
 template <typename TopologyElementType, typename VecT>
 void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
-    const sofa::type::vector< TopologyElementType >&,
+    const sofa::type::vector< TopologyElementType >& elems,
     const sofa::type::vector<sofa::type::vector<Index> >& ancestors,
     const sofa::type::vector<sofa::type::vector<SReal> >& coefs)
 {
-    this->add(nbElements, ancestors, coefs);
+    // Track TopologyData last index before applying changes. special case if id is invalid == start with empty buffer
+    int LastDataId = (this->m_lastElementIndex == sofa::InvalidID) ? -1 : int(this->m_lastElementIndex);
+
+    // if no new element are added to this subset. Just update the lastElementIndex for future deletion
+    if (!this->isNewTopologyElementsSupported())
+    {
+        this->m_lastElementIndex = Index(LastDataId + nbElements);
+        return;
+    }
+
+    helper::WriteOnlyAccessor<Data<container_type> > data = this;
+
+    // first resize the subsetData. value will be applied in the loop using callbacks
+    Size size = data.size();
+    data.resize(size + nbElements);
+    
+
+    if (this->p_onCreationCallback)
+    {
+        for (std::size_t i = 0; i < nbElements; ++i)
+        {
+            Index id = Index(size + i);
+            value_type& t = data[id];
+            
+            // update map if needed
+            addPostProcess(LastDataId + i + 1);
+
+            this->p_onCreationCallback(id, t, elems[i], 
+                (ancestors.empty() || coefs.empty()) ? s_empty_ancestors : ancestors[i],
+                (ancestors.empty() || coefs.empty()) ? s_empty_coefficients : coefs[i]);
+
+        }
+    }
+    else
+    {
+        this->m_lastElementIndex = Index(LastDataId + nbElements);
+    }
+
 }
 
 
@@ -137,9 +142,10 @@ void TopologySubsetData <TopologyElementType, VecT>::add(const sofa::type::vecto
     const sofa::type::vector< sofa::type::vector< SReal > >& coefs,
     const sofa::type::vector< AncestorElem >& ancestorElems)
 {
-    SOFA_UNUSED(elems);
     SOFA_UNUSED(ancestorElems);
-    this->add(index.size(), ancestors, coefs);
+
+    const sofa::Size nbElements = index.size();
+    this->add(nbElements, elems, ancestors, coefs);
 }
 
 
@@ -155,51 +161,39 @@ void TopologySubsetData <TopologyElementType, VecT>::move(const sofa::type::vect
 template <typename TopologyElementType, typename VecT>
 void TopologySubsetData <TopologyElementType, VecT>::remove(const sofa::type::vector<Index>& index)
 {
-    container_type& data = *(this->beginEdit());
+    helper::WriteOnlyAccessor<Data<container_type> > data = this;
     
-    unsigned int cptDone = 0;
-    Index last = data.size() - 1;
-
-    // check for each element remove if it concern this subsetData
-    for (Index idRemove : index)
+    // check for each element index to remove if it concern this subsetData
+    for (Index elemId : index)
     {
-        Index idElem = sofa::InvalidID;
+        // Check if this element is inside the subset map
+        Index dataId = this->indexOfElement(elemId);
         
-        idElem = this->indexOfElement(idRemove);
-        if (idElem != sofa::InvalidID) // index in the map, need to update the subsetData
+        if (dataId != sofa::InvalidID) // index in the map, need to update the subsetData
         {
+            // if in the map, apply callback if set
             if (this->p_onDestructionCallback)
             {
-                this->p_onDestructionCallback(idElem, data[idElem]);
+                this->p_onDestructionCallback(dataId, data[dataId]);
             }
 
-            this->swap(idElem, last);
-            cptDone++;
-            if (last == 0)
-                break;
-            else
-                --last;
+            // Like in topological change, will swap before poping back
+            Index lastDataId = data.size() - 1;
+            this->swap(dataId, lastDataId);
+
+            // Remove last subsetData element and update the map
+            data.resize(lastDataId);
+            removePostProcess(lastDataId);
         }
 
-        // need to check if lastIndex in the map        
-        idElem = this->indexOfElement(this->m_lastElementIndex);
-        if (idElem != sofa::InvalidID)
+        // Need to check if last element index is in the map. If yes need to replace that value to follow topological changes
+        dataId = this->indexOfElement(this->m_lastElementIndex);
+        if (dataId != sofa::InvalidID)
         {
-            updateLastIndex(idElem, idRemove);
+            updateLastIndex(dataId, elemId);
         }
         this->m_lastElementIndex--;
     }
-
-    if (cptDone != 0)
-    {
-        sofa::Size nbElements = 0;
-        if (cptDone < data.size()) {
-            nbElements = data.size() - cptDone;
-        }
-        data.resize(nbElements);
-        removePostProcess(nbElements);
-    }
-    this->endEdit();
 }
 
 template <typename TopologyElementType, typename VecT>
@@ -241,13 +235,10 @@ void TopologySubsetData <TopologyElementType, VecT>::removePostProcess(sofa::Siz
 
 
 template <typename TopologyElementType, typename VecT>
-void TopologySubsetData <TopologyElementType, VecT>::addPostProcess(sofa::Size nbElements)
+void TopologySubsetData<TopologyElementType, VecT>::addPostProcess(sofa::Index dataLastId)
 {
-    for (unsigned int i = 0; i < nbElements; ++i)
-    {
-        this->m_lastElementIndex++;
-        m_map2Elements.push_back(this->m_lastElementIndex);
-    }
+    this->m_lastElementIndex = dataLastId;
+    m_map2Elements.push_back(dataLastId);
 }
 
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -34,7 +34,6 @@ namespace sofa::core::topology
 template <typename TopologyElementType, typename VecT>
 TopologySubsetData <TopologyElementType, VecT>::TopologySubsetData(const typename sofa::core::topology::BaseTopologyData< VecT >::InitData& data)
     : sofa::core::topology::TopologyData< TopologyElementType, VecT >(data)
-    , m_isConcerned(false)
 {
 
 }
@@ -82,7 +81,9 @@ void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
     const sofa::type::vector<sofa::type::vector<Index> >& ancestors,
     const sofa::type::vector<sofa::type::vector<SReal> >& coefs)
 {
-    if (!this->getSparseDataStatus()) {
+    // if no new element are added to this subset. Just update the lastElementIndex for future deletion
+    if (!this->isNewTopologyElementsSupported())
+    {
         this->m_lastElementIndex += nbElements;
         return;
     }

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
@@ -67,9 +67,9 @@ void TopologySubsetIndices::removePostProcess(sofa::Size nbElements)
 }
 
 
-void TopologySubsetIndices::addPostProcess(sofa::Size nbElements)
+void TopologySubsetIndices::addPostProcess(sofa::Index dataLastId)
 {
-    this->m_lastElementIndex += nbElements;
+    this->m_lastElementIndex = dataLastId;
 }
 
 void TopologySubsetIndices::updateLastIndex(Index posLastIndex, Index newGlobalId)

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
@@ -57,7 +57,7 @@ protected:
 
     void removePostProcess(sofa::Size nbElements) override;
 
-    void addPostProcess(sofa::Size nbElements) override;
+    void addPostProcess(sofa::Index dataLastId) override;
 
     void updateLastIndex(Index posLastIndex, Index newGlobalId) override;
 };


### PR DESCRIPTION
this PR is based on #2869 

Sevral fixes in `TopologyData `/ `TopologySubsetData `/ `TopologySubsetIndices`

- Fix: `TopologyData::m_lastElementIndex` was set to invalid when passing empty buffer size. keep value to 0 in this case.
- Rename: `TopologySubSetData `option **isConcerned** by **addNewelements**. This method is used to allow TopologySubsetData to growth following topological changes
- Fix: TopologySubSetData **add** methods. Value where not really set but using default constructor instead of value in callback.
- Clean: TopologySubSetData **remove** method from unecessary checks/loop

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
