### PR TITLE
[runSofa] Fix CMake error if all plugins are disabled

### DIFF
--- a/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
+++ b/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
@@ -9,46 +9,44 @@ macro(sofa_generate_plugin_config config_filename)
 
     list(LENGTH _allTargets nbTargets)
 
-    # if no plugin (or no deprecated "module") then quit
-    if (${nbTargets} EQUAL 0)
-        return()
-    endif()
+    # do the generation only if there is any plugin
+    if (${nbTargets} NOT EQUAL 0)
+        math(EXPR len "${nbTargets} - 1")
 
-    math(EXPR len "${nbTargets} - 1")
+        set(_modulePrefix "MODULE")
+        set(_pluginPrefix "PLUGIN")
+        foreach(counter RANGE ${len})
+            list(GET _allTargets ${counter} _target)
+            list(GET _allTargetNames ${counter} _targetName)
 
-    set(_modulePrefix "MODULE")
-    set(_pluginPrefix "PLUGIN")
-    foreach(counter RANGE ${len})
-        list(GET _allTargets ${counter} _target)
-        list(GET _allTargetNames ${counter} _targetName)
+            string(SUBSTRING "${_targetName}" 0 6 _testPlugin)
+            if(${_testPlugin} MATCHES "${_modulePrefix}.*" OR ${_testPlugin} MATCHES "${_pluginPrefix}.*")
+                if(${${_targetName}})
+                    get_target_property(_version ${_target} VERSION )
+                    if(${_version} MATCHES ".*NOTFOUND")
+                        set(_version "NO_VERSION")
+                    endif()
 
-        string(SUBSTRING "${_targetName}" 0 6 _testPlugin)
-        if(${_testPlugin} MATCHES "${_modulePrefix}.*" OR ${_testPlugin} MATCHES "${_pluginPrefix}.*")
-            if(${${_targetName}})
-                get_target_property(_version ${_target} VERSION )
-                if(${_version} MATCHES ".*NOTFOUND")
-                    set(_version "NO_VERSION")
+                    set(_target_filename ${_target})
+                    get_target_property(target_output_name ${_target} OUTPUT_NAME)
+                    if(target_output_name)
+                        set(_target_filename ${target_output_name})
+                    endif()
+
+                    string(CONCAT _pluginConfig "${_pluginConfig}\n${_target_filename} ${_version}")
                 endif()
-
-                set(_target_filename ${_target})
-                get_target_property(target_output_name ${_target} OUTPUT_NAME)
-                if(target_output_name)
-                    set(_target_filename ${target_output_name})
-                endif()
-
-                string(CONCAT _pluginConfig "${_pluginConfig}\n${_target_filename} ${_version}")
             endif()
-        endif()
-    endforeach()
-    FILE(WRITE ${config_filename} ${_pluginConfig})
+        endforeach()
+        FILE(WRITE ${config_filename} ${_pluginConfig})
 
-    # only useful for devs working directly with a build version (not installed)
-    # With Win/MVSC, we can only know $CONFIG at build time
-    if (MSVC)
-        add_custom_target(do_always ALL
-            COMMAND if exist "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/" # does not exist if using MSVC without Visual Studio IDE
-            "${CMAKE_COMMAND}" -E copy "${config_filename}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
-            )
-    endif(MSVC)
+        # only useful for devs working directly with a build version (not installed)
+        # With Win/MVSC, we can only know $CONFIG at build time
+        if (MSVC)
+            add_custom_target(do_always ALL
+                COMMAND if exist "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/" # does not exist if using MSVC without Visual Studio IDE
+                "${CMAKE_COMMAND}" -E copy "${config_filename}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
+                )
+        endif(MSVC)
+    endif()
 
 endmacro()

--- a/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
+++ b/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
@@ -10,7 +10,7 @@ macro(sofa_generate_plugin_config config_filename)
     list(LENGTH _allTargets nbTargets)
 
     # do the generation only if there is any plugin
-    if (${nbTargets} NOT EQUAL 0)
+    if (NOT ${nbTargets} EQUAL 0)
         math(EXPR len "${nbTargets} - 1")
 
         set(_modulePrefix "MODULE")

--- a/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
+++ b/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
@@ -8,6 +8,12 @@ macro(sofa_generate_plugin_config config_filename)
     get_property(_allTargetNames GLOBAL PROPERTY __GlobalTargetNameList__)
 
     list(LENGTH _allTargets nbTargets)
+
+    # if no plugin (or no deprecated "module") then quit
+    if (${nbTargets} EQUAL 0)
+        return()
+    endif()
+
     math(EXPR len "${nbTargets} - 1")
 
     set(_modulePrefix "MODULE")


### PR DESCRIPTION
With SofaNG now, the mandatory libs are neither plugin nor the deprecated "module" notion,

So while trying to configure SOFA for a minimum build (i.e no plugin) and without the compat layer (so no module),  I stumbled in this error which was trying to generate the list of plugins/modules. 
There was no check on the list itself (as the empty modules/plugins could never have been empty before)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
