### PR TITLE
[S.C.Mapping] Fix assertion in BarycentricMapper

### DIFF
--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
@@ -792,7 +792,7 @@ const sofa::linearalgebra::BaseMatrix* BarycentricMapperMeshTopology<In,Out>::ge
             ++rowId;
         }
     }
-    assert(i == m_map1d.size() + m_map2d.size() + m_map3d.size());
+    assert(static_cast<std::size_t>(rowId) == m_map1d.size() + m_map2d.size() + m_map3d.size());
 
     m_matrixJ->compress();
     m_updateJ = false;


### PR DESCRIPTION
assertion was using an undeclared variable so the debug build was failing.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
