### PR TITLE
[Core] Remove warning from VisualManagerLoop

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
@@ -171,7 +171,7 @@ void Simulation::init ( Node* root )
 
     if(!root->getVisualLoop())
     {
-        msg_warning(root) <<
+        msg_info(root) <<
             "Default Visual Manager Loop will be used. Add DefaultVisualManagerLoop to the root node of scene file to remove this warning";
 
         DefaultVisualManagerLoop::SPtr vloop = sofa::core::objectmodel::New<DefaultVisualManagerLoop>(root);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
@@ -161,8 +161,10 @@ void Simulation::init ( Node* root )
 
     if (!root->getAnimationLoop())
     {
-        msg_warning(root) <<
-            "Default Animation Manager Loop will be used. Add DefaultAnimationLoop to the root node of scene file to remove this warning";
+        msg_warning(root) << "An animation loop is required, but has not been found. Add an animation loop in the root "
+                            "of your scene to fix this warning. The list of available animation loop components is: ["
+        << sofa::core::ObjectFactory::getInstance()->listClassesDerivedFrom<sofa::core::behavior::BaseAnimationLoop>()
+        << "]. A component of type " << DefaultAnimationLoop::GetClass()->className << " will be automatically added for you.";
         
         DefaultAnimationLoop::SPtr aloop = sofa::core::objectmodel::New<DefaultAnimationLoop>(root);
         aloop->setName(root->getNameHelper().resolveName(aloop->getClassName(), sofa::core::ComponentNameHelper::Convention::python));
@@ -171,8 +173,10 @@ void Simulation::init ( Node* root )
 
     if(!root->getVisualLoop())
     {
-        msg_info(root) <<
-            "Default Visual Manager Loop will be used. Add DefaultVisualManagerLoop to the root node of scene file to remove this warning";
+        msg_info(root) << "A visual loop is required, but has not been found. Add a visual loop in the root "
+                            "of your scene to fix this warning. The list of available visual loop components is: ["
+        << sofa::core::ObjectFactory::getInstance()->listClassesDerivedFrom<sofa::core::visual::VisualLoop>()
+        << "]. A component of type " << DefaultVisualManagerLoop::GetClass()->className << " will be automatically added for you.";
 
         DefaultVisualManagerLoop::SPtr vloop = sofa::core::objectmodel::New<DefaultVisualManagerLoop>(root);
         vloop->setName(root->getNameHelper().resolveName(vloop->getClassName(), sofa::core::ComponentNameHelper::Convention::python));


### PR DESCRIPTION
Since it's annoying every single user and developer!



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
