### PR TITLE
[objectmodel] Remove redefinition of initData

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -275,6 +275,16 @@ public:
 
     /// Helper method used to initialize a data field containing a value of type T
     template<class T>
+    BaseData::BaseInitData initData(::sofa::core::objectmodel::Data<T>* field, const char* name, const char* help,
+    ::sofa::core::objectmodel::BaseData::DataFlags dataflags)
+    {
+        ::sofa::core::objectmodel::BaseData::BaseInitData res;
+        this->initData0(field, res, name, help, dataflags);
+        return res;
+    }
+
+    /// Helper method used to initialize a data field containing a value of type T
+    template<class T>
     BaseData::BaseInitData initData( Data<T>* field, const char* name, const char* help, bool isDisplayed=true, bool isReadOnly=false )
     {
         BaseData::BaseInitData res;

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -267,32 +267,6 @@ public:
     virtual const ::sofa::core::objectmodel::BaseClass* getClass() const override \
 { return GetClass(); }                                              \
     static const char* HeaderFileLocation() { return __FILE__; }        \
-    template<class SOFA_T> ::sofa::core::objectmodel::BaseData::BaseInitData \
-    initData(::sofa::core::objectmodel::Data<SOFA_T>* field, const char* name, const char* help,   \
-    ::sofa::core::objectmodel::BaseData::DataFlags dataflags)  \
-{                                                                   \
-    ::sofa::core::objectmodel::BaseData::BaseInitData res;          \
-    this->initData0(field, res, name, help, dataflags);             \
-    return res;                                                     \
-}                                                                   \
-    template<class SOFA_T> ::sofa::core::objectmodel::BaseData::BaseInitData \
-    initData(::sofa::core::objectmodel::Data<SOFA_T>* field, const char* name, const char* help,   \
-    bool isDisplayed=true, bool isReadOnly=false)              \
-{                                                                   \
-    ::sofa::core::objectmodel::BaseData::BaseInitData res;          \
-    this->initData0(field, res, name, help,                         \
-    isDisplayed, isReadOnly);                       \
-    return res;                                                     \
-}                                                                   \
-    template<class SOFA_T> typename ::sofa::core::objectmodel::Data<SOFA_T>::InitData initData(    \
-    ::sofa::core::objectmodel::Data<SOFA_T>* field, const SOFA_T& value, const char* name,     \
-    const char* help, bool isDisplayed=true, bool isReadOnly=false) \
-{                                                                   \
-    typename ::sofa::core::objectmodel::Data<SOFA_T>::InitData res; \
-    this->initData0(field, res, value, name, help,                  \
-    isDisplayed, isReadOnly);                       \
-    return res;                                                     \
-}                                                                   \
     ::sofa::core::objectmodel::BaseLink::InitLink<MyType>               \
     initLink(const char* name, const char* help)                        \
 {                                                                   \

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -267,7 +267,7 @@ public:
     virtual const ::sofa::core::objectmodel::BaseClass* getClass() const override \
 { return GetClass(); }                                              \
     static const char* HeaderFileLocation() { return __FILE__; }        \
-    using Base::initData;                                               \
+    using ::sofa::core::objectmodel::Base::initData;                    \
     ::sofa::core::objectmodel::BaseLink::InitLink<MyType>               \
     initLink(const char* name, const char* help)                        \
 {                                                                   \

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -267,6 +267,7 @@ public:
     virtual const ::sofa::core::objectmodel::BaseClass* getClass() const override \
 { return GetClass(); }                                              \
     static const char* HeaderFileLocation() { return __FILE__; }        \
+    using Base::initData;                                               \
     ::sofa::core::objectmodel::BaseLink::InitLink<MyType>               \
     initLink(const char* name, const char* help)                        \
 {                                                                   \


### PR DESCRIPTION
If a class inherits from `Base` it already has 2 `initData` overloads available. So why redefining them in the `SOFA_CLASS` macro?
The third overload is not defined in `Base`, so I did it and remove the one in `SOFA_CLASS`.
In summary, the 3 `initData` overloads are only defined in `Base` and nowhere else.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
