### PR TITLE
[SofaGui] Restore and update CMake variables and modules

### DIFF
--- a/SofaGui/CMakeLists.txt
+++ b/SofaGui/CMakeLists.txt
@@ -24,9 +24,12 @@ set(SOFAGUI_TARGETS Sofa.GUI.Component Sofa.GUI.Common Sofa.GUI.Batch)
 if(Sofa.GUI.Qt_FOUND)
     list(APPEND SOFAGUI_TARGETS Sofa.GUI.Qt)
 endif()
+sofa_set_01(SOFAGUI_HAVE_SOFAGUIQT VALUE ${Sofa.GUI.Qt_FOUND})
+
 if(Sofa.GUI.HeadlessRecorder_FOUND)
     list(APPEND SOFAGUI_TARGETS Sofa.GUI.HeadlessRecorder)
 endif()
+sofa_set_01(SOFAGUI_HAVE_SOFAHEADLESSRECORDER VALUE ${Sofa.GUI.HeadlessRecorder_FOUND})
 
 # Keep legacy modules for compatibility
 # they merely redirect to the new modules

--- a/SofaGui/SofaGuiConfig.cmake.in
+++ b/SofaGui/SofaGuiConfig.cmake.in
@@ -6,9 +6,9 @@
 set(SOFAGUI_HAVE_SOFAHEADLESSRECORDER @SOFAGUI_HAVE_SOFAHEADLESSRECORDER@)
 set(SOFAGUI_HAVE_SOFAGUIQT @SOFAGUI_HAVE_SOFAGUIQT@)
 
-find_package(Sofa.GUI.Component REQUIRED)
-find_package(Sofa.GUI.Common REQUIRED)
-find_package(Sofa.GUI.Batch REQUIRED)
+find_package(Sofa.GUI.Component QUIET REQUIRED)
+find_package(Sofa.GUI.Common QUIET REQUIRED)
+find_package(Sofa.GUI.Batch QUIET REQUIRED)
 
 if(SOFAGUI_HAVE_SOFAGUIQT)
     find_package(Sofa.GUI.Qt QUIET REQUIRED)

--- a/SofaGui/SofaGuiConfig.cmake.in
+++ b/SofaGui/SofaGuiConfig.cmake.in
@@ -3,19 +3,19 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
-set(SOFAGUI_TARGETS @SOFAGUI_TARGETS@)
-
 set(SOFAGUI_HAVE_SOFAHEADLESSRECORDER @SOFAGUI_HAVE_SOFAHEADLESSRECORDER@)
 set(SOFAGUI_HAVE_SOFAGUIQT @SOFAGUI_HAVE_SOFAGUIQT@)
 
-find_package(SofaGuiCommon QUIET REQUIRED)
+find_package(Sofa.GUI.Component REQUIRED)
+find_package(Sofa.GUI.Common REQUIRED)
+find_package(Sofa.GUI.Batch REQUIRED)
 
 if(SOFAGUI_HAVE_SOFAGUIQT)
-    find_package(SofaGuiQt QUIET REQUIRED)
+    find_package(Sofa.GUI.Qt QUIET REQUIRED)
 endif()
 
 if(SOFAGUI_HAVE_SOFAHEADLESSRECORDER)
-    find_package(SofaHeadlessRecorder QUIET REQUIRED)
+    find_package(Sofa.GUI.HeadlessRecorder QUIET REQUIRED)
 endif()
 
 if(NOT TARGET @PROJECT_NAME@)


### PR DESCRIPTION
- The variables `SOFAGUI_HAVE_SOFAGUIQT` and `SOFAGUI_HAVE_SOFAHEADLESSRECORDER` were not defined whereas they are used in `SofaGui/SofaGuiConfig.cmake.in`.
- Modules in `SofaGui/SofaGuiConfig.cmake.in` have been updated. 

I expect it will also fix the SofaPython3 GitHub actions (see for example https://github.com/sofa-framework/SofaPython3/runs/6592539251?check_suite_focus=true)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
