### PR TITLE
[objectmodel] Reduce memory leaks

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -370,7 +370,6 @@ protected:
         for (int i=0; i<TClassParents<Parents>::nb(); ++i)
             parents[i] = TClassParents<Parents>::get(i);
     }
-    ~TClass() override {}
 
     Base* dynamicCast(Base* obj) const override
     {
@@ -384,10 +383,20 @@ protected:
 
 public:
 
+    ~TClass() override {}
+
     static const BaseClass* get()
     {
-        static TClass<T, Parents> *theClass=new TClass<T, Parents>();
-        return theClass;
+        if constexpr (std::is_abstract_v<T>)
+        {
+            static TClass<T, Parents> *theClass = new TClass<T, Parents>();
+            return theClass;
+        }
+        else
+        {
+            static TClass<T, Parents> theClass;
+            return &theClass;
+        }
     }
 };
 


### PR DESCRIPTION
`TClass<T, Parents>` was instantiated on the heap and never free, causing memory leaks. An option is to instantiate the class on the stack so it is destroyed at the end of the program. But currently, the compilation fails if `TClass<T, Parents>` is instantiated on the stack with T an abstract class. That is why there are now two implementations.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
