### PR TITLE
[Core] Dynamic control of the computation of the bounding box

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -753,9 +753,9 @@ void ConstraintAnimationLoop::step ( const core::ExecParams* params, SReal dt )
     }
     sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
 
-    if (!SOFA_NO_UPDATE_BBOX)
+    if (d_computeBoundingBox.getValue())
     {
-        sofa::helper::ScopedAdvancedTimer timer("UpdateBBox");
+        sofa::helper::ScopedAdvancedTimer updateBBoxTimer("UpdateBBox");
         this->gnode->execute<UpdateBoundingBoxVisitor>(params);
     }
 

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -296,7 +296,7 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
         }
     }
 
-    if (!SOFA_NO_UPDATE_BBOX)
+    if (d_computeBoundingBox.getValue())
     {
         ScopedAdvancedTimer timer("UpdateBBox");
         gnode->execute<UpdateBoundingBoxVisitor>(params);

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
@@ -130,7 +130,7 @@ void MultiStepAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt
     }
     sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
 
-    if (!SOFA_NO_UPDATE_BBOX)
+    if (d_computeBoundingBox.getValue())
     {
         sofa::helper::ScopedAdvancedTimer timer("UpdateBBox");
         this->gnode->execute<UpdateBoundingBoxVisitor>(params);

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
@@ -131,7 +131,7 @@ void MultiTagAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt)
     }
     sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
 
-    if (!SOFA_NO_UPDATE_BBOX)
+    if (d_computeBoundingBox.getValue())
     {
         sofa::helper::ScopedAdvancedTimer timer("UpdateBBox");
         this->gnode->execute<UpdateBoundingBoxVisitor>(params);

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseAnimationLoop.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseAnimationLoop.cpp
@@ -30,6 +30,7 @@ namespace sofa::core::behavior
 
 BaseAnimationLoop::BaseAnimationLoop()
     : m_resetTime(0.)
+    , d_computeBoundingBox(initData(&d_computeBoundingBox, !SOFA_NO_UPDATE_BBOX, "computeBoundingBox", "If true, compute the global bounding box of the scene at each time step. Used mostly for rendering."))
 {}
 
 BaseAnimationLoop::~BaseAnimationLoop()

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseAnimationLoop.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseAnimationLoop.h
@@ -73,6 +73,8 @@ public:
     bool insertInNode( objectmodel::BaseNode* node ) override;
     bool removeInNode( objectmodel::BaseNode* node ) override;
 
+    Data<bool> d_computeBoundingBox;
+
 };
 
 } // namespace sofa::core::behavior

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseAnimationLoop.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseAnimationLoop.h
@@ -73,7 +73,7 @@ public:
     bool insertInNode( objectmodel::BaseNode* node ) override;
     bool removeInNode( objectmodel::BaseNode* node ) override;
 
-    Data<bool> d_computeBoundingBox;
+    Data<bool> d_computeBoundingBox; ///< If true, compute the global bounding box of the scene at each time step. Used mostly for rendering.
 
 };
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -135,7 +135,7 @@ void DefaultAnimationLoop::step(const core::ExecParams* params, SReal dt)
     }
     sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
 
-    if (!SOFA_NO_UPDATE_BBOX)
+    if (d_computeBoundingBox.getValue())
     {
         sofa::helper::ScopedAdvancedTimer timer("UpdateBBox");
         gnode->execute< UpdateBoundingBoxVisitor >(params);

--- a/examples/Components/constraint/InextensiblePendulum.scn
+++ b/examples/Components/constraint/InextensiblePendulum.scn
@@ -2,7 +2,7 @@
 
 <!-- A pendulum made of a string of particles connected by distance constraints -->
 <!-- Inspired by the CompliantPendulum.scn from the Compliant plugin -->
-<Node   name="Root" gravity="0 -10 0" time="0" animate="0"  dt="0.01" >
+<Node name="Root" gravity="0 -10 0" time="0" animate="0"  dt="0.01">
     <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
     <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [GenericConstraintCorrection] -->
     <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Model"/> <!-- Needed to use components [UniformConstraint] -->
@@ -22,7 +22,7 @@
     <DefaultVisualManagerLoop/>
     <VisualStyle displayFlags="hideVisualModels showBehaviorModels showMappings showForceFields" />
 
-    <FreeMotionAnimationLoop solveVelocityConstraintFirst="true" />
+    <FreeMotionAnimationLoop solveVelocityConstraintFirst="true" computeBoundingBox="false"/>
     <GenericConstraintSolver tolerance="1e-9" maxIterations="1000"/>
     <!-- resolution = number of particles (including the fixed one) -->
     <!-- scale = total length of the pendulum -->
@@ -69,7 +69,7 @@
         <Node name="extensionsNode" >
             <MechanicalObject template="Vec1d"  name="extensionsDOF" />
             <DistanceMapping  name="distanceMapping" />
-            <UniformConstraint template="Vec1d" iterative="false" /> 
+            <UniformConstraint template="Vec1d" iterative="false" />
         </Node>
     </Node>
     


### PR DESCRIPTION
A user can chose in the scene to update the bounding box or not. It is no longer a compile-time selection.

In InextensiblePendulum.scn, the second pendulum explodes. An update of the bbox would adapt to the exploded object. The bbox is so large that the first pendulum is no longer visible. It may lead the user to think that the scene is not working properly.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
