### PR TITLE
[Sofa.Component] Put the initilization code in init() instead of the entrypoint initExternalPlugin()

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/init.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::animationloop

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/init.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/init.cpp
@@ -32,11 +32,8 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
+
 }
 
 const char* getModuleName()
@@ -51,7 +48,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+     first = false;
+    }
 }
 
 } // namespace sofa::component::collision::detection::algorithm

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/init.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::collision::detection::intersection

--- a/Sofa/Component/Collision/Detection/src/sofa/component/collision/detection/init.cpp
+++ b/Sofa/Component/Collision/Detection/src/sofa/component/collision/detection/init.cpp
@@ -35,15 +35,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {        
-        // force dependencies at compile-time
-        sofa::component::collision::detection::algorithm::init();
-        sofa::component::collision::detection::intersection::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -58,7 +50,15 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::collision::detection::algorithm::init();
+        sofa::component::collision::detection::intersection::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::collision::detection

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/init.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::collision::geometry

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/init.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::collision::response::contact

--- a/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/init.cpp
+++ b/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::collision::response::mapper

--- a/Sofa/Component/Collision/Response/src/sofa/component/collision/response/init.cpp
+++ b/Sofa/Component/Collision/Response/src/sofa/component/collision/response/init.cpp
@@ -35,15 +35,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {        
-        // force dependencies at compile-time
-        sofa::component::collision::response::mapper::init();
-        sofa::component::collision::response::contact::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -58,7 +50,15 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::collision::response::mapper::init();
+        sofa::component::collision::response::contact::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::collision::response

--- a/Sofa/Component/Collision/src/sofa/component/collision/init.cpp
+++ b/Sofa/Component/Collision/src/sofa/component/collision/init.cpp
@@ -36,16 +36,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        // force dependencies at compile-time
-        sofa::component::collision::geometry::init();
-        sofa::component::collision::detection::init();
-        sofa::component::collision::response::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -60,7 +51,16 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::collision::geometry::init();
+        sofa::component::collision::detection::init();
+        sofa::component::collision::response::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::collision

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::constraint::lagrangian::correction

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::constraint::lagrangian::model

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/src/sofa/component/constraint/lagrangian/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/src/sofa/component/constraint/lagrangian/init.cpp
@@ -36,15 +36,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {        
-        // force dependencies at compile-time
-        sofa::component::constraint::lagrangian::model::init();
-        sofa::component::constraint::lagrangian::correction::init();
-        sofa::component::constraint::lagrangian::solver::init();
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -59,7 +51,15 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::constraint::lagrangian::model::init();
+        sofa::component::constraint::lagrangian::correction::init();
+        sofa::component::constraint::lagrangian::solver::init();
+        first = false;
+    }
 }
 
 } // namespace sofa::component::constraint::lagrangian

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/init.cpp
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/src/sofa/component/constraint/init.cpp
+++ b/Sofa/Component/Constraint/src/sofa/component/constraint/init.cpp
@@ -35,15 +35,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {        
-        // force dependencies at compile-time
-        sofa::component::constraint::lagrangian::init();
-        sofa::component::constraint::projective::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -58,7 +50,15 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::constraint::lagrangian::init();
+        sofa::component::constraint::projective::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::constraint

--- a/Sofa/Component/Controller/src/sofa/component/controller/init.cpp
+++ b/Sofa/Component/Controller/src/sofa/component/controller/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::controller

--- a/Sofa/Component/Diffusion/src/sofa/component/diffusion/init.cpp
+++ b/Sofa/Component/Diffusion/src/sofa/component/diffusion/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::diffusion

--- a/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/init.cpp
+++ b/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::engine::analyze

--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/init.cpp
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::engine::generate

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/init.cpp
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::engine::select

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/init.cpp
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::engine::transform

--- a/Sofa/Component/Engine/src/sofa/component/engine/init.cpp
+++ b/Sofa/Component/Engine/src/sofa/component/engine/init.cpp
@@ -37,17 +37,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {        
-        // force dependencies at compile-time
-        sofa::component::engine::analyze::init();
-        sofa::component::engine::generate::init();
-        sofa::component::engine::select::init();
-        sofa::component::engine::transform::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -62,7 +52,17 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::engine::analyze::init();
+        sofa::component::engine::generate::init();
+        sofa::component::engine::select::init();
+        sofa::component::engine::transform::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::engine

--- a/Sofa/Component/Haptics/src/sofa/component/haptics/init.cpp
+++ b/Sofa/Component/Haptics/src/sofa/component/haptics/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::haptics

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/init.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::io::mesh

--- a/Sofa/Component/IO/src/sofa/component/io/init.cpp
+++ b/Sofa/Component/IO/src/sofa/component/io/init.cpp
@@ -34,14 +34,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {        
-        // force dependencies at compile-time
-        sofa::component::io::mesh::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -56,7 +49,14 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::io::mesh::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::io

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/init.cpp
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::linearsolver::direct

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/init.cpp
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::linearsolver::iterative

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/init.cpp
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::linearsolver::preconditioner

--- a/Sofa/Component/LinearSolver/src/sofa/component/linearsolver/init.cpp
+++ b/Sofa/Component/LinearSolver/src/sofa/component/linearsolver/init.cpp
@@ -36,16 +36,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        // force dependencies at compile-time
-        sofa::component::linearsolver::direct::init();
-        sofa::component::linearsolver::iterative::init();
-        sofa::component::linearsolver::preconditioner::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -60,7 +51,16 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::linearsolver::direct::init();
+        sofa::component::linearsolver::iterative::init();
+        sofa::component::linearsolver::preconditioner::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::linearsolver

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/init.cpp
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::mapping::linear

--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/init.cpp
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::mapping::mappedmatrix

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/init.cpp
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::mapping::nonlinear

--- a/Sofa/Component/Mapping/src/sofa/component/mapping/init.cpp
+++ b/Sofa/Component/Mapping/src/sofa/component/mapping/init.cpp
@@ -36,15 +36,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        sofa::component::mapping::linear::init();
-        sofa::component::mapping::nonlinear::init();
-        sofa::component::mapping::mappedmatrix::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -59,7 +51,15 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        sofa::component::mapping::linear::init();
+        sofa::component::mapping::nonlinear::init();
+        sofa::component::mapping::mappedmatrix::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::mapping

--- a/Sofa/Component/Mass/src/sofa/component/mass/init.cpp
+++ b/Sofa/Component/Mass/src/sofa/component/mass/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::mass

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/init.cpp
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::mechanicalload

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/init.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::odesolver::backward

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/init.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::odesolver::forward

--- a/Sofa/Component/ODESolver/src/sofa/component/odesolver/init.cpp
+++ b/Sofa/Component/ODESolver/src/sofa/component/odesolver/init.cpp
@@ -35,15 +35,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        // force dependencies at compile-time
-        sofa::component::odesolver::backward::init();
-        sofa::component::odesolver::forward::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -58,7 +50,15 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::odesolver::backward::init();
+        sofa::component::odesolver::forward::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::odesolver

--- a/Sofa/Component/Playback/src/sofa/component/playback/init.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::playback

--- a/Sofa/Component/Setting/src/sofa/component/setting/init.cpp
+++ b/Sofa/Component/Setting/src/sofa/component/setting/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::setting

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/init.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/init.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::solidmechanics::fem::hyperelastic

--- a/Sofa/Component/SolidMechanics/FEM/src/sofa/component/solidmechanics/fem/init.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/src/sofa/component/solidmechanics/fem/init.cpp
@@ -35,15 +35,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        // force dependencies at compile-time
-        sofa::component::solidmechanics::fem::elastic::init();
-        sofa::component::solidmechanics::fem::hyperelastic::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -58,7 +50,15 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::solidmechanics::fem::elastic::init();
+        sofa::component::solidmechanics::fem::hyperelastic::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::solidmechanics::fem

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/init.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/init.cpp
+++ b/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::solidmechanics::tensormass

--- a/Sofa/Component/SolidMechanics/src/sofa/component/solidmechanics/init.cpp
+++ b/Sofa/Component/SolidMechanics/src/sofa/component/solidmechanics/init.cpp
@@ -36,16 +36,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        // force dependencies at compile-time
-        sofa::component::solidmechanics::spring::init();
-        sofa::component::solidmechanics::fem::init();
-        sofa::component::solidmechanics::tensormass::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -60,7 +51,16 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::solidmechanics::spring::init();
+        sofa::component::solidmechanics::fem::init();
+        sofa::component::solidmechanics::tensormass::init();
+
+        first = false;
+    }
 }
 
 } // namespace sofa::component::solidmechanics

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/init.cpp
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::statecontainer

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/init.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::topology::container::constant

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/init.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/init.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::topology::container::grid

--- a/Sofa/Component/Topology/Container/src/sofa/component/topology/container/init.cpp
+++ b/Sofa/Component/Topology/Container/src/sofa/component/topology/container/init.cpp
@@ -36,16 +36,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        // force dependencies at compile-time
-        sofa::component::topology::container::constant::init();
-        sofa::component::topology::container::dynamic::init();
-        sofa::component::topology::container::grid::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -60,7 +51,16 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::topology::container::constant::init();
+        sofa::component::topology::container::dynamic::init();
+        sofa::component::topology::container::grid::init();
+
+        first = false;
+    }
 }
 
 

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/init.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::topology::mapping

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/init.cpp
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::topology::utility

--- a/Sofa/Component/Topology/src/sofa/component/topology/init.cpp
+++ b/Sofa/Component/Topology/src/sofa/component/topology/init.cpp
@@ -36,16 +36,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        // force dependencies at compile-time
-        sofa::component::topology::container::init();
-        sofa::component::topology::mapping::init();
-        sofa::component::topology::utility::init();
-
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -60,7 +51,16 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        // force dependencies at compile-time
+        sofa::component::topology::container::init();
+        sofa::component::topology::mapping::init();
+        sofa::component::topology::utility::init();
+
+        first = false;
+    }
 }
 
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/init.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/init.cpp
@@ -32,11 +32,7 @@ extern "C" {
 
 void initExternalModule()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+    init();
 }
 
 const char* getModuleName()
@@ -51,7 +47,11 @@ const char* getModuleVersion()
 
 void init()
 {
-    initExternalModule();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 } // namespace sofa::component::visual

--- a/Sofa/Component/src/sofa/component/init.cpp
+++ b/Sofa/Component/src/sofa/component/init.cpp
@@ -54,6 +54,21 @@ extern "C" {
 
 void initExternalModule()
 {
+    init();
+}
+
+const char* getModuleName()
+{
+    return MODULE_NAME;
+}
+
+const char* getModuleVersion()
+{
+    return MODULE_VERSION;
+}
+
+void init()
+{
     static bool first = true;
     if (first)
     {
@@ -77,24 +92,9 @@ void initExternalModule()
         sofa::component::statecontainer::init();
         sofa::component::topology::init();
         sofa::component::visual::init();
-        
+
         first = false;
     }
-}
-
-const char* getModuleName()
-{
-    return MODULE_NAME;
-}
-
-const char* getModuleVersion()
-{
-    return MODULE_VERSION;
-}
-
-void init()
-{
-    initExternalModule();
 }
 
 } // namespace sofa::component


### PR DESCRIPTION
Investigation from the problem I got with regression, which was that the sofa::component::init()
In GCC, it was crashing, whereas on clang/msvc it was not.

After debugging, it appears that there was a infinite loop when calling all the init() of the submodules.
E.g Sofa.Component calls sofa::component::collision::init() which calls initExternalModule of Sofa.Component.Collision. 
But with gcc, it was not calling initExternalModule() of Sofa.Component.Collision but the one of Sofa.Component. and then tries to call again init() etc.

I suspect problems with demangling the function name in the binary (extern "C") and stuff like that, but I did not go further.
The solution anyway is to put the call of the initialization in init() and not in initExternalModule() (and not vice versa)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
