### PR TITLE
[Topology.Container] Fix save/restoreLastState in draw method were missing

### DIFF
--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.cpp
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.cpp
@@ -76,7 +76,7 @@ void FixedConstraint<Rigid3Types>::draw(const core::visual::VisualParams* vparam
     
     std::vector< Vector3 > points;
     
-    if (d_fixAll.getValue() == true)
+    if (d_fixAll.getValue())
     {
         for (unsigned i = 0; i < x.size(); i++)
             points.push_back(x[i].getCenter());

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.cpp
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.cpp
@@ -64,18 +64,23 @@ template class SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API FixedConstraint<Rigid2Ty
 template <>
 void FixedConstraint<Rigid3Types>::draw(const core::visual::VisualParams* vparams)
 {
-    if (!vparams->displayFlags().getShowBehaviorModels()) return;
+    if (this->d_componentState.getValue() != ComponentState::Valid) return;
     if (!d_showObject.getValue()) return;
     if (!this->isActive()) return;
+    if (!vparams->displayFlags().getShowBehaviorModels()) return;
+
+    vparams->drawTool()->saveLastState();
 
     const SetIndexArray & indices = d_indices.getValue();
-    if (!vparams->displayFlags().getShowBehaviorModels()) return;
+    const VecCoord& x = mstate->read(core::ConstVecCoordId::position())->getValue();
+    
     std::vector< Vector3 > points;
-
-    const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
-    if( d_fixAll.getValue()==true )
-        for (unsigned i=0; i<x.size(); i++ )
+    
+    if (d_fixAll.getValue() == true)
+    {
+        for (unsigned i = 0; i < x.size(); i++)
             points.push_back(x[i].getCenter());
+    }
     else
     {
         if( x.size() < indices.size() )
@@ -94,21 +99,23 @@ void FixedConstraint<Rigid3Types>::draw(const core::visual::VisualParams* vparam
         vparams->drawTool()->drawPoints(points, 10, sofa::type::RGBAColor(1,0.5,0.5,1));
     else
         vparams->drawTool()->drawSpheres(points, (float)d_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
+
+    vparams->drawTool()->restoreLastState();
 }
 
 template <>
 void FixedConstraint<Rigid2Types>::draw(const core::visual::VisualParams* vparams)
 {
-    if (!vparams->displayFlags().getShowBehaviorModels()) return;
+    if (this->d_componentState.getValue() != ComponentState::Valid) return;
     if (!d_showObject.getValue()) return;
     if (!this->isActive()) return;
-
-    const SetIndexArray & indices = d_indices.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
 
     vparams->drawTool()->saveLastState();
 
+    const SetIndexArray& indices = d_indices.getValue();
     const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
+
     vparams->drawTool()->setLightingEnabled(false);
     constexpr sofa::type::RGBAColor color (1,0.5,0.5,1);
     std::vector<sofa::type::Vector3> vertices;
@@ -116,16 +123,12 @@ void FixedConstraint<Rigid2Types>::draw(const core::visual::VisualParams* vparam
     if(d_fixAll.getValue())
     {
         for (unsigned i=0; i<x.size(); i++ )
-            vertices.push_back(sofa::type::Vector3(x[i].getCenter()[0],
-                                                          x[i].getCenter()[1],
-                                                          0.0));
+            vertices.emplace_back(x[i].getCenter()[0], x[i].getCenter()[1], 0.0);
     }
     else
     {
         for (SetIndex::const_iterator it = indices.begin(); it != indices.end(); ++it)
-            vertices.push_back(sofa::type::Vector3(x[*it].getCenter()[0],
-                                                          x[*it].getCenter()[1],
-                                                          0.0));
+            vertices.emplace_back(x[*it].getCenter()[0], x[*it].getCenter()[1], 0.0);
     }
 
     vparams->drawTool()->drawPoints(vertices, 10, color);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
@@ -363,12 +363,14 @@ void FixedConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
         std::vector< sofa::type::Vector3 > points;
         sofa::type::Vector3 point;
 
-        if( d_fixAll.getValue() )
-            for (unsigned i=0; i<x.size(); i++ )
+        if (d_fixAll.getValue())
+        {
+            for (unsigned i = 0; i < x.size(); i++)
             {
                 point = DataTypes::getCPos(x[i]);
                 points.push_back(point);
             }
+        }
         else
         {
             for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -2669,6 +2669,8 @@ SReal MeshTopology::getPosZ(Index i) const
 
 void MeshTopology::draw(const core::visual::VisualParams* vparams)
 {
+    vparams->drawTool()->saveLastState();
+
     // Draw Edges
     if(_drawEdges.getValue())
     {
@@ -2677,8 +2679,8 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
         for (EdgeID i=0; i<getNbEdges(); i++)
         {
             const Edge& c = getEdge(i);
-            pos.push_back(type::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
-            pos.push_back(type::Vector3(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1])));
+            pos.emplace_back(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0]));
+            pos.emplace_back(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1]));
         }
         vparams->drawTool()->drawLines(pos, 1.0f, sofa::type::RGBAColor(0.4f,1.0f,0.3f,1.0f));
     }
@@ -2691,9 +2693,9 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
         for (TriangleID i=0; i<getNbTriangles(); i++)
         {
             const Triangle& c = getTriangle(i);
-            pos.push_back(type::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
-            pos.push_back(type::Vector3(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1])));
-            pos.push_back(type::Vector3(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2])));
+            pos.emplace_back(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0]));
+            pos.emplace_back(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1]));
+            pos.emplace_back(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2]));
         }
         vparams->drawTool()->drawTriangles(pos, sofa::type::RGBAColor(0.4f,1.0f,0.3f,1.0f));
     }
@@ -2706,10 +2708,10 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
         for (QuadID i=0; i<getNbQuads(); i++)
         {
             const Quad& c = getQuad(i);
-            pos.push_back(type::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
-            pos.push_back(type::Vector3(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1])));
-            pos.push_back(type::Vector3(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2])));
-            pos.push_back(type::Vector3(getPosX(c[3]), getPosY(c[3]), getPosZ(c[3])));
+            pos.emplace_back(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0]));
+            pos.emplace_back(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1]));
+            pos.emplace_back(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2]));
+            pos.emplace_back(getPosX(c[3]), getPosY(c[3]), getPosZ(c[3]));
         }
         vparams->drawTool()->drawQuads(pos, sofa::type::RGBAColor(0.4f,1.0f,0.3f,1.0f));
     }
@@ -2724,23 +2726,23 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
         for (HexahedronID i=0; i<getNbHexahedra(); i++)
         {
             const Hexa& c = getHexahedron(i);
-            pos1.push_back(type::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
-            pos1.push_back(type::Vector3(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1])));
-            pos1.push_back(type::Vector3(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2])));
-            pos1.push_back(type::Vector3(getPosX(c[3]), getPosY(c[3]), getPosZ(c[3])));
-            pos1.push_back(type::Vector3(getPosX(c[4]), getPosY(c[4]), getPosZ(c[4])));
-            pos1.push_back(type::Vector3(getPosX(c[5]), getPosY(c[5]), getPosZ(c[5])));
-            pos1.push_back(type::Vector3(getPosX(c[6]), getPosY(c[6]), getPosZ(c[6])));
-            pos1.push_back(type::Vector3(getPosX(c[7]), getPosY(c[7]), getPosZ(c[7])));
+            pos1.emplace_back(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0]));
+            pos1.emplace_back(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1]));
+            pos1.emplace_back(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2]));
+            pos1.emplace_back(getPosX(c[3]), getPosY(c[3]), getPosZ(c[3]));
+            pos1.emplace_back(getPosX(c[4]), getPosY(c[4]), getPosZ(c[4]));
+            pos1.emplace_back(getPosX(c[5]), getPosY(c[5]), getPosZ(c[5]));
+            pos1.emplace_back(getPosX(c[6]), getPosY(c[6]), getPosZ(c[6]));
+            pos1.emplace_back(getPosX(c[7]), getPosY(c[7]), getPosZ(c[7]));
 
-            pos2.push_back(type::Vector3(getPosX(c[3]), getPosY(c[3]), getPosZ(c[3])));
-            pos2.push_back(type::Vector3(getPosX(c[7]), getPosY(c[7]), getPosZ(c[7])));
-            pos2.push_back(type::Vector3(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2])));
-            pos2.push_back(type::Vector3(getPosX(c[6]), getPosY(c[6]), getPosZ(c[6])));
-            pos2.push_back(type::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
-            pos2.push_back(type::Vector3(getPosX(c[4]), getPosY(c[4]), getPosZ(c[4])));
-            pos2.push_back(type::Vector3(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1])));
-            pos2.push_back(type::Vector3(getPosX(c[5]), getPosY(c[5]), getPosZ(c[5])));
+            pos2.emplace_back(getPosX(c[3]), getPosY(c[3]), getPosZ(c[3]));
+            pos2.emplace_back(getPosX(c[7]), getPosY(c[7]), getPosZ(c[7]));
+            pos2.emplace_back(getPosX(c[2]), getPosY(c[2]), getPosZ(c[2]));
+            pos2.emplace_back(getPosX(c[6]), getPosY(c[6]), getPosZ(c[6]));
+            pos2.emplace_back(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0]));
+            pos2.emplace_back(getPosX(c[4]), getPosY(c[4]), getPosZ(c[4]));
+            pos2.emplace_back(getPosX(c[1]), getPosY(c[1]), getPosZ(c[1]));
+            pos2.emplace_back(getPosX(c[5]), getPosY(c[5]), getPosZ(c[5]));
         }
         vparams->drawTool()->drawQuads(pos1, sofa::type::RGBAColor(0.4f,1.0f,0.3f,1.0f));
         vparams->drawTool()->drawLines(pos2, 1.0f, sofa::type::RGBAColor(0.4f,1.0f,0.3f,1.0f));
@@ -2754,27 +2756,28 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
         for (TetrahedronID i=0; i<getNbTetras(); i++)
         {
             const Tetra& t = getTetra(i);
-            pos.push_back(type::Vector3(getPosX(t[0]), getPosY(t[0]), getPosZ(t[0])));
-            pos.push_back(type::Vector3(getPosX(t[1]), getPosY(t[1]), getPosZ(t[1])));
+            pos.emplace_back(getPosX(t[0]), getPosY(t[0]), getPosZ(t[0]));
+            pos.emplace_back(getPosX(t[1]), getPosY(t[1]), getPosZ(t[1]));
 
-            pos.push_back(type::Vector3(getPosX(t[0]), getPosY(t[0]), getPosZ(t[0])));
-            pos.push_back(type::Vector3(getPosX(t[2]), getPosY(t[2]), getPosZ(t[2])));
+            pos.emplace_back(getPosX(t[0]), getPosY(t[0]), getPosZ(t[0]));
+            pos.emplace_back(getPosX(t[2]), getPosY(t[2]), getPosZ(t[2]));
 
-            pos.push_back(type::Vector3(getPosX(t[0]), getPosY(t[0]), getPosZ(t[0])));
-            pos.push_back(type::Vector3(getPosX(t[3]), getPosY(t[3]), getPosZ(t[3])));
+            pos.emplace_back(getPosX(t[0]), getPosY(t[0]), getPosZ(t[0]));
+            pos.emplace_back(getPosX(t[3]), getPosY(t[3]), getPosZ(t[3]));
 
-            pos.push_back(type::Vector3(getPosX(t[1]), getPosY(t[1]), getPosZ(t[1])));
-            pos.push_back(type::Vector3(getPosX(t[2]), getPosY(t[2]), getPosZ(t[2])));
+            pos.emplace_back(getPosX(t[1]), getPosY(t[1]), getPosZ(t[1]));
+            pos.emplace_back(getPosX(t[2]), getPosY(t[2]), getPosZ(t[2]));
 
-            pos.push_back(type::Vector3(getPosX(t[1]), getPosY(t[1]), getPosZ(t[1])));
-            pos.push_back(type::Vector3(getPosX(t[3]), getPosY(t[3]), getPosZ(t[3])));
+            pos.emplace_back(getPosX(t[1]), getPosY(t[1]), getPosZ(t[1]));
+            pos.emplace_back(getPosX(t[3]), getPosY(t[3]), getPosZ(t[3]));
 
-            pos.push_back(type::Vector3(getPosX(t[2]), getPosY(t[2]), getPosZ(t[2])));
-            pos.push_back(type::Vector3(getPosX(t[3]), getPosY(t[3]), getPosZ(t[3])));
+            pos.emplace_back(getPosX(t[2]), getPosY(t[2]), getPosZ(t[2]));
+            pos.emplace_back(getPosX(t[3]), getPosY(t[3]), getPosZ(t[3]));
         }
         vparams->drawTool()->drawLines(pos, 1.0f, sofa::type::RGBAColor(1.0f,0.0f,0.0f,1.0f));
     }
 
+    vparams->drawTool()->restoreLastState();
 }
 
 } //namespace sofa::component::topology::container::constant


### PR DESCRIPTION
Fix it also in FixedConstraint for Rigid3.
Also replace some push_back by emplace_back


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
