### PR TITLE
[SofaCUDA] Modernize CMake for CUDA

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(SofaCUDA)
+project(SofaCUDA LANGUAGES CUDA CXX)
 
 set(SOFACUDA_MAJOR_VERSION 0)
 set(SOFACUDA_MINOR_VERSION 1)
@@ -236,8 +236,6 @@ else()
 endif()
 
 set(README_FILES README.md)
-
-find_package(CUDA REQUIRED)
 
 find_package(SofaGeneralEngine REQUIRED)
 find_package(SofaGeneralDeformable REQUIRED)


### PR DESCRIPTION
Because `find_package(CUDA)` is deprecated. See https://cmake.org/cmake/help/latest/module/FindCUDA.html

Note that I had to re-install CUDA. It seems to be a common issue: https://stackoverflow.com/questions/56636714/cuda-compile-problems-on-windows-cmake-error-no-cuda-toolset-found


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
