### PR TITLE
[Sofa.GL] Fix draw function from *SetGeometryAlgorithms

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
@@ -701,6 +701,7 @@ typename DataTypes::Coord EdgeSetGeometryAlgorithms<DataTypes>::compute2EdgesInt
 template<class DataTypes>
 void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
+    vparams->drawTool()->saveLastState();
     PointSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
     // Draw Edges indices
@@ -749,6 +750,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         vparams->drawTool()->drawPoints(positions, 4.0f, _drawColor.getValue());
     }
 
+    vparams->drawTool()->restoreLastState();
 }
 
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
@@ -701,8 +701,9 @@ typename DataTypes::Coord EdgeSetGeometryAlgorithms<DataTypes>::compute2EdgesInt
 template<class DataTypes>
 void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
     PointSetGeometryAlgorithms<DataTypes>::draw(vparams);
+
+    vparams->drawTool()->saveLastState();
 
     // Draw Edges indices
     if (showEdgeIndices.getValue() && this->m_topology->getNbEdges() != 0)
@@ -948,8 +949,7 @@ bool EdgeSetGeometryAlgorithms<DataTypes>::computeEdgeSegmentIntersection(EdgeID
 template <class DataTypes>
 bool EdgeSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
 {
-    return this->m_topology->getNbEdges() != 0 && (d_drawEdges.getValue() || showEdgeIndices.getValue())
-        || Inherit1::mustComputeBBox();
+    return ( (this->m_topology->getNbEdges() != 0 && (d_drawEdges.getValue() || showEdgeIndices.getValue())) || Inherit1::mustComputeBBox() );
 }
 
 } //namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
@@ -829,6 +829,8 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
 {
     QuadSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
+    vparams->drawTool()->saveLastState();
+
     // Draw Hexa indices
     if (d_showHexaIndices.getValue() && this->m_topology->getNbHexahedra() != 0)
     {
@@ -894,13 +896,14 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
         if (vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0, false);
     }
+
+    vparams->drawTool()->restoreLastState();
 }
 
 template <class DataTypes>
 bool HexahedronSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
 {
-    return (d_showHexaIndices.getValue() || d_drawHexahedra.getValue()) && this->m_topology->getNbHexahedra() != 0
-        || Inherit1::mustComputeBBox();
+    return ((d_showHexaIndices.getValue() || d_drawHexahedra.getValue()) && this->m_topology->getNbHexahedra() != 0) || Inherit1::mustComputeBBox();
 }
 
 } //namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.inl
@@ -272,6 +272,8 @@ bool PointSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
 template<class DataTypes>
 void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
+    vparams->drawTool()->saveLastState();
+
     if (d_showPointIndices.getValue())
     {
         sofa::type::Vec3 sceneMinBBox, sceneMaxBBox;
@@ -293,11 +295,15 @@ void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParam
         }
         vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
     }
+
+    vparams->drawTool()->restoreLastState();
 }
 
 template <class DataTypes>
 void PointSetGeometryAlgorithms<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if (!onlyVisible) return;
     if (!this->object) return;
     if (!this->m_topology) return;

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
@@ -289,8 +289,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) co
 template <class DataTypes>
 bool QuadSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
 {
-    return (_drawQuads.getValue() || showQuadIndices.getValue()) && this->m_topology->getNbQuads() != 0
-        || Inherit1::mustComputeBBox();
+    return ((_drawQuads.getValue() || showQuadIndices.getValue()) && this->m_topology->getNbQuads() != 0) || Inherit1::mustComputeBBox();
 }
 
 template<class Coord>
@@ -348,6 +347,8 @@ template<class DataTypes>
 void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     EdgeSetGeometryAlgorithms<DataTypes>::draw(vparams);
+
+    vparams->drawTool()->saveLastState();
 
     // Draw Quads indices
     if (showQuadIndices.getValue() && this->m_topology->getNbQuads() != 0)
@@ -453,6 +454,8 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         if (vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0, false);
     }
+
+    vparams->drawTool()->restoreLastState();
 }
 
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
@@ -3231,8 +3231,7 @@ int TetrahedronSetGeometryAlgorithms<DataTypes>::subDivideRestTetrahedronWithPla
 template <class DataTypes>
 bool TetrahedronSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
 {
-    return (d_showTetrahedraIndices.getValue() || d_drawTetrahedra.getValue()) && this->m_topology->getNbTetrahedra() != 0
-        || Inherit1::mustComputeBBox();
+    return ((d_showTetrahedraIndices.getValue() || d_drawTetrahedra.getValue()) && this->m_topology->getNbTetrahedra() != 0) || Inherit1::mustComputeBBox();
 }
 
 
@@ -3243,6 +3242,8 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
         return;
 
     TriangleSetGeometryAlgorithms<DataTypes>::draw(vparams);
+
+    vparams->drawTool()->saveLastState();
 
     const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
     //Draw tetra indices
@@ -3342,6 +3343,8 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
         if (vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0, false);
     }
+
+    vparams->drawTool()->restoreLastState();
 }
 
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
@@ -2533,8 +2533,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::reorderTrianglesOrientationFromNo
 template <class DataTypes>
 bool TriangleSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
 {
-    return (showTriangleIndices.getValue() || _draw.getValue()) && this->m_topology->getNbTriangles() != 0
-        || Inherit1::mustComputeBBox();
+    return ((showTriangleIndices.getValue() || _draw.getValue()) && this->m_topology->getNbTriangles() != 0) || Inherit1::mustComputeBBox();
 }
 
 template<class Real>
@@ -4833,6 +4832,8 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
 {
     EdgeSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
+    vparams->drawTool()->saveLastState();
+
     // Draw Triangles indices
     if (showTriangleIndices.getValue() && this->m_topology->getNbTriangles() != 0)
     {
@@ -4967,6 +4968,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
         vparams->drawTool()->drawLines(vertices,1.0f,colors);
     }
 
+    vparams->drawTool()->restoreLastState();
 }
 
 


### PR DESCRIPTION
In all SetGeometryAlgorithms, this PR 
- adds save and restore state (creating rendering bugs in EdgeSetGA)
- fixes warning in mustComputeBbox function
- fix other warnings


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
