### PR TITLE
[Core.Topology] Remove array quadsInHexahedronArray, QuadsOrientationInHexahedronArray should be used

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
@@ -31,7 +31,7 @@ namespace sofa::component::topology::container::dynamic
 using namespace std;
 using namespace sofa::defaulttype;
 using sofa::core::topology::edgesInHexahedronArray;
-using sofa::core::topology::quadsInHexahedronArray;
+using sofa::core::topology::quadsOrientationInHexahedronArray;
 using sofa::core::topology::verticesInHexahedronArray;
 
 int HexahedronSetTopologyContainerClass = core::RegisterObject("Hexahedron set topology container")
@@ -589,10 +589,10 @@ HexahedronSetTopologyContainer::Edge HexahedronSetTopologyContainer::getLocalEdg
 HexahedronSetTopologyContainer::Quad HexahedronSetTopologyContainer::getLocalQuadsInHexahedron (const QuadID i) const
 {
     assert(i<6);
-    return Quad (quadsInHexahedronArray[i][0],
-            quadsInHexahedronArray[i][1],
-            quadsInHexahedronArray[i][2],
-            quadsInHexahedronArray[i][3]);
+    return Quad (quadsOrientationInHexahedronArray[i][0],
+        quadsOrientationInHexahedronArray[i][1],
+        quadsOrientationInHexahedronArray[i][2],
+        quadsOrientationInHexahedronArray[i][3]);
 }
 
  unsigned int HexahedronSetTopologyContainer::getLocalIndexFromBinaryIndex(const HexahedronBinaryIndex bi) const

--- a/Sofa/framework/Core/src/sofa/core/topology/Topology.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/Topology.cpp
@@ -46,7 +46,6 @@ const unsigned int trianglesOrientationInTetrahedronArray[4][3] = {{1,2,3}, {0,3
 
 // Hexahedron
 const unsigned int edgesInHexahedronArray[12][2] = {{0,1},{0,3},{0,4},{1,2},{1,5},{2,3},{2,6},{3,7},{4,5},{4,7},{5,6},{6,7}};
-const unsigned int quadsInHexahedronArray[6][4] = {{0,1,2,3}, {4,7,6,5}, {1,0,4,5}, {1,5,6,2}, {2,6,7,3}, {0,3,7,4}};
 const unsigned int quadsOrientationInHexahedronArray[6][4] = {{0,3,2,1}, {4,5,6,7}, {0,1,5,4}, {1,2,6,5}, {2,3,7,6}, {3,0,4,7}};
 const unsigned int verticesInHexahedronArray[2][2][2] = { {{0,4}, {3,7}}, {{1,5}, {2,6}} };
 

--- a/Sofa/framework/Core/src/sofa/core/topology/Topology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/Topology.h
@@ -136,7 +136,7 @@ SOFA_CORE_API extern const unsigned int trianglesOrientationInTetrahedronArray[4
 SOFA_CORE_API extern const unsigned int edgesInHexahedronArray[12][2];
 
 /// Old static array with not relevant orientation. @sa quadsOrientationInHexahedronArray is the right orientation convention
-SOFA_CORE_TOPOLOGY_ATTRIBUTE_DEPRECATED("quadsInHexahedronArray structure has been deprecated, please use the right array instead: quadsOrientationInHexahedronArray")
+SOFA_ATTRIBUTE_DEPRECATED("v22.06", "v22.12", "quadsInHexahedronArray structure has been deprecated, please use the right array instead: quadsOrientationInHexahedronArray")
 SOFA_CORE_API extern const DeprecatedAndRemoved quadsInHexahedronArray;
 
 /// List of 4 vertex indices (quad) in a hexahedron

--- a/Sofa/framework/Core/src/sofa/core/topology/Topology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/Topology.h
@@ -135,8 +135,6 @@ SOFA_CORE_API extern const unsigned int trianglesOrientationInTetrahedronArray[4
 /// List of pair of vertex indices (edge) in a hexahedron
 SOFA_CORE_API extern const unsigned int edgesInHexahedronArray[12][2];
 /// List of 4 vertex indices (quad) in a hexahedron
-SOFA_CORE_API extern const unsigned int quadsInHexahedronArray[6][4];
-/// List of 4 vertex indices (quad) in a hexahedron
 SOFA_CORE_API extern const unsigned int quadsOrientationInHexahedronArray[6][4];
 // List of vertex indices in a hexahedron
 SOFA_CORE_API extern const unsigned int verticesInHexahedronArray[2][2][2];

--- a/Sofa/framework/Core/src/sofa/core/topology/Topology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/Topology.h
@@ -137,7 +137,7 @@ SOFA_CORE_API extern const unsigned int edgesInHexahedronArray[12][2];
 
 /// Old static array with not relevant orientation. @sa quadsOrientationInHexahedronArray is the right orientation convention
 SOFA_ATTRIBUTE_DEPRECATED("v22.06", "v22.12", "quadsInHexahedronArray structure has been deprecated, please use the right array instead: quadsOrientationInHexahedronArray")
-SOFA_CORE_API extern const DeprecatedAndRemoved quadsInHexahedronArray;
+const DeprecatedAndRemoved quadsInHexahedronArray;
 
 /// List of 4 vertex indices (quad) in a hexahedron
 SOFA_CORE_API extern const unsigned int quadsOrientationInHexahedronArray[6][4];

--- a/Sofa/framework/Core/src/sofa/core/topology/Topology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/Topology.h
@@ -134,6 +134,11 @@ SOFA_CORE_API extern const unsigned int trianglesOrientationInTetrahedronArray[4
 
 /// List of pair of vertex indices (edge) in a hexahedron
 SOFA_CORE_API extern const unsigned int edgesInHexahedronArray[12][2];
+
+/// Old static array with not relevant orientation. @sa quadsOrientationInHexahedronArray is the right orientation convention
+SOFA_CORE_TOPOLOGY_ATTRIBUTE_DEPRECATED("quadsInHexahedronArray structure has been deprecated, please use the right array instead: quadsOrientationInHexahedronArray")
+SOFA_CORE_API extern const DeprecatedAndRemoved quadsInHexahedronArray;
+
 /// List of 4 vertex indices (quad) in a hexahedron
 SOFA_CORE_API extern const unsigned int quadsOrientationInHexahedronArray[6][4];
 // List of vertex indices in a hexahedron


### PR DESCRIPTION
quadsInHexahedronArray was not really used. 
QuadsOrientationInHexahedronArray  is the good one.

Quick way to fix #2003


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
