### PR TITLE
[IO][Tests] Add basic test for the MeshSTLLoader

### DIFF
--- a/Sofa/Component/IO/Mesh/tests/CMakeLists.txt
+++ b/Sofa/Component/IO/Mesh/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCE_FILES
     MeshExporter_test.cpp
     MeshGmshLoader_test.cpp
     MeshOBJLoader_test.cpp
+    MeshSTLLoader_test.cpp
     MeshVTKLoader_test.cpp
     MeshXspLoader_test.cpp
     STLExporter_test.cpp

--- a/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
@@ -23,70 +23,68 @@
 #include <sofa/testing/BaseTest.h>
 #include <sofa/helper/system/FileRepository.h>
 
-#include <SofaGeneralLoader/MeshSTLLoader.h>
+#include <sofa/component/io/mesh/MeshSTLLoader.h>
 #include <sofa/helper/BackTrace.h>
 
-using namespace sofa::component::loader;
+using namespace sofa::component::io::mesh;
 using sofa::testing::BaseTest;
 using sofa::helper::BackTrace;
 
-namespace sofa
-{
-namespace meshstlloader_test
+namespace sofa::meshstlloader_test
 {
 
-    int initTestEnvironment()
-    {
-        BackTrace::autodump();
-        return 0;
-    }
-    int s_autodump = initTestEnvironment();
+int initTestEnvironment()
+{
+    BackTrace::autodump();
+    return 0;
+}
+int s_autodump = initTestEnvironment();
 
 
-    class MeshSTLLoaderTest : public BaseTest,
-                              public MeshSTLLoader
-    {
-    public:
+class MeshSTLLoaderTest : public BaseTest, public MeshSTLLoader
+{
+public:
 
-        MeshSTLLoaderTest()
-        {}
+    MeshSTLLoaderTest()
+    {}
 
-        /**
-         * Helper function to check mesh loading.
-         * Compare basic values from a mesh with given results.
-         */
-        void loadTest(std::string filename, int nbPositions, int nbEdges, int nbTriangles, int nbQuads, int nbPolygons,
-                      int nbTetra, int nbHexa, int nbNormals)
-        {
-            this->setFilename(sofa::helper::system::DataRepository.getFile(filename));
-
-            EXPECT_EQ((size_t)nbPositions, this->d_positions.getValue().size());
-            EXPECT_EQ((size_t)nbEdges, this->d_edges.getValue().size());
-            EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size()) << "Added this failing test in PR#2999 (wrong number of triangles detected). To be fixed (see issue #3043)";
-            EXPECT_EQ((size_t)nbQuads, this->d_quads.getValue().size());
-            EXPECT_EQ((size_t)nbPolygons, this->d_polygons.getValue().size());
-            EXPECT_EQ((size_t)nbTetra, this->d_tetrahedra.getValue().size());
-            EXPECT_EQ((size_t)nbHexa, this->d_hexahedra.getValue().size());
-            EXPECT_EQ((size_t)nbNormals, this->d_normals.getValue().size());
-        }
-
-    };
-
-    /** MeshGmshLoader::load()
-    * For a given meshes check that imported data are correct
+    /**
+    * Helper function to check mesh loading.
+    * Compare basic values from a mesh with given results.
     */
-    TEST_F(MeshSTLLoaderTest, LoadCall)
+    void loadTest(std::string filename, int nbPositions, int nbEdges, int nbTriangles, int nbQuads, int nbPolygons,
+                    int nbTetra, int nbHexa, int nbNormals)
     {
-        //Check loader high level result for one file
-        this->setFilename(sofa::helper::system::DataRepository.getFile("mesh/circle_knot_ascii.stl"));
-        EXPECT_TRUE(this->load());
+        this->setFilename(sofa::helper::system::DataRepository.getFile(filename));
 
-        // Testing number of : nodes/positions, edges, triangles, quads, polygons, tetra, hexa, normals
-        // for several STL meshes in share/mesh/
-        loadTest("mesh/circle_knot_ascii.stl", 6144, 0, 12288, 0, 0, 0, 0, 12288);
-        loadTest("mesh/dragon.stl", 1190, 0, 2526, 0, 0, 0, 0, 2526);
-        loadTest("mesh/pliers_binary.stl", 5356, 0, 10708, 0, 0, 0, 0, 10712);
+        EXPECT_EQ((size_t)nbPositions, this->d_positions.getValue().size());
+        EXPECT_EQ((size_t)nbEdges, this->d_edges.getValue().size());
+        EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size()) << "Added this failing test in PR#2999 (wrong number of triangles detected). To be fixed (see issue #3043)";
+        EXPECT_EQ((size_t)nbQuads, this->d_quads.getValue().size());
+        EXPECT_EQ((size_t)nbPolygons, this->d_polygons.getValue().size());
+        EXPECT_EQ((size_t)nbTetra, this->d_tetrahedra.getValue().size());
+        EXPECT_EQ((size_t)nbHexa, this->d_hexahedra.getValue().size());
+        EXPECT_EQ((size_t)nbNormals, this->d_normals.getValue().size());
     }
 
-} // namespace meshstlloader_test
-} // namespace sofa
+};
+
+/** MeshSTLLoader::load()
+* For a given meshes check that imported data are correct
+*/
+TEST_F(MeshSTLLoaderTest, LoadCall)
+{
+    //Check loader high level result for one file
+    EXPECT_MSG_EMIT(Error);
+    EXPECT_FALSE(this->load());
+    this->setFilename(sofa::helper::system::DataRepository.getFile("mesh/circle_knot_ascii.stl"));
+    EXPECT_TRUE(this->load());
+
+    // Testing number of : nodes/positions, edges, triangles, quads, polygons, tetra, hexa, normals
+    // for several STL meshes in share/mesh/
+    loadTest("mesh/circle_knot_ascii.stl", 6144, 0, 12288, 0, 0, 0, 0, 12288);
+    loadTest("mesh/dragon.stl", 1190, 0, 2526, 0, 0, 0, 0, 2526);
+    loadTest("mesh/pliers_binary.stl", 5356, 0, 10708, 0, 0, 0, 0, 10712);
+}
+
+} // namespace sofa::meshstlloader_test

--- a/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
@@ -59,7 +59,7 @@ public:
 
         EXPECT_EQ((size_t)nbPositions, this->d_positions.getValue().size());
         EXPECT_EQ((size_t)nbEdges, this->d_edges.getValue().size());
-        EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size()) << "Added this failing test in PR#2999 (wrong number of triangles detected). To be fixed (see issue #3043)";
+        EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size());
         EXPECT_EQ((size_t)nbQuads, this->d_quads.getValue().size());
         EXPECT_EQ((size_t)nbPolygons, this->d_polygons.getValue().size());
         EXPECT_EQ((size_t)nbTetra, this->d_tetrahedra.getValue().size());

--- a/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
@@ -60,7 +60,6 @@ namespace meshstlloader_test
         {
             this->setFilename(sofa::helper::system::DataRepository.getFile(filename));
 
-            EXPECT_TRUE(this->load());
             EXPECT_EQ((size_t)nbPositions, this->d_positions.getValue().size());
             EXPECT_EQ((size_t)nbEdges, this->d_edges.getValue().size());
             EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size()) << "Added this failing test in PR#2999 (wrong number of triangles detected). To be fixed (see issue #3043)";

--- a/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
@@ -1,0 +1,93 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/testing/BaseTest.h>
+#include <sofa/helper/system/FileRepository.h>
+
+#include <SofaGeneralLoader/MeshSTLLoader.h>
+#include <sofa/helper/BackTrace.h>
+
+using namespace sofa::component::loader;
+using sofa::testing::BaseTest;
+using sofa::helper::BackTrace;
+
+namespace sofa
+{
+namespace meshstlloader_test
+{
+
+    int initTestEnvironment()
+    {
+        BackTrace::autodump();
+        return 0;
+    }
+    int s_autodump = initTestEnvironment();
+
+
+    class MeshSTLLoaderTest : public BaseTest,
+                              public MeshSTLLoader
+    {
+    public:
+
+        MeshSTLLoaderTest()
+        {}
+
+        /**
+         * Helper function to check mesh loading.
+         * Compare basic values from a mesh with given results.
+         */
+        void loadTest(std::string filename, int nbPositions, int nbEdges, int nbTriangles, int nbQuads, int nbPolygons,
+                      int nbTetra, int nbHexa, int nbNormals)
+        {
+            this->setFilename(sofa::helper::system::DataRepository.getFile(filename));
+
+            EXPECT_TRUE(this->load());
+            EXPECT_EQ((size_t)nbPositions, this->d_positions.getValue().size());
+            EXPECT_EQ((size_t)nbEdges, this->d_edges.getValue().size());
+            EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size());
+            EXPECT_EQ((size_t)nbQuads, this->d_quads.getValue().size());
+            EXPECT_EQ((size_t)nbPolygons, this->d_polygons.getValue().size());
+            EXPECT_EQ((size_t)nbTetra, this->d_tetrahedra.getValue().size());
+            EXPECT_EQ((size_t)nbHexa, this->d_hexahedra.getValue().size());
+            EXPECT_EQ((size_t)nbNormals, this->d_normals.getValue().size());
+        }
+
+    };
+
+    /** MeshGmshLoader::load()
+    * For a given meshes check that imported data are correct
+    */
+    TEST_F(MeshSTLLoaderTest, LoadCall)
+    {
+        //Check loader high level result for one file
+        this->setFilename(sofa::helper::system::DataRepository.getFile("mesh/circle_knot_ascii.stl"));
+        EXPECT_TRUE(this->load());
+
+        // Testing number of : nodes/positions, edges, triangles, quads, polygons, tetra, hexa, normals
+        // for several STL meshes in share/mesh/
+        loadTest("mesh/circle_knot_ascii.stl", 6144, 0, 12288, 0, 0, 0, 0, 12288);
+        loadTest("mesh/dragon.stl", 1190, 0, 2526, 0, 0, 0, 0, 2526);
+        loadTest("mesh/pliers_binary.stl", 5356, 0, 10712, 0, 0, 0, 0, 10712); //NB : Gmsh detects 10708 faces. Is that normal ?
+    }
+
+} // namespace meshstlloader_test
+} // namespace sofa

--- a/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
@@ -63,7 +63,7 @@ namespace meshstlloader_test
             EXPECT_TRUE(this->load());
             EXPECT_EQ((size_t)nbPositions, this->d_positions.getValue().size());
             EXPECT_EQ((size_t)nbEdges, this->d_edges.getValue().size());
-            EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size());
+            EXPECT_EQ((size_t)nbTriangles, this->d_triangles.getValue().size()) << "Added this failing test in PR#2999 (wrong number of triangles detected). To be fixed (see issue #3043)";
             EXPECT_EQ((size_t)nbQuads, this->d_quads.getValue().size());
             EXPECT_EQ((size_t)nbPolygons, this->d_polygons.getValue().size());
             EXPECT_EQ((size_t)nbTetra, this->d_tetrahedra.getValue().size());

--- a/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshSTLLoader_test.cpp
@@ -86,7 +86,7 @@ namespace meshstlloader_test
         // for several STL meshes in share/mesh/
         loadTest("mesh/circle_knot_ascii.stl", 6144, 0, 12288, 0, 0, 0, 0, 12288);
         loadTest("mesh/dragon.stl", 1190, 0, 2526, 0, 0, 0, 0, 2526);
-        loadTest("mesh/pliers_binary.stl", 5356, 0, 10712, 0, 0, 0, 0, 10712); //NB : Gmsh detects 10708 faces. Is that normal ?
+        loadTest("mesh/pliers_binary.stl", 5356, 0, 10708, 0, 0, 0, 0, 10712);
     }
 
 } // namespace meshstlloader_test


### PR DESCRIPTION
This PR adds a base test for the MeshSTLLoader component, based on similar tests for the OBJ and VTK loaders. It loads and checks the composition of the 3 .stl meshes available in share/meshes

Fix #2899
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
