### PR TITLE
[StateContainer] Fix VecId names for != V_COORD

### DIFF
--- a/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -1792,7 +1792,7 @@ void MechanicalObject<DataTypes>::setVecIdProperties(core::TVecId<vtype, vaccess
 {
     if (!properties.label.empty())
     {
-        vec_d->setName(properties.label + core::VecTypeLabels.at(core::V_COORD));
+        vec_d->setName(properties.label + core::VecTypeLabels.at(vtype));
         vec_d->setHelp("VecId: " + v.getName());
     }
     if (!properties.group.empty())


### PR DESCRIPTION
The Data had always the prefix `(V_COORD)`. Now it really depends on the type

The bug has been introduced in https://github.com/sofa-framework/sofa/pull/2811

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
