### PR TITLE
[LinearSolver] SparseLDLSolver: template warning to info message

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
@@ -85,7 +85,7 @@ public :
         if (templateString.empty())
         {
             const std::string header = "SparseLDLSolver(" + std::string(arg->getAttribute("name", "")) + ")";
-            msg_warning(header) << "Template is empty\n"
+            msg_info(header) << "Template is empty\n"
                                 << "By default " << helper::NameDecoder::getClassName<T>() << " uses blocks with a single double (to handle all cases of simulations).\n"
                                 << "If you are using only 3D DOFs, you may consider using blocks of Matrix3 to speedup the calculations.\n"
                                 << "If it is the case, add " << "template=\"CompressedRowSparseMatrixMat3x3d\" " << "to this object in your scene\n"

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
@@ -85,7 +85,7 @@ public :
         if (templateString.empty())
         {
             const std::string header = "SparseLDLSolver(" + std::string(arg->getAttribute("name", "")) + ")";
-            msg_info(header) << "Template is empty\n"
+            msg_advice(header) << "Template is empty\n"
                                 << "By default " << helper::NameDecoder::getClassName<T>() << " uses blocks with a single double (to handle all cases of simulations).\n"
                                 << "If you are using only 3D DOFs, you may consider using blocks of Matrix3 to speedup the calculations.\n"
                                 << "If it is the case, add " << "template=\"CompressedRowSparseMatrixMat3x3d\" " << "to this object in your scene\n"


### PR DESCRIPTION
If we don't set a template to SparseLDLSolver we get a warning message saying that it might be insteresting to set it to speedup the calculations. 
In my opinion this is an information. A warning should mean "be careful if you don't solve this warning bad things might happen".  



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
