### PR TITLE
[all] FIX scenegraph message's icons updates

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.cpp
@@ -346,11 +346,16 @@ void ObjectStateListener::notifyEndEdit()
 
 GraphListenerQListView::~GraphListenerQListView()
 {
-    for(auto item : items)
+    for(auto [key,item] : items)
     {
-        delete items[item.first];
+        delete item;
     }
     items.clear();
+
+    for(auto [key, listener] : listeners)
+    {
+        delete listener;
+    }
     listeners.clear();
 }
 
@@ -453,7 +458,7 @@ void GraphListenerQListView::onBeginAddChild(Node* parent, Node* child)
         items[child] = item;
 
         // Add a listener to connect changes on the component state with its graphical view.
-        listeners[child] = std::make_unique<ObjectStateListener>(item, child);
+        listeners[child] = new ObjectStateListener(item, child);
     }
 
     for (BaseObject::SPtr obj : child->object)
@@ -532,7 +537,7 @@ void GraphListenerQListView::onBeginAddObject(Node* parent, core::objectmodel::B
         setMessageIconFrom(item, object);
 
         items[object] = item;
-        listeners[object] = std::make_unique<ObjectStateListener>(item, object);
+        listeners[object] = new ObjectStateListener(item, object);
     }
     for (BaseObject::SPtr slave : object->getSlaves())
         onBeginAddSlave(object, slave.get());

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.h
@@ -28,6 +28,8 @@
 #include <QTreeWidgetItem>
 
 #include <sofa/simulation/fwd.h>
+#include <sofa/core/objectmodel/Base.h>
+#include <sofa/core/objectmodel/DDGNode.h>
 #include <sofa/simulation/MutationListener.h>
 
 
@@ -39,12 +41,33 @@ using sofa::simulation::MutationListener;
 
 QPixmap* getPixmap(core::objectmodel::Base* obj, bool, bool,bool);
 
+
+/// A listener to connect changes on the component state with its graphical view.
+/// The listener is added to the ComponentState of an object to track changes to
+/// and update the icon/treewidgetitem when this happens.
+class ObjectStateListener : public sofa::core::objectmodel::DDGNode
+{
+public:
+    QTreeWidgetItem* item;
+
+    // Use a SPtr here because otherwise sofa may decide to remove the base without notifying the ObjectStateListener
+    // is going to a segfault the right way.
+    sofa::core::objectmodel::Base::SPtr object;
+
+    ObjectStateListener(QTreeWidgetItem* item_, sofa::core::objectmodel::Base* object_);
+    ~ObjectStateListener() override;
+    void update() override;
+    void notifyEndEdit() override;
+};
+
+
 class SOFA_GUI_QT_API GraphListenerQListView : public MutationListener
 {
 public:
     //Q3ListView* widget;
     QTreeWidget* widget;
     bool frozen;
+    std::map<core::objectmodel::Base*, std::unique_ptr<ObjectStateListener> > listeners;
     std::map<core::objectmodel::Base*, QTreeWidgetItem* > items;
     std::map<core::objectmodel::BaseData*, QTreeWidgetItem* > datas;
     std::multimap<QTreeWidgetItem *, QTreeWidgetItem*> nodeWithMultipleParents;
@@ -53,7 +76,7 @@ public:
         : widget(w), frozen(false)
     {
     }
-
+    ~GraphListenerQListView() override;
 
     /*****************************************************************************************************************/
     QTreeWidgetItem* createItem(QTreeWidgetItem* parent);

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.h
@@ -67,7 +67,7 @@ public:
     //Q3ListView* widget;
     QTreeWidget* widget;
     bool frozen;
-    std::map<core::objectmodel::Base*, std::unique_ptr<ObjectStateListener> > listeners;
+    std::map<core::objectmodel::Base*, ObjectStateListener* > listeners;
     std::map<core::objectmodel::Base*, QTreeWidgetItem* > items;
     std::map<core::objectmodel::BaseData*, QTreeWidgetItem* > datas;
     std::multimap<QTreeWidgetItem *, QTreeWidgetItem*> nodeWithMultipleParents;

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
@@ -280,11 +280,13 @@ void Base::addMessage(const Message &m) const
         m_messageslog.pop_front();
     }
     m_messageslog.push_back(m) ;
+    d_messageLogCount = d_messageLogCount.getValue()+1;
 }
 
 void Base::clearLoggedMessages() const
 {
    m_messageslog.clear() ;
+   d_messageLogCount = 0;
 }
 
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -369,6 +369,8 @@ private:
     mutable std::deque<sofa::helper::logging::Message> m_messageslog ;
 
 public:
+    mutable Data<int> d_messageLogCount;
+
     /// write into component buffer + Message processedby message handlers
     /// default message type = Warning
     /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ mutable helper::system::SofaOStream<helper::logging::Message::Warning> serr;
@@ -389,6 +391,7 @@ public:
     void clearLoggedMessages() const ;
 
     inline bool notMuted() const { return f_printLog.getValue(); }
+
 
 protected:
     /// Helper method used by initData()


### PR DESCRIPTION
Currently the icons in the scene graph are not reflecting the real state of the corresponding component's message log because the icons are set at scene loading and not updated after.

This rise consistency issues for dynamic scene which adds at run-time new messages to component's log (see the example below where the messages is emitted on key pressed. 

This is a follow up of PR #2398 

The PR produce the expected behavior with this kind of scene
```python
import Sofa

class MyC(Sofa.Core.Controller):
    def __init__(self, *argv, **kwargs):
        Sofa.Core.Controller.__init__(self, *argv, **kwargs)
        self.node = kwargs.get("target")
            
    def onKeypressedEvent(self, event):
        Sofa.msg_info(self, "Info message in the component")
        Sofa.msg_error(self.node, "Error message in the target's node")

def createScene(root):
    root.addChild("Child1")
    root.addObject(MyC(name="Dmaien", target=root.Child1))
```

NB: I have considered having a Data<queue<Message>> but given how is implemented Data I need to provide << and >> operator which does not have real sense in this scenario. 
______________________________________________________
By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
