### PR TITLE
[Config][CMake] Fix include directories

### DIFF
--- a/Sofa/framework/Config/cmake/SofaMacrosInstall.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosInstall.cmake
@@ -424,6 +424,14 @@ macro(sofa_auto_set_target_include_directories)
             set(target ${aliased_target})
         endif()
 
+        get_target_property(target_sources ${target} SOURCES)
+        list(FILTER target_sources INCLUDE REGEX ".*(\\.h\\.in|\\.h|\\.inl)$") # keep only headers
+        if(NOT target_sources)
+            # target has no header
+            # setting include directories is not needed
+            continue()
+        endif()
+
         # Set target include directories (if not already set manually)
         set(include_source_root "${CMAKE_CURRENT_SOURCE_DIR}/..") # default but bad practice
         if(ARG_INCLUDE_SOURCE_DIR)


### PR DESCRIPTION
For old modules with no headers like SofaGTestMain, SofaHelper, SofaDefaultType, SofaCore, Sofa.SimulationCore, SofaGuiQt.

Should fix this kind of error:
```text
Imported target "SofaCore" includes non-existent path
  "/home/runner/work/BeamAdapter/BeamAdapter/sofa/include/SofaCore"
in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:
* The path was deleted, renamed, or moved to another location.
* An install or uninstall procedure did not complete successfully.
* The installation package was faulty and references files it does not
provide.
```
taken from https://github.com/sofa-framework/BeamAdapter/runs/6790181313?check_suite_focus=true


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
