### PR TITLE
[GUI] Remove the reset button, replaced by reload scene

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
@@ -219,15 +219,15 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QPushButton" name="ResetSceneButton">
+           <widget class="QPushButton" name="ReloadSceneButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
             <property name="toolTip">
-             <string>Reset the Simulation  (t=0)</string>
+             <string>Reload the Simulation  (t=0)</string>
             </property>
             <property name="text">
-             <string>&amp;Reset Scene</string>
+             <string>&amp;Reload Scene</string>
             </property>
             <property name="shortcut">
              <string>Alt+R</string>

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QSofaListView.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QSofaListView.cpp
@@ -106,7 +106,7 @@ QSofaListView::~QSofaListView()
 }
 
 
-void QSofaListView::Clear(Node* rootNode)
+void QSofaListView::Clear(Node* /*rootNode*/)
 {
     /*
     if(graphListener_ != nullptr)

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -381,7 +381,7 @@ RealGUI::RealGUI ( const char* viewername)
     connect ( timerStep, SIGNAL ( timeout() ), this, SLOT ( step() ) );
     connect ( this, SIGNAL ( quit() ), this, SLOT ( fileExit() ) );
     connect ( startButton, SIGNAL ( toggled ( bool ) ), this , SLOT ( playpauseGUI ( bool ) ) );
-    connect ( ResetSceneButton, SIGNAL ( clicked() ), this, SLOT ( resetScene() ) );
+    connect ( ReloadSceneButton, SIGNAL ( clicked() ), this, SLOT ( fileReload() ) );
     connect ( dtEdit, SIGNAL ( textChanged ( const QString& ) ), this, SLOT ( setDt ( const QString& ) ) );
     connect ( realTimeCheckBox, SIGNAL ( stateChanged ( int ) ), this, SLOT ( updateDtEditState() ) );
     connect ( stepButton, SIGNAL ( clicked() ), this, SLOT ( step() ) );


### PR DESCRIPTION
Reset button becomes Reload button (equivalent to CTRL+R)
Reset remains available with ALT+R 
If this PR gets accepted I would propagate to ImGUI




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
