### PR TITLE
[Constraint.Lagrangian.Correction] Searching for Direct Linear Solver in LinearSolverConstraintCorrection

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
@@ -145,6 +145,7 @@ private:
     int last_force, last_disp; //last_force indice du dof le plus petit portant la force/le dpt qui a ?t? modifi? pour la derni?re fois (wire optimisation only?)
     bool _new_force; // if true, a "new" force was added in setConstraintDForce which is not yet integrated by a new computation in addConstraintDisplacements
 
+    void addSolverToList(sofa::core::behavior::LinearSolver* s);
 };
 
 #if  !defined(SOFA_COMPONENT_CONSTRAINT_LINEARSOLVERCONSTRAINTCORRECTION_CPP)

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -79,7 +79,7 @@ void LinearSolverConstraintCorrection<DataTypes>::init()
         c->get(s);
         if(s)
         {
-            if (s->getTemplateName() == "GraphScattered")
+            if (s->getTemplateName() == sofa::component::linearsolver::GraphScatteredMatrix::Name())
                 msg_warning() << "Can not use the solver " << s->getName() << " because it is templated on GraphScatteredType";
             else
                 linearsolvers.push_back(s);

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -94,7 +94,7 @@ void LinearSolverConstraintCorrection<DataTypes>::init()
 
             if(s)
             {
-                if (s->getTemplateName() == "GraphScattered")
+                if (s->getTemplateName() == sofa::component::linearsolver::GraphScatteredMatrix::Name())
                     msg_warning() << "Can not use the solver " << solverNames[i] << " because it is templated on GraphScatteredType";
                 else
                     linearsolvers.push_back(s);

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -73,19 +73,34 @@ void LinearSolverConstraintCorrection<DataTypes>::init()
     linearsolvers.clear();
 
     std::stringstream tmp ;
-    if (solverNames.size() == 0)
+    if (solverNames.empty())
     {
-        linearsolvers.push_back(c->get<sofa::core::behavior::LinearSolver>());
+        sofa::core::behavior::LinearSolver* s = nullptr;
+        c->get(s);
+        if(s)
+        {
+            if (s->getTemplateName() == "GraphScattered")
+                msg_warning() << "Can not use the solver " << s->getName() << " because it is templated on GraphScatteredType";
+            else
+                linearsolvers.push_back(s);
+        }
     }
-
     else
     {
-        for (unsigned int i=0; i<solverNames.size(); ++i)
+        for(unsigned int i=0; i<solverNames.size(); ++i)
         {
             sofa::core::behavior::LinearSolver* s = nullptr;
             c->get(s, solverNames[i]);
-            if (s) linearsolvers.push_back(s);
-            else tmp << "- searching for solver \'" << solverNames[i] << "\' but cannot find it upward in the scene graph." << msgendl ;
+
+            if(s)
+            {
+                if (s->getTemplateName() == "GraphScattered")
+                    msg_warning() << "Can not use the solver " << solverNames[i] << " because it is templated on GraphScatteredType";
+                else
+                    linearsolvers.push_back(s);
+            } 
+            else
+                msg_warning() << "Solver \"" << solverNames[i] << "\" not found.";
         }
     }
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -31,6 +31,8 @@
 #include <sstream>
 #include <list>
 
+#include <sofa/component/linearsolver/iterative/GraphScatteredTypes.h>
+
 namespace sofa::component::constraint::lagrangian::correction
 {
 
@@ -72,35 +74,30 @@ void LinearSolverConstraintCorrection<DataTypes>::init()
 
     linearsolvers.clear();
 
-    std::stringstream tmp ;
     if (solverNames.empty())
     {
         sofa::core::behavior::LinearSolver* s = nullptr;
         c->get(s);
         if(s)
         {
-            if (s->getTemplateName() == sofa::component::linearsolver::GraphScatteredMatrix::Name())
-                msg_warning() << "Can not use the solver " << s->getName() << " because it is templated on GraphScatteredType";
-            else
-                linearsolvers.push_back(s);
+            addSolverToList(s);
         }
     }
     else
     {
-        for(unsigned int i=0; i<solverNames.size(); ++i)
+        for (const auto& solver : solverNames)
         {
             sofa::core::behavior::LinearSolver* s = nullptr;
-            c->get(s, solverNames[i]);
+            c->get(s, solver);
 
             if(s)
             {
-                if (s->getTemplateName() == sofa::component::linearsolver::GraphScatteredMatrix::Name())
-                    msg_warning() << "Can not use the solver " << solverNames[i] << " because it is templated on GraphScatteredType";
-                else
-                    linearsolvers.push_back(s);
+                addSolverToList(s);
             } 
             else
-                msg_warning() << "Solver \"" << solverNames[i] << "\" not found.";
+            {
+                msg_warning() << "Solver \"" << solver << "\" not found.";
+            }
         }
     }
 
@@ -110,9 +107,9 @@ void LinearSolverConstraintCorrection<DataTypes>::init()
         d_componentState.setValue(ComponentState::Invalid) ;
         return;
     }
-    if (linearsolvers.size()==0)
+    if (linearsolvers.empty())
     {
-        msg_error() << "No LinearSolver found (component is disabled)." << tmp.str() ;
+        msg_error() << "No LinearSolver found (component is disabled).";
         d_componentState.setValue(ComponentState::Invalid) ;
         return;
     }
@@ -124,6 +121,19 @@ void LinearSolverConstraintCorrection<DataTypes>::init()
     }
 
     d_componentState.setValue(ComponentState::Valid) ;
+}
+
+template <class TDataTypes>
+void LinearSolverConstraintCorrection<TDataTypes>::addSolverToList(sofa::core::behavior::LinearSolver* s)
+{
+    if (s->getTemplateName() == sofa::component::linearsolver::GraphScatteredMatrix::Name())
+    {
+        msg_warning() << "Can not use the solver " << s->getName() << " because it is templated on GraphScatteredType";
+    }
+    else
+    {
+        linearsolvers.push_back(s);
+    }
 }
 
 template<class TDataTypes>


### PR DESCRIPTION
@hugtalbot 
Copied search for correct Direct Linear Solver from GenericConstraintCorrection.

As mentioned in https://github.com/sofa-framework/sofa/discussions/3046 the object did not check the correct type of the solver during init.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
