### PR TITLE
[Sofa.LinearAlgebra] Compressed property in CRS matrix depends on tmp vector

### DIFF
--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrix.h
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrix.h
@@ -199,7 +199,7 @@ public:
             // just clear the matrix
             for (Index i=0; i < (Index)colsValue.size(); ++i)
                 traits::clear(colsValue[i]);
-            compressed = colsValue.empty();
+            compressed = btemp.empty();
             btemp.clear();
         }
         else


### PR DESCRIPTION
A CompressedRowSparseMatrix is compressed if the temporary vector of triplets has been converted into the compressed format. Therefore, the boolean `compressed` must be set depending on the size of the temporary vector, not the size of the compressed values.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
