### PR TITLE
[Sofa.GUI.Common] Change the current GUI by default choice

### DIFF
--- a/Sofa/GUI/Batch/src/sofa/gui/batch/BatchGUI.h
+++ b/Sofa/GUI/Batch/src/sofa/gui/batch/BatchGUI.h
@@ -68,6 +68,8 @@ public:
     static const signed int DEFAULT_NUMBER_OF_ITERATIONS;
     /// @}
 
+    bool saveAsDefaultGUI() const override { return false; }
+
 protected:
     /// The destructor should not be called directly. Use the closeGUI() method instead.
     ~BatchGUI() override;

--- a/Sofa/GUI/Batch/src/sofa/gui/batch/BatchGUI.h
+++ b/Sofa/GUI/Batch/src/sofa/gui/batch/BatchGUI.h
@@ -68,7 +68,7 @@ public:
     static const signed int DEFAULT_NUMBER_OF_ITERATIONS;
     /// @}
 
-    bool saveAsDefaultGUI() const override { return false; }
+    bool canBeDefaultGUI() const override { return false; }
 
 protected:
     /// The destructor should not be called directly. Use the closeGUI() method instead.

--- a/Sofa/GUI/Common/src/sofa/gui/common/BaseGUI.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/BaseGUI.h
@@ -110,7 +110,7 @@ public:
     /// If the function returns true: when the GUI is created, its name will be saved so that it will be created when
     /// no GUI is specified. If the function returns false, the GUI name is not saved, and the last one will be used
     /// when no GUI is specified.
-    virtual bool saveAsDefaultGUI() const { return true; }
+    virtual bool canBeDefaultGUI() const { return true; }
 
 protected:
     BaseGUI();

--- a/Sofa/GUI/Common/src/sofa/gui/common/BaseGUI.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/BaseGUI.h
@@ -107,6 +107,11 @@ public:
     static void setConfigDirectoryPath(const std::string& path, bool createIfNecessary = false);
     static void setScreenshotDirectoryPath(const std::string& path, bool createIfNecessary = false);
 
+    /// If the function returns true: when the GUI is created, its name will be saved so that it will be created when
+    /// no GUI is specified. If the function returns false, the GUI name is not saved, and the last one will be used
+    /// when no GUI is specified.
+    virtual bool saveAsDefaultGUI() const { return true; }
+
 protected:
     BaseGUI();
     /// The destructor should not be called directly. Use the closeGUI() method instead.

--- a/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.cpp
@@ -235,11 +235,15 @@ int GUIManager::createGUI(sofa::simulation::Node::SPtr groot, const char* filena
             msg_error("GUIManager") << "GUI '"<<valid_guiname<<"' creation failed." ;
             return 1;
         }
-        //Save this GUI type as the last used GUI
-        const std::string lastGuiFilePath = BaseGUI::getConfigDirectoryPath() + "/lastUsedGUI.ini";
-        std::ofstream out(lastGuiFilePath.c_str(),std::ios::out);
-        out << valid_guiname << std::endl;
-        out.close();
+
+        if (currentGUI->saveAsDefaultGUI())
+        {
+            //Save this GUI type as the last used GUI
+            const std::string lastGuiFilePath = BaseGUI::getConfigDirectoryPath() + "/lastUsedGUI.ini";
+            std::ofstream out(lastGuiFilePath.c_str(),std::ios::out);
+            out << valid_guiname << std::endl;
+            out.close();
+        }
     }
     return 0;
 }

--- a/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.cpp
@@ -236,7 +236,7 @@ int GUIManager::createGUI(sofa::simulation::Node::SPtr groot, const char* filena
             return 1;
         }
 
-        if (currentGUI->saveAsDefaultGUI())
+        if (currentGUI->canBeDefaultGUI())
         {
             //Save this GUI type as the last used GUI
             const std::string lastGuiFilePath = BaseGUI::getConfigDirectoryPath() + "/lastUsedGUI.ini";


### PR DESCRIPTION
Currently, when running runSofa without using the -g option for specifying if we want the GUI or batch, SOFA picks the last used one. I would rather like it to be the GUI all the time, and if you want to run in batch, then you would have to specify it explicitly. The current behaviour is annoying when running SOFA in parallel for example with SOFA launcher, because it then saves the batch mode by default.
I am aware my fix is maybe not perfect, I want to start the debate!
Thank you!



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
