### PR TITLE
[Core] Make src an explicit link and support late update

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
@@ -348,12 +348,15 @@ bool BaseLink::updateLinks()
         Base* ptr;
         std::string path = getLinkedPath(i);
         /// Search for path and if any returns the pointer to the proper object.
-        /// Search for path and if any returns the pointer to the proper object.
         if(!getLinkedBase() && !path.empty())
         {
             ptr = PathResolver::FindBaseFromClassAndPath(getOwner(), getDestClass(), path);
             if(!ptr)
                 ok = false;
+            else
+            {
+                msg_info(this->getOwner()) << "Link '" << this->getName() << "' successfully updated";
+            }
             set(ptr,i);
         }
     }

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
@@ -352,7 +352,9 @@ bool BaseLink::updateLinks()
         {
             ptr = PathResolver::FindBaseFromClassAndPath(getOwner(), getDestClass(), path);
             if(!ptr)
+            {
                 ok = false;
+            }
             else
             {
                 msg_info(this->getOwner()) << "Link '" << this->getName() << "' successfully updated";

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
@@ -110,7 +110,7 @@ void BaseObject::parse( BaseObjectDescription* arg )
         }
         else
         {
-            msg_info(this->getClassName()) << "Link \"src\" to " << valueString << " could not be set now. Will try later";
+            msg_info(this) << "Link \"src\" to " << valueString << " could not be set.";
         }
     }
     Base::parse(arg);
@@ -189,38 +189,6 @@ Base* BaseObject::findLinkDestClass(const BaseClass* destType, const std::string
     else
         return this->getContext()->findLinkDestClass(destType, path, link);
 }
-
-void BaseObject::updateLinks(bool logErrors)
-{
-    for (BaseLink* iLink : m_vecLink)
-    {
-        const Base* previousTarget = iLink->getLinkedBase();
-        const bool ok = iLink->updateLinks();
-
-        if (!ok && iLink->storePath())
-        {
-            msg_warning_when(logErrors) << "Link update failed for " << iLink->getName() << " = " << iLink->getValueString() ;
-        }
-        else
-        {
-            const Base* currentTarget = iLink->getLinkedBase();
-            if (currentTarget && currentTarget != previousTarget)
-            {
-                if (iLink->getName() == "src")
-                {
-                    const std::string relativePath = BaseLink::CreateString(iLink->getLinkedBase(0), this);
-                    Base* target = iLink->getLinkedBase();
-                    if (const auto* targetObject = dynamic_cast<BaseObject*>(target))
-                    {
-                        this->setSrc(iLink->getLinkedPath(), targetObject, nullptr);
-                    }
-                }
-            }
-        }
-    }
-
-}
-
 
 const BaseContext* BaseObject::getContext() const
 {

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
@@ -176,10 +176,8 @@ public:
 
     Base* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link) override;
 
-    void updateLinks(bool logErrors = true) override;
-
     /// Return the full path name of this object
-    virtual std::string getPathName() const override;
+    std::string getPathName() const override;
 
     /// @name internalupdate
     ///   Methods related to tracking of data and the internal update

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
@@ -176,6 +176,7 @@ public:
 
     Base* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link) override;
 
+    void updateLinks(bool logErrors = true) override;
 
     /// Return the full path name of this object
     virtual std::string getPathName() const override;


### PR DESCRIPTION
if the attribute "src" is found, a link is dynamically added to the object. If the link is resolved right away, it links the Data. If the link is not resolved, it will try later in the `updateLinks` function.

It allows to write:

```xml
<OglModel  name="OglModel" src="@SOFA_pod" />
<MeshOBJLoader name="SOFA_pod" filename="mesh/SOFA_pod.obj" handleSeams="1" />
```

Before this PR, the src object must be declared before the `src` attribute. It was not possible to declare it after, such as in the previous example.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
