### PR TITLE
[Sofa.Core] Linear time getRoot() method in BaseNode and Node

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
@@ -35,18 +35,23 @@ namespace core
 namespace objectmodel
 {
 
-BaseNode::BaseNode()
-{}
+BaseNode::BaseNode() : m_root(this)
+{
+}
 
 BaseNode::~BaseNode()
 {}
 
 BaseNode* BaseNode::getRoot() const
 {
-    BaseNode* firstParent = getFirstParent();
-    if (!firstParent) return const_cast<BaseNode*>(this);
-    else return firstParent->getRoot();
+    return m_root;
 }
+
+void BaseNode::setRoot(BaseNode* newroot)
+{
+    m_root = newroot;
+}
+
 
 core::behavior::BaseAnimationLoop* BaseNode::getAnimationLoop() const
 {

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.h
@@ -54,6 +54,8 @@ protected:
     BaseNode() ;
     ~BaseNode() override;
 
+    BaseNode* m_root {nullptr} ;
+
 private:
     BaseNode(const BaseNode& n) ;
     BaseNode& operator=(const BaseNode& n) ;
@@ -77,7 +79,8 @@ public:
     virtual BaseNode* getFirstParent() const = 0;
 
     /// returns the root by following up the first parent for multinodes
-    virtual BaseNode* getRoot() const;
+    BaseNode* getRoot() const;
+    void setRoot(BaseNode*) ;
 
     /// Add a child node
     virtual void addChild(BaseNode::SPtr node) = 0;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -195,6 +195,7 @@ void Node::addChild(core::objectmodel::BaseNode::SPtr node)
     notifyBeginAddChild(this, dynamic_cast<Node*>(node.get()));
     doAddChild(node);
     notifyEndAddChild(this, dynamic_cast<Node*>(node.get()));
+    node->setRoot(getRoot());
 }
 
 /// Remove a child
@@ -203,15 +204,26 @@ void Node::removeChild(core::objectmodel::BaseNode::SPtr node)
     // If node has no parent
     if (node->getFirstParent() == nullptr)
         return;
+
     notifyBeginRemoveChild(this, static_cast<Node*>(node.get()));
     doRemoveChild(node);
     notifyEndRemoveChild(this, static_cast<Node*>(node.get()));
-}
 
+    if(node->getFirstParent())
+        node->setRoot(node->getFirstParent()->getRoot());
+    else
+        node->setRoot(node.get());
+}
 
 /// Move a node from another node
 void Node::moveChild(BaseNode::SPtr node, BaseNode::SPtr prev_parent)
 {
+    if(node->getRoot() != prev_parent->getRoot())
+    {
+        msg_error(this->getName()) << "Node::moveChild(BaseNode::SPtr node)\n" << node->getName() << " have different root node. Move is not allowed. use addChild instead!";
+        return;
+    }
+
     if (!prev_parent.get())
     {
         msg_error(this->getName()) << "Node::moveChild(BaseNode::SPtr node)\n" << node->getName() << " has no parent. Use addChild instead!";
@@ -220,6 +232,7 @@ void Node::moveChild(BaseNode::SPtr node, BaseNode::SPtr prev_parent)
     }
     doMoveChild(node, prev_parent);
 }
+
 /// Add an object. Detect the implemented interfaces and add the object to the corresponding lists.
 bool Node::addObject(BaseObject::SPtr obj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
 {
@@ -265,97 +278,80 @@ void Node::moveObject(BaseObject::SPtr obj)
 
 void Node::notifyBeginAddChild(Node::SPtr parent, Node::SPtr child) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onBeginAddChild(parent.get(), child.get());
 }
 
 void Node::notifyEndAddChild(Node::SPtr parent, Node::SPtr child) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onEndAddChild(parent.get(), child.get());
 }
 
 void Node::notifyBeginRemoveChild(Node::SPtr parent, Node::SPtr child) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onBeginRemoveChild(parent.get(), child.get());
 }
 
 void Node::notifyEndRemoveChild(Node::SPtr parent, Node::SPtr child) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onEndRemoveChild(parent.get(), child.get());
 }
 
 void Node::notifyBeginAddObject(Node::SPtr parent, core::objectmodel::BaseObject::SPtr obj) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onBeginAddObject(parent.get(), obj.get());
 }
 
 void Node::notifyEndAddObject(Node::SPtr parent, core::objectmodel::BaseObject::SPtr obj) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onEndAddObject(parent.get(), obj.get());
 }
 
 void Node::notifyBeginRemoveObject(Node::SPtr parent, core::objectmodel::BaseObject::SPtr obj) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onBeginRemoveObject(parent.get(), obj.get());
 }
 
 void Node::notifyEndRemoveObject(Node::SPtr parent, core::objectmodel::BaseObject::SPtr obj) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onEndRemoveObject(parent.get(), obj.get());
 }
 
 void Node::notifyBeginAddSlave(core::objectmodel::BaseObject* master, core::objectmodel::BaseObject* slave) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onBeginAddSlave(master, slave);
 }
 
 void Node::notifyEndAddSlave(core::objectmodel::BaseObject* master, core::objectmodel::BaseObject* slave) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onEndAddSlave(master, slave);
 }
 
 void Node::notifyBeginRemoveSlave(core::objectmodel::BaseObject* master, core::objectmodel::BaseObject* slave) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onBeginRemoveSlave(master, slave);
 }
 
 void Node::notifyEndRemoveSlave(core::objectmodel::BaseObject* master, core::objectmodel::BaseObject* slave) const
 {
-    Node* root = down_cast<Node>(this->getContext()->getRootContext()->toBaseNode());
-    for (auto& listener : root->listener)
+    for (auto& listener : getRoot()->listener)
         listener->onEndRemoveSlave(master, slave);
 }
 
 void Node::notifySleepChanged(Node* node) const
 {
-    if (this->getFirstParent() == nullptr) {
-        for (type::vector<MutationListener*>::const_iterator it = listener.begin(); it != listener.end(); ++it)
-            (*it)->sleepChanged(node);
-    }
-    else {
-        dynamic_cast<Node*>(this->getFirstParent())->notifySleepChanged(node);
-    }
+    for (auto& listener : getRoot()->listener)
+        listener->sleepChanged(node);
 }
 
 void Node::addListener(MutationListener* obj)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -481,6 +481,11 @@ public:
         return getRoot()->getContext();
     }
 
+    Node* getRoot() const
+    {
+        return static_cast<Node*>(BaseNode::getRoot());
+    }
+
     Node* setDebug(bool);
     bool getDebug() const;
     void printComponents();


### PR DESCRIPTION
The current approach consist in recursively crawling up to the root node of
the scenegraph. Which have linear complexity in the depth of the graph.

This PR implements a constant time mecanism.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
