### PR TITLE
[SofaCUDA] Add ConstraintCorrection instantiation in CudaVec3f/CudaVec3f1

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -156,8 +156,7 @@ set(SOURCE_FILES
     sofa/gpu/cuda/CudaSphereModel.cpp
     sofa/gpu/cuda/CudaTriangleModel.cpp
 
-    ### Constraints
-    sofa/gpu/cuda/CudaConstraintCorrection.cpp
+    ### Constraints  
     sofa/gpu/cuda/CudaFixedConstraint.cpp
     sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
     sofa/gpu/cuda/CudaLinearMovementConstraint.cpp
@@ -169,6 +168,11 @@ set(SOURCE_FILES
     sofa/gpu/cuda/CudaSphereROI.cpp
 
     sofa/gpu/cuda/CudaIndexValueMapper.cpp
+    
+    ### ConstraintCorrection
+    sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
+    sofa/gpu/cuda/CudaPrecomputedConstraintCorrection.cpp
+    sofa/gpu/cuda/CudaUncoupledConstraintCorrection.cpp
 )
 
 set(CUDA_SOURCES

--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -157,6 +157,7 @@ set(SOURCE_FILES
     sofa/gpu/cuda/CudaTriangleModel.cpp
 
     ### Constraints
+    sofa/gpu/cuda/CudaConstraintCorrection.cpp
     sofa/gpu/cuda/CudaFixedConstraint.cpp
     sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
     sofa/gpu/cuda/CudaLinearMovementConstraint.cpp

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -71,8 +71,8 @@ using namespace sofa::component::collision;
 using namespace sofa::component::collision::geometry;
 using namespace sofa::component::collision::response::mapper;
 
+sofa::component::collision::response::mapper::ContactMapperCreator< sofa::component::collision::response::mapper::ContactMapper<CudaSphereCollisionModel> > CudaSphereContactMapperClass("PenalityContactForceField",true);
 
-response::mapper::ContactMapperCreator< response::mapper::ContactMapper<sofa::component::collision::geometry::SphereCollisionModel<gpu::cuda::CudaVec3Types>> > CudaSphereContactMapperClass("PenalityContactForceField", true);
 
 helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TComponentMouseInteraction<CudaVec3fTypes> > ComponentMouseInteractionCudaVec3fClass ("MouseSpringCudaVec3f",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer <CudaVec3fTypes> >  AttachBodyPerformerCudaVec3fClass("AttachBody",true);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaConstraintCorrection.cpp
@@ -1,0 +1,67 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <sofa/core/ObjectFactory.h>
+#include <SofaConstraint/UncoupledConstraintCorrection.h>
+#include <SofaConstraint/UncoupledConstraintCorrection.inl>
+#include <sofa/core/behavior/ConstraintCorrection.inl>
+
+#include <SofaConstraint/LinearSolverConstraintCorrection.h>
+#include <SofaConstraint/LinearSolverConstraintCorrection.inl>
+
+#include <SofaConstraint/PrecomputedConstraintCorrection.h>
+#include <SofaConstraint/PrecomputedConstraintCorrection.inl>
+
+
+namespace sofa::component::constraintset
+{
+using namespace sofa::gpu::cuda;
+
+template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3fTypes >;
+template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3f1Types >;
+
+const int CudaUncoupledConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
+.add< UncoupledConstraintCorrection< CudaVec3fTypes > >()
+.add< UncoupledConstraintCorrection< CudaVec3f1Types > >()
+;
+
+
+
+template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3fTypes >;
+template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3f1Types >;
+
+const int CudaLinearSolverConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
+.add< LinearSolverConstraintCorrection< CudaVec3fTypes > >()
+.add< LinearSolverConstraintCorrection< CudaVec3f1Types > >()
+;
+
+
+template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3fTypes >;
+template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3f1Types >;
+
+int CudaPrecomputedConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
+.add< PrecomputedConstraintCorrection< CudaVec3fTypes > >()
+.add< PrecomputedConstraintCorrection< CudaVec3f1Types > >()
+;
+
+
+} // namespace sofa::component::constraintset

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
@@ -22,10 +22,9 @@
 #include <sofa/gpu/cuda/CudaTypes.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/behavior/ConstraintCorrection.inl>
-#include <SofaConstraint/LinearSolverConstraintCorrection.h>
-#include <SofaConstraint/LinearSolverConstraintCorrection.inl>
+#include <sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl>
 
-namespace sofa::component::constraintset
+namespace sofa::component::constraint::lagrangian::correction
 {
 using namespace sofa::gpu::cuda;
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/ConstraintCorrection.inl>
+#include <SofaConstraint/LinearSolverConstraintCorrection.h>
+#include <SofaConstraint/LinearSolverConstraintCorrection.inl>
+
+namespace sofa::component::constraintset
+{
+using namespace sofa::gpu::cuda;
+
+template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3fTypes >;
+template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3f1Types >;
+
+const int CudaLinearSolverConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
+.add< LinearSolverConstraintCorrection< CudaVec3fTypes > >()
+.add< LinearSolverConstraintCorrection< CudaVec3f1Types > >()
+;
+
+} // namespace sofa::component::constraintset

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
@@ -36,4 +36,4 @@ const int CudaLinearSolverConstraintCorrectionClass = core::RegisterObject("Supp
 .add< LinearSolverConstraintCorrection< CudaVec3f1Types > >()
 ;
 
-} // namespace sofa::component::constraintset
+} // namespace sofa::component::constraint::lagrangian::correction

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
@@ -31,9 +31,17 @@ using namespace sofa::gpu::cuda;
 template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3fTypes >;
 template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3f1Types >;
 
-const int CudaLinearSolverConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
-.add< LinearSolverConstraintCorrection< CudaVec3fTypes > >()
-.add< LinearSolverConstraintCorrection< CudaVec3f1Types > >()
-;
-
 } // namespace sofa::component::constraint::lagrangian::correction
+
+
+namespace sofa::gpu::cuda
+{
+    using namespace sofa::component::constraint::lagrangian::correction;
+
+const int CudaLinearSolverConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
+    .add< LinearSolverConstraintCorrection< CudaVec3fTypes > >()
+    .add< LinearSolverConstraintCorrection< CudaVec3f1Types > >()
+    ;
+
+} // namespace sofa::gpu::cuda
+

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.cpp
@@ -23,6 +23,13 @@
 #include "CudaPenalityContactForceField.inl"
 #include <sofa/core/ObjectFactory.h>
 
+namespace sofa::component::collision::response::contact
+{
+using namespace sofa::gpu::cuda;
+template class SOFA_GPU_CUDA_API PenalityContactForceField< CudaVec3fTypes>;
+template class SOFA_GPU_CUDA_API PenalityContactForceField< CudaVec3f1Types>;
+
+} // sofa::component::collision::response::contact
 namespace sofa::gpu::cuda
 {
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-#include "CudaPenalityContactForceField.h"
+#include <sofa/gpu/cuda/CudaPenalityContactForceField.h>
 #include <sofa/component/collision/response/contact/PenalityContactForceField.inl>
 #include <sofa/gl/template.h>
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPrecomputedConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPrecomputedConstraintCorrection.cpp
@@ -22,21 +22,24 @@
 #include <sofa/gpu/cuda/CudaTypes.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/behavior/ConstraintCorrection.inl>
-#include <SofaConstraint/PrecomputedConstraintCorrection.h>
-#include <SofaConstraint/PrecomputedConstraintCorrection.inl>
+#include <sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl>
 
-
-namespace sofa::component::constraintset
+namespace sofa::component::constraint::lagrangian::correction
 {
 using namespace sofa::gpu::cuda;
 
 template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3fTypes >;
 template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3f1Types >;
 
-int CudaPrecomputedConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
-.add< PrecomputedConstraintCorrection< CudaVec3fTypes > >()
-.add< PrecomputedConstraintCorrection< CudaVec3f1Types > >()
-;
+} // namespace sofa::component::constraint::lagrangian::correction
 
+namespace sofa::gpu::cuda
+{
+    using namespace sofa::component::constraint::lagrangian::correction;
 
-} // namespace sofa::component::constraintset
+const int CudaPrecomputedConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
+    .add< PrecomputedConstraintCorrection< CudaVec3fTypes > >()
+    .add< PrecomputedConstraintCorrection< CudaVec3f1Types > >()
+    ;
+
+} // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPrecomputedConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPrecomputedConstraintCorrection.cpp
@@ -1,0 +1,42 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/ConstraintCorrection.inl>
+#include <SofaConstraint/PrecomputedConstraintCorrection.h>
+#include <SofaConstraint/PrecomputedConstraintCorrection.inl>
+
+
+namespace sofa::component::constraintset
+{
+using namespace sofa::gpu::cuda;
+
+template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3fTypes >;
+template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3f1Types >;
+
+int CudaPrecomputedConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
+.add< PrecomputedConstraintCorrection< CudaVec3fTypes > >()
+.add< PrecomputedConstraintCorrection< CudaVec3f1Types > >()
+;
+
+
+} // namespace sofa::component::constraintset

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUncoupledConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUncoupledConstraintCorrection.cpp
@@ -21,20 +21,26 @@
 ******************************************************************************/
 #include <sofa/gpu/cuda/CudaTypes.h>
 #include <sofa/core/ObjectFactory.h>
-#include <SofaConstraint/UncoupledConstraintCorrection.h>
-#include <SofaConstraint/UncoupledConstraintCorrection.inl>
+#include <sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.h>
+#include <sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.inl>
 #include <sofa/core/behavior/ConstraintCorrection.inl>
 
-namespace sofa::component::constraintset
+namespace sofa::component::constraint::lagrangian::correction
 {
 using namespace sofa::gpu::cuda;
 
 template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3fTypes >;
 template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3f1Types >;
 
+} // namespace sofa::component::constraint::lagrangian::correction
+
+namespace sofa::gpu::cuda
+{
+using namespace sofa::component::constraint::lagrangian::correction;
+
 const int CudaUncoupledConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
 .add< UncoupledConstraintCorrection< CudaVec3fTypes > >()
 .add< UncoupledConstraintCorrection< CudaVec3f1Types > >()
 ;
 
-} // namespace sofa::component::constraintset
+} // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUncoupledConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUncoupledConstraintCorrection.cpp
@@ -25,13 +25,6 @@
 #include <SofaConstraint/UncoupledConstraintCorrection.inl>
 #include <sofa/core/behavior/ConstraintCorrection.inl>
 
-#include <SofaConstraint/LinearSolverConstraintCorrection.h>
-#include <SofaConstraint/LinearSolverConstraintCorrection.inl>
-
-#include <SofaConstraint/PrecomputedConstraintCorrection.h>
-#include <SofaConstraint/PrecomputedConstraintCorrection.inl>
-
-
 namespace sofa::component::constraintset
 {
 using namespace sofa::gpu::cuda;
@@ -43,25 +36,5 @@ const int CudaUncoupledConstraintCorrectionClass = core::RegisterObject("Support
 .add< UncoupledConstraintCorrection< CudaVec3fTypes > >()
 .add< UncoupledConstraintCorrection< CudaVec3f1Types > >()
 ;
-
-
-
-template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3fTypes >;
-template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3f1Types >;
-
-const int CudaLinearSolverConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
-.add< LinearSolverConstraintCorrection< CudaVec3fTypes > >()
-.add< LinearSolverConstraintCorrection< CudaVec3f1Types > >()
-;
-
-
-template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3fTypes >;
-template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3f1Types >;
-
-int CudaPrecomputedConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
-.add< PrecomputedConstraintCorrection< CudaVec3fTypes > >()
-.add< PrecomputedConstraintCorrection< CudaVec3f1Types > >()
-;
-
 
 } // namespace sofa::component::constraintset


### PR DESCRIPTION
Add instantiation in CudaVec3f/CudaVec3f1 for
- LinearSolverConstraintCorrection
- PrecomputedConstraintCorrection
- UncoupledConstraintCorrection



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
