### PR TITLE
[SceneChecking] MissingRequiredPlugins: Adapts messages for xml and python users

### DIFF
--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheck.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheck.h
@@ -46,7 +46,7 @@ public:
     virtual const std::string getDesc() = 0;
     virtual void doInit(sofa::simulation::Node* node) { SOFA_UNUSED(node); }
     virtual void doCheckOn(sofa::simulation::Node* node) = 0;
-    virtual void doPrintSummary() {}
+    virtual void doPrintSummary(std::string sceneExtension) { SOFA_UNUSED(sceneExtension); }
 };
 
 } // namespace sofa::_scenechecking_

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.cpp
@@ -77,8 +77,9 @@ void SceneCheckAPIChange::doInit(sofa::simulation::Node* node)
     }
 }
 
-void SceneCheckAPIChange::doPrintSummary()
+void SceneCheckAPIChange::doPrintSummary(std::string sceneExtension)
 {
+    SOFA_UNUSED(sceneExtension);
 }
 
 void SceneCheckAPIChange::doCheckOn(sofa::simulation::Node* node)

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.h
@@ -58,7 +58,7 @@ public:
     virtual const std::string getDesc() override;
     void doInit(sofa::simulation::Node* node) override;
     void doCheckOn(sofa::simulation::Node* node) override;
-    void doPrintSummary() override;
+    void doPrintSummary(std::string sceneExtension) override;
 
     void installDefaultChangeSets();
     void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct);

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
@@ -98,8 +98,9 @@ void SceneCheckCollisionResponse::doCheckOn(Node* node)
     }
 }
 
-void SceneCheckCollisionResponse::doPrintSummary()
+void SceneCheckCollisionResponse::doPrintSummary(std::string sceneExtension)
 {
+    SOFA_UNUSED(sceneExtension);
     if(m_checkDone && m_message.str()!= "")
     {
         msg_warning(this->getName()) << m_message.str();

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
@@ -40,7 +40,7 @@ public:
     virtual const std::string getDesc() override;
     void doInit(sofa::simulation::Node* node) override;
     void doCheckOn(sofa::simulation::Node* node) override;
-    void doPrintSummary() override;
+    void doPrintSummary(std::string sceneExtension) override;
 
 private:
     bool m_checkDone = false;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
@@ -63,8 +63,10 @@ void SceneCheckDeprecatedComponents::doCheckOn(Node* node)
     }
 }
 
-void SceneCheckDeprecatedComponents::doPrintSummary()
-{}
+void SceneCheckDeprecatedComponents::doPrintSummary(std::string sceneExtension)
+{
+    SOFA_UNUSED(sceneExtension);
+}
 
 std::shared_ptr<SceneCheckDeprecatedComponents> SceneCheckDeprecatedComponents::newSPtr()
 {

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.h
@@ -37,7 +37,7 @@ public:
     const std::string getDesc() override;
     void doInit(sofa::simulation::Node* node) override;
     void doCheckOn(sofa::simulation::Node* node) override;
-    void doPrintSummary() override;
+    void doPrintSummary(std::string sceneExtension) override;
 };
 
 } //namespace sofa::_scenechecking_

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
@@ -79,8 +79,9 @@ void SceneCheckDuplicatedName::doCheckOn(sofa::simulation::Node* node)
     }
 }
 
-void SceneCheckDuplicatedName::doPrintSummary()
+void SceneCheckDuplicatedName::doPrintSummary(std::string sceneExtension)
 {
+    SOFA_UNUSED(sceneExtension);
     if(m_hasDuplicates)
     {
         msg_warning(this->getName()) << msgendl

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.h
@@ -40,7 +40,7 @@ public:
     virtual const std::string getDesc() override;
     void doInit(sofa::simulation::Node* node) override;
     void doCheckOn(sofa::simulation::Node* node) override;
-    void doPrintSummary() override;
+    void doPrintSummary(std::string sceneExtension) override;
 
 private:
     bool m_hasDuplicates;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
@@ -114,9 +114,16 @@ void SceneCheckMissingRequiredPlugin::getSummaryXML(std::stringstream& stream)
 void SceneCheckMissingRequiredPlugin::getSummaryPython(std::stringstream &stream)
 {
     const std::string indent { "  "};
-    stream << indent << "rootnode.addObject('RequiredPlugin', pluginName=[";
-    for(const auto& kv : m_requiredPlugins)
-        stream << "\"" << kv.first << "\", ";
+    stream << indent << "rootnode.addObject('RequiredPlugin', pluginName=[" << msgendl;
+    for(const auto& kv : m_requiredPlugins){
+        stream << "\"" << kv.first << "\",  # Needed to use components ";
+        if (!kv.second.empty())
+        {
+            std::copy(kv.second.begin(), kv.second.end() - 1, std::ostream_iterator<std::string>(stream, ", "));
+            stream << kv.second.back();
+        }
+        stream << msgendl;
+    }
     stream <<"])" << msgendl;
 }
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.h
@@ -45,11 +45,14 @@ public:
     virtual const std::string getDesc() override;
     void doInit(sofa::simulation::Node* node) override;
     void doCheckOn(sofa::simulation::Node* node) override;
-    void doPrintSummary() override;
+    void doPrintSummary(std::string sceneExtension) override;
 
 private:    
     std::map<std::string, bool > m_loadedPlugins;
     std::map<std::string, std::vector<std::string> > m_requiredPlugins;
+
+    void getSummaryXML(std::stringstream &stream);
+    void getSummaryPython(std::stringstream& stream);
 };
 
 } // namespace sofa::_scenechecking_

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.cpp
@@ -61,8 +61,10 @@ const std::string SceneCheckUsingAlias::getDesc()
     return "Check if a Component has been created using an Alias.";
 }
 
-void SceneCheckUsingAlias::doPrintSummary()
+void SceneCheckUsingAlias::doPrintSummary(std::string sceneExtension)
 {
+    SOFA_UNUSED(sceneExtension);
+
     if ( this->m_componentsCreatedUsingAlias.empty() )
     {
         return;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.h
@@ -42,7 +42,7 @@ public:
     virtual const std::string getDesc() override;
     void doInit(sofa::simulation::Node* node) override { SOFA_UNUSED(node); }
     void doCheckOn(sofa::simulation::Node* node) override { SOFA_UNUSED(node); }
-    void doPrintSummary() override;
+    void doPrintSummary(std::string sceneExtension) override;
 
 private:
     std::map<std::string, std::vector<std::string>> m_componentsCreatedUsingAlias;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.h
@@ -49,6 +49,8 @@ public:
         SOFA_UNUSED(node);
     }
 
+    void setSceneExtension(std::string sceneExtension) {m_sceneChecker.setSceneExtension(sceneExtension);}
+
 private:
     SceneCheckerListener();
     SceneCheckerVisitor m_sceneChecker;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.cpp
@@ -71,7 +71,7 @@ void SceneCheckerVisitor::validate(sofa::simulation::Node* node)
 
     for(SceneCheck::SPtr& check : m_checkset)
     {
-        check->doPrintSummary() ;
+        check->doPrintSummary(m_sceneExtension) ;
     }
     msg_info("SceneCheckerVisitor") << "Finished validating node \""<< node->getName() << "\".";
 }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.h
@@ -43,9 +43,11 @@ public:
 
     void addCheck(SceneCheck::SPtr check) ;
     void removeCheck(SceneCheck::SPtr check) ;
+    void setSceneExtension(std::string sceneExtension) {m_sceneExtension=sceneExtension;}
 
 private:
     std::vector<SceneCheck::SPtr> m_checkset ;
+    std::string m_sceneExtension ;
 };
 
 } // namespace sofa::_scenechecking_

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -440,7 +440,10 @@ int main(int argc, char** argv)
     // Create and register the SceneCheckerListener before scene loading
     if(!noSceneCheck)
     {
-        sofa::simulation::SceneLoader::addListener( SceneCheckerListener::getInstance() );
+        SceneCheckerListener* sceneCheckerListener = SceneCheckerListener::getInstance();
+        std::string ext = sofa::helper::system::SetDirectory::GetExtension(fileName.c_str());
+        sceneCheckerListener->setSceneExtension(ext);
+        sofa::simulation::SceneLoader::addListener( sceneCheckerListener );
     }
 
     const std::vector<std::string> sceneArgs = sofa::gui::ArgumentParser::extra_args();


### PR DESCRIPTION
This PR improves the message about missing required plugins for python users. Before it was printing lines to cut and paste in the scene (which is really nice!), but only for xml users. Now I propose to check the scene's extension and adapt the message.

Here's an example for python:

![image](https://user-images.githubusercontent.com/12150715/173034896-f7547d53-6a99-475a-892f-b481709ed0c4.png)
 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
