### PR TITLE
[Sofa.Type] Quat: Optimize rotate() (and inverseRotate())

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Quat.h
+++ b/Sofa/framework/Type/src/sofa/type/Quat.h
@@ -113,10 +113,10 @@ public:
     void toHomogeneousMatrix(Mat4x4 &m) const;
 
     /// Apply the rotation to a given vector
-    auto rotate( const Vec3& v ) const -> Vec3;
+    constexpr auto rotate( const Vec3& v ) const -> Vec3;
 
     /// Apply the inverse rotation to a given vector
-    auto inverseRotate( const Vec3& v ) const -> Vec3;
+    constexpr auto inverseRotate( const Vec3& v ) const -> Vec3;
 
     /// Given two quaternions, add them together to get a third quaternion.
     /// Adding quaternions to get a compound rotation is analagous to adding

--- a/Sofa/framework/Type/src/sofa/type/Quat.h
+++ b/Sofa/framework/Type/src/sofa/type/Quat.h
@@ -116,7 +116,7 @@ public:
     inline constexpr auto rotate( const Vec3& v ) const -> Vec3
     {
         const Vec3 qxyz{ _q[0], _q[1] , _q[2] };
-        const auto& t = qxyz.cross(v) * 2;
+        const auto t = qxyz.cross(v) * 2;
         return (v + _q[3] * t + qxyz.cross(t));
     }
 
@@ -124,7 +124,7 @@ public:
     inline constexpr auto inverseRotate( const Vec3& v ) const -> Vec3
     {
         const Vec3 qxyz{ -_q[0], -_q[1] , -_q[2] };
-        const auto& t = qxyz.cross(v) * 2;
+        const auto t = qxyz.cross(v) * 2;
         return (v + _q[3] * t + qxyz.cross(t));
     }
 

--- a/Sofa/framework/Type/src/sofa/type/Quat.h
+++ b/Sofa/framework/Type/src/sofa/type/Quat.h
@@ -113,10 +113,20 @@ public:
     void toHomogeneousMatrix(Mat4x4 &m) const;
 
     /// Apply the rotation to a given vector
-    constexpr auto rotate( const Vec3& v ) const -> Vec3;
+    inline constexpr auto rotate( const Vec3& v ) const -> Vec3
+    {
+        const Vec3 qxyz{ _q[0], _q[1] , _q[2] };
+        const auto& t = qxyz.cross(v) * 2;
+        return (v + _q[3] * t + qxyz.cross(t));
+    }
 
     /// Apply the inverse rotation to a given vector
-    constexpr auto inverseRotate( const Vec3& v ) const -> Vec3;
+    inline constexpr auto inverseRotate( const Vec3& v ) const -> Vec3
+    {
+        const Vec3 qxyz{ -_q[0], -_q[1] , -_q[2] };
+        const auto& t = qxyz.cross(v) * 2;
+        return (v + _q[3] * t + qxyz.cross(t));
+    }
 
     /// Given two quaternions, add them together to get a third quaternion.
     /// Adding quaternions to get a compound rotation is analagous to adding

--- a/Sofa/framework/Type/src/sofa/type/Quat.h
+++ b/Sofa/framework/Type/src/sofa/type/Quat.h
@@ -113,7 +113,7 @@ public:
     void toHomogeneousMatrix(Mat4x4 &m) const;
 
     /// Apply the rotation to a given vector
-    inline constexpr auto rotate( const Vec3& v ) const -> Vec3
+    constexpr auto rotate( const Vec3& v ) const -> Vec3
     {
         const Vec3 qxyz{ _q[0], _q[1] , _q[2] };
         const auto t = qxyz.cross(v) * 2;
@@ -121,7 +121,7 @@ public:
     }
 
     /// Apply the inverse rotation to a given vector
-    inline constexpr auto inverseRotate( const Vec3& v ) const -> Vec3
+    constexpr auto inverseRotate( const Vec3& v ) const -> Vec3
     {
         const Vec3 qxyz{ -_q[0], -_q[1] , -_q[2] };
         const auto t = qxyz.cross(v) * 2;

--- a/Sofa/framework/Type/src/sofa/type/Quat.inl
+++ b/Sofa/framework/Type/src/sofa/type/Quat.inl
@@ -813,23 +813,6 @@ void Quat<Real>::toHomogeneousMatrix(Mat<4,4,Real>& m) const
     m[3][3] = 1.0f;
 }
 
-/// Apply the rotation to a given vector
-template<class Real>
-constexpr auto Quat<Real>::rotate(const Vec3& v) const -> Vec3
-{
-    const Vec3 qxyz{ _q[0], _q[1] , _q[2] };
-    const auto& t = qxyz.cross(v) * 2;
-    return (v + _q[3] * t + qxyz.cross(t));
-}
-
-template<class Real>
-constexpr auto Quat<Real>::inverseRotate(const Vec3& v) const -> Vec3
-{
-    const Vec3 qxyz{ -_q[0], -_q[1] , -_q[2] };
-    const auto& t = qxyz.cross(v) * 2;
-    return (v + _q[3] * t + qxyz.cross(t));
-}
-
 template<class Real>
 auto Quat<Real>::createFromRotationVector(const Vec3& a) -> Quat
 {

--- a/Sofa/framework/Type/src/sofa/type/Quat.inl
+++ b/Sofa/framework/Type/src/sofa/type/Quat.inl
@@ -815,22 +815,19 @@ void Quat<Real>::toHomogeneousMatrix(Mat<4,4,Real>& m) const
 
 /// Apply the rotation to a given vector
 template<class Real>
-auto Quat<Real>::rotate( const Vec3& v ) const -> Vec3
+constexpr auto Quat<Real>::rotate(const Vec3& v) const -> Vec3
 {
-    return Vec3(((1.0f - 2.0f * (_q[1] * _q[1] + _q[2] * _q[2]))*v[0] + (2.0f * (_q[0] * _q[1] - _q[2] * _q[3])) * v[1] + (2.0f * (_q[2] * _q[0] + _q[1] * _q[3])) * v[2]),
-            ((2.0f * (_q[0] * _q[1] + _q[2] * _q[3]))*v[0] + (1.0f - 2.0f * (_q[2] * _q[2] + _q[0] * _q[0]))*v[1] + (2.0f * (_q[1] * _q[2] - _q[0] * _q[3]))*v[2]),
-            ((2.0f * (_q[2] * _q[0] - _q[1] * _q[3]))*v[0] + (2.0f * (_q[1] * _q[2] + _q[0] * _q[3]))*v[1] + (1.0f - 2.0f * (_q[1] * _q[1] + _q[0] * _q[0]))*v[2])
-            );
+    const Vec3 qxyz{ _q[0], _q[1] , _q[2] };
+    const auto& t = qxyz.cross(v) * 2;
+    return (v + _q[3] * t + qxyz.cross(t));
 }
 
 template<class Real>
-auto Quat<Real>::inverseRotate( const Vec3& v ) const -> Vec3
+constexpr auto Quat<Real>::inverseRotate(const Vec3& v) const -> Vec3
 {
-    return Vec3(
-                ((1.0f - 2.0f * (_q[1] * _q[1] + _q[2] * _q[2]))*v[0] + (2.0f * (_q[0] * _q[1] + _q[2] * _q[3])) * v[1] + (2.0f * (_q[2] * _q[0] - _q[1] * _q[3])) * v[2]),
-            ((2.0f * (_q[0] * _q[1] - _q[2] * _q[3]))*v[0] + (1.0f - 2.0f * (_q[2] * _q[2] + _q[0] * _q[0]))*v[1] + (2.0f * (_q[1] * _q[2] + _q[0] * _q[3]))*v[2]),
-            ((2.0f * (_q[2] * _q[0] + _q[1] * _q[3]))*v[0] + (2.0f * (_q[1] * _q[2] - _q[0] * _q[3]))*v[1] + (1.0f - 2.0f * (_q[1] * _q[1] + _q[0] * _q[0]))*v[2])
-            );
+    const Vec3 qxyz{ -_q[0], -_q[1] , -_q[2] };
+    const auto& t = qxyz.cross(v) * 2;
+    return (v + _q[3] * t + qxyz.cross(t));
 }
 
 template<class Real>

--- a/Sofa/framework/Type/test/Quater_test.cpp
+++ b/Sofa/framework/Type/test/Quater_test.cpp
@@ -221,6 +221,22 @@ TEST(QuaterTest, QuaterdRotateVec)
     EXPECT_NEAR(4.580932858428164, rp[0], errorThreshold);
     EXPECT_NEAR(3.448650396246470, rp[1], errorThreshold);
     EXPECT_NEAR(9.649967077199914, rp[2], errorThreshold);
+
+    // Compare with previous implementation of Quat::rotate()
+    auto previousRotateImpl = [](const Quat<double>& _q, const sofa::type::Vec3d& v)
+    {
+        return  sofa::type::Vec3d(
+            ((1.0f - 2.0f * (_q[1] * _q[1] + _q[2] * _q[2])) * v[0] + (2.0f * (_q[0] * _q[1] - _q[2] * _q[3])) * v[1] + (2.0f * (_q[2] * _q[0] + _q[1] * _q[3])) * v[2]),
+            ((2.0f * (_q[0] * _q[1] + _q[2] * _q[3])) * v[0] + (1.0f - 2.0f * (_q[2] * _q[2] + _q[0] * _q[0])) * v[1] + (2.0f * (_q[1] * _q[2] - _q[0] * _q[3])) * v[2]),
+            ((2.0f * (_q[2] * _q[0] - _q[1] * _q[3])) * v[0] + (2.0f * (_q[1] * _q[2] + _q[0] * _q[3])) * v[1] + (1.0f - 2.0f * (_q[1] * _q[1] + _q[0] * _q[0])) * v[2])
+        );
+    };
+
+    const auto& previousRotateRes = previousRotateImpl(quat, p);
+
+    EXPECT_NEAR(0.0, rp[0] - previousRotateRes[0], errorThreshold);
+    EXPECT_NEAR(0.0, rp[1] - previousRotateRes[1], errorThreshold);
+    EXPECT_NEAR(0.0, rp[2] - previousRotateRes[2], errorThreshold);
 }
 
 TEST(QuaterTest, QuaterdInvRotateVec)
@@ -234,6 +250,22 @@ TEST(QuaterTest, QuaterdInvRotateVec)
     EXPECT_NEAR(3.077954984157941, rp[0], errorThreshold);
     EXPECT_NEAR(8.272072482340949, rp[1], errorThreshold);
     EXPECT_NEAR(6.935344977893669, rp[2], errorThreshold);
+
+    // Compare with previous implementation of Quat::inverseRotate()
+    auto previousInverseRotateImpl = [](const Quat<double>& _q, const sofa::type::Vec3d& v)
+    {
+        return sofa::type::Vec3(
+            ((1.0f - 2.0f * (_q[1] * _q[1] + _q[2] * _q[2])) * v[0] + (2.0f * (_q[0] * _q[1] + _q[2] * _q[3])) * v[1] + (2.0f * (_q[2] * _q[0] - _q[1] * _q[3])) * v[2]),
+            ((2.0f * (_q[0] * _q[1] - _q[2] * _q[3])) * v[0] + (1.0f - 2.0f * (_q[2] * _q[2] + _q[0] * _q[0])) * v[1] + (2.0f * (_q[1] * _q[2] + _q[0] * _q[3])) * v[2]),
+            ((2.0f * (_q[2] * _q[0] + _q[1] * _q[3])) * v[0] + (2.0f * (_q[1] * _q[2] - _q[0] * _q[3])) * v[1] + (1.0f - 2.0f * (_q[1] * _q[1] + _q[0] * _q[0])) * v[2])
+        );
+    };
+
+    const auto& previousInverseRotateRes = previousInverseRotateImpl(quat, p);
+
+    EXPECT_NEAR(0.0, rp[0] - previousInverseRotateRes[0], errorThreshold);
+    EXPECT_NEAR(0.0, rp[1] - previousInverseRotateRes[1], errorThreshold);
+    EXPECT_NEAR(0.0, rp[2] - previousInverseRotateRes[2], errorThreshold);
 }
 
 TEST(QuaterTest, QuaterdOperatorAdd)


### PR DESCRIPTION
Through a blog, i tried a new way to compute the rotation of a Vec3 with a Quaternion from the famous [glm library](https://github.com/g-truc/glm)
(that is to say, the method is tested thoroughly I suppose....)
https://github.com/g-truc/glm/blob/cc98465e3508535ba8c7f6208df934c156a018dc/glm/detail/type_quat.inl#L347

Measured with SofaBenchmark (), MSVC/full optim enabled (LTO and full-inlining):
```
before:  BM_Quat_rotateVec/8192                46.4 us
after:   BM_Quat_rotateVec/8192                33.6 us
```
FYI, RelWithDebInfo (no inlining) 
```
after:   BM_Quat_rotateVec/8192                38.0 us
```

GCC on Ubuntu has pretty much the same behavior.

And this PR add some tests between the previous and the new implementations.

Related SofaBenchmark PR : https://github.com/alxbilger/SofaBenchmark/pull/25
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
