### PR TITLE
[Sofa.Component.Engine] Change the default drawSize from 0.0 to 1.0 for ROIs.

### DIFF
--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/BoxROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/BoxROI.inl
@@ -87,7 +87,7 @@ BoxROI<DataTypes>::BoxROI()
     , d_drawTetrahedra( initData(&d_drawTetrahedra,false,"drawTetrahedra","Draw Tetrahedra. (default = false)") )
     , d_drawHexahedra( initData(&d_drawHexahedra,false,"drawHexahedra","Draw Tetrahedra. (default = false)") )
     , d_drawQuads( initData(&d_drawQuads,false,"drawQuads","Draw Quads. (default = false)") )
-    , d_drawSize( initData(&d_drawSize,0.0,"drawSize","rendering size for box and topological elements") )
+    , d_drawSize( initData(&d_drawSize,1.0,"drawSize","rendering size for box and topological elements") )
     , d_doUpdate( initData(&d_doUpdate,(bool)true,"doUpdate","If true, updates the selection at the beginning of simulation steps. (default = true)") )
 
     /// In case you add a new attribute please also add it into to the BoxROI_test.cpp::attributesTests

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.inl
@@ -50,7 +50,7 @@ PlaneROI<DataTypes>::PlaneROI()
     , p_drawEdges( initData(&p_drawEdges,false,"drawEdges","Draw Edges") )
     , p_drawTriangles( initData(&p_drawTriangles,false,"drawTriangles","Draw Triangles") )
     , p_drawTetrahedra( initData(&p_drawTetrahedra,false,"drawTetrahedra","Draw Tetrahedra") )
-    , _drawSize( initData(&_drawSize, 0.0f,"drawSize","rendering size for box and topological elements") )
+    , _drawSize( initData(&_drawSize, 1.0f,"drawSize","rendering size for box and topological elements") )
 {
     planes.beginEdit()->push_back(Vec10(sofa::type::Vec<9,Real>(0,0,0,0,0,0,0,0,0),0));
     planes.endEdit();

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.inl
@@ -44,7 +44,7 @@ ProximityROI<DataTypes>::ProximityROI()
     , f_indicesOut( initData(&f_indicesOut,"indicesOut","Indices of the points not contained in the ROI") )
     , p_drawSphere( initData(&p_drawSphere,false,"drawSphere","Draw shpere(s)") )
     , p_drawPoints( initData(&p_drawPoints,false,"drawPoints","Draw Points") )
-    , _drawSize( initData(&_drawSize,0.0,"drawSize","rendering size for box and topological elements") )
+    , _drawSize( initData(&_drawSize,1.0,"drawSize","rendering size for box and topological elements") )
 {
     //Adding alias to handle TrianglesInSphereROI input/output
     addAlias(&p_drawSphere,"isVisible");

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SphereROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SphereROI.inl
@@ -61,7 +61,7 @@ SphereROI<DataTypes>::SphereROI()
     , p_drawTriangles( initData(&p_drawTriangles,false,"drawTriangles","Draw Triangles") )
     , p_drawQuads( initData(&p_drawQuads,false,"drawQuads","Draw Quads") )
     , p_drawTetrahedra( initData(&p_drawTetrahedra,false,"drawTetrahedra","Draw Tetrahedra") )
-    , _drawSize( initData(&_drawSize,0.0f,"drawSize","rendering size for box and topological elements") )
+    , _drawSize( initData(&_drawSize,1.0f,"drawSize","rendering size for box and topological elements") )
 {
     //Adding alias to handle TrianglesInSphereROI input/output
     addAlias(&p_drawSphere,"isVisible");

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.inl
@@ -70,7 +70,7 @@ SubsetTopology<DataTypes>::SubsetTopology()
     , p_drawEdges( initData(&p_drawEdges,false,"drawEdges","Draw Edges") )
     , p_drawTriangles( initData(&p_drawTriangles,false,"drawTriangle","Draw Triangles") )
     , p_drawTetrahedra( initData(&p_drawTetrahedra,false,"drawTetrahedra","Draw Tetrahedra") )
-    , _drawSize( initData(&_drawSize,0.0,"drawSize","rendering size for box and topological elements") )
+    , _drawSize( initData(&_drawSize,1.0,"drawSize","rendering size for box and topological elements") )
 {
     boxes.beginEdit()->push_back(Vec6(0,0,0,1,1,1));
     boxes.endEdit();


### PR DESCRIPTION
It makes no sense to have a drawSize set to zero by default given that the
drawing is activated by an additional drawPoints/drawBox boolean.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
