### PR TITLE
[Container.Dynamic] Compute the bounding box of *GeometryAlgorithms

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.h
@@ -168,6 +168,8 @@ protected:
     Data<RGBAColor> _drawColor; ///< RGB code color used to draw edges.
     /// include cubature points
     NumericalIntegrationDescriptor<Real,1> edgeNumericalIntegration;
+
+    bool mustComputeBBox() const override;
 };
 
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_EDGESETGEOMETRYALGORITHMS_CPP)

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
@@ -943,5 +943,11 @@ bool EdgeSetGeometryAlgorithms<DataTypes>::computeEdgeSegmentIntersection(EdgeID
     return is_intersect;
 }
 
+template <class DataTypes>
+bool EdgeSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
+{
+    return this->m_topology->getNbEdges() != 0 && (d_drawEdges.getValue() || showEdgeIndices.getValue())
+        || Inherit1::mustComputeBBox();
+}
 
 } //namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.h
@@ -158,6 +158,8 @@ protected:
     Data<sofa::type::RGBAColor> d_drawColorHexahedra; ///< RGB code color used to draw hexahedra.
 	/// include cubature points
 	NumericalIntegrationDescriptor<Real,3> hexahedronNumericalIntegration;
+
+	bool mustComputeBBox() const override;
 };
 
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_HEXAHEDRONSETGEOMETRYALGORITHMS_CPP)

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
@@ -33,298 +33,298 @@ using sofa::core::topology::verticesInHexahedronArray;
 template< class DataTypes>
 NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3> &HexahedronSetGeometryAlgorithms< DataTypes >::getHexahedronNumericalIntegrationDescriptor()
 {
-	// initialize the cubature table only if needed.
-	if (initializedHexahedronCubatureTables==false) {
-		initializedHexahedronCubatureTables=true;
-		defineHexahedronCubaturePoints();
-	}
-	return hexahedronNumericalIntegration;
+    // initialize the cubature table only if needed.
+    if (initializedHexahedronCubatureTables==false) {
+        initializedHexahedronCubatureTables=true;
+        defineHexahedronCubaturePoints();
+    }
+    return hexahedronNumericalIntegration;
 }
 
 template< class DataTypes>
 void HexahedronSetGeometryAlgorithms< DataTypes >::defineHexahedronCubaturePoints() {
-	typedef typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePoint QuadraturePoint;
-	typedef typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::BarycentricCoordinatesType BarycentricCoordinatesType;
-	// Gauss method
-	typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadratureMethod m=NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::GAUSS_LEGENDRE_METHOD;
-	typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePointArray qpa;
-	typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadraturePointArray qpa1D;
+    typedef typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePoint QuadraturePoint;
+    typedef typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::BarycentricCoordinatesType BarycentricCoordinatesType;
+    // Gauss method
+    typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadratureMethod m=NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::GAUSS_LEGENDRE_METHOD;
+    typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePointArray qpa;
+    typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadraturePointArray qpa1D;
 
-	BarycentricCoordinatesType v;
-	Real w;
-
-
-	NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1> &nide=this->getEdgeNumericalIntegrationDescriptor();
-
-	/// create gauss points as tensor product of Gauss Legendre points in 1D
-	/// create integration method up to order 8 (could go up to 12 if needed) where the number of gauss points is the cube of the number of 1D Gauss points
-	size_t o,i,j,k;
-	for (o=1;o<8;++o) {
-		qpa.clear();
-		qpa1D=nide.getQuadratureMethod(NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::GAUSS_LEGENDRE_METHOD,o);
-		for (i=0;i<qpa1D.size();++i) {
-			for (j=0;j<qpa1D.size();++j) {
-				for (k=0;k<qpa1D.size();++k) {
-					v=BarycentricCoordinatesType(qpa1D[i].first[0],qpa1D[j].first[0],qpa1D[k].first[0]);
-					w=qpa1D[i].second*qpa1D[j].second*qpa1D[k].second;
-					qpa.push_back(QuadraturePoint(v,(Real)w));
-				}
-			}
-		}
-		hexahedronNumericalIntegration.addQuadratureMethod(m,o,qpa);
-	}
-	/*
-	/// consider non tensor product rules : taken from getfem++ file Hexahedron_5.im
-	 m=NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::GAUSS_CUBE_METHOD;
-	/// integration with  accuracy of order 5 with 14 gauss points.
-	Real a=0.8979112128771107316322744102380675;
-	Real b=0.5;
-	w=0.1108033240997229916897506925207755;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		v[i]=a;
-		qpa.push_back(QuadraturePoint(v,w));
-		v[i]=1-a;
-		qpa.push_back(QuadraturePoint(v,w));
-	}
-	a=0.8793934553196640731345171390561335;
-	w=0.0418975069252077562326869806094182;
-	for (i=0;i<2;++i) {
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				/// barycentric coordinates are either a or 1-a
-				v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	hexahedronNumericalIntegration.addQuadratureMethod(m,5,qpa);
+    BarycentricCoordinatesType v;
+    Real w;
 
 
-	/// consider non tensor product rules : taken from getfem++ file Hexahedron_9.im
-	/// integration with  accuracy of order 9 with 58 gauss points.
+    NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1> &nide=this->getEdgeNumericalIntegrationDescriptor();
 
-	/// 6 points
-	a=.8068407347958544969174424448702780;
-	b=0.5;
-	w=.0541593744687068178762288491492902;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		v[i]=a;
-		qpa.push_back(QuadraturePoint(v,w));
-		v[i]=1-a;
-		qpa.push_back(QuadraturePoint(v,w));
-	}
-	// 12 points
-	a=0.9388435616288391432433878794971660;
-	b=0.5;
-	w=0.0114737257670222052714055736149557;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		for (j=0;j<2;++j) {
-			v[(i+1)%3]=a+j*(1-2*a);
-			for (k=0;k<2;++k) {
-				v[(i+2)%3]=a+k*(1-2*a);
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	/// 8 points
-	a=0.7820554035100150271333094993315360;
-	w=0.0248574797680029375401085898232011;
-	for (i=0;i<2;++i) {
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				/// barycentric coordinates are either a or 1-a
-				v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	/// 8 points
-	a=0.9350498923309879588075319044319620;
-	w=0.0062685994124186287334314359655827;
-	for (i=0;i<2;++i) {
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				/// barycentric coordinates are either a or 1-a
-				v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	/// 24 points 
-	a=0.7161339513154310822080124307584715;
-	b=0.9692652109323358726644884348015390;
-	w=0.0120146004391716708040599923089382;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		for (j=0;j<2;++j) {
-			v[(i+1)%3]=a+j*(1-2*a);
-			for (k=0;k<2;++k) {
-				v[i]=b;
-				v[(i+2)%3]=a+k*(1-2*a);
-				qpa.push_back(QuadraturePoint(v,w));
-				v[i]=1-b;
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	hexahedronNumericalIntegration.addQuadratureMethod(m,9,qpa);
-	
-	
-	/// consider non tensor product rules : taken from getfem++ file Hexahedron_11.im
-	/// integration with  accuracy of order 11 with 90 gauss points.
+    /// create gauss points as tensor product of Gauss Legendre points in 1D
+    /// create integration method up to order 8 (could go up to 12 if needed) where the number of gauss points is the cube of the number of 1D Gauss points
+    size_t o,i,j,k;
+    for (o=1;o<8;++o) {
+        qpa.clear();
+        qpa1D=nide.getQuadratureMethod(NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::GAUSS_LEGENDRE_METHOD,o);
+        for (i=0;i<qpa1D.size();++i) {
+            for (j=0;j<qpa1D.size();++j) {
+                for (k=0;k<qpa1D.size();++k) {
+                    v=BarycentricCoordinatesType(qpa1D[i].first[0],qpa1D[j].first[0],qpa1D[k].first[0]);
+                    w=qpa1D[i].second*qpa1D[j].second*qpa1D[k].second;
+                    qpa.push_back(QuadraturePoint(v,(Real)w));
+                }
+            }
+        }
+        hexahedronNumericalIntegration.addQuadratureMethod(m,o,qpa);
+    }
+    /*
+    /// consider non tensor product rules : taken from getfem++ file Hexahedron_5.im
+     m=NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::GAUSS_CUBE_METHOD;
+    /// integration with  accuracy of order 5 with 14 gauss points.
+    Real a=0.8979112128771107316322744102380675;
+    Real b=0.5;
+    w=0.1108033240997229916897506925207755;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        v[i]=a;
+        qpa.push_back(QuadraturePoint(v,w));
+        v[i]=1-a;
+        qpa.push_back(QuadraturePoint(v,w));
+    }
+    a=0.8793934553196640731345171390561335;
+    w=0.0418975069252077562326869806094182;
+    for (i=0;i<2;++i) {
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                /// barycentric coordinates are either a or 1-a
+                v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    hexahedronNumericalIntegration.addQuadratureMethod(m,5,qpa);
 
-	/// 6 points
-	a=.9063071670498132481961877986898720;
-	b=0.5;
-	w=.0253096342016000238231671413708773;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		v[i]=a;
-		qpa.push_back(QuadraturePoint(v,w));
-		v[i]=1-a;
-		qpa.push_back(QuadraturePoint(v,w));
-	}
-	// 12 points
-	a=.8673341434985040086731923849337745;
-	b=0.5;
-	w=0.0181499182325144622865632250992823;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		for (j=0;j<2;++j) {
-			v[(i+1)%3]=a+j*(1-2*a);
-			for (k=0;k<2;++k) {
-				v[(i+2)%3]=a+k*(1-2*a);
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	/// 8 points
-	a=.6566967022580273605228866152789755;
-	w=.0269990056568711411641833332980551;
-	for (i=0;i<2;++i) {
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				/// barycentric coordinates are either a or 1-a
-				v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	/// 8 points
-	a=.8008376320991313508172065028926585;
-	w= .0146922934945570350487414755013352;
-	for (i=0;i<2;++i) {
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				/// barycentric coordinates are either a or 1-a
-				v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-		/// 8 points
-	a=.9277278805088799923375457353451730;
-	w= .0055804890098536552051251442852662;
-	for (i=0;i<2;++i) {
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				/// barycentric coordinates are either a or 1-a
-				v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	/// 24 points 
-	a=.9706224286053016319555750788155670;
-	b=.6769514072983150674551564354064455;
-	w=.0028267870173527355278995288336230;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		for (j=0;j<2;++j) {
-			v[(i+1)%3]=a+j*(1-2*a);
-			for (k=0;k<2;++k) {
-				v[i]=b;
-				v[(i+2)%3]=a+k*(1-2*a);
-				qpa.push_back(QuadraturePoint(v,w));
-				v[i]=1-b;
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	/// 24 points 
-	a=.7253999675572547151889421728651345;
-	b=.9825498327563551314651409115626720;
-	w=.0076802492622294169003437555791307;
-	for (i=0;i<3;++i) {
-		v=BarycentricCoordinatesType(b,b,b);
-		for (j=0;j<2;++j) {
-			v[(i+1)%3]=a+j*(1-2*a);
-			for (k=0;k<2;++k) {
-				v[i]=b;
-				v[(i+2)%3]=a+k*(1-2*a);
-				qpa.push_back(QuadraturePoint(v,w));
-				v[i]=1-b;
-				qpa.push_back(QuadraturePoint(v,w));
-			}
-		}
-	}
-	hexahedronNumericalIntegration.addQuadratureMethod(m,11,qpa);
-	*/
-	
+
+    /// consider non tensor product rules : taken from getfem++ file Hexahedron_9.im
+    /// integration with  accuracy of order 9 with 58 gauss points.
+
+    /// 6 points
+    a=.8068407347958544969174424448702780;
+    b=0.5;
+    w=.0541593744687068178762288491492902;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        v[i]=a;
+        qpa.push_back(QuadraturePoint(v,w));
+        v[i]=1-a;
+        qpa.push_back(QuadraturePoint(v,w));
+    }
+    // 12 points
+    a=0.9388435616288391432433878794971660;
+    b=0.5;
+    w=0.0114737257670222052714055736149557;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        for (j=0;j<2;++j) {
+            v[(i+1)%3]=a+j*(1-2*a);
+            for (k=0;k<2;++k) {
+                v[(i+2)%3]=a+k*(1-2*a);
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    /// 8 points
+    a=0.7820554035100150271333094993315360;
+    w=0.0248574797680029375401085898232011;
+    for (i=0;i<2;++i) {
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                /// barycentric coordinates are either a or 1-a
+                v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    /// 8 points
+    a=0.9350498923309879588075319044319620;
+    w=0.0062685994124186287334314359655827;
+    for (i=0;i<2;++i) {
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                /// barycentric coordinates are either a or 1-a
+                v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    /// 24 points
+    a=0.7161339513154310822080124307584715;
+    b=0.9692652109323358726644884348015390;
+    w=0.0120146004391716708040599923089382;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        for (j=0;j<2;++j) {
+            v[(i+1)%3]=a+j*(1-2*a);
+            for (k=0;k<2;++k) {
+                v[i]=b;
+                v[(i+2)%3]=a+k*(1-2*a);
+                qpa.push_back(QuadraturePoint(v,w));
+                v[i]=1-b;
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    hexahedronNumericalIntegration.addQuadratureMethod(m,9,qpa);
+
+
+    /// consider non tensor product rules : taken from getfem++ file Hexahedron_11.im
+    /// integration with  accuracy of order 11 with 90 gauss points.
+
+    /// 6 points
+    a=.9063071670498132481961877986898720;
+    b=0.5;
+    w=.0253096342016000238231671413708773;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        v[i]=a;
+        qpa.push_back(QuadraturePoint(v,w));
+        v[i]=1-a;
+        qpa.push_back(QuadraturePoint(v,w));
+    }
+    // 12 points
+    a=.8673341434985040086731923849337745;
+    b=0.5;
+    w=0.0181499182325144622865632250992823;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        for (j=0;j<2;++j) {
+            v[(i+1)%3]=a+j*(1-2*a);
+            for (k=0;k<2;++k) {
+                v[(i+2)%3]=a+k*(1-2*a);
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    /// 8 points
+    a=.6566967022580273605228866152789755;
+    w=.0269990056568711411641833332980551;
+    for (i=0;i<2;++i) {
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                /// barycentric coordinates are either a or 1-a
+                v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    /// 8 points
+    a=.8008376320991313508172065028926585;
+    w= .0146922934945570350487414755013352;
+    for (i=0;i<2;++i) {
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                /// barycentric coordinates are either a or 1-a
+                v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+        /// 8 points
+    a=.9277278805088799923375457353451730;
+    w= .0055804890098536552051251442852662;
+    for (i=0;i<2;++i) {
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                /// barycentric coordinates are either a or 1-a
+                v=BarycentricCoordinatesType(a+i*(1-2*a),a+j*(1-2*a),a+k*(1-2*a));
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    /// 24 points
+    a=.9706224286053016319555750788155670;
+    b=.6769514072983150674551564354064455;
+    w=.0028267870173527355278995288336230;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        for (j=0;j<2;++j) {
+            v[(i+1)%3]=a+j*(1-2*a);
+            for (k=0;k<2;++k) {
+                v[i]=b;
+                v[(i+2)%3]=a+k*(1-2*a);
+                qpa.push_back(QuadraturePoint(v,w));
+                v[i]=1-b;
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    /// 24 points
+    a=.7253999675572547151889421728651345;
+    b=.9825498327563551314651409115626720;
+    w=.0076802492622294169003437555791307;
+    for (i=0;i<3;++i) {
+        v=BarycentricCoordinatesType(b,b,b);
+        for (j=0;j<2;++j) {
+            v[(i+1)%3]=a+j*(1-2*a);
+            for (k=0;k<2;++k) {
+                v[i]=b;
+                v[(i+2)%3]=a+k*(1-2*a);
+                qpa.push_back(QuadraturePoint(v,w));
+                v[i]=1-b;
+                qpa.push_back(QuadraturePoint(v,w));
+            }
+        }
+    }
+    hexahedronNumericalIntegration.addQuadratureMethod(m,11,qpa);
+    */
+
 }
 template< class DataTypes>
 bool HexahedronSetGeometryAlgorithms< DataTypes >::isHexahedronAffine(const HexaID hx, const VecCoord& p, const Real tolerance) const
 {
-	/// check that the hexahedron is a parallelepiped returns true if it is the case and false otherwise.
-	/// given 4 points of binary coordinates 000 010 100 001 checks that the 4 other points are translated versions
-	const Hexahedron &h = this->m_topology->getHexahedron(hx);
-	Coord dpos;
-	dpos=(p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[1][0][0]]])-(p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]]);
-	if (dpos.norm()>tolerance)
-		return false;
-	else {
-		dpos=(p[h[verticesInHexahedronArray[1][1][0]]]-p[h[verticesInHexahedronArray[1][0][0]]])-(p[h[verticesInHexahedronArray[0][1][0]]]-p[h[verticesInHexahedronArray[0][0][0]]]);
-		if (dpos.norm()>tolerance)
-			return false;
-		else {
-			dpos=(p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][1]]])-(p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]]);
-			if (dpos.norm()>tolerance)
-				return false;
-			else {
-				dpos=(p[h[verticesInHexahedronArray[1][1][1]]]-p[h[verticesInHexahedronArray[0][1][1]]])-(p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][1]]]);
-				if (dpos.norm()>tolerance)
-					return false;
-				else
-					return true;
-			}
-		}
-	}
+    /// check that the hexahedron is a parallelepiped returns true if it is the case and false otherwise.
+    /// given 4 points of binary coordinates 000 010 100 001 checks that the 4 other points are translated versions
+    const Hexahedron &h = this->m_topology->getHexahedron(hx);
+    Coord dpos;
+    dpos=(p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[1][0][0]]])-(p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]]);
+    if (dpos.norm()>tolerance)
+        return false;
+    else {
+        dpos=(p[h[verticesInHexahedronArray[1][1][0]]]-p[h[verticesInHexahedronArray[1][0][0]]])-(p[h[verticesInHexahedronArray[0][1][0]]]-p[h[verticesInHexahedronArray[0][0][0]]]);
+        if (dpos.norm()>tolerance)
+            return false;
+        else {
+            dpos=(p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][1]]])-(p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]]);
+            if (dpos.norm()>tolerance)
+                return false;
+            else {
+                dpos=(p[h[verticesInHexahedronArray[1][1][1]]]-p[h[verticesInHexahedronArray[0][1][1]]])-(p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][1]]]);
+                if (dpos.norm()>tolerance)
+                    return false;
+                else
+                    return true;
+            }
+        }
+    }
 }
 template< class DataTypes>
 typename  DataTypes::Real HexahedronSetGeometryAlgorithms< DataTypes >::computeShapeFunction(const LocalCoord nc,const HexahedronBinaryIndex bi) const 
 {
-	return((bi[0] ? nc[0] : 1-nc[0])*(bi[1] ? nc[1] : 1-nc[1])*(bi[2] ? nc[2] : 1-nc[2]));
+    return((bi[0] ? nc[0] : 1-nc[0])*(bi[1] ? nc[1] : 1-nc[1])*(bi[2] ? nc[2] : 1-nc[2]));
 }
 template< class DataTypes>
 typename DataTypes::Coord HexahedronSetGeometryAlgorithms< DataTypes >::computeNodalValue(const HexaID hx,const LocalCoord nc,const VecCoord& p) const
 {
-	 const Hexahedron &h = this->m_topology->getHexahedron(hx);
-	 sofa::Index i,j,k;
-	 Coord pos[8];
-	 for (i=0;i<8;++i) 
-		 pos[i]=p[h[i]];
-	 Coord res;
+     const Hexahedron &h = this->m_topology->getHexahedron(hx);
+     sofa::Index i,j,k;
+     Coord pos[8];
+     for (i=0;i<8;++i)
+         pos[i]=p[h[i]];
+     Coord res;
 
-	 for (i=0;i<2;++i) {
-		 for (j=0;j<2;++j) {
-			 for (k=0;k<2;++k) {
-				 res+= (i ? nc[0] : 1-nc[0])*(j ? nc[1] : 1-nc[1])*(k ? nc[2] : 1-nc[2])*pos[h[verticesInHexahedronArray[i][j][k]]];
-			 }
-		 }
-	 }
+     for (i=0;i<2;++i) {
+         for (j=0;j<2;++j) {
+             for (k=0;k<2;++k) {
+                 res+= (i ? nc[0] : 1-nc[0])*(j ? nc[1] : 1-nc[1])*(k ? nc[2] : 1-nc[2])*pos[h[verticesInHexahedronArray[i][j][k]]];
+             }
+         }
+     }
 /*
     const Coord pos = p[0] * ((1-fx) * (1-fy) * (1-fz))
             + p[1] * ((  fx) * (1-fy) * (1-fz))
@@ -341,37 +341,37 @@ typename DataTypes::Coord HexahedronSetGeometryAlgorithms< DataTypes >::computeN
 template< class DataTypes>
 void HexahedronSetGeometryAlgorithms< DataTypes >::computePositionDerivative(const HexaID hx,const LocalCoord nc,const VecCoord& p,  Coord dpos[3]) const
 {
-	 const Hexahedron &h = this->m_topology->getHexahedron(hx);
-	 sofa::Index i,j,k;
-	 sofa::Index ind[3];
+     const Hexahedron &h = this->m_topology->getHexahedron(hx);
+     sofa::Index i,j,k;
+     sofa::Index ind[3];
 
-	 Coord pos[8];
-	 for (i=0;i<8;++i) 
+     Coord pos[8];
+     for (i=0;i<8;++i)
          pos[i]=p[h[i]];
 
-	 for (i=0;i<3;++i) {
-		 Coord pos0,pos1;
-		 for (j=0;j<2;++j) {
-			 for (k=0;k<2;++k) {
-				 ind[i]=1;
-				 ind[(i+1)%3]=j;
-				 ind[(i+2)%3]=k;
-				 pos1+= (j ? nc[(i+1)%3] : 1-nc[(i+1)%3])*(k ? nc[(i+2)%3] : 1-nc[(i+2)%3])*p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
-				 ind[i]=0;
-				 pos0+= (j ? nc[(i+1)%3] : 1-nc[(i+1)%3])*(k ? nc[(i+2)%3] : 1-nc[(i+2)%3])*p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
-			 }
-		 }
-		 dpos[i]=pos1-pos0;
-	 }
+     for (i=0;i<3;++i) {
+         Coord pos0,pos1;
+         for (j=0;j<2;++j) {
+             for (k=0;k<2;++k) {
+                 ind[i]=1;
+                 ind[(i+1)%3]=j;
+                 ind[(i+2)%3]=k;
+                 pos1+= (j ? nc[(i+1)%3] : 1-nc[(i+1)%3])*(k ? nc[(i+2)%3] : 1-nc[(i+2)%3])*p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
+                 ind[i]=0;
+                 pos0+= (j ? nc[(i+1)%3] : 1-nc[(i+1)%3])*(k ? nc[(i+2)%3] : 1-nc[(i+2)%3])*p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
+             }
+         }
+         dpos[i]=pos1-pos0;
+     }
 
 }
 
 template< class DataTypes>
 typename DataTypes::Real HexahedronSetGeometryAlgorithms< DataTypes >::computeJacobian(const HexaID hx,const LocalCoord nc,const VecCoord& p) const
 {
-	Coord dpos[3];
-	this->computePositionDerivative(hx,nc,p,dpos);
-	return (tripleProduct(dpos[0],dpos[1],dpos[2]));
+    Coord dpos[3];
+    this->computePositionDerivative(hx,nc,p,dpos);
+    return (tripleProduct(dpos[0],dpos[1],dpos[2]));
 }
 
 template< class DataTypes>
@@ -639,7 +639,7 @@ typename DataTypes::Real HexahedronSetGeometryAlgorithms< DataTypes >::computeEl
 template< class DataTypes>
 int HexahedronSetGeometryAlgorithms< DataTypes >::findNearestElement(const Coord& pos, sofa::type::Vector3& baryC, Real& distance) const
 {
-	sofa::Index index = sofa::InvalidID;
+    sofa::Index index = sofa::InvalidID;
     distance = std::numeric_limits<Real>::max();
 
     for(sofa::Index c=0; c<this->m_topology->getNbHexahedra(); ++c)
@@ -674,8 +674,8 @@ void HexahedronSetGeometryAlgorithms< DataTypes >::findNearestElements(const Vec
 template< class DataTypes>
 int HexahedronSetGeometryAlgorithms< DataTypes >::findNearestElementInRestPos(const Coord& pos, sofa::type::Vector3& baryC, Real& distance) const
 {
-	sofa::Index index = sofa::InvalidID;
-	distance = std::numeric_limits<Real>::max();
+    sofa::Index index = sofa::InvalidID;
+    distance = std::numeric_limits<Real>::max();
 
     for(sofa::Index c=0; c<this->m_topology->getNbHexahedra(); ++c)
     {
@@ -708,31 +708,31 @@ typename DataTypes::Real HexahedronSetGeometryAlgorithms< DataTypes >::computeHe
 {
  const Hexahedron &h = this->m_topology->getHexahedron(hexa);
     const VecCoord& p = (this->object->read(core::ConstVecCoordId::position())->getValue());
-	Coord dp[3];
-	unsigned char i,j,k,ind[3];
-	Real volume;
-	for (i=0;i<3;++i) {
-		dp[i]=Coord();
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				ind[i]=1;
-				ind[(i+1)%3]=j;
-				ind[(i+2)%3]=k;
-				dp[i]+=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
-				ind[i]=0;
-				dp[i]-=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
-			}
-		}
-	}
-	volume=tripleProduct(dp[0],dp[1],dp[2])/48.0f;
-	dp[0]=p[h[verticesInHexahedronArray[0][1][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
-	dp[1]=p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
-	dp[2]=p[h[verticesInHexahedronArray[1][1][0]]]-p[h[verticesInHexahedronArray[0][0][0]]];
-	volume-=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
-	dp[0]=p[h[verticesInHexahedronArray[1][0][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
-	dp[1]=p[h[verticesInHexahedronArray[0][1][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
-	dp[2]=p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[1][1][1]]];
-	volume+=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
+    Coord dp[3];
+    unsigned char i,j,k,ind[3];
+    Real volume;
+    for (i=0;i<3;++i) {
+        dp[i]=Coord();
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                ind[i]=1;
+                ind[(i+1)%3]=j;
+                ind[(i+2)%3]=k;
+                dp[i]+=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
+                ind[i]=0;
+                dp[i]-=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
+            }
+        }
+    }
+    volume=tripleProduct(dp[0],dp[1],dp[2])/48.0f;
+    dp[0]=p[h[verticesInHexahedronArray[0][1][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
+    dp[1]=p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
+    dp[2]=p[h[verticesInHexahedronArray[1][1][0]]]-p[h[verticesInHexahedronArray[0][0][0]]];
+    volume-=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
+    dp[0]=p[h[verticesInHexahedronArray[1][0][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
+    dp[1]=p[h[verticesInHexahedronArray[0][1][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
+    dp[2]=p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[1][1][1]]];
+    volume+=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
     return volume;
 }
 
@@ -741,31 +741,31 @@ typename DataTypes::Real HexahedronSetGeometryAlgorithms< DataTypes >::computeRe
 {
     const Hexahedron &h = this->m_topology->getHexahedron(hexa);
     const VecCoord& p =  (this->object->read(core::ConstVecCoordId::restPosition())->getValue());
-	Coord dp[3];
-	size_t i,j,k,ind[3];
-	Real volume;
-	for (i=0;i<3;++i) {
-		dp[i]=Coord();
-		for (j=0;j<2;++j) {
-			for (k=0;k<2;++k) {
-				ind[i]=1;
-				ind[(i+1)%3]=j;
-				ind[(i+2)%3]=k;
-				dp[i]+=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
-				ind[i]=0;
-				dp[i]-=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
-			}
-		}
-	}
-	volume=tripleProduct(dp[0],dp[1],dp[2])/48.0f;
-	dp[0]=p[h[verticesInHexahedronArray[0][1][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
-	dp[1]=p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
-	dp[2]=p[h[verticesInHexahedronArray[1][1][0]]]-p[h[verticesInHexahedronArray[0][0][0]]];
-	volume-=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
-	dp[0]=p[h[verticesInHexahedronArray[1][0][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
-	dp[1]=p[h[verticesInHexahedronArray[0][1][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
-	dp[2]=p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[1][1][1]]];
-	volume+=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
+    Coord dp[3];
+    size_t i,j,k,ind[3];
+    Real volume;
+    for (i=0;i<3;++i) {
+        dp[i]=Coord();
+        for (j=0;j<2;++j) {
+            for (k=0;k<2;++k) {
+                ind[i]=1;
+                ind[(i+1)%3]=j;
+                ind[(i+2)%3]=k;
+                dp[i]+=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
+                ind[i]=0;
+                dp[i]-=p[h[verticesInHexahedronArray[ind[0]][ind[1]][ind[2]]]];
+            }
+        }
+    }
+    volume=tripleProduct(dp[0],dp[1],dp[2])/48.0f;
+    dp[0]=p[h[verticesInHexahedronArray[0][1][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
+    dp[1]=p[h[verticesInHexahedronArray[1][0][1]]]-p[h[verticesInHexahedronArray[0][0][0]]];
+    dp[2]=p[h[verticesInHexahedronArray[1][1][0]]]-p[h[verticesInHexahedronArray[0][0][0]]];
+    volume-=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
+    dp[0]=p[h[verticesInHexahedronArray[1][0][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
+    dp[1]=p[h[verticesInHexahedronArray[0][1][0]]]-p[h[verticesInHexahedronArray[1][1][1]]];
+    dp[2]=p[h[verticesInHexahedronArray[0][0][1]]]-p[h[verticesInHexahedronArray[1][1][1]]];
+    volume+=tripleProduct(dp[0],dp[1],dp[2])/12.0f;
     return volume;
 }
 
@@ -896,7 +896,11 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
     }
 }
 
-
-
+template <class DataTypes>
+bool HexahedronSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
+{
+    return (d_showHexaIndices.getValue() || d_drawHexahedra.getValue()) && this->m_topology->getNbHexahedra() != 0
+        || Inherit1::mustComputeBBox();
+}
 
 } //namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.h
@@ -65,6 +65,8 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
+    void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
+
     /** return the centroid of the set of points */
     Coord getPointSetCenter() const;
 
@@ -121,6 +123,10 @@ protected:
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<PointSetGeometryAlgorithms<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
+    /// Return true if the visibility parameters are showing the object in any way whatsoever, false otherwise
+    virtual bool mustComputeBBox() const;
+
 };
 
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_POINTSETGEOMETRYALGORITHMS_CPP)

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.inl
@@ -263,6 +263,11 @@ void PointSetGeometryAlgorithms<DataTypes>::initPointAdded(PointID index, const 
     }
 }
 
+template <class DataTypes>
+bool PointSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
+{
+    return this->m_topology->getNbPoints() != 0 && d_showPointIndices.getValue();
+}
 
 template<class DataTypes>
 void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
@@ -290,5 +295,19 @@ void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParam
     }
 }
 
+template <class DataTypes>
+void PointSetGeometryAlgorithms<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
+{
+    if (!onlyVisible) return;
+    if (!this->object) return;
+    if (!this->m_topology) return;
+
+    if (mustComputeBBox())
+    {
+        const auto bbox = this->object->computeBBox(); //this may compute twice the mstate bbox, but there is no way to determine if the bbox has already been computed
+        this->object->f_bbox.setValue(std::move(bbox));
+    }
+    this->f_bbox.setValue(type::BoundingBox());
+}
 
 } //namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.h
@@ -110,6 +110,7 @@ protected:
     Data<bool> _drawQuads; ///< if true, draw the quads in the topology
     Data<sofa::type::RGBAColor> _drawColor; ///< RGB code color used to draw quads.
 
+    bool mustComputeBBox() const override;
 };
 
 template<class Coord>

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
@@ -286,6 +286,13 @@ void QuadSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) co
     myfile.close();
 }
 
+template <class DataTypes>
+bool QuadSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
+{
+    return (_drawQuads.getValue() || showQuadIndices.getValue()) && this->m_topology->getNbQuads() != 0
+        || Inherit1::mustComputeBBox();
+}
+
 template<class Coord>
 bool is_point_in_quad(const Coord& p,
         const Coord& a, const Coord& b,

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.h
@@ -181,6 +181,8 @@ protected:
     TetrahedronSetTopologyContainer*					m_container;
     TetrahedronSetTopologyModifier*						m_modifier;
     unsigned int	m_intialNbPoints;
+
+    bool mustComputeBBox() const override;
 };
 
 #if !defined(SOFA_COMPONENT_TOPOLOGY_TETRAHEDRONSETGEOMETRYALGORITHMS_CPP)

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
@@ -3228,7 +3228,12 @@ int TetrahedronSetGeometryAlgorithms<DataTypes>::subDivideRestTetrahedronWithPla
     return 0;
 }
 
-
+template <class DataTypes>
+bool TetrahedronSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
+{
+    return (d_showTetrahedraIndices.getValue() || d_drawTetrahedra.getValue()) && this->m_topology->getNbTetrahedra() != 0
+        || Inherit1::mustComputeBBox();
+}
 
 
 template<class DataTypes>

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
@@ -367,6 +367,8 @@ protected:
     /// include cubature points
     NumericalIntegrationDescriptor<Real,3> triangleNumericalIntegration;
 
+    bool mustComputeBBox() const override;
+
 private:
     TriangleSetTopologyContainer*				m_container;
     TriangleSetTopologyModifier*				m_modifier;

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
@@ -2530,6 +2530,12 @@ void TriangleSetGeometryAlgorithms<DataTypes>::reorderTrianglesOrientationFromNo
 }
 
 
+template <class DataTypes>
+bool TriangleSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
+{
+    return (showTriangleIndices.getValue() || _draw.getValue()) && this->m_topology->getNbTriangles() != 0
+        || Inherit1::mustComputeBBox();
+}
 
 template<class Real>
 bool is_point_in_triangle(const sofa::type::Vec<3,Real>& p, const sofa::type::Vec<3,Real>& a, const sofa::type::Vec<3,Real>& b, const sofa::type::Vec<3,Real>& c)

--- a/Sofa/framework/Core/src/sofa/core/State.h
+++ b/Sofa/framework/Core/src/sofa/core/State.h
@@ -143,6 +143,9 @@ public:
 
     /// @}
 
+    /// Compute the bounding box independently from the visibility parameters
+    sofa::type::TBoundingBox<Real> computeBBox() const;
+
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
 };
 

--- a/Sofa/framework/Core/src/sofa/core/State.inl
+++ b/Sofa/framework/Core/src/sofa/core/State.inl
@@ -57,13 +57,13 @@ const objectmodel::BaseData* State<DataTypes>::baseRead(ConstVecId v) const
 }
 
 template<class DataTypes>
-void State<DataTypes>::computeBBox(const core::ExecParams*, bool)
+auto State<DataTypes>::computeBBox() const -> sofa::type::TBoundingBox<Real>
 {
     const VecCoord& x = read(ConstVecCoordId::position())->getValue();
     const size_t xSize = x.size();
 
     if (xSize <= 0)
-        return;
+        return {};
 
     Real p[3];
     DataTypes::get(p[0], p[1], p[2], x[0]);
@@ -83,7 +83,13 @@ void State<DataTypes>::computeBBox(const core::ExecParams*, bool)
         }
     }
 
-    this->f_bbox.setValue(sofa::type::TBoundingBox<Real>(minBBox,maxBBox));
+    return sofa::type::TBoundingBox<Real>(minBBox,maxBBox);
+}
+
+template<class DataTypes>
+void State<DataTypes>::computeBBox(const core::ExecParams*, bool)
+{
+    this->f_bbox.setValue(computeBBox());
 }
 
 } // namespace core

--- a/Sofa/framework/Type/src/sofa/type/BoundingBox.h
+++ b/Sofa/framework/Type/src/sofa/type/BoundingBox.h
@@ -109,6 +109,7 @@ public:
     {
     }
 
+    TBoundingBox() : BoundingBox() {}
 };
 
 

--- a/examples/Components/constraint/InextensiblePendulum.scn
+++ b/examples/Components/constraint/InextensiblePendulum.scn
@@ -19,7 +19,9 @@
     <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [EdgeSetGeometryAlgorithms EdgeSetTopologyContainer] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
 
+    <DefaultVisualManagerLoop/>
     <VisualStyle displayFlags="hideVisualModels showBehaviorModels showMappings showForceFields" />
+
     <FreeMotionAnimationLoop solveVelocityConstraintFirst="true" />
     <GenericConstraintSolver tolerance="1e-9" maxIterations="1000"/>
     <!-- resolution = number of particles (including the fixed one) -->
@@ -38,7 +40,7 @@
         <GenericConstraintCorrection />
 
         <EdgeSetTopologyContainer position="@translate.output_position" edges="@../loader.edges" />
-        <MechanicalObject name="defoDOF" template="Vec3d" showObject="1" />
+        <MechanicalObject name="defoDOF" template="Vec3d" />
         <EdgeSetGeometryAlgorithms drawEdges="true" />
         <FixedConstraint indices="0" />
         <!-- 1 g for the total mass of the wire -->
@@ -59,7 +61,7 @@
         <!-- resolution = number of particles (including the fixed one) -->
         <!-- scale = total length of the pendulum -->
         <EdgeSetTopologyContainer position="@translate.output_position" edges="@../loader.edges" />
-        <MechanicalObject name="defoDOF" template="Vec3d"  />
+        <MechanicalObject name="defoDOF" template="Vec3d" />
         <EdgeSetGeometryAlgorithms drawEdges="true" />
         <FixedConstraint indices="0" />
         <!-- 1 g for the total mass of the wire -->


### PR DESCRIPTION
Initially fixes the visualization in InextensiblePendulum.scn. The second pendulum was out of the frustrum because the bounding box was not computed.

The indentation has been changed from tabs to spaces in HexahedronSetGeometryAlgorithms.inl






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
