### PR TITLE
[GUI.Qt] Fix MSAA sampling setup

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -246,7 +246,7 @@ void RealGUI::setupSurfaceFormat()
 
         if (mArgumentParser)
         {
-            unsigned int viewerMSAANbSampling;
+            unsigned int viewerMSAANbSampling = 0;
             mArgumentParser->getValueFromKey("msaa", viewerMSAANbSampling);
             if (viewerMSAANbSampling > 1)
             {


### PR DESCRIPTION
If the user did not specify any sampling number for MSAA (by default), `viewerMSAANbSampling` was not set in getValueFromKey(), and as it was not initialized, it had some random number (usually huge).
Consequently, MSAA was always activated with the highest number of samples even if the user did not specify it.
(and got some bogus message like `[INFO]    [RealGUI] Set multisampling anti-aliasing (MSAA) with 1538452832 samples.` )



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
