### PR TITLE
[Sofa.Component.Collision] Remove un-needed msg_warning in LocalMinDistance.cpp

### DIFF
--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
@@ -186,27 +186,34 @@ int LocalMinDistance::computeIntersection(Line& e1, Line& e2, OutputVector* cont
     double alpha = 0.5;
     double beta = 0.5;
 
+    // If line are not parallel
     if (det < -1.0e-30 || det > 1.0e-30)
     {
+        // compute the parametric coordinates along the line
         alpha = (b[0]*A[1][1] - b[1]*A[0][1])/det;
         beta  = (b[1]*A[0][0] - b[0]*A[1][0])/det;
+
+        // if parameters are outside of ]0,1[ then there is no intersection
+        // the intersection is outside of the edge supporting point.
         if (alpha < 1e-15 || alpha > (1.0-1e-15) ||
             beta  < 1e-15  || beta  > (1.0-1e-15) )
             return 0;
     }
-    else
     {
-        // several possibilities :
-        // -one point in common (auto-collision) => return false !
-        // -no point in common but line are // => we can continue to test
-        msg_warning() <<"Determinant is null";
+        // lines are parallel,
+        // the alpha/beta parameters are set to 0.5 so the collision
+        // output is in the middle of the line
+        alpha = 0.5;
+        beta = 0.5;
     }
+
 
     Vector3 P,Q,PQ;
     P = e1.p1() + AB * alpha;
     Q = e2.p1() + CD * beta;
     PQ = Q-P;
 
+    // If we are above
     if (PQ.norm2() >= alarmDist*alarmDist)
         return 0;
 

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
@@ -199,6 +199,7 @@ int LocalMinDistance::computeIntersection(Line& e1, Line& e2, OutputVector* cont
             beta  < 1e-15  || beta  > (1.0-1e-15) )
             return 0;
     }
+    else
     {
         // lines are parallel,
         // the alpha/beta parameters are set to 0.5 so the collision
@@ -213,7 +214,7 @@ int LocalMinDistance::computeIntersection(Line& e1, Line& e2, OutputVector* cont
     Q = e2.p1() + CD * beta;
     PQ = Q-P;
 
-    // If we are above
+    // If the geometric distance between P and Q is higher than the alarm distance/
     if (PQ.norm2() >= alarmDist*alarmDist)
         return 0;
 

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
@@ -123,8 +123,8 @@ bool LocalMinDistance::testIntersection(Line& e1, Line& e2)
 
     const double det = type::determinant(A);
 
-    double alpha = 0.5;
-    double beta = 0.5;
+    double alpha;
+    double beta;
 
     if (det < -1.0e-30 || det > 1.0e-30)
     {

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
@@ -123,8 +123,8 @@ bool LocalMinDistance::testIntersection(Line& e1, Line& e2)
 
     const double det = type::determinant(A);
 
-    double alpha;
-    double beta;
+    double alpha = 0.5;
+    double beta = 0.5;
 
     if (det < -1.0e-30 || det > 1.0e-30)
     {
@@ -183,8 +183,8 @@ int LocalMinDistance::computeIntersection(Line& e1, Line& e2, OutputVector* cont
     b[1] = -CD*AC;
     const double det = type::determinant(A);
 
-    double alpha = 0.5;
-    double beta = 0.5;
+    double alpha;
+    double beta;
 
     // If lines are not parallel
     if (det < -1.0e-30 || det > 1.0e-30)

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
@@ -186,7 +186,7 @@ int LocalMinDistance::computeIntersection(Line& e1, Line& e2, OutputVector* cont
     double alpha = 0.5;
     double beta = 0.5;
 
-    // If line are not parallel
+    // If lines are not parallel
     if (det < -1.0e-30 || det > 1.0e-30)
     {
         // compute the parametric coordinates along the line


### PR DESCRIPTION
LocalMinDistance is printing a msg_warning when the lines are parallel.
This is a legitimate case that is properly handled in the rest of the code
so I and @EulalieCoevoet removed the message and document a bit the code while I was trying
to understand it.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
