### PR TITLE
[Topology.Container.Dynamic] Fix duplicate Data Points in PointSetTopologyContainer

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.cpp
@@ -59,24 +59,12 @@ PointSetTopologyContainer::PointSetTopologyContainer(Size npoints)
     : d_initPoints (initData(&d_initPoints, "position", "Initial position of points",true,true))
     , d_checkTopology (initData(&d_checkTopology, false, "checkTopology", "Parameter to activate internal topology checks (might slow down the simulation)"))
     , nbPoints (initData(&nbPoints, npoints, "nbPoints", "Number of points"))
-    , points(initData(&points, "points","List of point indices"))
 {
     addAlias(&d_initPoints,"points");
 }
 
 void PointSetTopologyContainer::setNbPoints(Size n)
 {
-
-    int diffSize = n - nbPoints.getValue();
-    sofa::helper::WriteAccessor< sofa::Data< sofa::type::vector<PointID> > > points = this->points;
-    points.resize(n);
-
-    if( diffSize > 0 )
-    {
-        GeneratePointID generator( PointID( nbPoints.getValue() ) );
-        std::generate( points.begin()+nbPoints.getValue(), points.end(), generator );
-    }
-
     nbPoints.setValue(n);  
 }
 
@@ -95,8 +83,6 @@ void PointSetTopologyContainer::clear()
     nbPoints.setValue(0);
     helper::WriteAccessor< Data<InitTypes::VecCoord> > initPoints = d_initPoints;
     initPoints.clear();
-    sofa::helper::WriteAccessor< sofa::Data< sofa::type::vector<PointID> > > points = this->points;
-    points.clear();
 }
 
 void PointSetTopologyContainer::addPoint(SReal px, SReal py, SReal pz)
@@ -177,11 +163,6 @@ void PointSetTopologyContainer::removePoint()
 {
     //nbPoints.setValue(nbPoints.getValue()-1);
     setNbPoints( nbPoints.getValue() - 1 );
-}
-
-const sofa::type::vector< PointSetTopologyContainer::PointID >& PointSetTopologyContainer::getPoints() const
-{
-    return points.getValue();
 }
 
 void PointSetTopologyContainer::setPointTopologyToDirty()

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.h
@@ -136,8 +136,6 @@ public:
         return in;
     }
 
-    const sofa::type::vector<PointID>& getPoints() const;
-
     bool linkTopologyHandlerToData(core::topology::TopologyHandler* topologyHandler, sofa::geometry::ElementType elementType) override;
 
 protected:
@@ -157,10 +155,8 @@ protected:
     bool m_pointTopologyDirty = false;
 
 private:
-    
     Data<Size> nbPoints; ///< Number of points
 
-    Data<sofa::type::vector<PointID> > points; ///< List of point indices
 };
 
 } //namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.h
@@ -136,6 +136,9 @@ public:
         return in;
     }
 
+    SOFA_ATTRIBUTE_DEPRECATED("v22.06", "v22.12", "Data points has been removed from PointSetTopologyContainer. Only the nbPoints should be used.")
+    const sofa::type::vector<PointID>& getPoints() const = delete;
+
     bool linkTopologyHandlerToData(core::topology::TopologyHandler* topologyHandler, sofa::geometry::ElementType elementType) override;
 
 protected:
@@ -157,6 +160,8 @@ protected:
 private:
     Data<Size> nbPoints; ///< Number of points
 
+    SOFA_ATTRIBUTE_DEPRECATED("v22.06", "v22.12", "Data points has been removed from PointSetTopologyContainer. Only the nbPoints should be used.")
+    DeprecatedAndRemoved points; ///< List of point indices
 };
 
 } //namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Dynamic/tests/EdgeSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/EdgeSetTopology_test.cpp
@@ -53,7 +53,6 @@ bool EdgeSetTopology_test::testEmptyContainer()
     
     EXPECT_EQ(edgeContainer->d_initPoints.getValue().size(), 0);
     EXPECT_EQ(edgeContainer->getNbPoints(), 0);
-    EXPECT_EQ(edgeContainer->getPoints().size(), 0);
 
     return true;
 }
@@ -142,9 +141,7 @@ bool EdgeSetTopology_test::testVertexBuffers()
     //// check only the vertex buffer size: Full test on vertics are done in PointSetTopology_test
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), nbrVertex);
     EXPECT_EQ(topoCon->getNbPoints(), nbrVertex); 
-    EXPECT_EQ(topoCon->getPoints().size(), nbrVertex);
-
-
+    
     // check EdgesAroundVertex buffer access
     EXPECT_EQ(edgeAroundVertices.size(), nbrVertex);
     const EdgeSetTopologyContainer::EdgesAroundVertex& edgeAVertex = edgeAroundVertices[0];

--- a/Sofa/Component/Topology/Container/Dynamic/tests/HexahedronSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/HexahedronSetTopology_test.cpp
@@ -66,7 +66,6 @@ bool HexahedronSetTopology_test::testEmptyContainer()
 
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), 0);
     EXPECT_EQ(topoCon->getNbPoints(), 0);
-    EXPECT_EQ(topoCon->getPoints().size(), 0);
 
     return true;
 }
@@ -357,9 +356,7 @@ bool HexahedronSetTopology_test::testVertexBuffers()
     //// check only the vertex buffer size: Full test on vertics are done in PointSetTopology_test
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), nbrVertex);
     EXPECT_EQ(topoCon->getNbPoints(), nbrVertex); //TODO: check why 0 and not 20
-    EXPECT_EQ(topoCon->getPoints().size(), nbrVertex);
-
-
+   
     // check HexahedraAroundVertex buffer access
     EXPECT_EQ(elemAroundVertices.size(), nbrVertex);
     const HexahedronSetTopologyContainer::HexahedraAroundVertex& elemAVertex = elemAroundVertices[1];

--- a/Sofa/Component/Topology/Container/Dynamic/tests/PointSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/PointSetTopology_test.cpp
@@ -33,7 +33,6 @@ TEST( PointSetTopology_test, checkPointSetTopologyIsEmptyConstructed )
 {
     PointSetTopologyContainer::SPtr pointContainer = sofa::core::objectmodel::New< PointSetTopologyContainer >();
     EXPECT_EQ( 0, pointContainer->getNbPoints() );
-    EXPECT_EQ( 0, pointContainer->getPoints().size() );
 }
 
 
@@ -46,15 +45,7 @@ TEST( PointSetTopology_test, checkPointSetTopologyInitialization )
 
     pointContainer->init();
 
-    const sofa::type::vector< PointSetTopologyContainer::PointID >& points = pointContainer->getPoints();
     EXPECT_EQ( 50, pointContainer->getNbPoints() );
-    EXPECT_EQ( 50, points.size() );
-
-    
-    for(std::size_t i=0;i<50;++i)
-    {
-        EXPECT_EQ( PointSetTopologyContainer::PointID(i), points[i] );
-    }
 }
 
 TEST( PointSetTopology_test, checkAddPoint )
@@ -62,11 +53,7 @@ TEST( PointSetTopology_test, checkAddPoint )
     PointSetTopologyContainer::SPtr pointContainer = sofa::core::objectmodel::New< PointSetTopologyContainer >();
     pointContainer->addPoint();
 
-    const sofa::type::vector< PointSetTopologyContainer::PointID >& points = pointContainer->getPoints();
-
     EXPECT_EQ( 1, pointContainer->getNbPoints() );
-    ASSERT_EQ( 1, points.size() );
-    EXPECT_EQ( PointSetTopologyContainer::PointID(0), points[0] );
 }
 
 TEST( PointSetTopology_test, checkAddPoints )
@@ -74,25 +61,11 @@ TEST( PointSetTopology_test, checkAddPoints )
     PointSetTopologyContainer::SPtr pointContainer = sofa::core::objectmodel::New< PointSetTopologyContainer >();
     pointContainer->addPoints(10);
 
-    const sofa::type::vector< PointSetTopologyContainer::PointID >& points = pointContainer->getPoints();
-
     EXPECT_EQ( 10, pointContainer->getNbPoints() );
-    ASSERT_EQ( 10, points.size() );
-
-    for(std::size_t i=0;i<10;++i)
-    {
-        EXPECT_EQ( PointSetTopologyContainer::PointID(i), points[i] );
-    }
 
     pointContainer->addPoints(5);
 
     EXPECT_EQ( 15, pointContainer->getNbPoints() );
-    ASSERT_EQ( 15, points.size() );
-
-    for(std::size_t i=10;i<15;++i)
-    {
-        EXPECT_EQ( PointSetTopologyContainer::PointID(i), points[i] );
-    }
 }
 
 TEST( PointSetTopology_test, checkRemovePoint )
@@ -100,10 +73,8 @@ TEST( PointSetTopology_test, checkRemovePoint )
     PointSetTopologyContainer::SPtr pointContainer = sofa::core::objectmodel::New< PointSetTopologyContainer >();
     pointContainer->addPoint();
     pointContainer->removePoint();
-    const sofa::type::vector< PointSetTopologyContainer::PointID >& points = pointContainer->getPoints();
-
+   
     EXPECT_EQ( 0, pointContainer->getNbPoints() );
-    ASSERT_EQ( 0, points.size() );
 }
 
 TEST( PointSetTopology_test, checkRemovePoints )
@@ -111,26 +82,12 @@ TEST( PointSetTopology_test, checkRemovePoints )
     PointSetTopologyContainer::SPtr pointContainer = sofa::core::objectmodel::New< PointSetTopologyContainer >();
     pointContainer->addPoints(10);
     pointContainer->removePoints(3);
-    const sofa::type::vector< PointSetTopologyContainer::PointID >& points = pointContainer->getPoints();
-
+    
     EXPECT_EQ( 7, pointContainer->getNbPoints() );
-    ASSERT_EQ( 7, points.size() );
-
-    for(std::size_t i=0;i<7;++i)
-    {
-        EXPECT_EQ( PointSetTopologyContainer::PointID(i), points[i] );
-    }
 
     pointContainer->removePoints(3);
 
     EXPECT_EQ( 4, pointContainer->getNbPoints() );
-    ASSERT_EQ( 4, points.size() );
-
-    for(std::size_t i=0;i<4;++i)
-    {
-        EXPECT_EQ( PointSetTopologyContainer::PointID(i), points[i] );
-    }
-
 
 }
 

--- a/Sofa/Component/Topology/Container/Dynamic/tests/QuadSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/QuadSetTopology_test.cpp
@@ -60,8 +60,7 @@ bool QuadSetTopology_test::testEmptyContainer()
 
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), 0);
     EXPECT_EQ(topoCon->getNbPoints(), 0);
-    EXPECT_EQ(topoCon->getPoints().size(), 0);
-
+    
     return true;
 }
 
@@ -248,9 +247,7 @@ bool QuadSetTopology_test::testVertexBuffers()
     //// check only the vertex buffer size: Full test on vertics are done in PointSetTopology_test
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), nbrVertex);
     EXPECT_EQ(topoCon->getNbPoints(), nbrVertex); //TODO: check why 0 and not 20
-    EXPECT_EQ(topoCon->getPoints().size(), nbrVertex);
-
-
+    
     // check QuadsAroundVertex buffer access
     EXPECT_EQ(elemAroundVertices.size(), nbrVertex);
     const QuadSetTopologyContainer::QuadsAroundVertex& elemAVertex = elemAroundVertices[1];

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TetrahedronSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TetrahedronSetTopology_test.cpp
@@ -68,8 +68,7 @@ bool TetrahedronSetTopology_test::testEmptyContainer()
 
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), 0);
     EXPECT_EQ(topoCon->getNbPoints(), 0);
-    EXPECT_EQ(topoCon->getPoints().size(), 0);
-
+    
     return true;
 }
 
@@ -359,8 +358,6 @@ bool TetrahedronSetTopology_test::testVertexBuffers()
     //// check only the vertex buffer size: Full test on vertics are done in PointSetTopology_test
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), nbrVertex);
     EXPECT_EQ(topoCon->getNbPoints(), nbrVertex); //TODO: check why 0 and not 20
-    EXPECT_EQ(topoCon->getPoints().size(), nbrVertex);
-
 
     // check TetrahedraAroundVertex buffer access
     EXPECT_EQ(elemAroundVertices.size(), nbrVertex);

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
@@ -59,7 +59,6 @@ bool TriangleSetTopology_test::testEmptyContainer()
 
     EXPECT_EQ(triangleContainer->d_initPoints.getValue().size(), 0);
     EXPECT_EQ(triangleContainer->getNbPoints(), 0);
-    EXPECT_EQ(triangleContainer->getPoints().size(), 0);
 
     return true;
 }
@@ -247,8 +246,6 @@ bool TriangleSetTopology_test::testVertexBuffers()
     //// check only the vertex buffer size: Full test on vertics are done in PointSetTopology_test
     EXPECT_EQ(topoCon->d_initPoints.getValue().size(), nbrVertex);
     EXPECT_EQ(topoCon->getNbPoints(), nbrVertex);
-    EXPECT_EQ(topoCon->getPoints().size(), nbrVertex);
-
 
     // check TrianglesAroundVertex buffer access
     EXPECT_EQ(triAroundVertices.size(), nbrVertex);


### PR DESCRIPTION
Remove unused Data buffer of point indices.

quick way to fix #1591 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
