### PR TITLE
[Core.Topology] Fix info message when Topology given to topologyHandler is not dynamic

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyData.inl
@@ -60,7 +60,7 @@ void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core:
     this->m_topologyHandler->init();
 
     // Register the TopologyHandler
-    m_isTopologyDynamic = this->m_topologyHandler->registerTopology(_topology);
+    m_isTopologyDynamic = this->m_topologyHandler->registerTopology(_topology, sofa::helper::logging::notMuted(this->getOwner()));
     if (m_isTopologyDynamic)
     {
         this->linkToElementDataArray((TopologyElementType*)nullptr);

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyHandler.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyHandler.cpp
@@ -147,13 +147,14 @@ void TopologyHandler::addCallBack(core::topology::TopologyChangeType type, Topol
     m_callbackMap[type] = callback;
 }
 
-bool TopologyHandler::registerTopology(sofa::core::topology::BaseMeshTopology* _topology)
+bool TopologyHandler::registerTopology(sofa::core::topology::BaseMeshTopology* _topology, bool printLog)
 {
     m_topology = dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology);
 
     if (m_topology == nullptr)
     {
-        msg_info("TopologyHandler") << "Topology: " << _topology->getName() << " is not dynamic, topology engine on Data '" << m_data_name << "' won't be registered.";
+        msg_info_when(printLog, "TopologyHandler") << "The " << m_prefix << " managing the TopologyData '" << m_data_name
+            << "' won't be registered because linked topology '" << _topology->getName() << "' is not dynamic. Topological changes won't be supported by this Data.";
         return false;
     }
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyHandler.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyHandler.h
@@ -157,7 +157,7 @@ public:
     /** Function to link the topological Data with the engine and the current topology. And init everything.
     * This function should be used at the end of the all declaration link to this Data while using it in a component.
     */
-    virtual bool registerTopology(sofa::core::topology::BaseMeshTopology* _topology);
+    virtual bool registerTopology(sofa::core::topology::BaseMeshTopology* _topology, bool printLog = false);
 
     /// Method to add a CallBack method to be used when a @sa core::topology::TopologyChangeType event is fired. The call back should use the @TopologyChangeCallback 
     /// signature and pass the corresponding core::topology::TopologyChange* structure.


### PR DESCRIPTION
Message before was:
```[INFO]    [TopologyHandler] Topology: lines is not dynamic, topology engine on Data 'indices' won't be registered.```

Now looks like:
```[INFO]    [TopologyHandler] The TopologyDataHandler( FixedConstraint ) managing the TopologyData 'indices' won't be registered because linked topology 'lines' is not dynamic. Topological changes won't be supported by this Data.```

Also this message only pop up if component owner is not muted (printLog == true)






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
