### PR TITLE
[SofaCUDA][SofaSphFluid] Remove some getTemplateName deprecated methods

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.h
@@ -119,16 +119,6 @@ public:
     virtual void updateNormals();
     virtual void handleTopologyChange() override;
 
-    virtual std::string getTemplateName() const override
-    {
-        return templateName(this);
-    }
-    static std::string templateName(const CudaVisualModel<TDataTypes>* = NULL)
-    {
-        return TDataTypes::Name();
-    }
-
-
     virtual void computeBBox(const core::ExecParams* params, bool=false) override;
 
 protected:

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.h
@@ -99,16 +99,6 @@ public:
 
     virtual void updateVisual() override;
 
-    static std::string templateName(const OglFluidModel<DataTypes>* = NULL)
-    {
-        return DataTypes::Name();
-    }
-
-    virtual std::string getTemplateName() const override
-    {
-        return templateName(this);
-    }
-
 };
 
 }

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SpatialGridContainer.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SpatialGridContainer.h
@@ -357,15 +357,6 @@ public:
     }
     bool sortPoints();
 
-    virtual std::string getTemplateName() const override
-    {
-        return templateName(this);
-    }
-
-    static std::string templateName(const SpatialGridContainer<DataTypes>* = nullptr)
-    {
-        return DataTypes::Name();
-    }
 protected:
     core::behavior::MechanicalState<DataTypes>* mstate;
 };


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
