### PR TITLE
[objectmodel] Remove memory leaks

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -160,7 +160,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 2 base classes
 #define SOFA_CLASS2(T,Parent1,Parent2) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<Parent1,Parent2> > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     SOFA_CLASS_DECL
@@ -168,7 +168,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 2 base classes
 #define SOFA_ABSTRACT_CLASS2(T,Parent1,Parent2) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<Parent1,Parent2> > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     SOFA_ABSTRACT_CLASS_DECL
@@ -176,7 +176,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 3 base classes
 #define SOFA_CLASS3(T,Parent1,Parent2,Parent3) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<Parent1,std::pair<Parent2,Parent3> > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -185,7 +185,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 3 base classes
 #define SOFA_ABSTRACT_CLASS3(T,Parent1,Parent2,Parent3) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<Parent1,std::pair<Parent2,Parent3> > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -194,7 +194,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 4 base classes
 #define SOFA_CLASS4(T,Parent1,Parent2,Parent3,Parent4) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<std::pair<Parent1,Parent2>,std::pair<Parent3,Parent4> > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3, Parent4> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -204,7 +204,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 4 base classes
 #define SOFA_ABSTRACT_CLASS4(T,Parent1,Parent2,Parent3,Parent4) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<std::pair<Parent1,Parent2>,std::pair<Parent3,Parent4> > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3, Parent4> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -214,7 +214,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 5 base classes
 #define SOFA_CLASS5(T,Parent1,Parent2,Parent3,Parent4,Parent5) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<std::pair<Parent1,Parent2>,std::pair<Parent3,std::pair<Parent4,Parent5> > > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3, Parent4, Parent5> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -225,7 +225,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 5 base classes
 #define SOFA_ABSTRACT_CLASS5(T,Parent1,Parent2,Parent3,Parent4,Parent5) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<std::pair<Parent1,Parent2>,std::pair<Parent3,std::pair<Parent4,Parent5> > > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3, Parent4, Parent5> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -236,7 +236,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 5 base classes
 #define SOFA_CLASS6(T,Parent1,Parent2,Parent3,Parent4,Parent5,Parent6) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<std::pair<Parent1,Parent2>,std::pair<std::pair<Parent3,Parent4>,std::pair<Parent5,Parent6> > > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3, Parent4, Parent5, Parent6> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -248,7 +248,7 @@ public:
 // This macro should now be used at the beginning of all declarations of classes with 5 base classes
 #define SOFA_ABSTRACT_CLASS6(T,Parent1,Parent2,Parent3,Parent4,Parent5,Parent6) \
     typedef T MyType;                                               \
-    typedef ::sofa::core::objectmodel::TClass< T, std::pair<std::pair<Parent1,Parent2>,std::pair<std::pair<Parent3,Parent4>,std::pair<Parent5,Parent6> > > > MyClass; \
+    typedef ::sofa::core::objectmodel::TClass< T, ::sofa::core::objectmodel::Parents<Parent1, Parent2, Parent3, Parent4, Parent5, Parent6> > MyClass; \
     typedef Parent1 Inherit1; \
     typedef Parent2 Inherit2; \
     typedef Parent3 Inherit3; \
@@ -306,51 +306,71 @@ public:
     \
     friend class sofa::core::objectmodel::New<MyType>
 
-template <class Parents>
-class TClassParents
+/**
+ * Represents a list of types with ability to get the number of types, and the ith type BaseClass
+ */
+template<class T, class ...Types>
+struct Parents
 {
-public:
-    static int nb()
+    static constexpr std::size_t nb = sizeof...(Types) + 1;
+
+    static const BaseClass* get(const std::size_t i)
+    {
+        if (i == 0)
+        {
+            return T::GetClass();
+        }
+        if constexpr (sizeof...(Types) == 0)
+        {
+            return nullptr;
+        }
+        else
+        {
+            return Parents<Types...>::get(i-1);
+        }
+    }
+};
+
+template <typename Parent>
+struct TClassParents
+{
+    static constexpr std::size_t nb()
     {
         return 1;
     }
-    static const BaseClass* get(int i)
+    static const BaseClass* get(const std::size_t i)
     {
         if (i==0)
-            return Parents::GetClass();
-        else
-            return nullptr;
+        {
+            return Parent::GetClass();
+        }
+        return nullptr;
     }
 };
 
 template<>
-class TClassParents<void>
+struct TClassParents<void>
 {
-public:
-    static int nb()
+    static constexpr std::size_t nb()
     {
         return 0;
     }
-    static const BaseClass* get(int)
+    static const BaseClass* get(const std::size_t i)
     {
         return nullptr;
     }
 };
 
-template<class P1, class P2>
-class TClassParents< std::pair<P1,P2> >
+template<typename ...Types>
+struct TClassParents<Parents<Types...> >
 {
-public:
-    static int nb()
+    static constexpr std::size_t nb()
     {
-        return TClassParents<P1>::nb() + TClassParents<P2>::nb();
+        return Parents<Types...>::nb;
     }
-    static const BaseClass* get(int i)
+    static const BaseClass* get(const std::size_t i)
     {
-        if (i<TClassParents<P1>::nb())
-            return TClassParents<P1>::get(i);
-        else
-            return TClassParents<P2>::get(i-TClassParents<P1>::nb());
+        return Parents<Types...>::get(i);
     }
 };
 
@@ -367,8 +387,10 @@ protected:
         shortName = NameDecoder::getShortName<T>();
 
         parents.resize(TClassParents<Parents>::nb());
-        for (int i=0; i<TClassParents<Parents>::nb(); ++i)
+        for (std::size_t i = 0; i < TClassParents<Parents>::nb(); ++i)
+        {
             parents[i] = TClassParents<Parents>::get(i);
+        }
     }
     ~TClass() override {}
 
@@ -386,8 +408,8 @@ public:
 
     static const BaseClass* get()
     {
-        static TClass<T, Parents> *theClass=new TClass<T, Parents>();
-        return theClass;
+        static TClass<T, Parents> theClass;
+        return &theClass;
     }
 };
 


### PR DESCRIPTION
The following code create memory leaks:

```cpp
static const BaseClass* get()
{
  static TClass<T, Parents> *theClass=new TClass<T, Parents>();
  return theClass;
}
```

To remove the memory leak, it has to be replaced by:

```cpp
static const BaseClass* get()
{
  static TClass<T, Parents> theClass;
  return &theClass;
}
```

However, `Parents` can be a `std::pair`, which one of the pair type can be an abstract type. Since it is not possible to instantiate an abstract type, the compilation fails.

This PR removes the use of `std::pair` to introduce a structure that does not need to instantiate the types. The compilation now succeeds.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
