### PR TITLE
Topology changes for SphereCollisionModel on EdgeSetTopologyContainer

### DIFF
--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.h
@@ -97,6 +97,8 @@ protected:
     SphereCollisionModel();
 
     SphereCollisionModel(core::behavior::MechanicalState<TDataTypes>* _mstate );
+
+    virtual void updateFromTopology();
 public:
     void init() override;
 
@@ -113,7 +115,7 @@ public:
     void draw(const core::visual::VisualParams* vparams) override;
 
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
 
     const VecReal& getR() const { return this->radius.getValue(); }
 
@@ -162,11 +164,19 @@ public:
     Data< SReal > defaultRadius; ///< Default Radius
     Data< bool > d_showImpostors; ///< Draw spheres as impostors instead of "real" spheres
 
-
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
 
+    sofa::core::topology::BaseMeshTopology* getCollisionTopology() override
+    {
+        return l_topology.get();
+    }
+
 protected:
-    core::behavior::MechanicalState<DataTypes>* mstate;
+    core::behavior::MechanicalState<DataTypes>* m_mstate;
+    sofa::core::topology::BaseMeshTopology* m_topology; ///< Pointer to the corresponding Topology
+    bool m_needsUpdate; ///< parameter storing the info boundingTree has to be recomputed.
+    int m_topologyRevision; ///< internal revision number to check if topology has changed.
+
     SingleLink<SphereCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 };
 
@@ -182,28 +192,28 @@ inline TSphere<DataTypes>::TSphere(const core::CollisionElementIterator& i)
 }
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::center() const { return DataTypes::getCPos(this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::center() const { return DataTypes::getCPos(this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[this->index]); }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord & TSphere<DataTypes>::rigidCenter() const { return this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[this->index];}
+inline const typename DataTypes::Coord & TSphere<DataTypes>::rigidCenter() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[this->index];}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::p() const { return DataTypes::getCPos(this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[this->index]);}
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::p() const { return DataTypes::getCPos(this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[this->index]);}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::pFree() const { return (*this->model->mstate->read(core::ConstVecCoordId::freePosition())).getValue()[this->index]; }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::pFree() const { return (*this->model->m_mstate->read(core::ConstVecCoordId::freePosition())).getValue()[this->index]; }
 
 template<class DataTypes>
-inline const typename SphereCollisionModel<DataTypes>::Coord& SphereCollisionModel<DataTypes>::velocity(Index index) const { return DataTypes::getDPos(mstate->read(core::ConstVecDerivId::velocity())->getValue()[index]);}
+inline const typename SphereCollisionModel<DataTypes>::Coord& SphereCollisionModel<DataTypes>::velocity(Index index) const { return DataTypes::getDPos(m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[index]);}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::v() const { return DataTypes::getDPos(this->model->mstate->read(core::ConstVecDerivId::velocity())->getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::v() const { return DataTypes::getDPos(this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[this->index]); }
 
 template<class DataTypes>
 inline typename DataTypes::Real TSphere<DataTypes>::r() const { return (Real) this->model->getRadius((unsigned)this->index); }
 
 template<class DataTypes>
-inline bool TSphere<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::ConstVecCoordId::freePosition())->isSet(); }
+inline bool TSphere<DataTypes>::hasFreePosition() const { return this->model->m_mstate->read(core::ConstVecCoordId::freePosition())->isSet(); }
 
 using Sphere = TSphere<sofa::defaulttype::Vec3Types>;
 using RigidSphere = TSphere<sofa::defaulttype::Rigid3Types>;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.h
@@ -26,6 +26,8 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/topology/TopologyData.h>
+
 
 namespace sofa::component::collision::geometry
 {
@@ -89,6 +91,7 @@ public:
 
     typedef typename DataTypes::CPos Coord;
     //typedef typename DataTypes::Coord Coord;
+    typedef typename sofa::core::topology::PointData<sofa::type::vector<Real>> PointData;
     typedef typename DataTypes::Real Real;
     typedef typename DataTypes::VecReal VecReal;
     typedef TSphere<DataTypes> Element;
@@ -160,7 +163,7 @@ public:
     }
 
     //TODO(dmarchal) guideline de sofa.
-    Data< VecReal > radius; ///< Radius of each sphere
+    PointData radius; ///< Radius of each sphere
     Data< SReal > defaultRadius; ///< Default Radius
     Data< bool > d_showImpostors; ///< Draw spheres as impostors instead of "real" spheres
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.inl
@@ -61,6 +61,7 @@ void SphereCollisionModel<DataTypes>::resize(Size size)
 {
     this->core::CollisionModel::resize(size);
 
+    // TODO should this be a WriteAccessor<PointData>? r then has no attribute size()
     helper::WriteAccessor< Data<VecReal> > r = radius;
 
     if (r.size() < size)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -650,7 +650,7 @@ core::topology::BaseMeshTopology* Node::getMeshTopologyLink(SearchDirection dir)
     if (this->meshTopology)
         return this->meshTopology;
     else
-        return get<core::topology::BaseMeshTopology>(SearchParents);
+        return get<core::topology::BaseMeshTopology>(dir);
 }
 
 /// Degrees-of-Freedom

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -89,7 +89,7 @@ void CarvingManager::init()
     {
         // We look for a CollisionModel identified with the CarvingSurface Tag.
         std::vector<core::CollisionModel*> models;
-        getContext()->get<core::CollisionModel>(&models, core::objectmodel::Tag("CarvingSurface"), core::objectmodel::BaseContext::SearchRoot);
+        getContext()->get<core::CollisionModel>(&models, core::objectmodel::Tag("CarvingSurface"), core::objectmodel::BaseContext::SearchDown);
     
         // If topological mapping, iterate into child Node to find mapped topology
 	    sofa::core::topology::TopologicalMapping* topoMapping;
@@ -97,7 +97,9 @@ void CarvingManager::init()
         {
             core::CollisionModel* m = models[i];
             m->getContext()->get(topoMapping);
-            if (topoMapping == NULL) continue;
+            if (topoMapping == NULL) {
+                msg_error() << "CarvingSurface on collision model " << m->name.getValue() << " does not have a topological mapping (e.g. IdentityTopologicalMapping) and none were found in the child nodes. Make sure this is correct.";
+            }
                         
             m_surfaceCollisionModels.push_back(m);
         }
@@ -189,6 +191,7 @@ void CarvingManager::doCarve()
             if (c.value < d_carvingDistance.getValue())
             {
                 auto triangleIdx = (c.elem.first.getCollisionModel() == m_toolCollisionModel ? c.elem.second.getIndex() : c.elem.first.getIndex());
+                // TODO generalize this for non-triangle collision models
                 elemsToRemove.push_back(triangleIdx);
             }
         }

--- a/examples/Components/visualmodel/OglShadowShader_Directional.scn
+++ b/examples/Components/visualmodel/OglShadowShader_Directional.scn
@@ -7,13 +7,14 @@
 
 	<BackgroundSetting color="0.5 0.5 0.5" />
 	<MeshOBJLoader name="meshLoader_0" filename="mesh/dragon.obj"  translation="0 0 -5"  scale3d="0.3 0.3 0.3" handleSeams="1" />
-	<OglModel template="Vec3d" name="VisualModel" src="@meshLoader_0"  material="Default Diffuse 1 0 1 0 1 Ambient 1 0 0.2 0 1 Specular 0 0 1 0 1 Emissive 0 0 1 0 1 Shininess 0 45 No texture linked to the material No bump texture linked to the material "  blendEquation="GL_FUNC_ADD"  sfactor="GL_SRC_ALPHA"  dfactor="GL_ONE_MINUS_SRC_ALPHA" />
+    <OglModel template="Vec3d" name="VisualModel" src="@meshLoader_0" texturename="/home/paul/repos/sofa/src/share/textures/cubemap_fr.bmp"/>
+    <!-- material="Default Diffuse 1 0 1 0 1 Ambient 1 0 0.2 0 1 Specular 0 0 1 0 1 Emissive 0 0 1 0 1 Shininess 0 45 No texture linked to the material No bump texture linked to the material "  blendEquation="GL_FUNC_ADD"  sfactor="GL_SRC_ALPHA"  dfactor="GL_ONE_MINUS_SRC_ALPHA" /> -->
 	
 	<MeshOBJLoader name="meshLoader_1" filename="mesh/floor.obj"  translation="0 -2.5 0"  scale3d="0.5 0.5 0.5" handleSeams="1" />
 	<OglModel template="Vec3d" name="FloorV" src="@meshLoader_1"  material="Default Diffuse 1 0.5 0.5 0.8 1 Ambient 1 0.1 0.1 0.1 1 Specular 0 0.5 0.5 0.5 1 Emissive 0 0.5 0.5 0.5 1 Shininess 0 45 No texture linked to the material No bump texture linked to the material "  blendEquation="GL_FUNC_ADD"  sfactor="GL_SRC_ALPHA"  dfactor="GL_ONE_MINUS_SRC_ALPHA" />
 	<LightManager name="lightManager1"  listening="1"  shadows="1"  softShadows="0" />
 	<OglShadowShader name="oglShadowShader1" />
-	<DirectionalLight name="spotLight1"  shadowTextureSize="512" direction="-0.5 -0.5 -0.5"  shadowFactor="1" />
+	<DirectionalLight name="spotLight1"   direction="0.5 0.5 0.5"   />
 	<!-- <OglViewport screenPosition="0 0" screenSize="250 250" cameraPosition="-200 0 0" cameraOrientation="0 0.707 0 -0.707" zNear="1" zFar="1000" /> -->
 
 </Node>


### PR DESCRIPTION
Hi,
removing `SphereCollisionModel` elements from a `EdgeSetTopologyContainer` currently does not work, because 

`TopologicalChangeManager::removeItemsFromSphereModel` calls `getCollisionTopology`
https://github.com/sofa-framework/sofa/blob/d42e3547dffaf385448fb077d466fc0bebc39bc9/Sofa/GUI/Component/src/sofa/gui/component/performer/TopologicalChangeManager.cpp#L297
which is not implemented in `SphereCollisionModel`, and the default from `BaseMeshTopology` returns `nullptr`.
https://github.com/sofa-framework/sofa/blob/471a3df6a377f92155f34ab4a75e931ec9559f7f/Sofa/framework/Core/src/sofa/core/CollisionModel.h#L357

I tried porting over the topology linking from [TriangleModel](https://github.com/ScheiklP/sofa/blob/sphere_on_edge_topo_changes/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleModel.inl), but it seems I am missing something, because it does not work :D 
https://cloud.ipr.kit.edu/s/ZHW7Jkz5yE6wb42

Is anyone seeing something obvious?

Cheers,
Paul

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
