### PR TITLE
[CMake] FIX parent modules library consistency

### DIFF
--- a/Sofa/Component/CMakeLists.txt
+++ b/Sofa/Component/CMakeLists.txt
@@ -3,35 +3,29 @@ project(Sofa.Component LANGUAGES CXX)
 
 set(SOFACOMPONENT_SOURCE_DIR "src/sofa/component")
 
-set(SOFACOMPONENT_DIRS
-    ODESolver
-    IO
-    Playback
-    SceneUtility
-    Topology
-    Visual
-    LinearSolver
-    Mass
-    Diffusion
-    Mapping
-    SolidMechanics
-    StateContainer
-    Constraint
-    AnimationLoop
-    MechanicalLoad
-    Collision
-    Setting
-    Controller
-    Engine
-    Haptics
+sofa_add_subdirectory_modules(SOFACOMPONENT_TARGETS
+    DIRECTORIES
+        ODESolver
+        IO
+        Playback
+        SceneUtility
+        Topology
+        Visual
+        LinearSolver
+        Mass
+        Diffusion
+        Mapping
+        SolidMechanics
+        StateContainer
+        Constraint
+        AnimationLoop
+        MechanicalLoad
+        Collision
+        Setting
+        Controller
+        Engine
+        Haptics
 )
-set(SOFACOMPONENT_TARGETS)
-foreach(component_dir ${SOFACOMPONENT_DIRS})
-    sofa_add_subdirectory(module ${component_dir} ${PROJECT_NAME}.${component_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${component_dir})
-        list(APPEND SOFACOMPONENT_TARGETS ${PROJECT_NAME}.${component_dir})
-    endif()
-endforeach()
 
 set(HEADER_FILES
     ${SOFACOMPONENT_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Collision/CMakeLists.txt
+++ b/Sofa/Component/Collision/CMakeLists.txt
@@ -3,14 +3,9 @@ project(Sofa.Component.Collision LANGUAGES CXX)
 
 set(SOFACOMPONENTCOLLISION_SOURCE_DIR "src/sofa/component/collision")
 
-set(SOFACOMPONENTCOLLISION_DIRS Geometry Detection Response)
-set(SOFACOMPONENTCOLLISION_TARGETS)
-foreach(collision_dir ${SOFACOMPONENTCOLLISION_DIRS})
-    sofa_add_subdirectory(module ${collision_dir} ${PROJECT_NAME}.${collision_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${collision_dir})
-        list(APPEND SOFACOMPONENTCOLLISION_TARGETS ${PROJECT_NAME}.${collision_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTCOLLISION_TARGETS
+    DIRECTORIES Geometry Detection Response
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTCOLLISION_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Collision/Detection/CMakeLists.txt
+++ b/Sofa/Component/Collision/Detection/CMakeLists.txt
@@ -3,14 +3,9 @@ project(Sofa.Component.Collision.Detection LANGUAGES CXX)
 
 set(SOFACOMPONENTCOLLISIONDETECTION_SOURCE_DIR "src/sofa/component/collision/detection")
 
-set(SOFACOMPONENTCOLLISIONDETECTION_DIRS Algorithm Intersection)
-set(SOFACOMPONENTCOLLISIONDETECTION_TARGETS)
-foreach(detection_dir ${SOFACOMPONENTCOLLISIONDETECTION_DIRS})
-    sofa_add_subdirectory(module ${detection_dir} ${PROJECT_NAME}.${detection_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${detection_dir})
-        list(APPEND SOFACOMPONENTCOLLISIONDETECTION_TARGETS ${PROJECT_NAME}.${detection_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTCOLLISIONDETECTION_TARGETS
+    DIRECTORIES Algorithm Intersection
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTCOLLISIONDETECTION_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Collision/Response/CMakeLists.txt
+++ b/Sofa/Component/Collision/Response/CMakeLists.txt
@@ -3,14 +3,9 @@ project(Sofa.Component.Collision.Response LANGUAGES CXX)
 
 set(SOFACOMPONENTCOLLISIONRESPONSE_SOURCE_DIR "src/sofa/component/collision/response")
 
-set(SOFACOMPONENTCOLLISIONRESPONSE_DIRS Mapper Contact)
-set(SOFACOMPONENTCOLLISIONRESPONSE_TARGETS)
-foreach(response_dir ${SOFACOMPONENTCOLLISIONRESPONSE_DIRS})
-    sofa_add_subdirectory(module ${response_dir} ${PROJECT_NAME}.${response_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${response_dir})
-        list(APPEND SOFACOMPONENTCOLLISIONRESPONSE_TARGETS ${PROJECT_NAME}.${response_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTCOLLISIONRESPONSE_TARGETS
+    DIRECTORIES Mapper Contact
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTCOLLISIONRESPONSE_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Constraint/CMakeLists.txt
+++ b/Sofa/Component/Constraint/CMakeLists.txt
@@ -3,15 +3,9 @@ project(Sofa.Component.Constraint LANGUAGES CXX)
 
 set(SOFACOMPONENTCONSTRAINT_SOURCE_DIR "src/sofa/component/constraint")
 
-set(SOFACOMPONENTCONSTRAINT_DIRS Lagrangian Projective)
-set(SOFACOMPONENTCONSTRAINT_TARGETS)
-foreach(constraint_dir ${SOFACOMPONENTCONSTRAINT_DIRS})
-    sofa_add_subdirectory(module ${constraint_dir} ${PROJECT_NAME}.${constraint_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${constraint_dir})
-        list(APPEND SOFACOMPONENTCONSTRAINT_TARGETS ${PROJECT_NAME}.${constraint_dir})
-    endif()
-endforeach()
-
+sofa_add_subdirectory_modules(SOFACOMPONENTCONSTRAINT_TARGETS
+    DIRECTORIES Lagrangian Projective
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTCONSTRAINT_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Constraint/Lagrangian/CMakeLists.txt
+++ b/Sofa/Component/Constraint/Lagrangian/CMakeLists.txt
@@ -3,15 +3,9 @@ project(Sofa.Component.Constraint.Lagrangian LANGUAGES CXX)
 
 set(SOFACOMPONENTCONSTRAINTLAGRANGIAN_SOURCE_DIR "src/sofa/component/constraint/lagrangian")
 
-set(SOFACOMPONENTCONSTRAINTLAGRANGIAN_DIRS Model Correction Solver)
-set(SOFACOMPONENTCONSTRAINTLAGRANGIAN_TARGETS)
-foreach(lagrangian_dir ${SOFACOMPONENTCONSTRAINTLAGRANGIAN_DIRS})
-    sofa_add_subdirectory(module ${lagrangian_dir} ${PROJECT_NAME}.${lagrangian_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${lagrangian_dir})
-        list(APPEND SOFACOMPONENTCONSTRAINTLAGRANGIAN_TARGETS ${PROJECT_NAME}.${lagrangian_dir})
-    endif()
-endforeach()
-
+sofa_add_subdirectory_modules(SOFACOMPONENTCONSTRAINTLAGRANGIAN_TARGETS
+    DIRECTORIES Model Correction Solver
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTCONSTRAINTLAGRANGIAN_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Engine/CMakeLists.txt
+++ b/Sofa/Component/Engine/CMakeLists.txt
@@ -3,15 +3,9 @@ project(Sofa.Component.Engine LANGUAGES CXX)
 
 set(SOFACOMPONENTENGINE_SOURCE_DIR "src/sofa/component/engine")
 
-set(SOFACOMPONENTENGINE_DIRS Analyze Generate Select Transform)
-set(SOFACOMPONENTENGINE_TARGETS)
-foreach(engine_dir ${SOFACOMPONENTENGINE_DIRS})
-    sofa_add_subdirectory(module ${engine_dir} ${PROJECT_NAME}.${engine_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${engine_dir})
-        list(APPEND SOFACOMPONENTENGINE_TARGETS ${PROJECT_NAME}.${engine_dir})
-    endif()
-endforeach()
-
+sofa_add_subdirectory_modules(SOFACOMPONENTENGINE_TARGETS
+    DIRECTORIES Analyze Generate Select Transform
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTENGINE_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/IO/CMakeLists.txt
+++ b/Sofa/Component/IO/CMakeLists.txt
@@ -3,15 +3,9 @@ project(Sofa.Component.IO LANGUAGES CXX)
 
 set(SOFACOMPONENTIO_SOURCE_DIR "src/sofa/component/io")
 
-set(SOFACOMPONENTIO_DIRS Mesh)
-set(SOFACOMPONENTIO_TARGETS)
-foreach(io_dir ${SOFACOMPONENTIO_DIRS})
-    sofa_add_subdirectory(module ${io_dir} ${PROJECT_NAME}.${io_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${io_dir})
-        list(APPEND SOFACOMPONENTIO_TARGETS ${PROJECT_NAME}.${io_dir})
-    endif()
-endforeach()
-
+sofa_add_subdirectory_modules(SOFACOMPONENTIO_TARGETS
+    DIRECTORIES Mesh
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTIO_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/LinearSolver/CMakeLists.txt
+++ b/Sofa/Component/LinearSolver/CMakeLists.txt
@@ -3,14 +3,9 @@ project(Sofa.Component.LinearSolver LANGUAGES CXX)
 
 set(SOFACOMPONENTLINEARSOLVER_SOURCE_DIR "src/sofa/component/linearsolver")
 
-set(SOFACOMPONENTLINEARSOLVER_DIRS Iterative Direct Preconditioner)
-set(SOFACOMPONENTLINEARSOLVER_TARGETS)
-foreach(linearsolver_dir ${SOFACOMPONENTLINEARSOLVER_DIRS})
-    sofa_add_subdirectory(module ${linearsolver_dir} ${PROJECT_NAME}.${linearsolver_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${linearsolver_dir})
-        list(APPEND SOFACOMPONENTLINEARSOLVER_TARGETS ${PROJECT_NAME}.${linearsolver_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTLINEARSOLVER_TARGETS
+    DIRECTORIES Iterative Direct Preconditioner
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTLINEARSOLVER_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Mapping/CMakeLists.txt
+++ b/Sofa/Component/Mapping/CMakeLists.txt
@@ -3,15 +3,9 @@ project(Sofa.Component.Mapping LANGUAGES CXX)
 
 set(SOFACOMPONENTMAPPING_SOURCE_DIR "src/sofa/component/mapping")
 
-set(SOFACOMPONENTMAPPING_DIRS Linear NonLinear MappedMatrix)
-set(SOFACOMPONENTMAPPING_TARGETS)
-foreach(mapping_dir ${SOFACOMPONENTMAPPING_DIRS})
-    sofa_add_subdirectory(module ${mapping_dir} ${PROJECT_NAME}.${mapping_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${mapping_dir})
-        list(APPEND SOFACOMPONENTMAPPING_TARGETS ${PROJECT_NAME}.${mapping_dir})
-    endif()
-endforeach()
-
+sofa_add_subdirectory_modules(SOFACOMPONENTMAPPING_TARGETS
+    DIRECTORIES Linear NonLinear MappedMatrix
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTMAPPING_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/ODESolver/CMakeLists.txt
+++ b/Sofa/Component/ODESolver/CMakeLists.txt
@@ -3,14 +3,9 @@ project(Sofa.Component.ODESolver LANGUAGES CXX)
 
 set(SOFACOMPONENTODESOLVER_SOURCE_DIR "src/sofa/component/odesolver")
 
-set(SOFACOMPONENTODESOLVER_DIRS Forward Backward)
-set(SOFACOMPONENTODESOLVER_TARGETS)
-foreach(odesolver_dir ${SOFACOMPONENTODESOLVER_DIRS})
-    sofa_add_subdirectory(module ${odesolver_dir} ${PROJECT_NAME}.${odesolver_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${odesolver_dir})
-        list(APPEND SOFACOMPONENTODESOLVER_TARGETS ${PROJECT_NAME}.${odesolver_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTODESOLVER_TARGETS
+    DIRECTORIES Forward Backward
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTODESOLVER_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/SolidMechanics/CMakeLists.txt
+++ b/Sofa/Component/SolidMechanics/CMakeLists.txt
@@ -3,13 +3,9 @@ project(Sofa.Component.SolidMechanics LANGUAGES CXX)
 
 set(SOFACOMPONENTSOLIDMECHANICS_SOURCE_DIR "src/sofa/component/solidmechanics")
 
-set(SOFACOMPONENTSOLIDMECHANICS_DIRS Spring FEM TensorMass)
-foreach(solidmechanics_dir ${SOFACOMPONENTSOLIDMECHANICS_DIRS})
-    sofa_add_subdirectory(module ${solidmechanics_dir} ${PROJECT_NAME}.${solidmechanics_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${solidmechanics_dir})
-        list(APPEND SOFACOMPONENTSOLIDMECHANICS_TARGETS ${PROJECT_NAME}.${solidmechanics_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTSOLIDMECHANICS_TARGETS
+    DIRECTORIES Spring FEM TensorMass
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTSOLIDMECHANICS_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Topology/CMakeLists.txt
+++ b/Sofa/Component/Topology/CMakeLists.txt
@@ -3,14 +3,9 @@ project(Sofa.Component.Topology LANGUAGES CXX)
 
 set(SOFACOMPONENTTOPOLOGY_SOURCE_DIR "src/sofa/component/topology")
 
-set(SOFACOMPONENTTOPOLOGY_DIRS Container Mapping Utility)
-set(SOFACOMPONENTTOPOLOGY_TARGETS)
-foreach(topology_dir ${SOFACOMPONENTTOPOLOGY_DIRS})
-    sofa_add_subdirectory(module ${topology_dir} ${PROJECT_NAME}.${topology_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${topology_dir})
-        list(APPEND SOFACOMPONENTTOPOLOGY_TARGETS ${PROJECT_NAME}.${topology_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTTOPOLOGY_TARGETS
+    DIRECTORIES Container Mapping Utility
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTTOPOLOGY_SOURCE_DIR}/config.h.in

--- a/Sofa/Component/Topology/Container/CMakeLists.txt
+++ b/Sofa/Component/Topology/Container/CMakeLists.txt
@@ -3,14 +3,9 @@ project(Sofa.Component.Topology.Container LANGUAGES CXX)
 
 set(SOFACOMPONENTTOPOLOGYCONTAINER_SOURCE_DIR "src/sofa/component/topology/container")
 
-set(SOFACOMPONENTTOPOLOGYCONTAINER_DIRS Constant Dynamic Grid)
-set(SOFACOMPONENTTOPOLOGYCONTAINER_TARGETS)
-foreach(container_dir ${SOFACOMPONENTTOPOLOGYCONTAINER_DIRS})
-    sofa_add_subdirectory(module ${container_dir} ${PROJECT_NAME}.${container_dir} ON)
-    if(TARGET ${PROJECT_NAME}.${container_dir})
-        list(APPEND SOFACOMPONENTTOPOLOGYCONTAINER_TARGETS ${PROJECT_NAME}.${container_dir})
-    endif()
-endforeach()
+sofa_add_subdirectory_modules(SOFACOMPONENTTOPOLOGYCONTAINER_TARGETS
+    DIRECTORIES Constant Dynamic Grid
+)
 
 set(HEADER_FILES
     ${SOFACOMPONENTTOPOLOGYCONTAINER_SOURCE_DIR}/config.h.in

--- a/Sofa/GUI/CMakeLists.txt
+++ b/Sofa/GUI/CMakeLists.txt
@@ -3,23 +3,34 @@ project(Sofa.GUI LANGUAGES CXX)
 
 set(SOFAGUI_SOURCE_DIR "src/sofa/gui")
 
+set(SOFAGUI_TARGETS)
+set(SOFAGUI_MISSINGTARGETS)
+
 sofa_add_subdirectory(module Component ${PROJECT_NAME}.Component ON)
 if(TARGET ${PROJECT_NAME}.Component)
     list(APPEND SOFAGUI_TARGETS ${PROJECT_NAME}.Component)
+else()
+    list(APPEND SOFAGUI_MISSINGTARGETS ${PROJECT_NAME}.Component)
 endif()
 
 set(SOFAGUI_DIRS Common Batch Qt)
-set(SOFAGUI_TARGETS)
 foreach(dir ${SOFAGUI_DIRS})
     sofa_add_subdirectory(library ${dir} ${PROJECT_NAME}.${dir} ON)
     if(TARGET ${PROJECT_NAME}.${dir})
         list(APPEND SOFAGUI_TARGETS ${PROJECT_NAME}.${dir})
+    else()
+        list(APPEND SOFAGUI_MISSINGTARGETS ${PROJECT_NAME}.${dir})
     endif()
 endforeach()
 
 sofa_add_subdirectory(library HeadlessRecorder ${PROJECT_NAME}.HeadlessRecorder OFF)
 if(TARGET ${PROJECT_NAME}.HeadlessRecorder)
     list(APPEND SOFAGUI_TARGETS ${PROJECT_NAME}.HeadlessRecorder)
+endif()
+
+if(SOFAGUI_MISSINGTARGETS)
+    message("${PROJECT_NAME}: package and library will not be created because some dependencies are missing or disabled: ${SOFAGUI_MISSINGTARGETS}")
+    return()
 endif()
 
 set(HEADER_FILES

--- a/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
@@ -300,6 +300,31 @@ macro(sofa_add_subdirectory type directory name)
 endmacro()
 
 
+
+macro(sofa_add_subdirectory_modules output_targets)
+    set(optionArgs)
+    set(oneValueArgs)
+    set(multiValueArgs DIRECTORIES)
+    cmake_parse_arguments("ARG" "${optionArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(${output_targets})
+    set(missing_targets)
+    foreach(dir ${ARG_DIRECTORIES})
+        set(subdir_name "${PROJECT_NAME}.${dir}")
+        sofa_add_subdirectory(module ${dir} ${subdir_name} ON)
+        if(TARGET ${subdir_name})
+            list(APPEND ${output_targets} ${subdir_name})
+        else()
+            list(APPEND missing_targets ${subdir_name})
+        endif()
+    endforeach()
+    if(missing_targets)
+        message("${PROJECT_NAME}: package and library will not be created because some dependencies are missing or disabled: ${missing_targets}")
+        return()
+    endif()
+endmacro()
+
+
 # sofa_set_01
 #
 # Defines a variable to


### PR DESCRIPTION
Parent modules must always interface the same libraries.
e.g. Sofa.Component.dll must always be the same

Thus, if some of its child modules are disabled, parent module will not generate a library.

This PR creates and uses a new macro `sofa_add_subdirectory_modules`.
This macro is meant for parent modules to easily add their child modules and sets a variable with all added targets.
If a child module is missing or disabled, a message will be shown (not an error) and the library will not be created.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
