### PR TITLE
[Lagrangian.Correction] LinearSolverConstraintCorrection: Trivial optimisations for MSVC

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -572,6 +572,7 @@ void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(doub
 
     _new_force = false;
 
+    const auto positionIntegrationFactor = odesolver->getPositionIntegrationFactor();
     // TODO => optimisation => for each bloc store J[bloc,dof]
     for (int i = begin; i <= end; i++)
     {
@@ -588,7 +589,7 @@ void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(doub
 
                 for(Size j = 0; j < derivDim; j++)
                 {
-                    disp[j] = (Real)(systemLHVector_buf->element(dof * derivDim + j) * odesolver->getPositionIntegrationFactor());
+                    disp[j] = (Real)(systemLHVector_buf->element(dof * derivDim + j) * positionIntegrationFactor);
                 }
 
                 d[i] += colIt.val() * disp;

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -585,7 +585,7 @@ void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(doub
             for (MatrixDerivColConstIterator colIt = rowIt.begin(); colIt != rowEnd; ++colIt)
             {
                 const auto dof = colIt.index();
-                Deriv disp;
+                Deriv disp(type::NOINIT);
 
                 for(Size j = 0; j < derivDim; j++)
                 {

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -75,6 +75,13 @@ public:
         clear();
     }
 
+    explicit RigidDeriv(type::NoInit)
+        : vCenter(type::NOINIT)
+        , vOrientation(type::NOINIT)
+    {
+
+    }
+
     RigidDeriv(const Vec3 &velCenter, const Vec3 &velOrient)
         : vCenter(velCenter), vOrientation(velOrient)
     {}
@@ -1046,6 +1053,13 @@ private:
 
 public:
     friend class RigidCoord<2,real>;
+
+    explicit RigidDeriv(type::NoInit)
+        : vCenter(type::NOINIT)
+        , vOrientation(type::NOINIT)
+    {
+
+    }
 
     RigidDeriv()
     {

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.h
@@ -69,10 +69,11 @@ public:
     class SOFA_DEFAULTTYPE_API SpatialVector
     {
     public:
-        Vec lineVec;
-        Vec freeVec;
+        Vec lineVec{ type::NOINIT };
+        Vec freeVec{ type::NOINIT };
+
         void clear();
-        SpatialVector();
+        SpatialVector() = default;
         /**
         \param l The line vector: angular velocity, or force
         \param f The free vector: linear velocity, or torque

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.inl
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.inl
@@ -34,12 +34,6 @@ namespace defaulttype
 {
 
 template<class R>
-SolidTypes<R>::SpatialVector::SpatialVector()
-{}
-
-
-
-template<class R>
 SolidTypes<R>::SpatialVector::SpatialVector( const Vec& l, const Vec& f ):lineVec(l),freeVec(f)
 {}
 
@@ -112,8 +106,10 @@ typename SolidTypes<R>::SpatialVector SolidTypes<R>::SpatialVector::operator * (
 
 template<class R>
 SolidTypes<R>::Transform::Transform()
+    : orientation_() // default constructor set to identity
+    , origin_() // default constructor set to {0, 0, 0}
 {
-    *this = this->identity();
+
 }
 
 /// Define using Featherstone's conventions


### PR DESCRIPTION
It seems msvc is quite (much!) less clever than gcc.

2 optimizations (only useful when not building in Release mode)
 - add and use a NOINIT RigidDeriv constructor (avoiding to init a deriv which is filled afterwards)
 - default ctor directly call the identity of its components (which is their default ctor by the way)

and 1 ridiculous optimization
 - avoid calling getPositionIntegrationFactor() in the nested loop
 
This optimization brings a whooping 30% speedup on my setup (VC2022, Release/LTO enabled)
Test scene: 3instruments_collis.scn from BeamAdapter, 2000 iterations in batch mode
 - before: 16.5669 s ( 120.723 FPS)
 - after: 12.829 s ( 155.897 FPS)

GCC was doing the same by the way with or without these optims (and is faster than msvc, even in a VM 🤔)

NOTE: do not forget to enable the LTO option for Windows when deploying, it brings full inlining & stuff and it is really useful for perf
(w/o LTO, before the optims it is 21.9883 s ( 90.9575 FPS) )

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
