### PR TITLE
[MappedMatrix] MechanicalMatrixMapper: adds option

### DIFF
--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.h
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.h
@@ -113,6 +113,7 @@ protected:
     Data <bool> d_skipJ2tKJ2; ///< Boolean to choose whether to skip J2tKJ2 to avoid 2 contributions, in case 2 MechanicalMatrixMapper are used
     Data <bool> d_fastMatrixProduct; ///< If true, an accelerated method to compute matrix products based on the pre-computation of the matrices intersection is used. Regular matrix product otherwise.
     Data <bool> d_parallelTasks; ///< Execute some tasks in parallel for better performances
+    Data <bool> d_forceFieldAndMass; ///< If true, allows forceField and mass to be in the same component.
     SingleLink < MechanicalMatrixMapper<DataTypes1, DataTypes2>, sofa::core::behavior::BaseMechanicalState , BaseLink::FLAG_NONE > l_mechanicalState;
     SingleLink < MechanicalMatrixMapper<DataTypes1, DataTypes2>, sofa::core::behavior::BaseMass , BaseLink::FLAG_NONE > l_mappedMass;
     MultiLink  < MechanicalMatrixMapper<DataTypes1, DataTypes2>, sofa::core::behavior::BaseForceField, BaseLink::FLAG_NONE > l_forceField;

--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
@@ -103,6 +103,7 @@ MechanicalMatrixMapper<DataTypes1, DataTypes2>::MechanicalMatrixMapper()
       d_skipJ2tKJ2(initData(&d_skipJ2tKJ2,false,"skipJ2tKJ2","Boolean to choose whether to skip J2tKJ2 to avoid 2 contributions, in case 2 MechanicalMatrixMapper are used")),
       d_fastMatrixProduct(initData(&d_fastMatrixProduct, true, "fastMatrixProduct", "If true, an accelerated method to compute matrix products based on the pre-computation of the matrices intersection is used. Regular matrix product otherwise.")),
       d_parallelTasks(initData(&d_parallelTasks, true, "parallelTasks", "Execute some tasks in parallel for better performances")),
+      d_forceFieldAndMass(initData(&d_forceFieldAndMass, false, "forceFieldAndMass", "If true, allows forceField and mass to be in the same component.")),
       l_mechanicalState(initLink("mechanicalState","The mechanicalState with which the component will work on (filled automatically during init)")),
       l_mappedMass(initLink("mass","mass with which the component will work on (filled automatically during init)")),
       l_forceField(initLink("forceField","The ForceField(s) attached to this node (filled automatically during init)"))
@@ -200,7 +201,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::parseNode(sofa::simulation:
     msg_info() << "parsing node:";
     for(BaseForceField* forcefield : node->forceField)
     {
-        if (forcefield->name.getValue() != massName)
+        if (forcefield->name.getValue() != massName || d_forceFieldAndMass.getValue())
         {
             bool found = true;
             if (!empty)


### PR DESCRIPTION
For the moment we cannot use the component MechanicalMatrixMapper if the force field and mass are in the same component (for example AdaptiveBeamForceFieldAndMass from the plugin BeamAdapter). This PR just adds the option. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
