### PR TITLE
[All] Remove warnings

### DIFF
--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/GenerateGrid.inl
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/GenerateGrid.inl
@@ -90,7 +90,7 @@ void GenerateGrid<DataTypes>::doUpdate()
     Coord origin;
 
     const auto& minCorder = d_minCorner.getValue();
-    for (auto i = 0; i < Coord::spatial_dimensions; i++)
+    for (sofa::Index i = 0; i < Coord::spatial_dimensions; i++)
     {
         origin[i] = minCorder[i];
     }
@@ -107,7 +107,7 @@ void GenerateGrid<DataTypes>::doUpdate()
             for(i=0;i<=freqL;i++) {
                 // handle Vec2D case
                 const Vec3 t { i * length, j * width, k * height };
-                for (auto c = 0; c < Coord::spatial_dimensions; c++)
+                for (sofa::Index c = 0; c < Coord::spatial_dimensions; c++)
                 {
                     pos[c] = t[c];
                 }

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/AsyncSparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/AsyncSparseLDLSolver.inl
@@ -91,6 +91,8 @@ void AsyncSparseLDLSolver<TMatrix, TVector, TThreadManager>::solveSystem()
 template <class TMatrix, class TVector, class TThreadManager>
 void AsyncSparseLDLSolver<TMatrix, TVector, TThreadManager>::solve(Matrix& M, Vector& x, Vector& b)
 {
+    SOFA_UNUSED(M);
+
     Inherit1::solve_cpu(&x[0],&b[0], m_mainThreadInvertData);
 }
 
@@ -104,6 +106,8 @@ template <class TMatrix, class TVector, class TThreadManager>
 bool AsyncSparseLDLSolver<TMatrix, TVector, TThreadManager>::addJMInvJtLocal(TMatrix* M, ResMatrixType* result,
     const JMatrixType* J, SReal fact)
 {
+    SOFA_UNUSED(M);
+
     if (newInvertDataReady)
     {
         swapInvertData();

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/SSORPreconditioner.cpp
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/SSORPreconditioner.cpp
@@ -40,7 +40,6 @@ void SSORPreconditioner<linearalgebra::CompressedRowSparseMatrix<SReal>, lineara
     const Index n = M.rowSize();
     const Real w = (Real)f_omega.getValue();
 
-    const Matrix::VecIndex& rowIndex = M.getRowIndex();
     const Matrix::VecIndex& colsIndex = M.getColsIndex();
     const Matrix::VecBlock& colsValue = M.getColsValue();
     // Solve (D/w+U) * t = r;
@@ -85,13 +84,11 @@ void SSORPreconditioner< linearalgebra::CompressedRowSparseMatrix< type::Mat<3,3
 {
     SSORPreconditionerInvertData * data = (SSORPreconditionerInvertData *) this->getMatrixInvertData(&M);
 
-    static constexpr std::size_t BlocSize = 3;
+    static constexpr sofa::Size BlocSize = 3;
 
-    const Index n = M.rowSize();
     const Index nb = M.rowBSize();
     const Real w = (Real)f_omega.getValue();
 
-    const Matrix::VecIndex& rowIndex = M.getRowIndex();
     const typename Matrix::VecIndex& colsIndex = M.getColsIndex();
     const typename Matrix::VecBlock& colsValue = M.getColsValue();
     // Solve (D+U) * t = r;
@@ -111,7 +108,6 @@ void SSORPreconditioner< linearalgebra::CompressedRowSparseMatrix< type::Mat<3,3
             const typename Matrix::Block& b = colsValue[xi];
             for (Index j1=0; j1<BlocSize; ++j1)
             {
-                Index j = j0+j1;
                 for (Index i1=0; i1<BlocSize; ++i1)
                 {
                     Index i = i0+i1;
@@ -149,7 +145,6 @@ void SSORPreconditioner< linearalgebra::CompressedRowSparseMatrix< type::Mat<3,3
             const typename Matrix::Block& b = colsValue[xi];
             for (Index j1=0; j1<BlocSize; ++j1)
             {
-                Index j = j0+j1;
                 for (Index i1=0; i1<BlocSize; ++i1)
                 {
                     Index i = i0+i1;

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/WarpPreconditioner.inl
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/WarpPreconditioner.inl
@@ -117,7 +117,7 @@ void WarpPreconditioner<TMatrix,TVector,ThreadManager >::setSystemMBKMatrix(cons
         if (!this->linearSystem.systemMatrix) this->linearSystem.systemMatrix = this->createMatrix();
     }
 
-    if (first || d_updateStep.getValue() > 0 && nextRefreshStep >= d_updateStep.getValue() || d_updateStep.getValue() == 0)
+    if (first || ( d_updateStep.getValue() > 0 && nextRefreshStep >= d_updateStep.getValue()) || (d_updateStep.getValue() == 0))
     {
         realSolver->setSystemMBKMatrix(mparams);
         nextRefreshStep = 1;

--- a/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -1430,7 +1430,6 @@ void DiagonalMass<DataTypes, GeometricalTypes>::draw(const core::visual::VisualP
 
     std::vector<  sofa::type::Vector3 > points;
 
-    constexpr auto dimensions = std::min(static_cast<std::size_t>(GeometricalTypes::spatial_dimensions), static_cast<std::size_t>(3));
     for (unsigned int i = 0; i < x.size(); i++)
     {
         sofa::type::Vector3 p;

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.cpp
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.cpp
@@ -43,9 +43,9 @@ Vector6 MeshMatrixMass<Vec3Types>::getMomentum ( const core::MechanicalParams*, 
     for( unsigned int i=0 ; i<v.size() ; i++ )
     {
         Deriv linearMomentum = v[i] * vertexMass[i];
-        for( int j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[j] += linearMomentum[j];
+        for( Index j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[j] += linearMomentum[j];
         Deriv angularMomentum = cross( x[i], linearMomentum );
-        for( int j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[3+j] += angularMomentum[j];
+        for( Index j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[3+j] += angularMomentum[j];
     }
 
     const auto& edges = l_topology->getEdges();
@@ -58,14 +58,14 @@ Vector6 MeshMatrixMass<Vec3Types>::getMomentum ( const core::MechanicalParams*, 
         const MassType m = edgeMass[i] * static_cast<MassType>(0.5);
 
         Deriv linearMomentum = v[v0] * m;
-        for( int j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[j] += linearMomentum[j];
+        for( Index j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[j] += linearMomentum[j];
         Deriv angularMomentum = cross( x[v0], linearMomentum );
-        for( int j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[3+j] += angularMomentum[j];
+        for( Index j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[3+j] += angularMomentum[j];
 
         linearMomentum = v[v1] * m;
-        for( int j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[j] += linearMomentum[j];
+        for( Index j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[j] += linearMomentum[j];
         angularMomentum = cross( x[v1], linearMomentum );
-        for( int j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[3+j] += angularMomentum[j];
+        for( Index j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[3+j] += angularMomentum[j];
     }
 
     return momentum;

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -120,6 +120,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTriangleCreatio
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -176,6 +178,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTriangleCreation(
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -327,6 +331,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassQuadCreation(co
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -384,6 +390,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassQuadCreation(cons
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -541,6 +549,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTetrahedronCrea
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -598,6 +608,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTetrahedronCreati
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -753,6 +765,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassHexahedronCreat
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -814,6 +828,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassHexahedronCreatio
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs)
 {
+    SOFA_UNUSED(elems);
+
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
@@ -2292,12 +2308,12 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::draw(const core::visual::Visua
     Real totalMass=0.0;
 
     std::vector<  type::Vector3 > points;
-    constexpr auto dimensions = std::min(static_cast<std::size_t>(GeometricalTypes::spatial_dimensions), static_cast<std::size_t>(3));
+    constexpr sofa::Size dimensions = std::min(static_cast<sofa::Size>(GeometricalTypes::spatial_dimensions), static_cast<sofa::Size>(3));
     for (unsigned int i = 0; i < x.size(); i++)
     {
         const auto& position = GeometricalTypes::getCPos(x[i]);
         type::Vector3 p;
-        for (auto j = 0; j < dimensions; j++)
+        for (sofa::Index j = 0; j < dimensions; j++)
         {
             p[j] = position[j];
         }

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/PlaneForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/PlaneForceField.inl
@@ -208,8 +208,8 @@ void PlaneForceField<DataTypes>::addKToMatrix(const core::MechanicalParams* mpar
     for (unsigned int i=0; i<this->m_contacts.size(); i++)
     {
         unsigned int p = this->m_contacts[i];
-        for (int l=0; l<Deriv::total_size; ++l)
-            for (int c=0; c<Deriv::total_size; ++c)
+        for (sofa::Index l=0; l<Deriv::total_size; ++l)
+            for (sofa::Index c=0; c<Deriv::total_size; ++c)
             {
                 SReal coef = normal[l] * fact * normal[c];
                 mat->add(offset + p*Deriv::total_size + l, offset + p*Deriv::total_size + c, coef);

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SphereForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SphereForceField.inl
@@ -114,8 +114,8 @@ void SphereForceField<DataTypes>::addKToMatrix(sofa::linearalgebra::BaseMatrix *
     {
         const Contact& c = (this->contacts.getValue())[i];
         unsigned int p = c.index;
-        for (int l=0; l<Deriv::total_size; ++l)
-            for (int k=0; k<Deriv::total_size; ++k)
+        for (sofa::Index l=0; l<Deriv::total_size; ++l)
+            for (sofa::Index k=0; k<Deriv::total_size; ++k)
             {
                 SReal coef = (c.normal[l] * c.normal[k] * c.fact + (l==k ? (1 - c.fact) : (SReal)0.0)) * fact;
                 mat->add(offset + p*Deriv::total_size + l, offset + p*Deriv::total_size + k, coef);

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -253,7 +253,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::init()
 template <class DataTypes>
 void FastTetrahedralCorotationalForceField<DataTypes>::updateTopologyInformation()
 {
-    int nbTetrahedra=m_topology->getNbTetrahedra();
+    sofa::Size nbTetrahedra=m_topology->getNbTetrahedra();
 
     helper::WriteOnlyAccessor< Data< VecTetrahedronRestInformation > > tetrahedronInf = tetrahedronInfo;
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
@@ -211,17 +211,17 @@ protected:
     type::vector<type::fixed_array<Coord,8> > _rotatedInitialElements;   ///< The initials positions in its frame
     type::vector<Transformation> _rotations;
     type::vector<Transformation> _initialrotations;
-    void initLarge(int i, const Element&elem);
+    void initLarge(sofa::Index i, const Element&elem);
     static void computeRotationLarge( Transformation &r, Coord &edgex, Coord &edgey);
     virtual void accumulateForceLarge( WDataRefVecDeriv &f, RDataRefVecCoord &p, sofa::Index i, const Element&elem  );
 
     ////////////// polar decomposition method
-    void initPolar(int i, const Element&elem);
+    void initPolar(sofa::Index i, const Element&elem);
     void computeRotationPolar( Transformation &r, type::Vec<8,Coord> &nodes);
     virtual void accumulateForcePolar( WDataRefVecDeriv &f, RDataRefVecCoord &p, sofa::Index i, const Element&elem  );
 
     ////////////// small decomposition method
-    void initSmall(int i, const Element&elem);
+    void initSmall(sofa::Index i, const Element&elem);
     virtual void accumulateForceSmall( WDataRefVecDeriv &f, RDataRefVecCoord &p, sofa::Index i, const Element&elem  );
 
     bool _alreadyInit;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
@@ -166,7 +166,7 @@ void HexahedronFEMForceField<DataTypes>::reinit()
     {
     case LARGE :
     {
-        unsigned int i=0;
+        sofa::Index i=0;
         typename VecElement::const_iterator it;
         for(it = this->getIndexedElements()->begin() ; it != this->getIndexedElements()->end() ; ++it, ++i)
         {
@@ -177,7 +177,7 @@ void HexahedronFEMForceField<DataTypes>::reinit()
     }
     case POLAR :
     {
-        unsigned int i=0;
+        sofa::Index i=0;
         typename VecElement::const_iterator it;
         for(it = this->getIndexedElements()->begin() ; it != this->getIndexedElements()->end() ; ++it, ++i)
         {
@@ -188,7 +188,7 @@ void HexahedronFEMForceField<DataTypes>::reinit()
     }
     case SMALL :
     {
-        unsigned int i=0;
+        sofa::Index i=0;
         typename VecElement::const_iterator it;
         for(it = this->getIndexedElements()->begin() ; it != this->getIndexedElements()->end() ; ++it, ++i)
         {
@@ -736,7 +736,7 @@ void HexahedronFEMForceField<DataTypes>::computeForce( Displacement &F, const Di
 ////////////// small displacements method
 
 template<class DataTypes>
-void HexahedronFEMForceField<DataTypes>::initSmall(int i, const Element &elem)
+void HexahedronFEMForceField<DataTypes>::initSmall(sofa::Index i, const Element &elem)
 {
     // Rotation matrix identity
     Transformation t; t.identity();
@@ -801,7 +801,7 @@ void HexahedronFEMForceField<DataTypes>::accumulateForceSmall ( WDataRefVecDeriv
 /////////////////////////////////////////////////
 ////////////// large displacements method
 template<class DataTypes>
-void HexahedronFEMForceField<DataTypes>::initLarge(int i, const Element &elem)
+void HexahedronFEMForceField<DataTypes>::initLarge(sofa::Index i, const Element &elem)
 {
     // Rotation matrix (initial Tetrahedre/world)
     // edges mean on 3 directions
@@ -904,7 +904,7 @@ void HexahedronFEMForceField<DataTypes>::accumulateForceLarge( WDataRefVecDeriv 
 /////////////////////////////////////////////////
 ////////////// polar decomposition method
 template<class DataTypes>
-void HexahedronFEMForceField<DataTypes>::initPolar(int i, const Element& elem)
+void HexahedronFEMForceField<DataTypes>::initPolar(sofa::Index i, const Element& elem)
 {
     type::Vec<8,Coord> nodes;
     for(int j=0; j<8; ++j)

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
@@ -36,6 +36,11 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::createTetrahedronInformati
         const sofa::type::vector<Index>& ancestors,
         const sofa::type::vector<SReal>& coefs)
 {
+    SOFA_UNUSED(tInfo);
+    SOFA_UNUSED(tetra);
+    SOFA_UNUSED(ancestors);
+    SOFA_UNUSED(coefs);
+
     const core::topology::BaseMeshTopology::Tetrahedron t=this->m_topology->getTetrahedron(tetrahedronIndex);
     Index a = t[0];
     Index b = t[1];

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
@@ -794,7 +794,7 @@ void TriangularFEMForceField<DataTypes>::computeStress(type::Vec<3, Real>& stres
         m_triangleUtils.computeDisplacementLarge(D, R_0_2, triangleInf[elementIndex].rotatedInitialElements, p[a], p[b], p[c]);
 
         // and compute postions of a, b, c in the co-rotational frame
-        Coord A = Coord(0, 0, 0);
+        Coord A = Coord(0, 0, 0); SOFA_UNUSED(A);
         Coord B = R_0_2 * (p[b] - p[a]);
         Coord C = R_0_2 * (p[c] - p[a]);
 
@@ -1068,7 +1068,7 @@ void TriangularFEMForceField<DataTypes>::accumulateForceLarge(VecCoord& f, const
     type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginWriteOnly());
     sofa::Size nbTriangles = m_topology->getNbTriangles();
     auto triangles = m_topology->getTriangles();
-    for (int i = 0; i < nbTriangles; i++)
+    for (sofa::Index i = 0; i < nbTriangles; i++)
     {
         TriangleInformation& tInfo = triangleInf[i];
         const Triangle& tri = triangles[i];

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
@@ -555,7 +555,7 @@ type::fixed_array <typename TriangularFEMForceFieldOptim<DataTypes>::Coord, 3> T
 {
     sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleInfo > > triInfo = d_triangleInfo;
     type::fixed_array <Coord, 3> positions;
-    if (elemId < 0 && elemId >= triInfo.size())
+    if (elemId >= triInfo.size())
     {
         msg_warning() << "Method getRotatedInitialElement called with element index: " << elemId
             << " which is out of bounds: [0, " << triInfo.size() << "]. Returning default empty array of coordinates.";
@@ -575,7 +575,7 @@ template<class DataTypes>
 typename TriangularFEMForceFieldOptim<DataTypes>::Transformation TriangularFEMForceFieldOptim<DataTypes>::getRotationMatrix(Index elemId)
 {
     sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleState > > triState = d_triangleState;
-    if (elemId >= 0 && elemId < triState.size())
+    if (elemId < triState.size())
         return triState[elemId].frame;
 
     msg_warning() << "Method getRotationMatrix called with element index: "
@@ -588,7 +588,7 @@ template<class DataTypes>
 typename TriangularFEMForceFieldOptim<DataTypes>::MaterialStiffness TriangularFEMForceFieldOptim<DataTypes>::getMaterialStiffness(Index elemId)
 {
     sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleInfo > > triInfo = d_triangleInfo;
-    if (elemId < 0 && elemId >= triInfo.size())
+    if (elemId >= triInfo.size())
     {
         msg_warning() << "Method getMaterialStiffness called with element index: "
             << elemId << " which is out of bounds: [0, " << triInfo.size() << "]. Returning default empty matrix.";
@@ -614,7 +614,7 @@ template<class DataTypes>
 sofa::type::Vec3 TriangularFEMForceFieldOptim<DataTypes>::getStrainDisplacementFactors(Index elemId)
 {
     sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleInfo > > triInfo = d_triangleInfo;
-    if (elemId < 0 && elemId >= triInfo.size())
+    if (elemId >= triInfo.size())
     {
         msg_warning() << "Method getStrainDisplacementFactors called with element index: "
             << elemId << " which is out of bounds: [0, " << triInfo.size() << "]. Returning default empty displacements.";
@@ -629,7 +629,7 @@ template<class DataTypes>
 typename TriangularFEMForceFieldOptim<DataTypes>::Real TriangularFEMForceFieldOptim<DataTypes>::getTriangleFactor(Index elemId)
 {
     sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleInfo > > triInfo = d_triangleInfo;
-    if (elemId < 0 && elemId >= triInfo.size())
+    if (elemId >= triInfo.size())
     {
         msg_warning() << "Method getTriangleFactor called with element index: "
             << elemId << " which is out of bounds: [0, " << triInfo.size() << "]. Returning 0.";

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
@@ -393,6 +393,8 @@ void SpringForceField<DataTypes>::draw(const core::visual::VisualParams* vparams
 template <class DataTypes>
 void SpringForceField<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( !onlyVisible ) return;
 
     if (!this->mstate1 || !this->mstate2)
@@ -411,10 +413,11 @@ void SpringForceField<DataTypes>::computeBBox(const core::ExecParams* params, bo
 
     constexpr Real max_real = std::numeric_limits<Real>::max();
     constexpr Real min_real = std::numeric_limits<Real>::lowest();
+
     Real maxBBox[DataTypes::spatial_dimensions];
     Real minBBox[DataTypes::spatial_dimensions];
 
-    for (int c = 0; c < DataTypes::spatial_dimensions; ++c)
+    for (sofa::Index c = 0; c < DataTypes::spatial_dimensions; ++c)
     {
         maxBBox[c] = min_real;
         minBBox[c] = max_real;
@@ -434,7 +437,7 @@ void SpringForceField<DataTypes>::computeBBox(const core::ExecParams* params, bo
                 const auto& b = p2[spring.m2];
                 for (const auto& p : {a, b})
                 {
-                    for (int c = 0; c < DataTypes::spatial_dimensions; ++c)
+                    for (sofa::Index c = 0; c < DataTypes::spatial_dimensions; ++c)
                     {
                         if (p[c] > maxBBox[c])
                             maxBBox[c] = p[c];

--- a/Sofa/GUI/Common/src/sofa/gui/common/ColourPickingVisitor.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/ColourPickingVisitor.cpp
@@ -27,10 +27,10 @@
 #include <sofa/component/collision/geometry/SphereModel.h>
 #include <sofa/component/collision/geometry/TriangleModel.h>
 
-#if SOFAGUICOMMON_HAVE_SOFA_GL == 1
+#if SOFA_GUI_COMMON_HAVE_SOFA_GL == 1
 #include <sofa/gl/gl.h>
 #include <sofa/gl/BasicShapes.h>
-#endif // SOFAGUICOMMON_HAVE_SOFA_GL  == 1
+#endif // SOFA_GUI_COMMON_HAVE_SOFA_GL  == 1
 
 namespace sofa::gui::common
 {
@@ -110,7 +110,7 @@ void ColourPickingVisitor::processCollisionModel(simulation::Node*  node , core:
 
 void ColourPickingVisitor::processTriangleModel(simulation::Node * node, sofa::component::collision::geometry::TriangleCollisionModel<sofa::defaulttype::Vec3Types> * tmodel)
 {
-#if SOFAGUICOMMON_HAVE_SOFA_GL  == 1
+#if SOFA_GUI_COMMON_HAVE_SOFA_GL  == 1
     using namespace sofa::core::collision;
     using namespace sofa::defaulttype;
     glDisable(GL_LIGHTING);
@@ -140,7 +140,7 @@ void ColourPickingVisitor::processTriangleModel(simulation::Node * node, sofa::c
         for( int i=0 ; i<size; i++)
         {
             g = (float)i / (float)size;
-            component::collision::Triangle t(tmodel,i);
+            sofa::component::collision::geometry::Triangle t(tmodel,i);
             normals.push_back(t.n() );
             points.push_back( t.p1() );
             points.push_back( t.p2() );
@@ -153,7 +153,7 @@ void ColourPickingVisitor::processTriangleModel(simulation::Node * node, sofa::c
     case ENCODE_RELATIVEPOSITION:
         for( int i=0 ; i<size; i++)
         {
-            component::collision::Triangle t(tmodel,i);
+            sofa::component::collision::geometry::Triangle t(tmodel,i);
             normals.push_back(t.n() );
             points.push_back( t.p1() );
             points.push_back( t.p2() );
@@ -166,12 +166,15 @@ void ColourPickingVisitor::processTriangleModel(simulation::Node * node, sofa::c
     default: assert(false);
     }
     vparams->drawTool()->drawTriangles(points,normals,colours);
-#endif // SOFAGUICOMMON_HAVE_SOFA_GL  == 1
+#else
+    SOFA_UNUSED(node);
+    SOFA_UNUSED(tmodel);
+#endif // SOFA_GUI_COMMON_HAVE_SOFA_GL  == 1
 }
 
 void ColourPickingVisitor::processSphereModel(simulation::Node * node, sofa::component::collision::geometry::SphereCollisionModel<sofa::defaulttype::Vec3Types> * smodel)
 {
-#if SOFAGUICOMMON_HAVE_SOFA_GL  == 1
+#if SOFA_GUI_COMMON_HAVE_SOFA_GL  == 1
     typedef Sphere::Coord Coord;
 
     if( method == ENCODE_RELATIVEPOSITION ) return; // we pick the center of the sphere.
@@ -212,7 +215,10 @@ void ColourPickingVisitor::processSphereModel(simulation::Node * node, sofa::com
 
         glPopMatrix();
     }
-#endif // SOFAGUICOMMON_HAVE_SOFA_GL  == 1
+#else
+    SOFA_UNUSED(node);
+    SOFA_UNUSED(tmodel);
+#endif // SOFA_GUI_COMMON_HAVE_SOFA_GL  == 1
 }
 
 } // namespace sofa::gui::common

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyData.inl
@@ -241,6 +241,8 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::type::vector<Inde
     const sofa::type::vector<sofa::type::vector<SReal > >& coefs,
     const sofa::type::vector< AncestorElem >& ancestorElems)
 {
+    SOFA_UNUSED(ancestorElems);
+
     std::size_t nbElements = index.size();
     if (nbElements == 0) 
         return;

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -219,9 +219,10 @@ public:
     }
 
     /// Compile-time constant specifying the number of scalars within this vector (equivalent to the size() method)
-    enum { total_size = 6 };
+    static constexpr sofa::Size total_size = 6;
+
     /// Compile-time constant specifying the number of dimensions of space (NOT equivalent to total_size for rigids)
-    enum { spatial_dimensions = 3 };
+    static constexpr sofa::Size spatial_dimensions = 3;
 
     real* ptr() { return vCenter.ptr(); }
     const real* ptr() const { return vCenter.ptr(); }
@@ -664,9 +665,9 @@ public:
     }
 
     /// Compile-time constant specifying the number of scalars within this vector (equivalent to the size() method)
-    enum { total_size = 7 };
+    static constexpr sofa::Size total_size = 7;
     /// Compile-time constant specifying the number of dimensions of space (NOT equivalent to total_size for rigids)
-    enum { spatial_dimensions = 3 };
+    static constexpr sofa::Size spatial_dimensions = 3;
 
     real* ptr() { return center.ptr(); }
     const real* ptr() const { return center.ptr(); }
@@ -825,9 +826,9 @@ public:
     typedef typename Coord::Quat Quat;
     typedef type::Vec<3,Real> AngularVector;
 
-    enum { spatial_dimensions = Coord::spatial_dimensions };
-    enum { coord_total_size = Coord::total_size };
-    enum { deriv_total_size = Deriv::total_size };
+    static constexpr sofa::Size spatial_dimensions = Coord::spatial_dimensions;
+    static constexpr sofa::Size coord_total_size = Coord::total_size;
+    static constexpr sofa::Size deriv_total_size = Deriv::total_size;
 
     typedef typename Coord::Pos CPos;
     typedef typename Coord::Rot CRot;
@@ -1536,9 +1537,10 @@ public:
     }
 
     /// Compile-time constant specifying the number of scalars within this vector (equivalent to the size() method)
-    enum { total_size = 3 };
+    static constexpr sofa::Size total_size = 3;
+
     /// Compile-time constant specifying the number of dimensions of space (NOT equivalent to total_size for rigids)
-    enum { spatial_dimensions = 2 };
+    static constexpr sofa::Size spatial_dimensions = 2;
 
     real* ptr() { return center.ptr(); }
     const real* ptr() const { return center.ptr(); }
@@ -1708,9 +1710,9 @@ public:
     typedef RigidCoord<2,Real> Coord;
     typedef Real AngularVector;
 
-    enum { spatial_dimensions = Coord::spatial_dimensions };
-    enum { coord_total_size = Coord::total_size };
-    enum { deriv_total_size = Deriv::total_size };
+    static constexpr sofa::Size spatial_dimensions = Coord::spatial_dimensions;
+    static constexpr sofa::Size coord_total_size = Coord::total_size;
+    static constexpr sofa::Size deriv_total_size = Deriv::total_size;
 
     typedef typename Coord::Pos CPos;
     typedef typename Coord::Rot CRot;

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
@@ -49,9 +49,9 @@ public:
     typedef type::vector<Deriv> VecDeriv;
     typedef type::vector<Real> VecReal;
 
-    enum { spatial_dimensions = Coord::spatial_dimensions };
-    enum { coord_total_size = Coord::total_size };
-    enum { deriv_total_size = Deriv::total_size };
+    static constexpr sofa::Size spatial_dimensions = Coord::spatial_dimensions;
+    static constexpr sofa::Size coord_total_size = Coord::total_size;
+    static constexpr sofa::Size deriv_total_size = Deriv::total_size;
 
     typedef typename TCoord::Size Size;
 

--- a/Sofa/framework/Type/src/sofa/type/DualQuat.h
+++ b/Sofa/framework/Type/src/sofa/type/DualQuat.h
@@ -55,8 +55,9 @@ class SOFA_TYPE_API DualQuatCoord3
     typedef type::Vec<3,real> Pos;
     typedef type::Vec<3,real> Vec3;
     typedef type::Vec<4,real> Quat;
-    enum { total_size = 8 };
-    enum { spatial_dimensions = 3 };
+
+    static constexpr Size total_size = 8;
+    static constexpr Size spatial_dimensions = 3;
 
     Quat dual;
     Quat orientation;

--- a/Sofa/framework/Type/src/sofa/type/Quat.h
+++ b/Sofa/framework/Type/src/sofa/type/Quat.h
@@ -215,14 +215,14 @@ public:
     bool operator==(const Quat& q) const;
     bool operator!=(const Quat& q) const;
 
-    enum { static_size = 4 };
-    static unsigned int size() {return 4;}
+    static constexpr Size static_size = 4;
+    static Size size() {return static_size;}
 
     /// Compile-time constant specifying the number of scalars within this vector (equivalent to the size() method)
-    enum { total_size = 4 };
+    static constexpr Size total_size = 4;
 
     /// Compile-time constant specifying the number of dimensions of space (NOT equivalent to total_size for quaternions)
-    enum { spatial_dimensions = 3 };
+    static constexpr Size spatial_dimensions = 3;
 };
 
 /// write to an output stream

--- a/Sofa/framework/Type/src/sofa/type/Vec.h
+++ b/Sofa/framework/Type/src/sofa/type/Vec.h
@@ -63,9 +63,9 @@ public:
     typedef sofa::Size Size;
 
     /// Compile-time constant specifying the number of scalars within this vector (equivalent to static_size and size() method)
-    enum { total_size = N };
+    static constexpr Size total_size = N;
     /// Compile-time constant specifying the number of dimensions of space (equivalent to total_size here)
-    enum { spatial_dimensions = N };
+    static constexpr Size spatial_dimensions = N;
 
     /// Default constructor: sets all values to 0.
     constexpr Vec()
@@ -123,7 +123,7 @@ public:
     {
         constexpr Size maxN = std::min( N, N2 );
         for(Size i=0; i<maxN; i++)
-            this->elems[i] = (ValueType)v[i];
+            this->elems[i] = static_cast<ValueType>(v[i]);
         for(Size i=maxN; i<N ; i++)
             this->elems[i] = defaultvalue;
     }
@@ -153,7 +153,7 @@ public:
     constexpr Vec(const Vec<N, real2>& p) noexcept
     {
         for(Size i=0; i<N; i++)
-            this->elems[i] = (ValueType)p(i);
+            this->elems[i] = static_cast<ValueType>(p(i));
     }
 
     /// Constructor from an array of values.
@@ -161,7 +161,7 @@ public:
     explicit constexpr Vec(const real2* p) noexcept
     {
         for(Size i=0; i<N; i++)
-            this->elems[i] = (ValueType)p[i];
+            this->elems[i] = static_cast<ValueType>(p[i]);
     }
 
     /// Special access to first element.


### PR DESCRIPTION
An other session of warnings removal. it *should* be harmless 🤫

Most important change: replace usage of enum {xxx = yyy} with constexpr keyword for compile-time constant expressions.

This is clearer, was made for this, and you can specify the type, contrary to enum https://en.cppreference.com/w/cpp/language/enum :
```
Values of unscoped enumeration type are [implicitly-convertible](https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion) to integral types. 
If the underlying type is not fixed, the value is convertible to the first type from the following list able to hold their entire value range: int, unsigned int, long, unsigned long, long long, or unsigned long long, extended integer types with higher conversion rank (in rank order, signed given preference over unsigned) (since C++11).
```




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
