### PR TITLE
[FEM.elastic] Some optimisation to make FastTetrahedralCorotational even faster

### DIFF
--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.h
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.h
@@ -62,7 +62,8 @@ public:
     typedef Data<VecCoord>                  DataVecCoord;
     typedef Data<VecDeriv>                  DataVecDeriv;
 
-    typedef type::Mat<3,3,Real>       Mat3x3  ;
+    using Mat3x3 = type::Mat<3, 3, Real>;
+    using Mat3x3NoInit = type::MatNoInit<3, 3, Real>;
 
     typedef enum
     {

--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -316,7 +316,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::addForce(const sofa::core
 
     Coord displ[6],sv;
     Mat3x3NoInit deformationGradient,S,R;
-    auto tetrahedra = m_topology->getTetrahedra();
+    const auto& tetrahedra = m_topology->getTetrahedra();
 
     Coord tetraVertex[4];
     for(i=0; i<nbTetrahedra; i++ )
@@ -463,7 +463,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::addDForce(const sofa::cor
     const VecMat3x3& edgeDfDx = edgeInfo.getValue();
     Coord deltax;
 
-    auto edges = m_topology->getEdges();
+    const auto& edges = m_topology->getEdges();
     // use the already stored matrix
     for (i = 0; i < nbEdges; i++)
     {

--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -124,7 +124,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::createTetrahedronRestInfo
         // compute the rotation matrix of the initial tetrahedron for the QR decomposition
         computeQRRotation(my_tinfo.restRotation,my_tinfo.restEdgeVector);
     } else 	if (m_decompositionMethod ==POLAR_DECOMPOSITION_MODIFIED) {
-        Mat3x3 Transformation;
+        Mat3x3NoInit Transformation;
         Transformation[0]=point[1]-point[0];
         Transformation[1]=point[2]-point[0];
         Transformation[2]=point[3]-point[0];
@@ -315,7 +315,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::addForce(const sofa::core
 
 
     Coord displ[6],sv;
-    Mat3x3 deformationGradient,S,R;
+    Mat3x3NoInit deformationGradient,S,R;
     auto tetrahedra = m_topology->getTetrahedra();
 
     Coord tetraVertex[4];
@@ -425,7 +425,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::addDForce(const sofa::cor
         helper::WriteOnlyAccessor< Data< VecMat3x3 > > edgeDfDx = edgeInfo;
 
         int nbTetrahedra=m_topology->getNbTetrahedra();
-        Mat3x3 tmp;
+        Mat3x3NoInit tmp;
 
         updateMatrix=false;
 
@@ -503,7 +503,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::addKToMatrix(sofa::linear
     helper::WriteOnlyAccessor< Data< VecMat3x3 > > edgeDfDx = edgeInfo;
     helper::WriteOnlyAccessor< Data< VecMat3x3 > > pointDfDx = pointInfo;
 
-    Mat3x3 tmp;
+    Mat3x3NoInit tmp;
     if (updateMatrix==true) {
         /// if not done in addDForce: update off-diagonal blocks ("edges") of each element matrix
         updateMatrix=false;


### PR DESCRIPTION
Some small optimisation, thanks for all advices using VS Profiler and SofaBenchmarks

SofaBenchmark have been added on TetraXX FEMForcefield in https://github.com/alxbilger/SofaBenchmark/pull/23

```
-----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                   Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------------------
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/512        1339 ms         1344 ms            1 FPS=381.023/s frame=2.62451ms
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/1024       2662 ms         2656 ms            1 FPS=385.506/s frame=2.59399ms
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/2048       5259 ms         5266 ms            1 FPS=388.938/s frame=2.57111ms
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/4096      10451 ms        10453 ms            1 FPS=391.845/s frame=2.55203ms
```

```
-----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                   Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------------------
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/512         982 ms          984 ms            1 FPS=520.127/s frame=1.92261ms
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/1024       1966 ms         1953 ms            1 FPS=524.288/s frame=1.90735ms
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/2048       3988 ms         3969 ms            1 FPS=516.031/s frame=1.93787ms
BM_Scene_bench_StepFactor<TetrahedralFEMForceFieldOptimScene>/4096       7858 ms         7859 ms            1 FPS=521.161/s frame=1.91879ms
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
