### PR TITLE
[Metis] Disable compilation warnings

### DIFF
--- a/Component/LinearSolver/Direct/extlibs/metis-5.1.0/CMakeLists.txt
+++ b/Component/LinearSolver/Direct/extlibs/metis-5.1.0/CMakeLists.txt
@@ -15,6 +15,14 @@ endif()
 add_library(${PROJECT_NAME} STATIC ${metis_sources} ${GKlib_sources})
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GKlib>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libmetis>")
+
+# Disable warnings coming from the metis library
+target_compile_options(${PROJECT_NAME} PRIVATE
+     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+          -w>
+     $<$<CXX_COMPILER_ID:MSVC>:
+          /w>)
+
 if(UNIX)
     target_link_libraries(${PROJECT_NAME} m)
 endif()


### PR DESCRIPTION
Metis is an external library producing a few hundreds of compilation warnings (https://ci.inria.fr/sofa-ci-dev/job/sofa-framework/job/master/CI_CONFIG=windows_vs2017,CI_PLUGINS=options,CI_TYPE=release/3459/FullBuildWarnings-MSBuild/)

![image](https://user-images.githubusercontent.com/10572752/163556296-5c153462-6e47-4e57-94c0-d06a36c6d299.png)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
