### PR TITLE
[MeshGmsh]Fixed false error detection in MeshGmsh.cpp file

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/io/MeshGmsh.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/io/MeshGmsh.cpp
@@ -385,7 +385,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
         }
 
         std::getline(file, cmd);
-        if (cmd != "$EndNodes")
+        if (cmd.substr(0, 9) != "$EndNodes")
         {
             msg_error("MeshGmsh") << "'$EndNodes' expected, found '" << cmd << "'";
             return false;
@@ -395,7 +395,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
         // --- Parsing the $Elements section --- //
 
         std::getline(file, cmd);
-        if (cmd != "$Elements")
+        if (cmd.substr(0, 9) != "$Elements")
         {
             msg_error("MeshGmsh") << "'$Elements' expected, found '" << cmd << "'";
             return false;


### PR DESCRIPTION
Fixed false error detection in MeshGmsh.cpp file  when reading .msh type files.
Without these lines, we have this kind of error `'$Elements' expected, found '$Elements`





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
