### PR TITLE
[Sofa.Visual] Revert PR #2856

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -766,24 +766,28 @@ void VisualModelImpl::applyScale(const SReal sx, const SReal sy, const SReal sz)
 
 void VisualModelImpl::applyUVTranslation(const Real dU, const Real dV)
 {
-    auto vtexcoords = sofa::helper::getWriteOnlyAccessor(m_vtexcoords);
-
-    for (auto& vtexcoord : vtexcoords)
+    float dUf = float(dU);
+    float dVf = float(dV);
+    VecTexCoord& vtexcoords = *(m_vtexcoords.beginEdit());
+    for (std::size_t i = 0; i < vtexcoords.size(); i++)
     {
-        vtexcoord[0] += dU;
-        vtexcoord[1] += dV;
+        vtexcoords[i][0] += dUf;
+        vtexcoords[i][1] += dVf;
     }
+    m_vtexcoords.endEdit();
 }
 
 void VisualModelImpl::applyUVScale(const Real scaleU, const Real scaleV)
 {
-    auto vtexcoords = sofa::helper::getWriteOnlyAccessor(m_vtexcoords);
-
-    for (auto& vtexcoord : vtexcoords)
+    float scaleUf = float(scaleU);
+    float scaleVf = float(scaleV);
+    VecTexCoord& vtexcoords = *(m_vtexcoords.beginEdit());
+    for (std::size_t i = 0; i < vtexcoords.size(); i++)
     {
-        vtexcoord[0] *= scaleU;
-        vtexcoord[1] *= scaleV;
+        vtexcoords[i][0] *= scaleUf;
+        vtexcoords[i][1] *= scaleVf;
     }
+    m_vtexcoords.endEdit();
 }
 
 
@@ -1290,8 +1294,8 @@ void VisualModelImpl::computeUVSphereProjection()
 
         Coord pos = m_sphereV[i] - center;
         pos.normalize();
-        vtexcoords[i][0] = (0.5 + atan2(pos[1], pos[0]) / (2 * R_PI));
-        vtexcoords[i][1] = (0.5 - asin(pos[2]) / R_PI);
+        vtexcoords[i][0] = float(0.5 + atan2(pos[1], pos[0]) / (2 * R_PI));
+        vtexcoords[i][1] = float(0.5 - asin(pos[2]) / R_PI);
     }
 
     m_vtexcoords.endEdit();
@@ -1336,14 +1340,14 @@ void VisualModelImpl::flipFaces()
     m_quads.endEdit();
 }
 
-void VisualModelImpl::setColor(Real r, Real g, Real b, Real a)
+void VisualModelImpl::setColor(float r, float g, float b, float a)
 {
     Material M = material.getValue();
     M.setColor(r,g,b,a);
     material.setValue(M);
 }
 
-void VisualModelImpl::setColor(const std::string& color)
+void VisualModelImpl::setColor(std::string color)
 {
     if (color.empty())
         return;

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
@@ -76,6 +76,9 @@ class SOFA_COMPONENT_VISUAL_API VisualModelImpl : public core::visual::VisualMod
 public:
     SOFA_CLASS2(VisualModelImpl, core::visual::VisualModel, Vec3State);
 
+    typedef sofa::type::Vec<2, float> TexCoord;
+    typedef type::vector<TexCoord> VecTexCoord;
+
     using Index = sofa::Index;
     
     //Indices must be unsigned int for drawing
@@ -95,8 +98,6 @@ public:
     typedef DataTypes::Deriv Deriv;
     typedef DataTypes::VecDeriv VecDeriv;
 
-    typedef sofa::type::Vec<2, Real> TexCoord;
-    typedef type::vector<TexCoord> VecTexCoord;
 
     bool useTopology; ///< True if list of facets should be taken from the attached topology
     int lastMeshRev; ///< Time stamps from the last time the mesh was updated from the topology
@@ -254,9 +255,9 @@ public:
 
     std::string getFilename() {return fileMesh.getValue();}
 
-    void setColor(Real r, Real g, Real b, Real a);
+    void setColor(float r, float g, float b, float a);
 
-    void setColor(const std::string& color);
+    void setColor(std::string color);
 
     void setUseNormals(bool val)
     {

--- a/SofaKernel/modules/Sofa.GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/SofaKernel/modules/Sofa.GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -39,15 +39,12 @@ using sofa::type::Material;
 using namespace sofa::type;
 using namespace sofa::defaulttype;
 
-namespace // anonymous
-{
-    void glVertex3v(const float* d) { glVertex3fv(d); }
-    void glVertex3v(const double* d) { glVertex3dv(d); }
-
-}
-
 int OglModelClass = core::RegisterObject("Generic visual model for OpenGL display")
     .add< OglModel >();
+
+template<class T>
+const T* getData(const sofa::type::vector<T>& v) { return &v[0]; }
+
 
 OglModel::OglModel()
     : blendTransparency(initData(&blendTransparency, true, "blendTranslucency", "Blend transparent parts"))
@@ -198,7 +195,7 @@ void OglModel::drawGroup(int ig, bool transparent)
         glBindBuffer(GL_ARRAY_BUFFER, vbo);
 	    uintptr_t pt = (vertices.size()*sizeof(vertices[0]))
                     + (vnormals.size()*sizeof(vnormals[0]));
-        glTexCoordPointer(2, glTypeReal(), 0, reinterpret_cast<void*>(pt));
+        glTexCoordPointer(2, GL_FLOAT, 0, reinterpret_cast<void*>(pt));
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glEnableClientState(GL_TEXTURE_COORD_ARRAY);
     }
@@ -337,6 +334,30 @@ void OglModel::drawGroups(bool transparent)
     }
 }
 
+
+void glVertex3v(const float* d){ glVertex3fv(d); }
+void glVertex3v(const double* d){ glVertex3dv(d); }
+
+template<class T>
+GLuint glType(){ return GL_FLOAT; }
+
+template<>
+GLuint glType<double>(){ return GL_DOUBLE; }
+
+template<>
+GLuint glType<float>(){ return GL_FLOAT; }
+
+template<class InType, class OutType>
+void copyVector(const InType& src, OutType& dst)
+{
+    unsigned int i=0;
+    for(auto& item : src)
+    {
+        dst[i].set(item);
+        ++i;
+    }
+}
+
 void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool transparent)
 {
     if (!vparams->displayFlags().getShowVisualModels())
@@ -359,14 +380,16 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
     const VecCoord& vbitangents= this->getVbitangents();
     bool hasTangents = vtangents.size() && vbitangents.size();
 
+
     glEnable(GL_LIGHTING);
 
     glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_TRUE);
     glColor3f(1.0 , 1.0, 1.0);
 
-    constexpr GLuint datatype = glTypeReal();
-    constexpr GLuint vertexdatasize = sizeof(Coord);
-    constexpr GLuint normaldatasize = sizeof(Deriv);
+    /// Force the data to be of float type before sending to opengl...
+    GLuint datatype = GL_FLOAT;
+    GLuint vertexdatasize = sizeof(verticesTmpBuffer[0]);
+    GLuint normaldatasize = sizeof(normalsTmpBuffer[0]);
 
     GLulong vertexArrayByteSize = vertices.size() * vertexdatasize;
     GLulong normalArrayByteSize = vnormals.size() * normaldatasize;
@@ -376,6 +399,7 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
     glVertexPointer(3, datatype, 0, nullptr);
     glNormalPointer(datatype, 0, reinterpret_cast<void*>(vertexArrayByteSize));
     glBindBuffer(GL_ARRAY_BUFFER, 0);
+
 
     glEnableClientState(GL_NORMAL_ARRAY);
     glEnableClientState(GL_VERTEX_ARRAY);
@@ -388,22 +412,22 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
             tex->bind();
         }
 
-        size_t textureArrayByteSize = vtexcoords.size()*sizeof(TexCoord);
+        size_t textureArrayByteSize = vtexcoords.size()*sizeof(vtexcoords[0]);
         glBindBuffer(GL_ARRAY_BUFFER, vbo);
-        glTexCoordPointer(2, datatype, 0, reinterpret_cast<void*>(vertexArrayByteSize + normalArrayByteSize ));
+        glTexCoordPointer(2, GL_FLOAT, 0, reinterpret_cast<void*>(vertexArrayByteSize + normalArrayByteSize ));
         glBindBuffer(GL_ARRAY_BUFFER, 0);
 
         glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
         if (hasTangents)
         {
-            size_t tangentArrayByteSize = vtangents.size()*sizeof(Coord);
+            size_t tangentArrayByteSize = vtangents.size()*sizeof(vtangents[0]);
 
             glClientActiveTexture(GL_TEXTURE1);
             glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
             glBindBuffer(GL_ARRAY_BUFFER, vbo);
-            glTexCoordPointer(3, datatype, 0,
+            glTexCoordPointer(3, GL_DOUBLE, 0,
                               reinterpret_cast<void*>(vertexArrayByteSize + normalArrayByteSize + textureArrayByteSize));
             glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -411,7 +435,7 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
             glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
             glBindBuffer(GL_ARRAY_BUFFER, vbo);
-            glTexCoordPointer(3, datatype, 0,
+            glTexCoordPointer(3, GL_DOUBLE, 0,
                               reinterpret_cast<void*>(vertexArrayByteSize + normalArrayByteSize
                               + textureArrayByteSize + tangentArrayByteSize));
             glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -706,11 +730,11 @@ void OglModel::initTextures()
     }
     else
     {
-        for (auto* texture : textures)
+        if (!textures.empty())
         {
-            if (texture)
+            for (unsigned int i = 0 ; i < textures.size() ; i++)
             {
-                texture->init();
+                textures[i]->init();
             }
         }
     }
@@ -756,17 +780,17 @@ void OglModel::initVertexBuffer()
     const VecCoord& vbitangents= this->getVbitangents();
     bool hasTangents = vtangents.size() && vbitangents.size();
 
-    positionsBufferSize = (vertices.size()*sizeof(Coord));
-    normalsBufferSize = (vnormals.size()*sizeof(Deriv));
+    positionsBufferSize = (vertices.size()*sizeof(Vec3f));
+    normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
 
     if (tex || putOnlyTexCoords.getValue() || !textures.empty())
     {
-        textureCoordsBufferSize = vtexcoords.size() * sizeof(TexCoord);
+        textureCoordsBufferSize = vtexcoords.size() * sizeof(vtexcoords[0]);
 
         if (hasTangents)
         {
-            tangentsBufferSize = vtangents.size() * sizeof(Coord);
-            bitangentsBufferSize = vbitangents.size() * sizeof(Coord);
+            tangentsBufferSize = vtangents.size() * sizeof(vtangents[0]);
+            bitangentsBufferSize = vbitangents.size() * sizeof(vbitangents[0]);
         }
     }
 
@@ -832,35 +856,55 @@ void OglModel::updateVertexBuffer()
 
     positionsBufferSize = (vertices.size()*sizeof(vertices[0]));
     normalsBufferSize = (vnormals.size()*sizeof(vnormals[0]));
+    const void* positionBuffer = vertices.data();
+    const void* normalBuffer = vnormals.data();
+
+
+    verticesTmpBuffer.resize( vertices.size() );
+    normalsTmpBuffer.resize( vnormals.size() );
+
+    copyVector(vertices, verticesTmpBuffer);
+    copyVector(vnormals, normalsTmpBuffer);
+
+    positionsBufferSize = (vertices.size()*sizeof(Vec3f));
+    normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
+    positionBuffer = verticesTmpBuffer.data();
+    normalBuffer = normalsTmpBuffer.data();
+
+    if (tex || putOnlyTexCoords.getValue() || !textures.empty())
+    {
+        textureCoordsBufferSize = (vtexcoords.size() * sizeof(vtexcoords[0]));
+
+        if (hasTangents)
+        {
+            tangentsBufferSize = (vtangents.size() * sizeof(vtangents[0]));
+            bitangentsBufferSize = (vbitangents.size() * sizeof(vbitangents[0]));
+        }
+    }
 
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
     //Positions
     glBufferSubData(GL_ARRAY_BUFFER,
                     0,
                     positionsBufferSize,
-                    vertices.data());
+                    positionBuffer);
 
     //Normals
     glBufferSubData(GL_ARRAY_BUFFER,
                     positionsBufferSize,
                     normalsBufferSize,
-                    vnormals.data());
+                    normalBuffer);
 
     //Texture coords
     if(tex || putOnlyTexCoords.getValue() ||!textures.empty())
     {
-        textureCoordsBufferSize = (vtexcoords.size() * sizeof(vtexcoords[0]));
-
         glBufferSubData(GL_ARRAY_BUFFER,
                         positionsBufferSize + normalsBufferSize,
                         textureCoordsBufferSize,
-                        vtexcoords.data());
+                        getData(vtexcoords));
 
         if (hasTangents)
         {
-            tangentsBufferSize = (vtangents.size() * sizeof(vtangents[0]));
-            bitangentsBufferSize = (vbitangents.size() * sizeof(vbitangents[0]));
-
             glBufferSubData(GL_ARRAY_BUFFER,
                             positionsBufferSize + normalsBufferSize + textureCoordsBufferSize,
                             tangentsBufferSize,

--- a/SofaKernel/modules/Sofa.GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
+++ b/SofaKernel/modules/Sofa.GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
@@ -22,6 +22,8 @@
 #pragma once
 #include <sofa/gl/component/rendering3d/config.h>
 
+#include <vector>
+#include <string>
 #include <sofa/gl/template.h>
 #include <sofa/gl/Texture.h>
 #include <sofa/helper/OptionsGroup.h>
@@ -29,9 +31,8 @@
 #include <sofa/type/Vec.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/component/visual/VisualModelImpl.h>
-#include <vector>
-#include <string>
-#include <type_traits>
+
+#define   NB_MAX_TEXTURES 16
 
 namespace sofa::gl::component::rendering3d
 {
@@ -80,6 +81,11 @@ protected:
     bool VBOGenDone, initDone, useEdges, useTriangles, useQuads, canUsePatches;
     size_t oldVerticesSize, oldNormalsSize, oldTexCoordsSize, oldTangentsSize, oldBitangentsSize, oldEdgesSize, oldTrianglesSize, oldQuadsSize;
 
+    /// These two buffers are used to convert the data field to float type before being sent to
+    /// opengl
+    std::vector<sofa::type::Vec3f> verticesTmpBuffer;
+    std::vector<sofa::type::Vec3f> normalsTmpBuffer;
+
     void internalDraw(const core::visual::VisualParams* vparams, bool transparent) override;
 
     void drawGroup(int ig, bool transparent);
@@ -99,18 +105,6 @@ protected:
 
     ~OglModel() override;
 public:
-
-    static constexpr auto glTypeReal()
-    {
-        if constexpr (std::is_same_v< SReal, double>)
-        {
-            return GL_DOUBLE;
-        }
-        else
-        {
-            return GL_FLOAT;
-        }
-    }
 
     bool loadTexture(const std::string& filename) override;
     bool loadTextures() override;


### PR DESCRIPTION
Rendering using GL_DOUBLE has terrible performance on some hardware/os/drivers that are still commonly used. 

Reverts #2856

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
