### PR TITLE
[Helper] Deduce plugin name from path based on known extension

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -241,6 +241,18 @@ void PluginManager::removeOnPluginLoadedCallback(const std::string& key)
     m_onPluginLoadedCallbacks.erase(key);
 }
 
+std::string PluginManager::GetPluginNameFromPath(const std::string& pluginPath)
+{
+    const auto filename = sofa::helper::system::SetDirectory::GetFileName(pluginPath.c_str());
+    const std::string::size_type pos = filename.find_last_of("." + DynamicLibrary::extension);
+    if (pos != std::string::npos)
+    {
+        return filename.substr(0,pos);
+    }
+
+    return sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(pluginPath.c_str());;
+}
+
 bool PluginManager::loadPluginByName(const std::string& pluginName, const std::string& suffix, bool ignoreCase, bool recursive, std::ostream* errlog)
 {
     std::string pluginPath = findPlugin(pluginName, suffix, ignoreCase, recursive);
@@ -304,7 +316,7 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /
     {
         // check if a plugin with a same name but a different path is loaded
         // problematic case per se but at least we can warn the user
-        const auto& pluginName = sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(pluginPath.c_str());
+        const auto& pluginName = GetPluginNameFromPath(pluginPath);
         for (auto& k : m_pluginMap)
         {
             if (pluginName == k.second.getModuleName())
@@ -465,7 +477,7 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
         pluginPath = plugin;
 
         // argument is a path but we need to check if it was not already loaded with a different path
-        const auto& pluginName = sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(pluginPath.c_str());
+        const auto& pluginName = GetPluginNameFromPath(pluginPath);
         for (const auto& [loadedPath, loadedPlugin] : m_pluginMap)
         {
             if (pluginName == loadedPlugin.getModuleName() && pluginPath != loadedPath)

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -209,6 +209,8 @@ public:
     void addOnPluginLoadedCallback(const std::string& key, std::function<void(const std::string&, const Plugin&)> callback);
     void removeOnPluginLoadedCallback(const std::string& key);
 
+    static std::string GetPluginNameFromPath(const std::string& pluginPath);
+
 private:
     PluginManager();
     ~PluginManager();


### PR DESCRIPTION
`GetFileNameWithoutExtension` currently finds the first dot in the filename to deduce the plugin name from a path. However, the filename `SoftRobots.Inverse.dll` deduces to `SoftRobots`, which is another existing plugin.

To fix this behavior, I propose to rely the deduction on the extension of a dynamic library, which is known.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
