### PR TITLE
[LinearSolver.Direct] Move advice message into parse method

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
@@ -76,25 +76,6 @@ public :
         return new InvertData();
     }
 
-    // Override canCreate in order to analyze if template has been set or not.
-    template<class T>
-    static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        const std::string_view templateString = arg->getAttribute("template", "");
-
-        if (templateString.empty())
-        {
-            const std::string header = "SparseLDLSolver(" + std::string(arg->getAttribute("name", "")) + ")";
-            msg_advice(header) << "Template is empty\n"
-                                << "By default " << helper::NameDecoder::getClassName<T>() << " uses blocks with a single double (to handle all cases of simulations).\n"
-                                << "If you are using only 3D DOFs, you may consider using blocks of Matrix3 to speedup the calculations.\n"
-                                << "If it is the case, add " << "template=\"CompressedRowSparseMatrixMat3x3d\" " << "to this object in your scene\n"
-                                << "Otherwise, if you want to disable this message, add " << "template=\"CompressedRowSparseMatrixd\" " << ".";
-        }
-
-        return Inherit::canCreate(obj, context, arg);
-    }
-
 protected :
     SparseLDLSolver();
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -44,6 +44,24 @@ void SparseLDLSolver<TMatrix, TVector, TThreadManager>::parse(sofa::core::object
 {
     Inherit1::parse(arg);
 
+    if (!arg->getAttribute("template"))
+    {
+        std::string header = this->getClassName();
+        if (const std::string& name = this->getName(); !name.empty())
+        {
+            header.append("(" + name + ")");
+        }
+
+        static const char* blocksType =
+        sofa::linearalgebra::CompressedRowSparseMatrix<sofa::type::Mat<3, 3, SReal> >::Name();
+
+        msg_advice(header) << "Template is empty\n"
+                           << "By default " << this->getClassName() << " uses blocks with a single scalar (to handle all cases of simulations).\n"
+                           << "If you are using only 3D DOFs, you may consider using blocks of Matrix3 to speedup the calculations.\n"
+                           << "If it is the case, add template=\"" << blocksType << "\" to this object in your scene\n"
+                           << "Otherwise, if you want to disable this message, add " << "template=\"" << this->getTemplateName() << "\" " << ".";
+    }
+
     if (arg->getAttribute("savingMatrixToFile"))
     {
         msg_warning() << "It is no longer possible to export the linear system matrix from within " << this->getClassName() <<  ". Instead, use the component GlobalSystemMatrixExporter (from the SofaMatrix plugin).";


### PR DESCRIPTION
`canCreate` can be called several times by the object factory. It makes more sense to detect if the template parameter is empty in the `parse` method, i.e. once the object is instantiated.

Header of the message depends whether the component name is empty or not.

Remove hard coded string of the component class, as it does not apply to derived types.

Remove hard coded template strings.

![image](https://user-images.githubusercontent.com/10572752/172868099-18fb7a50-ecb2-40e4-b8b4-11fdac2be70d.png)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
