### PR TITLE
[CMake] Clean packaging for v22.06

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ if(SOFA_BUILD_RELEASE_PACKAGE)
         set(CPACK_NSIS_MENU_LINKS
             "https://www.sofa-framework.org/documentation/" "SOFA User Documentation"
             "https://www.sofa-framework.org/api/" "SOFA Developper API"
-            "https://www.sofa-framework.org/community/forum/" "SOFA Forum")
+            "https://github.com/sofa-framework/sofa/discussions" "SOFA Support")
     endif()
     #######################
 

--- a/tools/postinstall-fixup/linux-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/linux-postinstall-fixup.sh
@@ -22,36 +22,34 @@ fi
 echo "" > "$INSTALL_DIR/lib/plugin_list.conf"
 disabled_plugins='plugins_ignored_by_default'
 for plugin in \
-        SofaEulerianFluid     \
-        SofaDistanceGrid      \
-        SofaImplicitField     \
-        MultiThreading        \
-        DiffusionSolver       \
-        image                 \
-        Compliant             \
-        SofaPython            \
-        Flexible              \
-        Registration          \
-        ExternalBehaviorModel \
-        ManifoldTopologies    \
-        ManualMapping         \
-        THMPGSpatialHashing   \
-        SofaCarving           \
-        RigidScale            \
-                              \
-        LMConstraint          \
-        SofaHaptics           \
-        SofaValidation        \
-        SofaNonUniformFem     \
-        SofaExporter          \
-        SofaPreconditioner    \
-        SofaMiscTopology      \
-        SofaMiscExtra         \
-        SofaMiscForceField    \
-        SofaMiscEngine        \
-        SofaMiscSolver        \
-        SofaMiscFem           \
-        SofaMiscMapping       \
+        ArticulatedSystemPlugin   \
+        CollisionOBBCapsule       \
+        Compliant                 \
+        DiffusionSolver           \
+        ExternalBehaviorModel     \
+        Flexible                  \
+        Geomagic                  \
+        image                     \
+        InvertibleFVM             \
+        LMConstraint              \
+        ManifoldTopologies        \
+        ManualMapping             \
+        MultiThreading            \
+        OptiTrackNatNet           \
+        PluginExample             \
+        Registration              \
+        RigidScale                \
+        SensableEmulation         \
+        SofaAssimp                \
+        SofaCUDA                  \
+        SofaCarving               \
+        SofaDistanceGrid          \
+        SofaEulerianFluid         \
+        SofaImplicitField         \
+        SofaPython                \
+        SofaSimpleGUI             \
+        SofaSphFluid              \
+        THMPGSpatialHashing       \
     ; do
     disabled_plugins=$disabled_plugins'\|'$plugin
 done

--- a/tools/postinstall-fixup/macos-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/macos-postinstall-fixup.sh
@@ -29,36 +29,34 @@ echo "MACDEPLOYQT_EXE = $MACDEPLOYQT_EXE"
 echo "" > "$INSTALL_DIR/lib/plugin_list.conf"
 disabled_plugins='plugins_ignored_by_default'
 for plugin in \
-        SofaEulerianFluid     \
-        SofaDistanceGrid      \
-        SofaImplicitField     \
-        MultiThreading        \
-        DiffusionSolver       \
-        image                 \
-        Compliant             \
-        SofaPython            \
-        Flexible              \
-        Registration          \
-        ExternalBehaviorModel \
-        ManifoldTopologies    \
-        ManualMapping         \
-        THMPGSpatialHashing   \
-        SofaCarving           \
-        RigidScale            \
-                              \
-        LMConstraint          \
-        SofaHaptics           \
-        SofaValidation        \
-        SofaNonUniformFem     \
-        SofaExporter          \
-        SofaPreconditioner    \
-        SofaMiscTopology      \
-        SofaMiscExtra         \
-        SofaMiscForceField    \
-        SofaMiscEngine        \
-        SofaMiscSolver        \
-        SofaMiscFem           \
-        SofaMiscMapping       \
+        ArticulatedSystemPlugin   \
+        CollisionOBBCapsule       \
+        Compliant                 \
+        DiffusionSolver           \
+        ExternalBehaviorModel     \
+        Flexible                  \
+        Geomagic                  \
+        image                     \
+        InvertibleFVM             \
+        LMConstraint              \
+        ManifoldTopologies        \
+        ManualMapping             \
+        MultiThreading            \
+        OptiTrackNatNet           \
+        PluginExample             \
+        Registration              \
+        RigidScale                \
+        SensableEmulation         \
+        SofaAssimp                \
+        SofaCUDA                  \
+        SofaCarving               \
+        SofaDistanceGrid          \
+        SofaEulerianFluid         \
+        SofaImplicitField         \
+        SofaPython                \
+        SofaSimpleGUI             \
+        SofaSphFluid              \
+        THMPGSpatialHashing       \
     ; do
     disabled_plugins=$disabled_plugins'\|'$plugin
 done

--- a/tools/postinstall-fixup/windows-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/windows-postinstall-fixup.sh
@@ -26,36 +26,34 @@ echo "INSTALL_DIR_BIN = $INSTALL_DIR_BIN"
 echo "" > "$INSTALL_DIR_BIN/plugin_list.conf"
 disabled_plugins='plugins_ignored_by_default'
 for plugin in \
-        SofaEulerianFluid     \
-        SofaDistanceGrid      \
-        SofaImplicitField     \
-        MultiThreading        \
-        DiffusionSolver       \
-        image                 \
-        Compliant             \
-        SofaPython            \
-        Flexible              \
-        Registration          \
-        ExternalBehaviorModel \
-        ManifoldTopologies    \
-        ManualMapping         \
-        THMPGSpatialHashing   \
-        SofaCarving           \
-        RigidScale            \
-                              \
-        LMConstraint          \
-        SofaHaptics           \
-        SofaValidation        \
-        SofaNonUniformFem     \
-        SofaExporter          \
-        SofaPreconditioner    \
-        SofaMiscTopology      \
-        SofaMiscExtra         \
-        SofaMiscForceField    \
-        SofaMiscEngine        \
-        SofaMiscSolver        \
-        SofaMiscFem           \
-        SofaMiscMapping       \
+        ArticulatedSystemPlugin   \
+        CollisionOBBCapsule       \
+        Compliant                 \
+        DiffusionSolver           \
+        ExternalBehaviorModel     \
+        Flexible                  \
+        Geomagic                  \
+        image                     \
+        InvertibleFVM             \
+        LMConstraint              \
+        ManifoldTopologies        \
+        ManualMapping             \
+        MultiThreading            \
+        OptiTrackNatNet           \
+        PluginExample             \
+        Registration              \
+        RigidScale                \
+        SensableEmulation         \
+        SofaAssimp                \
+        SofaCUDA                  \
+        SofaCarving               \
+        SofaDistanceGrid          \
+        SofaEulerianFluid         \
+        SofaImplicitField         \
+        SofaPython                \
+        SofaSimpleGUI             \
+        SofaSphFluid              \
+        THMPGSpatialHashing       \
     ; do
     disabled_plugins=$disabled_plugins'\|'$plugin
 done


### PR DESCRIPTION
Update the list of plugins to NOT auto-load when executing runSofa from the release.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
