### PR TITLE
[Sofa.GL] Fix cmake config file for out-of-tree when trying to find glew on Windows

### DIFF
--- a/SofaKernel/modules/Sofa.GL/Sofa.GLConfig.cmake.in
+++ b/SofaKernel/modules/Sofa.GL/Sofa.GLConfig.cmake.in
@@ -5,10 +5,10 @@
 
 set(SOFA_GL_HAVE_GLEW @SOFA_GL_HAVE_GLEW@)
 
-find_package(OpenGL QUIET REQUIRED)
-find_package(GLEW QUIET REQUIRED)
 find_package(Sofa.Helper QUIET REQUIRED)
 find_package(Sofa.DefaultType QUIET REQUIRED)
+find_package(OpenGL QUIET REQUIRED)
+find_package(GLEW QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Fix a peculiar bug where:
 - one wants to compile a project out-of-tree,
 - on WIndows,
 - this project needs Sofa.GL
 - Sofa.GL is find_package()'d first.

As GLEW config on windows is special (windeppack stuff), its configuration is set-up in Sofa.Helper.
But the cmake config file for out-of-tree (Sofa.GLConfig.cmake.in) was trying to find GLEW before Sofa.Helper, hence cmake could not configure the projet and was yelling about not finding GLEW.
(got the case with registration plugin)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
