### PR TITLE
[SofaTest] Remove last usages and make it optional

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.12)
 
 find_package(Sofa.Framework)
 
-# SofaTest needs to be after SofaMiscCollision, as it depends on it
 if(SOFA_BUILD_TESTS OR SOFA_BUILD_RELEASE_PACKAGE)
-    # Library used to write high level tests involving many components.
-    add_subdirectory(SofaTest)
+    # (Deprecated) Library used to write high level tests involving many components.
+    sofa_add_plugin(SofaTest SofaTest)
 endif()
 
 sofa_add_plugin(CollisionOBBCapsule CollisionOBBCapsule)

--- a/applications/plugins/MultiThreading/test/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/test/CMakeLists.txt
@@ -7,9 +7,7 @@ set ( HEADER_FILES
 set(SOURCE_FILES
 )
 
-find_package(SofaTest REQUIRED)
-
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(${PROJECT_NAME} SofaTest SofaGTestMain Sofa.Simulation.Core)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Simulation.Core)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/SceneCreator/CMakeLists.txt
+++ b/applications/plugins/SceneCreator/CMakeLists.txt
@@ -40,6 +40,5 @@ add_subdirectory(sceneCreatorExamples)
 
 ## Add test project
 if(SOFA_BUILD_TESTS)
-    sofa_find_package(SofaTest QUIET)
     add_subdirectory(SceneCreator_test)
 endif()

--- a/applications/plugins/SceneCreator/SceneCreator_test/CMakeLists.txt
+++ b/applications/plugins/SceneCreator/SceneCreator_test/CMakeLists.txt
@@ -11,6 +11,6 @@ set(SOURCE_FILES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SceneCreator Sofa.Testing SofaTest)
+target_link_libraries(${PROJECT_NAME} SceneCreator Sofa.Testing)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/SceneCreator/SceneCreator_test/CMakeLists.txt
+++ b/applications/plugins/SceneCreator/SceneCreator_test/CMakeLists.txt
@@ -12,5 +12,7 @@ set(SOURCE_FILES
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SceneCreator Sofa.Testing)
+target_link_libraries(${PROJECT_NAME} Sofa.Component.SolidMechanics.FEM.Elastic Sofa.Component.StateContainer Sofa.Component.Topology.Container.Grid )
+
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
+++ b/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
@@ -58,7 +58,7 @@ class SceneCreator_test : public BaseSimulationTest
 public:
     void SetUp() override
     {
-        importPlugin("SofaComponentAll");
+        importPlugin("Sofa.Component");
     }
 
     bool createCubeFailed();

--- a/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
+++ b/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
@@ -59,6 +59,7 @@ public:
     void SetUp() override
     {
         importPlugin("Sofa.Component");
+        importPlugin("Sofa.GL.Component.Rendering3D");
     }
 
     bool createCubeFailed();

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
@@ -79,8 +79,6 @@ Node::SPtr createRootWithCollisionPipeline(const std::string& responseType)
                                 {"name", "Contact Manager"},
                                 {"response", responseType}
                             });
-
-    simpleapi::createObject(root, "DefaultCollisionGroupManager", {{"name", "Collision Group Manager"}});
     return root;
 }
 

--- a/applications/plugins/SceneCreator/src/SceneCreator/initSceneCreator.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/initSceneCreator.cpp
@@ -47,9 +47,7 @@ void initExternalModule()
         first = false;
     }
 
-    /// Required for DefaultCollisionGroupManager
-    PluginManager::getInstance().loadPlugin("SofaMiscCollision") ;
-    PluginManager::getInstance().loadPlugin("SofaComponentAll") ;
+    PluginManager::getInstance().loadPlugin("Sofa.Component") ;
 }
 
 const char* getModuleName()

--- a/applications/plugins/SofaAssimp/CMakeLists.txt
+++ b/applications/plugins/SofaAssimp/CMakeLists.txt
@@ -55,7 +55,6 @@ endif()
 
 #TODO
 if(SOFA_BUILD_TESTS)
-   find_package(SofaTest QUIET)
 #   add_subdirectory(CGALPlugin_test)
 endif()
 

--- a/applications/plugins/SofaCarving/CMakeLists.txt
+++ b/applications/plugins/SofaCarving/CMakeLists.txt
@@ -28,8 +28,5 @@ sofa_create_package_with_targets(
     )
 
 if(SOFA_BUILD_TESTS)
-    find_package(SofaTest QUIET)
-    if(SofaTest_FOUND)
-        add_subdirectory(SofaCarving_test)
-    endif()
+    add_subdirectory(SofaCarving_test)
 endif()

--- a/applications/plugins/SofaCarving/SofaCarving_test/CMakeLists.txt
+++ b/applications/plugins/SofaCarving/SofaCarving_test/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SOURCE_FILES
 add_definitions("-DSOFACARVING_TEST_RESOURCES_DIR=\"${CMAKE_SOURCE_DIR}/share\"")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaTest SofaCarving)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaCarving)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 

--- a/applications/plugins/SofaDistanceGrid/CMakeLists.txt
+++ b/applications/plugins/SofaDistanceGrid/CMakeLists.txt
@@ -74,10 +74,7 @@ else()
 endif()
 
 if(SOFA_BUILD_TESTS)
-    find_package(SofaTest QUIET)
-    if(SofaTest_FOUND)
-        add_subdirectory(SofaDistanceGrid_test)
-    endif()
+    add_subdirectory(SofaDistanceGrid_test)
 endif()
 
 ## Install rules for the library and headers; CMake package configurations files

--- a/applications/plugins/SofaDistanceGrid/SofaDistanceGrid_test/CMakeLists.txt
+++ b/applications/plugins/SofaDistanceGrid/SofaDistanceGrid_test/CMakeLists.txt
@@ -7,6 +7,6 @@ set(SOURCE_FILES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaTest SofaDistanceGrid)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaDistanceGrid)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/SofaDistanceGrid/SofaDistanceGrid_test/DistanceGrid_test.cpp
+++ b/applications/plugins/SofaDistanceGrid/SofaDistanceGrid_test/DistanceGrid_test.cpp
@@ -19,9 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaTest/Sofa_test.h>
-using sofa::Sofa_test ;
-
+#include <sofa/testing/NumericTest.h>
 #include <sofa/type/Vec.h>
 
 #include <SofaDistanceGrid/DistanceGrid.h>
@@ -37,7 +35,7 @@ namespace _distancegrid_
 {
 using sofa::type::Vector3 ;
 
-struct DistanceGrid_test : public Sofa_test<SReal>
+struct DistanceGrid_test : public sofa::testing::NumericTest<SReal>
 {
     void chekcValidConstructorsCube(){
         EXPECT_MSG_NOEMIT(Warning, Error) ;

--- a/applications/plugins/SofaImplicitField/CMakeLists.txt
+++ b/applications/plugins/SofaImplicitField/CMakeLists.txt
@@ -41,8 +41,7 @@ set(EXTRA_FILES
     examples/README.md
     )
 
-find_package(SofaTest QUIET)
-if(SofaTest_FOUND)
+if(SOFA_BUILD_TESTS)
     add_subdirectory(SofaImplicitField_test)
 endif()
 

--- a/applications/plugins/SofaImplicitField/SofaImplicitField_test/CMakeLists.txt
+++ b/applications/plugins/SofaImplicitField/SofaImplicitField_test/CMakeLists.txt
@@ -9,6 +9,6 @@ set(SOURCE_FILES
 
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest SofaImplicitField)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaImplicitField)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/SofaImplicitField/SofaImplicitField_test/ImplicitShape_test.cpp
+++ b/applications/plugins/SofaImplicitField/SofaImplicitField_test/ImplicitShape_test.cpp
@@ -1,4 +1,28 @@
-#include <SofaTest/Sofa_test.h>
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/testing/BaseTest.h>
+
+#include <sofa/type/Vec.h>
 using sofa::type::Vec3d ;
 
 #include <SofaImplicitField/components/geometry/SphericalField.h>
@@ -7,7 +31,7 @@ using sofa::component::geometry::SphericalField ;
 namespace
 {
 
-class SphericalFieldTest : public sofa::Sofa_test<>
+class SphericalFieldTest : public sofa::testing::BaseTest
 {
 public:
     bool checkSphericalField();

--- a/applications/plugins/SofaImplicitField/SofaImplicitField_test/ImplicitShape_test.cpp
+++ b/applications/plugins/SofaImplicitField/SofaImplicitField_test/ImplicitShape_test.cpp
@@ -13,7 +13,7 @@
 * more details.                                                               *
 *                                                                             *
 * You should have received a copy of the GNU General Public License along     *
-* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+* with this program. If not, see <http://www.gnuSceneCreator_test.org/licenses/>.              *
 *******************************************************************************
 * Authors: The SOFA Team and external contributors (see Authors.txt)          *
 *                                                                             *

--- a/applications/plugins/image/CMakeLists.txt
+++ b/applications/plugins/image/CMakeLists.txt
@@ -148,10 +148,7 @@ if(MultiThreading_FOUND)
 endif()
 
 if(SOFA_BUILD_TESTS)
-    find_package(SofaTest QUIET)
-    if(SofaTest_FOUND)
-        add_subdirectory(image_test)
-    endif()
+    add_subdirectory(image_test)
 endif()
 
 if(Sofa.GUI.Qt_FOUND)

--- a/applications/plugins/image/image_test/CMakeLists.txt
+++ b/applications/plugins/image/image_test/CMakeLists.txt
@@ -16,6 +16,6 @@ find_package(CImgPlugin REQUIRED)
 add_definitions("-DIMAGETEST_SCENES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/scenes\"")
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} image SofaTest Sofa.Testing CImgPlugin)
+target_link_libraries(${PROJECT_NAME} image Sofa.Testing SceneCreator Sofa.Component.Engine.Testing CImgPlugin)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/image/image_test/DataImage_test.cpp
+++ b/applications/plugins/image/image_test/DataImage_test.cpp
@@ -22,7 +22,7 @@
 #include <sofa/core/objectmodel/Data.h>
 #include <SceneCreator/SceneCreator.h>
 
-#include <SofaTest/Sofa_test.h>
+#include <sofa/testing/BaseTest.h>
 #include <image/ImageContainer.h>
 
 namespace sofa {
@@ -32,7 +32,7 @@ Create two data image and a link between them.
 The first data image is the data of an image container. Check that the second data image is the same image.
 Then compare data pointers to see if data link duplicates the datas.
   */
-struct DataImageLink_test : public Sofa_test<>
+struct DataImageLink_test : public sofa::testing::BaseTest
 {
     typedef defaulttype::Image<unsigned char> Image;
     // Image Container

--- a/applications/plugins/image/image_test/ImageEngine_test.cpp
+++ b/applications/plugins/image/image_test/ImageEngine_test.cpp
@@ -24,11 +24,12 @@
 //Including Simulation
 #include <sofa/simulation/graph/DAGSimulation.h>
 
-#include <SofaTest/Sofa_test.h>
-#include <SofaTest/DataEngine_test.h>
 #include <image/ImageContainer.h>
 #include <image/ImageViewer.h>
 #include "TestImageEngine.h"
+
+#include <sofa/testing/BaseTest.h>
+#include <sofa/component/engine/testing/DataEngineTestCreation.h>
 
 /// To activate showing the picture during the test.
 /// Set this to true.
@@ -43,7 +44,7 @@ namespace sofa {
  * Copy on Write option is true.
  * Note: the function draw of ImageViewer is actually not called in this test (it works with the gui).
   */
-struct ImageEngine_test : public Sofa_test<>
+struct ImageEngine_test : public sofa::testing::BaseTest
 {
 
     // Root of the scene graph

--- a/applications/projects/runSofa/CMakeLists.txt
+++ b/applications/projects/runSofa/CMakeLists.txt
@@ -72,10 +72,7 @@ else()
 endif()
 
 if(SOFA_BUILD_TESTS)
-    sofa_find_package(SofaTest QUIET)
-    if(SofaTest_FOUND)
-        add_subdirectory(runSofa_test)
-    endif()
+    add_subdirectory(runSofa_test)
 endif()
 
 # Create build and install versions of .ini file for resources finding

--- a/applications/projects/runSofa/runSofa_test/CMakeLists.txt
+++ b/applications/projects/runSofa/runSofa_test/CMakeLists.txt
@@ -7,6 +7,6 @@ set(SOURCE_FILES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} )
-target_link_libraries(${PROJECT_NAME} SofaTest Sofa.Testing)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
+++ b/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
@@ -21,8 +21,7 @@
 ******************************************************************************/
 
 #include <fstream>
-#include <gtest/gtest.h>
-#include <SofaTest/Sofa_test.h>
+#include <sofa/testing/BaseTest.h>
 
 #include <sofa/helper/system/PluginManager.h>
 #include <sofa/helper/system/FileRepository.h>
@@ -34,7 +33,7 @@ using sofa::helper::system::DataRepository;
 using sofa::helper::system::PluginRepository;
 using sofa::helper::system::PluginManager;
 
-class runSofa_test : public Sofa_test<>
+class runSofa_test : public sofa::testing::BaseTest
 {
 protected:
     std::string m_testConfigPluginName;


### PR DESCRIPTION
Based on
- #2996 

Remove last usages of SofaTest in plugins.
Now SofaTest needs to be enabled in cmake to be compiled (and not forcefully added)

Fix #1885 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
