### PR TITLE
[Helper] Convert path back slashes to slash

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
@@ -222,7 +222,7 @@ static std::string computeSofaPathPrefix()
     char* pathVar = getenv("SOFA_ROOT");
     if (pathVar != nullptr && FileSystem::exists(pathVar))
     {
-        return std::string(pathVar);
+        return FileSystem::convertBackSlashesToSlashes(pathVar);
     }
     else {
         const std::string exePath = Utils::getExecutablePath();


### PR DESCRIPTION
I copied/pasted a path with backslashes in the env variable SOFA_ROOT, and a bad thing happened.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
