### PR TITLE
[runSofa] Fix bug which makes sofa crash when changing a data in a node (issue #2919).

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -499,15 +499,23 @@ void ModifyObject::updateValues()
         core::objectmodel::BaseObject* object = sofa::core::castTo<core::objectmodel::BaseObject*>(basenode);
         if(dialogFlags_.REINIT_FLAG)
         {
-            if (node && transformation)
+            // if the selected object is a node
+            if (node)
             {
-                if (!transformation->isDefaultValues())
-                    transformation->applyTransformation(node);
-                transformation->setDefaultValues();
+                // and there is a transformation widget associated
+                if(transformation)
+                {
+                    // then do some dirty hack to change the value
+                    if (!transformation->isDefaultValues())
+                        transformation->applyTransformation(node);
+                    transformation->setDefaultValues();
+                }
+                // call the reinit function on the node OMG
                 node->reinit(sofa::core::execparams::defaultInstance());
             }
-            else if (object){
-                object->reinit();
+            else if (object)                 //< if the selected is an object
+            {
+                object->reinit();            //< we need to fully re-initialize the object to be sure it is ok.
             }
             else {
                 throw std::runtime_error("Invalid type, only Node and BaseObject are supported. "

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -507,17 +507,20 @@ void ModifyObject::updateValues()
                 {
                     // then do some dirty hack to change the value
                     if (!transformation->isDefaultValues())
+                    {
                         transformation->applyTransformation(node);
+                    }
                     transformation->setDefaultValues();
                 }
-                // call the reinit function on the node OMG
+                // call the reinit function on the node
                 node->reinit(sofa::core::execparams::defaultInstance());
             }
             else if (object)                 //< if the selected is an object
             {
                 object->reinit();            //< we need to fully re-initialize the object to be sure it is ok.
             }
-            else {
+            else 
+            {
                 throw std::runtime_error("Invalid type, only Node and BaseObject are supported. "
                                          "This is a BUG, please report to https://github.com/sofa-framework/sofa/issues");
             }


### PR DESCRIPTION
The existing code is falling back into the std::runtime_expection if a node's data
is modified and it is not a transformation (which actually happens a lot).






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
