### PR TITLE
[Sofa.DefaultType] Removes definition of GLdouble in SolidTypes

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.h
@@ -32,8 +32,6 @@
 #include <iostream>
 #include <map>
 
-typedef double GLdouble;
-
 namespace sofa
 {
 
@@ -287,7 +285,7 @@ public:
         /// Project a spatial vector from parent to child (the inverse of operator *). This method computes (*this).inversed()*sv without inverting (*this).
         SpatialVector operator / (const SpatialVector& sv ) const;
         /// Write an OpenGL matrix encoding the transformation of the coordinate system of the child wrt the coordinate system of the parent.
-        void writeOpenGlMatrix( GLdouble *m ) const;
+        void writeOpenGlMatrix( double *m ) const;
         /// Draw the axes of the child coordinate system in the parent coordinate system
         /// Print the origin of the child in the parent coordinate system and the quaternion defining the orientation of the child wrt the parent
         inline friend std::ostream& operator << (std::ostream& out, const Transform& t )

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.inl
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.inl
@@ -317,7 +317,7 @@ typename SolidTypes<R>::Transform SolidTypes<R>::Transform::inversed() const
 }
 
 template<class R>
-void SolidTypes<R>::Transform::writeOpenGlMatrix( GLdouble *m ) const
+void SolidTypes<R>::Transform::writeOpenGlMatrix( double *m ) const
 {
     orientation_.writeOpenGlMatrix(m);
     Vec t = getOrigin();


### PR DESCRIPTION
GLDouble is defined in SolidTypes. 
I assume this is because of the writeOpenGLMatrix method. 

But, such design is wrong because we don't want and shouldn't have a dependency to opengl.
So either we need to really know GLdouble to implement writeOpenGLMatrix... in that case writeOpenGLMatrix
should become a free function moved to some ogl packager which do the proper include to Opengl.h. 

Or we don't care so much about GLdouble and in that case we juste use "double" instead.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
