### PR TITLE
[SofaCUDA] fix HexahedronFEMForceField double compilation

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cpp
@@ -42,8 +42,8 @@ int HexahedronFEMForceFieldCudaClass = core::RegisterObject("Hexahedron FEM Forc
 .add< sofa::component::solidmechanics::fem::elastic::HexahedronFEMForceField<CudaVec3fTypes> >()
 .add< sofa::component::solidmechanics::fem::elastic::HexahedronFEMForceField<CudaVec3f1Types> >()
 #ifdef SOFA_GPU_CUDA_DOUBLE
-.add< component::forcefield::HexahedronFEMForceField<CudaVec3dTypes> >()
-.add< component::forcefield::HexahedronFEMForceField<CudaVec3d1Types> >()
+.add< component::solidmechanics::fem::elastic::HexahedronFEMForceField<CudaVec3dTypes> >()
+.add< component::solidmechanics::fem::elastic::HexahedronFEMForceField<CudaVec3d1Types> >()
 #endif // SOFA_GPU_CUDA_DOUBLE
 ;
 


### PR DESCRIPTION

Fix double compilation


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
