### PR TITLE
[SofaCUDA] Ignore CudaTLED-related scene on the CI

### DIFF
--- a/applications/plugins/SofaCUDA/scenes/.scene-tests
+++ b/applications/plugins/SofaCUDA/scenes/.scene-tests
@@ -23,3 +23,6 @@ ignore "benchmarks/TriangularFEMForceFieldOptim_tissue100x100_gpu.scn"
 
 iterations "benchmarks/QuadSpringsSphere_cpu.scn" "10"
 ignore "benchmarks/QuadSpringsSphere_gpu.scn"
+
+ignore "benchmarks/CudaTetrahedronTLEDForceField_beam10x10x40_gpu.scn"
+ignore "benchmarks/CudaTetrahedronTLEDForceField_beam16x16x76_gpu.scn"


### PR DESCRIPTION
... because the CI cannot load SofaCUDA



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
