### PR TITLE
[GUI.Qt] Save scene graph lock state persistently

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
@@ -399,6 +399,14 @@
               </item>
               <item>
                <widget class="QPushButton" name="sceneGraphRefreshToggleButton">
+                <property name="toolTip">
+                 <string>The scene graph update button has three states
+State 0: unlocked (all the changes on the graph are immediately taken into account)
+State 1: locked (the changes on the graph are not done but the simulation graph is set to dirty if
+         there is some changes on the graph. A click on the button unlocks the graph (go to state 0).
+State 2: dirty, in that state the button reflect the fact that the scene graph view has changed but not displayed.
+         A click on the button refreshes the graph view but does not change the Lock/Unlock state</string>
+                </property>
                 <property name="text">
                  <string/>
                 </property>

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -1930,7 +1930,25 @@ void RealGUI::createSimulationGraph()
     connect(this, SIGNAL( newScene() ), simulationGraph, SLOT( CloseAllDialogs() ) );
     connect(this, SIGNAL( newStep() ), simulationGraph, SLOT( UpdateOpenedDialogs() ) );
 
-    simulationGraph->unLock();
+    std::ifstream file( BaseGUI::getConfigDirectoryPath() + "/sceneGraphLock" );
+    if(file.is_open())
+    {
+        bool isLocked;
+        file >> isLocked;
+        if (isLocked)
+        {
+            simulationGraph->lock();
+        }
+        else
+        {
+            simulationGraph->unLock();
+        }
+        file.close();
+    }
+    else
+    {
+        simulationGraph->unLock();
+    }
 }
 
 // This slot is called when the sceneGraph view is set to dirty
@@ -1965,12 +1983,12 @@ void RealGUI::sceneGraphViewLockingChanged(bool isLocked)
     }
 }
 
-// The scenegraph update button has tree states
-// State 0: unLocked (all the changes on the graph are immediately taken into account)
-// State 1: locked (the changes on the graph are not done but the simulationGraph is set to dirty if
-//          there is some changes on the graph A click on the buttont load to UnLock the graph (go to state 1).
-// State 2: dirty, in that state the button reflect the fact that the scenegraphi view has changed but not displayed
-//          a click on the button, refresh the graph view but don't change the Lock/Unlock state
+// The scene graph update button has three states
+// State 0: unlocked (all the changes on the graph are immediately taken into account)
+// State 1: locked (the changes on the graph are not done but the simulation graph is set to dirty if
+//          there is some changes on the graph. A click on the button unlocks the graph (go to state 0).
+// State 2: dirty, in that state the button reflect the fact that the scene graph view has changed but not displayed.
+//          A click on the button refreshes the graph view but does not change the Lock/Unlock state
 void RealGUI::onSceneGraphRefreshButtonClicked()
 {
     if(simulationGraph->isLocked())
@@ -1980,6 +1998,13 @@ void RealGUI::onSceneGraphRefreshButtonClicked()
     else
     {
         simulationGraph->lock();
+    }
+
+    std::ofstream file( BaseGUI::getConfigDirectoryPath() + "/sceneGraphLock" );
+    if(file)
+    {
+        file << simulationGraph->isLocked();
+        file.close();
     }
 }
 


### PR DESCRIPTION
Also add a tooltip

Note that the scene graph is unlocked by default. It gives the impression that the simulation is slowed down, compared to before the introduction of the feature.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
