### PR TITLE
[Helper] Make clearer from where plugins are loaded

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
@@ -173,6 +173,7 @@ void SofaPluginManager::addLibrary()
             mbox->setText(sstream.str().c_str());
             mbox->show();
         }
+        savePluginsToIniFile();
     }
     else
     {

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
@@ -82,7 +82,7 @@ void SofaPluginManager::updatePluginsListView()
         {
             for (unsigned int i = 0; i < 4; ++i)
             {
-                item->setForeground(i, QColorConstants::Blue);
+                item->setForeground(i, QColor::fromRgb(0, 0, 255));
                 item->setToolTip(i, QString(std::string{"This plugin has been loaded by the GUI from the file " + m_pluginsIniFile}.c_str()));
             }
         }

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
@@ -74,8 +74,19 @@ void SofaPluginManager::updatePluginsListView()
         QString sname    = plugin.getModuleName();
         QString sversion = plugin.getModuleVersion();
         QString sfile    = (iter->first).c_str();
-        //QTreeWidgetItem * item = new QTreeWidgetItem(listPlugins, sname, slicense, sversion, sfile);
+
         QTreeWidgetItem * item = new QTreeWidgetItem(listPlugins);
+
+        if (std::find(m_loadedPlugins.begin(), m_loadedPlugins.end(), plugin.getModuleName()) != m_loadedPlugins.end() ||
+            std::find(m_loadedPlugins.begin(), m_loadedPlugins.end(), iter->first) != m_loadedPlugins.end())
+        {
+            for (unsigned int i = 0; i < 4; ++i)
+            {
+                item->setForeground(i, QColorConstants::Blue);
+                item->setToolTip(i, QString(std::string{"This plugin has been loaded by the GUI from the file " + m_pluginsIniFile}.c_str()));
+            }
+        }
+
         item->setText(0, sname);
         item->setText(1, slicense);
         item->setText(2, sversion);
@@ -116,8 +127,9 @@ void SofaPluginManager::addLibrary()
 #endif
     std::stringstream sstream;
 
-    std::string pluginFile = std::string(sfile.toStdString());
-    if(sofa::helper::system::PluginManager::getInstance().loadPluginByPath(pluginFile,&sstream))
+    const std::string pluginFile = std::string(sfile.toStdString());
+    const auto status = sofa::helper::system::PluginManager::getInstance().loadPluginByPath(pluginFile,&sstream);
+    if(status == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS)
     {
         typedef sofa::helper::system::Plugin    Plugin;
         if( ! sstream.str().empty())
@@ -150,6 +162,17 @@ void SofaPluginManager::addLibrary()
         //item->setSelectable(true);
         savePluginsToIniFile();
         emit( libraryAdded() );
+    }
+    else if (status == sofa::helper::system::PluginManager::PluginLoadStatus::ALREADY_LOADED)
+    {
+        if( !sstream.str().empty())
+        {
+            QMessageBox * mbox = new QMessageBox(this);
+            mbox->setWindowTitle("library loading warning");
+            mbox->setIcon(QMessageBox::Warning);
+            mbox->setText(sstream.str().c_str());
+            mbox->show();
+        }
     }
     else
     {
@@ -267,14 +290,15 @@ void SofaPluginManager::updateDescription()
 
 void SofaPluginManager::savePluginsToIniFile()
 {
-    const std::string pluginsIniFile = sofa::gui::common::BaseGUI::getConfigDirectoryPath() + "/loadedPlugins.ini";
-    sofa::helper::system::PluginManager::getInstance().writeToIniFile(pluginsIniFile);
+    m_pluginsIniFile = sofa::gui::common::BaseGUI::getConfigDirectoryPath() + "/loadedPlugins.ini";
+    sofa::helper::system::PluginManager::getInstance().writeToIniFile(m_pluginsIniFile);
 }
 
 void SofaPluginManager::loadPluginsFromIniFile()
 {
-    const std::string pluginsIniFile = sofa::gui::common::BaseGUI::getConfigDirectoryPath() + "/loadedPlugins.ini";
-    sofa::helper::system::PluginManager::getInstance().readFromIniFile(pluginsIniFile);
+    m_pluginsIniFile = sofa::gui::common::BaseGUI::getConfigDirectoryPath() + "/loadedPlugins.ini";
+    msg_info("SofaPluginManager") << "Loading automatically plugin list in " << m_pluginsIniFile;
+    sofa::helper::system::PluginManager::getInstance().readFromIniFile(m_pluginsIniFile, m_loadedPlugins);
 }
 
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.h
@@ -26,6 +26,8 @@
 
 #include <set>
 
+#include <sofa/type/vector.h>
+
 
 namespace sofa::gui::qt
 {
@@ -53,6 +55,9 @@ public:
     void updatePluginsListView();
 private:
     void savePluginsToIniFile();
+
+    std::string m_pluginsIniFile;
+    type::vector<std::string> m_loadedPlugins;
     void loadPluginsFromIniFile();
 };
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.h
@@ -56,8 +56,8 @@ public:
 private:
     void savePluginsToIniFile();
 
-    std::string m_pluginsIniFile;
-    type::vector<std::string> m_loadedPlugins;
+    std::string m_pluginsIniFile; ///< path to the saved/loaded list of plugins by SofaPluginManager
+    type::vector<std::string> m_loadedPlugins; ///< list of plugins loaded by SofaPluginManager
     void loadPluginsFromIniFile();
 };
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -159,7 +159,7 @@ std::string PluginManager::getDefaultSuffix()
 #endif
 }
 
-auto PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream* errlog) -> PluginLoadStatus
+PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream* errlog)
 {
     if (pluginIsLoaded(pluginPath))
     {

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -89,6 +89,12 @@ PluginManager::~PluginManager()
 
 void PluginManager::readFromIniFile(const std::string& path)
 {
+    type::vector<std::string> loadedPlugins;
+    readFromIniFile(path, loadedPlugins);
+}
+
+void PluginManager::readFromIniFile(const std::string& path, type::vector<std::string>& listLoadedPlugins)
+{
     std::ifstream instream(path.c_str());
     std::string plugin, line, version;
     while(std::getline(instream, line))
@@ -101,16 +107,18 @@ void PluginManager::readFromIniFile(const std::string& path)
             msg_deprecated("PluginManager") << path << " file is using a deprecated syntax (version information missing). Please update it in the near future.";
         else
             is >> version; // information not used for now
-        if(loadPlugin(plugin))
+        if (loadPlugin(plugin) == PluginLoadStatus::SUCCESS)
         {
             Plugin* p = getPlugin(plugin);
             if(p) // should always be true as we are protected by if(loadPlugin(...))
             {
                 p->initExternalModule();
+                listLoadedPlugins.push_back(plugin);
             }
         }
     }
     instream.close();
+    msg_info("PluginManager") << listLoadedPlugins.size() << " plugins have been loaded from " << path;
 }
 
 void PluginManager::writeToIniFile(const std::string& path)
@@ -151,11 +159,13 @@ std::string PluginManager::getDefaultSuffix()
 #endif
 }
 
-bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream* errlog)
+auto PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream* errlog) -> PluginLoadStatus
 {
     if (pluginIsLoaded(pluginPath))
     {
-        return true;
+        const std::string msg = "Plugin '" + pluginPath + "' is already loaded";
+        if (errlog) (*errlog) << msg << std::endl;
+        return PluginLoadStatus::ALREADY_LOADED;
     }
 
     if (!FileSystem::exists(pluginPath))
@@ -163,7 +173,7 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
         const std::string msg = "File not found: " + pluginPath;
         msg_error("PluginManager") << msg;
         if (errlog) (*errlog) << msg << std::endl;
-        return false;
+        return PluginLoadStatus::PLUGIN_FILE_NOT_FOUND;
     }
 
     DynamicLibrary::Handle d  = DynamicLibrary::load(pluginPath);
@@ -173,7 +183,7 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
         const std::string msg = "Plugin loading failed (" + pluginPath + "): " + DynamicLibrary::getLastError();
         msg_error("PluginManager") << msg;
         if (errlog) (*errlog) << msg << std::endl;
-        return false;
+        return PluginLoadStatus::INVALID_LOADING;
     }
     else
     {
@@ -182,13 +192,13 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
             const std::string msg = "Plugin loading failed (" + pluginPath + "): function initExternalModule() not found";
             msg_error("PluginManager") << msg;
             if (errlog) (*errlog) << msg << std::endl;
-            return false;
+            return PluginLoadStatus::MISSING_SYMBOL;
         }
         getPluginEntry(p.getModuleName,d);
 
         if (checkDuplicatedPlugin(p, pluginPath))
         {
-            return true;
+            return PluginLoadStatus::ALREADY_LOADED;
         }
 
         getPluginEntry(p.getModuleDescription,d);
@@ -211,7 +221,7 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
             if (errlog) (*errlog) << msg << std::endl;
 
             unloadPlugin(pluginPath);
-            return false;
+            return PluginLoadStatus::INIT_ERROR;
         }
     }
 
@@ -225,7 +235,7 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
         }
     }
 
-    return true;
+    return PluginLoadStatus::SUCCESS;
 }
 
 void PluginManager::addOnPluginLoadedCallback(const std::string& key, std::function<void(const std::string&, const Plugin&)> callback)
@@ -253,34 +263,38 @@ std::string PluginManager::GetPluginNameFromPath(const std::string& pluginPath)
     return sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(pluginPath.c_str());;
 }
 
-bool PluginManager::loadPluginByName(const std::string& pluginName, const std::string& suffix, bool ignoreCase, bool recursive, std::ostream* errlog)
+auto PluginManager::loadPluginByName(const std::string& pluginName, const std::string& suffix, bool ignoreCase,
+                                     bool recursive, std::ostream* errlog) -> PluginLoadStatus
 {
-    std::string pluginPath = findPlugin(pluginName, suffix, ignoreCase, recursive);
+    const std::string pluginPath = findPlugin(pluginName, suffix, ignoreCase, recursive);
 
     if (!pluginPath.empty())
     {
         return loadPluginByPath(pluginPath, errlog);
     }
+
+    const std::string msg = "Plugin not found: \"" + pluginName + suffix + "\"";
+    if (errlog)
+    {
+        (*errlog) << msg << std::endl;
+    }
     else
     {
-        const std::string msg = "Plugin not found: \"" + pluginName + suffix + "\"";
-        if (errlog) (*errlog) << msg << std::endl;
-        else msg_error("PluginManager") << msg;
-
-        return false;
+        msg_error("PluginManager") << msg;
     }
+
+    return PluginLoadStatus::PLUGIN_FILE_NOT_FOUND;
 }
 
-bool PluginManager::loadPlugin(const std::string& plugin, const std::string& suffix, bool ignoreCase, bool recursive, std::ostream* errlog)
+auto PluginManager::loadPlugin(const std::string& plugin, const std::string& suffix, bool ignoreCase, bool recursive,
+                               std::ostream* errlog) -> PluginLoadStatus
 {
     if (FileSystem::isFile(plugin))
     {
         return loadPluginByPath(plugin,  errlog);
     }
-    else
-    {
-        return loadPluginByName(plugin, suffix, ignoreCase, recursive, errlog);
-    }
+
+    return loadPluginByName(plugin, suffix, ignoreCase, recursive, errlog);
 }
 
 bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* errlog)
@@ -326,7 +340,7 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /
             }
         }
 
-        msg_info("PluginManager") << "Plugin not found in loaded plugins: " << plugin;
+        msg_warning("PluginManager") << "Plugin not found in loaded plugins: " << plugin;
         return nullptr;
     }
 }
@@ -336,13 +350,13 @@ Plugin* PluginManager::getPluginByName(const std::string& pluginName)
     for (PluginMap::iterator itP = m_pluginMap.begin(); itP != m_pluginMap.end(); ++itP)
     {
         std::string name(itP->second.getModuleName());
-        if (name.compare(pluginName) == 0)
+        if (name == pluginName)
         {
             return &itP->second;
         }
     }
 
-    msg_info("PluginManager") << "Plugin not found in loaded plugins: " << pluginName;
+    msg_warning("PluginManager") << "Plugin not found in loaded plugins: " << pluginName;
     return nullptr;
 }
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -29,6 +29,8 @@
 #include <memory>
 #include <functional>
 
+#include <sofa/type/vector.h>
+
 namespace sofa
 {
 namespace helper
@@ -155,6 +157,16 @@ public:
     /// Returns "_d" in debug configuration and an empty string otherwise 
     static std::string getDefaultSuffix();
 
+    enum class PluginLoadStatus : sofa::Size
+    {
+        SUCCESS,
+        ALREADY_LOADED,
+        PLUGIN_FILE_NOT_FOUND,
+        INVALID_LOADING,
+        MISSING_SYMBOL,
+        INIT_ERROR
+    };
+
     
     /// Loads a plugin library in process memory. 
     /// @param plugin Can be just the filename of the library to load (without extension) or the full path
@@ -162,12 +174,12 @@ public:
     /// @param ignoreCase Specify if the plugin search should be case insensitive (activated by default). 
     ///                   Not used if the plugin string passed as a parameter is a full path
     /// @param errlog An optional stream for error logging.
-    bool loadPlugin(const std::string& plugin, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog = nullptr);
-    
+    PluginLoadStatus loadPlugin(const std::string& plugin, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog = nullptr);
+
     /// Loads a plugin library in process memory. 
     /// @param path The full path of the plugin to load
     /// @param errlog An optional stream for error logging.
-    bool loadPluginByPath(const std::string& path, std::ostream* errlog= nullptr);
+    PluginLoadStatus loadPluginByPath(const std::string& path, std::ostream* errlog= nullptr);
     
     /// Loads a plugin library in process memory. 
     /// @param pluginName The filename without extension of the plugin to load
@@ -175,7 +187,7 @@ public:
     /// @param ignoreCase Specify if the plugin search should be case insensitive (activated by default). 
     ///                   Not used if the plugin string passed as a parameter is a full path
     /// @param errlog An optional stream for error logging.
-    bool loadPluginByName(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog= nullptr);
+    PluginLoadStatus loadPluginByName(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog= nullptr);
     
     /// Unloads a plugin from process memory.
     bool unloadPlugin(const std::string& path, std::ostream* errlog= nullptr);
@@ -202,6 +214,7 @@ public:
     Plugin* getPluginByName(const std::string& pluginName);
 
     void readFromIniFile(const std::string& path);
+    void readFromIniFile(const std::string& path, type::vector<std::string>& listLoadedPlugins);
     void writeToIniFile(const std::string& path);
 
     static std::string s_gui_postfix; ///< the postfix to gui plugin, default="gui" (e.g. myplugin_gui.so)

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -157,7 +157,7 @@ public:
     /// Returns "_d" in debug configuration and an empty string otherwise 
     static std::string getDefaultSuffix();
 
-    enum class PluginLoadStatus : sofa::Size
+    enum class PluginLoadStatus : unsigned char
     {
         SUCCESS,
         ALREADY_LOADED,

--- a/Sofa/framework/Helper/test/system/PluginManager_test.cpp
+++ b/Sofa/framework/Helper/test/system/PluginManager_test.cpp
@@ -112,7 +112,7 @@ TEST_F(PluginManager_test, loadTestPluginByPath)
         std::cout << "PluginManager_test.loadTestPluginByPath: "
                   << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
                   << std::endl;
-        ASSERT_TRUE(pm.loadPluginByPath(pluginPath));
+        ASSERT_EQ(pm.loadPluginByPath(pluginPath), PluginManager::PluginLoadStatus::SUCCESS);
         ASSERT_GT(pm.findPlugin(pluginName).size(), 0u);
     }
 
@@ -125,7 +125,7 @@ TEST_F(PluginManager_test, loadTestPluginByPath)
         std::cout << "PluginManager_test.loadTestPluginByPath: "
                   << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
                   << std::endl;
-        ASSERT_FALSE(pm.loadPluginByPath(nonpluginPath));
+        ASSERT_EQ(pm.loadPluginByPath(nonpluginPath), PluginManager::PluginLoadStatus::PLUGIN_FILE_NOT_FOUND);
         ASSERT_EQ(pm.findPlugin(nonpluginName).size(), 0u);
         std::cout << "PluginManager_test.loadTestPluginByPath: "
                   << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
@@ -142,7 +142,7 @@ TEST_F(PluginManager_test, loadTestPluginByName )
     {
         EXPECT_MSG_NOEMIT(Warning, Error);
 
-        ASSERT_TRUE(pm.loadPluginByName(pluginName) );
+        ASSERT_EQ(pm.loadPluginByName(pluginName), PluginManager::PluginLoadStatus::SUCCESS );
         std::string pluginPath = pm.findPlugin(pluginName);
         ASSERT_GT(pluginPath.size(), 0u);
     }
@@ -152,7 +152,7 @@ TEST_F(PluginManager_test, loadTestPluginByName )
     {
         EXPECT_MSG_NOEMIT(Warning);
         EXPECT_MSG_EMIT(Error);
-        ASSERT_FALSE(pm.loadPluginByName(nonpluginName));
+        ASSERT_EQ(pm.loadPluginByName(nonpluginName), PluginManager::PluginLoadStatus::PLUGIN_FILE_NOT_FOUND);
 
         ASSERT_EQ(pm.findPlugin(nonpluginName).size(), 0u);
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
@@ -113,8 +113,13 @@ bool RequiredPlugin::loadPlugin()
         bool isNameLoaded = false;
         for (const auto& suffix : suffixVec)
         {
-            if ( pluginManager.pluginIsLoaded(name) || 
-                 pluginManager.loadPlugin(name, suffix, true, true, &errmsg) )
+            bool isPluginLoaded = pluginManager.pluginIsLoaded(name);
+            if (!isPluginLoaded)
+            {
+                const auto status = pluginManager.loadPlugin(name, suffix, true, true, &errmsg);
+                isPluginLoaded = (status == PluginManager::PluginLoadStatus::SUCCESS || status == PluginManager::PluginLoadStatus::ALREADY_LOADED);
+            }
+            if (isPluginLoaded)
             {
                 loadedPlugins.push_back(name);
                 isNameLoaded = true;

--- a/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/SimpleApi.cpp
+++ b/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/SimpleApi.cpp
@@ -44,7 +44,8 @@ namespace sofa::simpleapi
 
 bool importPlugin(const std::string& name)
 {
-    return PluginManager::getInstance().loadPlugin(name) ;
+    const auto status = PluginManager::getInstance().loadPlugin(name);
+    return status == PluginManager::PluginLoadStatus::SUCCESS || status == PluginManager::PluginLoadStatus::ALREADY_LOADED;
 }
 
 void dumpScene(Node::SPtr root)

--- a/Sofa/framework/Testing/src/sofa/testing/BaseSimulationTest.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/BaseSimulationTest.cpp
@@ -40,7 +40,8 @@ namespace sofa::testing
 
 bool BaseSimulationTest::importPlugin(const std::string& name)
 {
-    return PluginManager::getInstance().loadPlugin(name) ;
+    const auto status = PluginManager::getInstance().loadPlugin(name);
+    return status == PluginManager::PluginLoadStatus::SUCCESS || status == PluginManager::PluginLoadStatus::ALREADY_LOADED;
 }
 
 BaseSimulationTest::SceneInstance::SceneInstance(const std::string& type, const std::string& desc)

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -387,11 +387,11 @@ int main(int argc, char** argv)
     for (unsigned int i=0; i<plugins.size(); i++)
         PluginManager::getInstance().loadPlugin(plugins[i]);
 
-    std::string configPluginPath = sofa_tostring(CONFIG_PLUGIN_FILENAME);
-    std::string defaultConfigPluginPath = sofa_tostring(DEFAULT_CONFIG_PLUGIN_FILENAME);
-
     if (!noAutoloadPlugins)
     {
+        std::string configPluginPath = sofa_tostring(CONFIG_PLUGIN_FILENAME);
+        std::string defaultConfigPluginPath = sofa_tostring(DEFAULT_CONFIG_PLUGIN_FILENAME);
+
         if (PluginRepository.findFile(configPluginPath, "", nullptr))
         {
             msg_info("runSofa") << "Loading automatically plugin list in " << configPluginPath;
@@ -403,10 +403,14 @@ int main(int argc, char** argv)
             PluginManager::getInstance().readFromIniFile(defaultConfigPluginPath);
         }
         else
+        {
             msg_info("runSofa") << "No plugin list found. No plugin will be automatically loaded.";
+        }
     }
     else
+    {
         msg_info("runSofa") << "Automatic plugin loading disabled.";
+    }
 
     PluginManager::getInstance().init();
 


### PR DESCRIPTION
- `loadPlugin` and `loadPluginByPath` return an enum: more detailed than a boolean
- `readFromIniFile` returns the list of plugins that have been loaded
- The plugin manager GUI highlights which plugins have been loaded in the GUI initialization (not the autoload file). Black text is for plugins that have been loaded prior the GUI initialization, or after. Blue for plugins loaded during init. See screenshot
- More log messages

![image](https://user-images.githubusercontent.com/10572752/177587029-83209468-2213-4601-8e30-5b39bd331a2e.png)




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
