### PR TITLE
[Sofa.DefaultType] Name() should be compile-time evaluable

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -917,7 +917,7 @@ public:
         getVCenter(c)[2] += (Real)z;
     }
 
-    static const char* Name();
+    static constexpr const char* Name();
 
     /// Return a Deriv with random value. Each entry with magnitude smaller than the given value.
     static Deriv randomDeriv( Real minMagnitude, Real maxMagnitude)
@@ -1025,8 +1025,8 @@ typedef StdRigidTypes<3,float> Rigid3fTypes;
 typedef RigidMass<3,float> Rigid3fMass;
 
 /// We now use template aliases so we do not break backward compatibility.
-template<> inline const char* Rigid3dTypes::Name() { return "Rigid3d"; }
-template<> inline const char* Rigid3fTypes::Name() { return "Rigid3f"; }
+template<> constexpr const char* Rigid3dTypes::Name() { return "Rigid3d"; }
+template<> constexpr const char* Rigid3fTypes::Name() { return "Rigid3f"; }
 
 typedef StdRigidTypes<3,SReal> Rigid3Types;  ///< un-defined precision type
 typedef StdRigidTypes<3,SReal> RigidTypes;   ///< alias (beurk)
@@ -1742,7 +1742,7 @@ public:
     static const DRot& getDRot(const Deriv& d) { return getVOrientation(d); }
     static void setDRot(Deriv& d, const DRot& v) { getVOrientation(d) = v; }
 
-    static const char* Name();
+    static constexpr const char* Name();
 
     typedef type::vector<Coord> VecCoord;
     typedef type::vector<Deriv> VecDeriv;
@@ -1860,8 +1860,8 @@ public:
 
 
 
-template<> inline const char* Rigid2dTypes::Name() { return "Rigid2d"; }
-template<> inline const char* Rigid2fTypes::Name() { return "Rigid2f"; }
+template<> constexpr const char* Rigid2dTypes::Name() { return "Rigid2d"; }
+template<> constexpr const char* Rigid2fTypes::Name() { return "Rigid2f"; }
 
 /// \endcond
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/SolidTypes.h
@@ -405,7 +405,7 @@ public:
 
     static ArticulatedInertia dyad ( const SpatialVector& u, const SpatialVector& v );
 
-    static const char* Name()
+    static constexpr const char* Name()
     {
         return "Solid";
     }

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
@@ -180,7 +180,7 @@ public:
         Impl<spatial_dimensions,T>::add(c,x,y,z);
     }
 
-    static const char* Name();
+    static constexpr const char* Name();
 
     static Coord interpolate(const type::vector< Coord > &ancestors, const type::vector< Real > &coefs)
     {
@@ -200,35 +200,35 @@ public:
 
 /// 3D DOFs, double precision
 typedef StdVectorTypes<type::Vec3d,type::Vec3d,double> Vec3dTypes;
-template<> inline const char* Vec3dTypes::Name() { return "Vec3d"; }
+template<> constexpr const char* Vec3dTypes::Name() { return "Vec3d"; }
 
 /// 2D DOFs, double precision
 typedef StdVectorTypes<type::Vec2d, type::Vec2d,double> Vec2dTypes;
-template<> inline const char* Vec2dTypes::Name() { return "Vec2d"; }
+template<> constexpr const char* Vec2dTypes::Name() { return "Vec2d"; }
 
 /// 1D DOFs, double precision
 typedef StdVectorTypes<type::Vec1d, type::Vec1d,double> Vec1dTypes;
-template<> inline const char* Vec1dTypes::Name() { return "Vec1d"; }
+template<> constexpr const char* Vec1dTypes::Name() { return "Vec1d"; }
 
 /// 6D DOFs, double precision
 typedef StdVectorTypes<type::Vec6d, type::Vec6d,double> Vec6dTypes;
-template<> inline const char* Vec6dTypes::Name() { return "Vec6d"; }
+template<> constexpr const char* Vec6dTypes::Name() { return "Vec6d"; }
 
 /// 3f DOFs, single precision
 typedef StdVectorTypes<type::Vec3f, type::Vec3f,float> Vec3fTypes;
-template<> inline const char* Vec3fTypes::Name() { return "Vec3f"; }
+template<> constexpr const char* Vec3fTypes::Name() { return "Vec3f"; }
 
 /// 2f DOFs, single precision
 typedef StdVectorTypes<type::Vec2f, type::Vec2f,float> Vec2fTypes;
-template<> inline const char* Vec2fTypes::Name() { return "Vec2f"; }
+template<> constexpr const char* Vec2fTypes::Name() { return "Vec2f"; }
 
 /// 1f DOFs, single precision
 typedef StdVectorTypes<type::Vec1f, type::Vec1f,float> Vec1fTypes;
-template<> inline const char* Vec1fTypes::Name() { return "Vec1f"; }
+template<> constexpr const char* Vec1fTypes::Name() { return "Vec1f"; }
 
 /// 6f DOFs, single precision
 typedef StdVectorTypes<type::Vec6f, type::Vec6f,float> Vec6fTypes;
-template<> inline const char* Vec6fTypes::Name() { return "Vec6f"; }
+template<> constexpr const char* Vec6fTypes::Name() { return "Vec6f"; }
 
 /// 6D DOFs, double precision (default)
 typedef StdVectorTypes<type::Vec6, type::Vec6, type::Vec6::value_type> Vec6Types;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -93,9 +93,9 @@ public:
     typedef CudaVector<Real> VecReal;
     typedef defaulttype::MapMapSparseMatrix<Deriv> MatrixDeriv;
 
-    enum { spatial_dimensions = Coord::spatial_dimensions };
-    enum { coord_total_size = Coord::total_size };
-    enum { deriv_total_size = Deriv::total_size };
+    static constexpr sofa::Size spatial_dimensions = Coord::spatial_dimensions;
+    static constexpr sofa::Size coord_total_size = Coord::total_size;
+    static constexpr sofa::Size deriv_total_size = Deriv::total_size;
 
     typedef Coord CPos;
     static const CPos& getCPos(const Coord& c) { return c; }
@@ -215,7 +215,7 @@ public:
         return coord;
     }
 
-    static const char* Name();
+    static constexpr const char* Name();
 };
 
 typedef sofa::type::Vec3f Vec3f;
@@ -433,7 +433,7 @@ typedef CudaVectorTypes<Vec3f,Vec3f,float> CudaVec3fTypes;
 typedef CudaVec3fTypes CudaVec3Types;
 
 template<>
-inline const char* CudaVec3fTypes::Name()
+constexpr const char* CudaVec3fTypes::Name()
 {
     return "CudaVec3f";
 }
@@ -443,7 +443,7 @@ typedef CudaVectorTypes<Vec1f,Vec1f,float> CudaVec1fTypes;
 typedef CudaVec1fTypes CudaVec1Types;
 
 template<>
-inline const char* CudaVec1fTypes::Name()
+constexpr const char* CudaVec1fTypes::Name()
 {
     return "CudaVec1f";
 }
@@ -452,7 +452,7 @@ typedef CudaVectorTypes<Vec2f,Vec2f,float> CudaVec2fTypes;
 typedef CudaVec2fTypes CudaVec2Types;
 
 template<>
-inline const char* CudaVec2fTypes::Name()
+constexpr const char* CudaVec2fTypes::Name()
 {
     return "CudaVec2f";
 }
@@ -460,7 +460,7 @@ inline const char* CudaVec2fTypes::Name()
 typedef CudaVectorTypes<Vec3f1,Vec3f1,float> CudaVec3f1Types;
 
 template<>
-inline const char* CudaVec3f1Types::Name()
+constexpr const char* CudaVec3f1Types::Name()
 {
     return "CudaVec3f1";
 }
@@ -469,7 +469,7 @@ typedef CudaVectorTypes<Vec6f,Vec6f,float> CudaVec6fTypes;
 typedef CudaVec6fTypes CudaVec6Types;
 
 template<>
-inline const char* CudaVec6fTypes::Name()
+constexpr const char* CudaVec6fTypes::Name()
 {
     return "CudaVec6f";
 }
@@ -492,9 +492,9 @@ public:
     typedef defaulttype::MapMapSparseMatrix<Deriv> MatrixDeriv;
     typedef Vec3 AngularVector;
 
-    enum { spatial_dimensions = Coord::spatial_dimensions };
-    enum { coord_total_size = Coord::total_size };
-    enum { deriv_total_size = Deriv::total_size };
+    static constexpr sofa::Size spatial_dimensions = Coord::spatial_dimensions;
+    static constexpr sofa::Size coord_total_size = Coord::total_size;
+    static constexpr sofa::Size deriv_total_size = Deriv::total_size;
 
     typedef typename Coord::Pos CPos;
     typedef typename Coord::Rot CRot;
@@ -616,7 +616,7 @@ public:
         return d;
     }
 
-    static const char* Name();
+    static constexpr const char* Name();
 
     /// double cross product: a * ( b * c )
     static Vec3 crosscross ( const Vec3& a, const Vec3& b, const Vec3& c)
@@ -629,7 +629,7 @@ typedef CudaRigidTypes<3,float> CudaRigid3fTypes;
 typedef CudaRigid3fTypes CudaRigid3Types;
 
 template<>
-inline const char* CudaRigid3fTypes::Name()
+constexpr const char* CudaRigid3fTypes::Name()
 {
     return "CudaRigid3f";
 }
@@ -649,7 +649,7 @@ typedef CudaVectorTypes<Vec3d,Vec3d,double> CudaVec3dTypes;
 //typedef CudaVec3dTypes CudaVec3Types;
 
 template<>
-inline const char* CudaVec3dTypes::Name()
+constexpr const char* CudaVec3dTypes::Name()
 {
     return "CudaVec3d";
 }
@@ -658,7 +658,7 @@ typedef CudaVectorTypes<Vec1d,Vec1d,double> CudaVec1dTypes;
 //typedef CudaVec1dTypes CudaVec1Types;
 
 template<>
-inline const char* CudaVec1dTypes::Name()
+constexpr const char* CudaVec1dTypes::Name()
 {
     return "CudaVec1d";
 }
@@ -667,7 +667,7 @@ typedef CudaVectorTypes<Vec2d,Vec2d,double> CudaVec2dTypes;
 //typedef CudaVec2dTypes CudaVec2Types;
 
 template<>
-inline const char* CudaVec2dTypes::Name()
+constexpr const char* CudaVec2dTypes::Name()
 {
     return "CudaVec2d";
 }
@@ -675,7 +675,7 @@ inline const char* CudaVec2dTypes::Name()
 typedef CudaVectorTypes<Vec3d1,Vec3d1,double> CudaVec3d1Types;
 
 template<>
-inline const char* CudaVec3d1Types::Name()
+constexpr const char* CudaVec3d1Types::Name()
 {
     return "CudaVec3d1";
 }
@@ -684,7 +684,7 @@ typedef CudaVectorTypes<Vec6d,Vec6d,double> CudaVec6dTypes;
 // typedef CudaVec6dTypes CudaVec6Types;
 
 template<>
-inline const char* CudaVec6dTypes::Name()
+constexpr const char* CudaVec6dTypes::Name()
 {
     return "CudaVec6d";
 }
@@ -694,7 +694,7 @@ typedef CudaRigidTypes<3,double> CudaRigid3dTypes;
 //typedef CudaRigid3dTypes CudaRigid3Types;
 
 template<>
-inline const char* CudaRigid3dTypes::Name()
+constexpr const char* CudaRigid3dTypes::Name()
 {
     return "CudaRigid3d";
 }


### PR DESCRIPTION
As the title says, all the Name() for the DataTypes (aka VecTypes, RigidTypes and their Cuda versions) have been defined with the constexpr keyword.
\+ SolidTypes

\+ constexpr keywords for the size in CudaTypes (like "normal" versions)
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
