### PR TITLE
[runSofa] Fix crash in runSofa when showing object with materials

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/MaterialDataWidget.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/MaterialDataWidget.cpp
@@ -177,7 +177,7 @@ bool VectorMaterialDataWidget::createWidgets()
     layout->addWidget(_comboBox);
     layout->addWidget(_materialDataWidget);
 
-    connect( _comboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &VectorMaterialDataWidget::changeMaterial );
+    connect( _comboBox, QOverload<int>::of(&QComboBox::activated), this, &VectorMaterialDataWidget::changeMaterial );
     connect( _materialDataWidget, &MaterialDataWidget::WidgetDirty, this, &VectorMaterialDataWidget::setWidgetDirty );
 
     readFromData();


### PR DESCRIPTION
The PR https://github.com/sofa-framework/sofa/pull/2943 replaced by mistake the "activated" with the "currentIndexChanged" one. But there is a slight difference between the two as currentIndexChanged can be called with
-1 (which makes the connected slot crash).

To revert back to the "activated" signal instead (but using the modernized syntax).

This PR fix issue #3017 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
