### PR TITLE
[ArticulatedSystemMapping] Fixed draw method

### DIFF
--- a/applications/plugins/ArticulatedSystemPlugin/src/ArticulatedSystemPlugin/ArticulatedSystemMapping.inl
+++ b/applications/plugins/ArticulatedSystemPlugin/src/ArticulatedSystemPlugin/ArticulatedSystemMapping.inl
@@ -545,39 +545,35 @@ void ArticulatedSystemMapping<TIn, TInRoot, TOut>::applyJT( InMatrixDeriv& out, 
 template <class TIn, class TInRoot, class TOut>
 void ArticulatedSystemMapping<TIn, TInRoot, TOut>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
-
-    if (!vparams->displayFlags().getShowMappings()) return;
-    std::vector< sofa::type::Vector3 > points;
-    std::vector< sofa::type::Vector3 > pointsLine;
-
-    auto ac = articulationCenters.begin();
-    auto acEnd = articulationCenters.end();
-    unsigned int i=0;
-    for (; ac != acEnd; ac++)
+    if (vparams->displayFlags().getShowMappings())
     {
-        type::vector< sofa::component::container::Articulation* > articulations = (*ac)->getArticulations();
-        auto a = articulations.begin();
-        auto aEnd = articulations.end();
-        for (; a != aEnd; a++)
+        vparams->drawTool()->saveLastState();
+
+        std::vector< sofa::type::Vector3 > points;
+        std::vector< sofa::type::Vector3 > pointsLine;
+
+        unsigned int i=0;
+        for (const auto & ac: articulationCenters)
         {
+            type::vector< sofa::component::container::Articulation* > articulations = ac->getArticulations();
+            for (const auto & a: articulations)
+            {
+                // Articulation Pos and Axis are based on the configuration of the parent
+                int ind= a->articulationIndex.getValue();
+                points.push_back(ArticulationPos[ind]);
 
-            // Articulation Pos and Axis are based on the configuration of the parent
-            int ind= (*a)->articulationIndex.getValue();
-            points.push_back(ArticulationPos[ind]);
+                pointsLine.push_back(ArticulationPos[ind]);
+                sofa::type::Vec<3,OutReal> Pos_axis = ArticulationPos[ind] + ArticulationAxis[ind];
+                pointsLine.push_back(Pos_axis);
 
-            pointsLine.push_back(ArticulationPos[ind]);
-            sofa::type::Vec<3,OutReal> Pos_axis = ArticulationPos[ind] + ArticulationAxis[ind];
-            pointsLine.push_back(Pos_axis);
-
-            i++;
+                i++;
+            }
         }
+
+        vparams->drawTool()->drawPoints(points, 10, sofa::type::RGBAColor(1,0.5,0.5,1));
+        vparams->drawTool()->drawLines(pointsLine, 1, sofa::type::RGBAColor::blue());
+
+        vparams->drawTool()->restoreLastState();
     }
-
-    vparams->drawTool()->drawPoints(points, 10, sofa::type::RGBAColor(1,0.5,0.5,1));
-    vparams->drawTool()->drawLines(pointsLine, 1, sofa::type::RGBAColor::blue());
-
-    vparams->drawTool()->restoreLastState();
 }
-
 } //namespace sofa::component::mapping


### PR DESCRIPTION
Bugfix for problem discussed in https://github.com/sofa-framework/sofa/discussions/2691#discussioncomment-2183354 with @hugtalbot 

When calling a scene with an `ArticulatedSystemMapping` through `runSofa`, everything works as expected.
When running the same scene through `SofaPython3` with `OpenGL` as rendering, the stack overflows.
Through some commenting out code, I found that saving the `saveLastState` without `restoreLastState` leads to the stack overflow.
Restoring was not done, because the function returned immediately after checking if mappings should be shown.

Changes:
- Pulling `restoreLastState` and `saveLastState` into the `if`
- Modernized the loops for readability

Scene for testing:
test_articulation.py:

```python
import Sofa
import Sofa.Core
import Sofa.SofaGL
import Sofa.Simulation
import os
import time

sofa_directory = os.environ["SOFA_ROOT"]
import pygame
from OpenGL.GL import *
from OpenGL.GLU import *

display_size = (800, 600)


def init_display(node):
    pygame.display.init()
    pygame.display.set_mode(display_size, pygame.DOUBLEBUF | pygame.OPENGL)

    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
    glEnable(GL_LIGHTING)
    glEnable(GL_DEPTH_TEST)
    Sofa.SofaGL.glewInit()
    Sofa.Simulation.initVisual(node)
    Sofa.Simulation.initTextures(node)
    glMatrixMode(GL_PROJECTION)
    glLoadIdentity()
    gluPerspective(45, (display_size[0] / display_size[1]), 0.1, 50.0)

    glMatrixMode(GL_MODELVIEW)
    glLoadIdentity()


def simple_render(rootNode):
    """
    Get the OpenGL Context to render an image (snapshot) of the simulation state
    """
    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
    glEnable(GL_LIGHTING)
    glEnable(GL_DEPTH_TEST)
    glMatrixMode(GL_PROJECTION)
    glLoadIdentity()
    gluPerspective(45, (display_size[0] / display_size[1]), 0.1, 50.0)
    glMatrixMode(GL_MODELVIEW)
    glLoadIdentity()

    cameraMVM = rootNode.camera.getOpenGLModelViewMatrix()
    glMultMatrixd(cameraMVM)
    Sofa.SofaGL.draw(rootNode)

    pygame.display.get_surface().fill((0, 0, 0))
    pygame.display.flip()


def createScene(root: Sofa.Core.Node):
    root.addObject("RequiredPlugin", name="ArticulatedSystemPlugin")  # <- [ArticulatedHierarchyContainer, ArticulatedSystemMapping, Articulation, ArticulationCenter]
    root.addObject("RequiredPlugin", name="Sofa.Component.LinearSolver.Iterative")  # <- [CGLinearSolver]
    root.addObject("RequiredPlugin", name="Sofa.Component.Mass")  # <- [UniformMass]
    root.addObject("RequiredPlugin", name="Sofa.Component.ODESolver.Backward")  # <- [EulerImplicitSolver]
    root.addObject("RequiredPlugin", name="Sofa.Component.StateContainer")  # <- [MechanicalObject]
    root.addObject("RequiredPlugin", name="Sofa.GL.Component.Shader")  # <- [LightManager]
    root.addObject("RequiredPlugin", name="Sofa.Component.Visual")  # <- [InteractiveCamera]

    neutral_pose = [0, 0, 0, 0, 0, 0, 1]
    instrument_node = root.addChild("instrument")

    instrument_node.addObject("EulerImplicitSolver")
    instrument_node.addObject("CGLinearSolver")

    angle_mo = instrument_node.addObject("MechanicalObject", template="Vec1d", position=[-0.4, 0.4])

    body_node = instrument_node.addChild("body")

    body_mo = body_node.addObject(
        "MechanicalObject",
        template="Rigid3d",
        position=neutral_pose * 3,
        showObject=True,
        showObjectScale=0.1,
    )

    body_node.addObject("UniformMass", totalMass=0.05)

    body_node.addObject(
        "ArticulatedSystemMapping",
        input1=angle_mo.getLinkPath(),
        output=body_mo.getLinkPath(),
    )
    # [ERROR]   [PythonScript] GLError: GLError(
    #         err = 1283,
    #         description = b'stack overflow',
    #         baseOperation = glClear,
    #         cArguments = (16640,)
    # )
    #   File "test_articulation.py", line 146, in <module>
    #     simple_render(root)
    #   File "test_articulation.py", line 39, in simple_render
    #     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
    #   File "src/errorchecker.pyx", line 58, in OpenGL_accelerate.errorchecker._ErrorChecker.glCheckError

    instrument_node.addObject("ArticulatedHierarchyContainer")

    articulation_hierarchy_node = instrument_node.addChild("articulation_hierarchy")

    articulation_center_node_1 = articulation_hierarchy_node.addChild("center_1")
    articulation_center_node_1.addObject(
        "ArticulationCenter",
        parentIndex=0,
        childIndex=1,
        posOnParent=[0, 0, 0],
        posOnChild=[0, 0, 0],
    )

    articulation_node_1 = articulation_center_node_1.addChild("articulation_1")
    articulation_node_1.addObject(
        "Articulation",
        translation=False,
        rotation=True,
        rotationAxis=[0, 0, 1],
        articulationIndex=0,
    )

    articulation_center_node_2 = articulation_hierarchy_node.addChild("center_2")
    articulation_center_node_2.addObject(
        "ArticulationCenter",
        parentIndex=0,
        childIndex=2,
        posOnParent=[0, 0, 0],
        posOnChild=[0, 0, 0],
    )

    articulation_node_2 = articulation_center_node_2.addChild("articulation_2")
    articulation_node_2.addObject(
        "Articulation",
        translation=False,
        rotation=True,
        rotationAxis=[0, 0, 1],
        articulationIndex=1,
    )

    # place light and a camera
    root.addObject("LightManager")
    root.addObject("DirectionalLight", direction=[0, 1, 0])
    root.addObject("InteractiveCamera", name="camera", position=[0, 0, 5], lookAt=[0, 0, 0], distance=37, fieldOfView=45, zNear=0.63, zFar=55.69)


if __name__ == "__main__":
    root = Sofa.Core.Node("myroot")
    createScene(root)
    Sofa.Simulation.init(root)
    init_display(root)
    try:
        while True:
            Sofa.Simulation.animate(root, root.getDt())
            Sofa.Simulation.updateVisual(root)
            simple_render(root)
            time.sleep(root.getDt())
    except KeyboardInterrupt:
        pass
```

To reproduce the issue, run `python3 test_articulation.py` and `runSofa test_articulation.py`.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
