### PR TITLE
[LinearSolver.Direct] BTDLinearSolver: Clean debug informations and rename data

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
@@ -45,12 +45,24 @@ class BTDLinearSolver : public sofa::component::linearsolver::MatrixLinearSolver
 public:
     SOFA_CLASS(SOFA_TEMPLATE2(BTDLinearSolver, Matrix, Vector), SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver, Matrix, Vector));
 
-    Data<bool> f_verbose; ///< Dump system state at each iteration
-    Data<bool> problem; ///< display debug informations about subpartSolve computation
-    Data<bool> subpartSolve; ///< Allows for the computation of a subpart of the system
+    Data<bool> d_verbose; ///< Dump system state at each iteration
+    Data<bool> d_problem; ///< display debug informations about subpartSolve computation
+    Data<bool> d_subpartSolve; ///< Allows for the computation of a subpart of the system
+    Data<bool> d_verification; ///< verification of the subpartSolve
+    Data<int> d_blockSize; ///< dimension of the blocks in the matrix
 
-    Data<bool> verification; ///< verification of the subpartSolve
-    Data<bool> test_perf; ///< verification of performance
+    SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME("To fix your code, use d_verbose")
+    DeprecatedAndRemoved f_verbose;
+    SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME("To fix your code, use d_problem")
+    DeprecatedAndRemoved problem;
+    SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME("To fix your code, use d_subpartSolve")
+    DeprecatedAndRemoved subpartSolve;
+    SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME("To fix your code, use d_verification")
+    DeprecatedAndRemoved verification;
+    SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME("To fix your code, use d_blockSize")
+    DeprecatedAndRemoved f_blockSize;
+    SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME("test_perf has been removed and not replaced.")
+    DeprecatedAndRemoved test_perf;
 
     typedef typename Vector::SubVectorType SubVector;
     typedef typename Matrix::SubMatrixType SubMatrix;
@@ -84,23 +96,20 @@ public:
 
     type::vector<Index> nBlockComputedMinv;
     Vector Y;
-
-    Data<int> f_blockSize; ///< dimension of the blocks in the matrix
 protected:
     BTDLinearSolver()
-        : f_verbose( initData(&f_verbose,false,"verbose","Dump system state at each iteration") )
-        , problem(initData(&problem, false,"showProblem", "display debug informations about subpartSolve computation") )
-        , subpartSolve(initData(&subpartSolve, false,"subpartSolve", "Allows for the computation of a subpart of the system") )
-        , verification(initData(&verification, false,"verification", "verification of the subpartSolve"))
-        , test_perf(initData(&test_perf, false,"test_perf", "verification of performance"))
-        , f_blockSize( initData(&f_blockSize,6,"blockSize","dimension of the blocks in the matrix") )
+        : d_verbose( initData(&d_verbose,false,"verbose","Dump system state at each iteration") )
+        , d_problem(initData(&d_problem, false,"showProblem", "display debug informations about subpartSolve computation") )
+        , d_subpartSolve(initData(&d_subpartSolve, false,"subpartSolve", "Allows for the computation of a subpart of the system") )
+        , d_verification(initData(&d_verification, false,"verification", "verification of the subpartSolve"))
+        , d_blockSize( initData(&d_blockSize,6,"blockSize","dimension of the blocks in the matrix") )
     {
         Index bsize = Matrix::getSubMatrixDim(0);
         if (bsize > 0)
         {
             // the template uses fixed bloc size
-            f_blockSize.setValue((int)bsize);
-            f_blockSize.setReadOnly(true);
+            d_blockSize.setValue((int)bsize);
+            d_blockSize.setReadOnly(true);
         }
     }
 public:

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
@@ -433,6 +433,7 @@ template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::bwdAccumulateRHinBloc(Index indMaxBloc)
 {
     const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const bool showProblem = problem.getValue();
 
     Index b=indMaxBloc;
 
@@ -461,10 +462,7 @@ void BTDLinearSolver<Matrix,Vector>::bwdAccumulateRHinBloc(Index indMaxBloc)
         // accumulate this contribution on LH on the lower blocs
         _acc_lh_bloc =  -(lambda[b]*_acc_lh_bloc);
 
-        if (problem.getValue())
-            std::cout<<"bwdLH["<<b<<"] = H["<<b<<"]["<<b+1<<"] * ( Minv["<<b+1<<"]["<<b+1<<"] * RH["<<b+1<< "] +bwdLH["<<b+1<<"])"<<std::endl;
-
-
+        dmsg_info_when(showProblem) << "bwdLH[" << b << "] = H[" << b << "][" << b + 1 << "] * (Minv[" << b + 1 << "][" << b + 1 << "] * RH[" << b + 1 << "] + bwdLH[" << b + 1 << "])";
 
         // store the contribution as bwdContributionOnLH
         bwdContributionOnLH.asub(b,bsize) = _acc_lh_bloc;
@@ -476,8 +474,7 @@ void BTDLinearSolver<Matrix,Vector>::bwdAccumulateRHinBloc(Index indMaxBloc)
     this->linearSystem.systemLHVector->asub(b,bsize) = Minv.asub( b, b ,bsize,bsize) * ( fwdContributionOnRH.asub(b, bsize) + this->linearSystem.systemRHVector->asub(b,bsize) ) +
             bwdContributionOnLH.asub(b, bsize);
 
-    if (problem.getValue())
-        std::cout<<"LH["<<b<<"] = Minv["<<b<<"]["<<b<<"] * (fwdRH("<<b<< ") + RH("<<b<<")) + bwdLH("<<b<<")"<<std::endl;
+    dmsg_info_when(showProblem) << "LH[" << b << "] = Minv[" << b << "][" << b << "] * (fwdRH(" << b << ") + RH(" << b << ")) + bwdLH(" << b << ")";
 
 
     // here b==current_bloc
@@ -493,11 +490,11 @@ void BTDLinearSolver<Matrix,Vector>::bwdAccumulateLHGlobal( )
     const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
     _acc_lh_bloc =  bwdContributionOnLH.asub(current_bloc, bsize);
 
+    const bool showProblem = problem.getValue();
+
     while( current_bloc > 0)
     {
-
-        if (problem.getValue())
-            std::cout<<"bwdLH["<<current_bloc-1<<"] = H["<<current_bloc-1<<"]["<<current_bloc<<"] *( bwdLH["<<current_bloc<<"] + Minv["<<current_bloc<<"]["<<current_bloc<<"] * RH["<<current_bloc<< "])"<<std::endl;
+        dmsg_info_when(showProblem) << "bwdLH[" << current_bloc - 1 << "] = H[" << current_bloc - 1 << "][" << current_bloc << "] *( bwdLH[" << current_bloc << "] + Minv[" << current_bloc << "][" << current_bloc << "] * RH[" << current_bloc << "])";
 
         // BwdLH += Minv*RH
         _acc_lh_bloc +=  Minv.asub(current_bloc,current_bloc,bsize,bsize) * this->linearSystem.systemRHVector->asub(current_bloc,bsize) ;
@@ -534,6 +531,8 @@ void BTDLinearSolver<Matrix,Vector>::fwdAccumulateRHGlobal(Index indMinBloc)
     const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
     _acc_rh_bloc =fwdContributionOnRH.asub(current_bloc, bsize);
 
+    const bool showProblem = problem.getValue();
+
     while( current_bloc< indMinBloc)
     {
 
@@ -546,9 +545,7 @@ void BTDLinearSolver<Matrix,Vector>::fwdAccumulateRHGlobal(Index indMinBloc)
 
         fwdContributionOnRH.asub(current_bloc, bsize) = _acc_rh_bloc;
 
-        if (problem.getValue())
-            std::cout<<"fwdRH["<<current_bloc<<"] = H["<<current_bloc<<"]["<<current_bloc-1<<"] * (fwdRH["<<current_bloc-1<< "] + RH["<<current_bloc-1<<"])"<<std::endl;
-
+        dmsg_info_when(showProblem) << "fwdRH[" << current_bloc << "] = H[" << current_bloc << "][" << current_bloc - 1 << "] * (fwdRH[" << current_bloc - 1 << "] + RH[" << current_bloc - 1 << "])";
     }
 
     _indMaxFwdLHComputed = current_bloc;
@@ -559,9 +556,7 @@ void BTDLinearSolver<Matrix,Vector>::fwdAccumulateRHGlobal(Index indMinBloc)
     this->linearSystem.systemLHVector->asub(b,bsize) = Minv.asub( b, b ,bsize,bsize) * ( fwdContributionOnRH.asub(b, bsize) + this->linearSystem.systemRHVector->asub(b,bsize) ) +
             bwdContributionOnLH.asub(b, bsize);
 
-    if (problem.getValue())
-        std::cout<<"LH["<<b<<"] = Minv["<<b<<"]["<<b<<"] * (fwdRH("<<b<< ") + RH("<<b<<")) + bwdLH("<<b<<")"<<std::endl;
-
+    dmsg_info_when(showProblem) << "LH[" << b << "] = Minv[" << b << "][" << b << "] * (fwdRH(" << b << ") + RH(" << b << ")) + bwdLH(" << b << ")";
 
 }
 
@@ -573,6 +568,7 @@ void BTDLinearSolver<Matrix,Vector>::fwdComputeLHinBloc(Index indMaxBloc)
 {
 
     const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const bool showProblem = problem.getValue();
 
     Index b;
 
@@ -583,8 +579,7 @@ void BTDLinearSolver<Matrix,Vector>::fwdComputeLHinBloc(Index indMaxBloc)
 
         if(b>=0)
         {
-            if (problem.getValue())
-                std::cout<<" fwdRH["<<b+1<<"] = H["<<b+1<<"]["<<b<<"] * (fwdRH("<<b<< ") + RH("<<b<<"))"<<std::endl;
+            dmsg_info_when(showProblem) << " fwdRH[" << b + 1 << "] = H[" << b + 1 << "][" << b << "] * (fwdRH(" << b << ") + RH(" << b << "))";
             // fwdRH(n+1) = H(n+1)(n) * (fwdRH(n) + RH(n))
             fwdContributionOnRH.asub(b+1, bsize) = (-lambda[b].t())* ( fwdContributionOnRH.asub(b, bsize) + this->linearSystem.systemRHVector->asub(b,bsize) ) ;
         }
@@ -594,8 +589,8 @@ void BTDLinearSolver<Matrix,Vector>::fwdComputeLHinBloc(Index indMaxBloc)
         // compute the bloc which indice is _indMaxFwdLHComputed
         this->linearSystem.systemLHVector->asub(b,bsize) = Minv.asub( b, b ,bsize,bsize) * ( fwdContributionOnRH.asub(b, bsize) + this->linearSystem.systemRHVector->asub(b,bsize) ) +
                 bwdContributionOnLH.asub(b, bsize);
-        if (problem.getValue())
-            std::cout<<"LH["<<b<<"] = Minv["<<b<<"]["<<b<<"] * (fwdRH("<<b<< ") + RH("<<b<<")) + bwdLH("<<b<<")"<<std::endl;
+
+        dmsg_info_when(showProblem) << "LH["<<b<<"] = Minv["<<b<<"]["<<b<<"] * (fwdRH("<<b<< ") + RH("<<b<<")) + bwdLH("<<b<<")";
 
     }
 
@@ -608,6 +603,8 @@ template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex&  Iin , bool NewIn)  ///*Matrix& M, Vector& result, Vector& rh, */
 {
 
+    const bool showProblem = problem.getValue();
+
     Index MinIdBloc_OUT = Iout.front();
     Index MaxIdBloc_OUT = Iout.back();
     if( NewIn)
@@ -616,8 +613,7 @@ void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex& 
         Index MinIdBloc_IN = Iin.front(); //  Iin needs to be sorted
         Index MaxIdBloc_IN = Iin.back();  //
         //debug
-        if (problem.getValue())
-            std::cout<<"STEP1: new force on bloc between dofs "<< MinIdBloc_IN<< "  and "<<MaxIdBloc_IN<<std::endl;
+        dmsg_info_when(showProblem) << "STEP1: new force on bloc between dofs "<< MinIdBloc_IN<< "  and "<<MaxIdBloc_IN;
 
         if (MaxIdBloc_IN > this->_indMaxNonNullForce)
             this->_indMaxNonNullForce = MaxIdBloc_IN;
@@ -632,42 +628,37 @@ void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex& 
     if (current_bloc > MinIdBloc_OUT)
     {
         //debug
-        if (problem.getValue())
-            std::cout<<"STEP2 (bwd GLOBAL on structure) : current_bloc ="<<current_bloc<<" > to  MinIdBloc_OUT ="<<MinIdBloc_OUT<<std::endl;
+        dmsg_info_when(showProblem) << "STEP2 (bwd GLOBAL on structure) : current_bloc ="<<current_bloc<<" > to  MinIdBloc_OUT ="<<MinIdBloc_OUT;
 
         // step 2:
         bwdAccumulateLHGlobal();
 
         //debug
-        if (problem.getValue())
-            std::cout<<" new current_bloc = "<<current_bloc<<std::endl;
+        dmsg_info_when(showProblem) << " new current_bloc = " << current_bloc;
     }
 
 
     if (current_bloc < MinIdBloc_OUT)
     {
         //debug
-        if (problem.getValue())
-            std::cout<<"STEP3 (fwd GLOBAL on structure) : current_bloc ="<<current_bloc<<" < to  MinIdBloc_OUT ="<<MinIdBloc_OUT<<std::endl;
+        dmsg_info_when(showProblem) << "STEP3 (fwd GLOBAL on structure) : current_bloc =" << current_bloc << " < to  MinIdBloc_OUT =" << MinIdBloc_OUT;
 
         //step 3:
         fwdAccumulateRHGlobal(MinIdBloc_OUT);
 
         // debug
         if (problem.getValue())
-            std::cout<<" new current_bloc = "<<current_bloc<<std::endl;
+            dmsg_info_when(showProblem) << " new current_bloc = " << current_bloc;
     }
 
     if ( _indMaxFwdLHComputed < MaxIdBloc_OUT)
     {
         //debug
-        if (problem.getValue())
-            std::cout<<" STEP 4 :_indMaxFwdLHComputed = "<<_indMaxFwdLHComputed<<" < "<<"MaxIdBloc_OUT = "<<MaxIdBloc_OUT<<"  - verify that current_bloc="<<current_bloc<<" == "<<" MinIdBloc_OUT ="<<MinIdBloc_OUT<<std::endl;
+        dmsg_info_when(showProblem) << " STEP 4 :_indMaxFwdLHComputed = " << _indMaxFwdLHComputed << " < " << "MaxIdBloc_OUT = " << MaxIdBloc_OUT << "  - verify that current_bloc=" << current_bloc << " == " << " MinIdBloc_OUT =" << MinIdBloc_OUT;
 
         fwdComputeLHinBloc(MaxIdBloc_OUT );
         //debug
-        if (problem.getValue())
-            std::cout<<"  new _indMaxFwdLHComputed = "<<_indMaxFwdLHComputed<<std::endl;
+        dmsg_info_when(showProblem) << "  new _indMaxFwdLHComputed = " << _indMaxFwdLHComputed;
     }
     // debug: test
     if (verification.getValue())
@@ -694,22 +685,25 @@ void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex& 
             normR += (Result->asub(i,bsize)).norm();
         }
 
+        std::ostringstream oss;
         if (normDR > ((1.0e-7)*normR + 1.0e-20) )
         {
-            std::cout<<"++++++++++++++++ WARNING +++++++++++\n \n Found solution for bloc OUT :";
+            oss <<"++++++++++++++++ WARNING +++++++++++\n \n Found solution for bloc OUT :";
             for (Index i=MinIdBloc_OUT; i<=MaxIdBloc_OUT; i++)
             {
-                std::cout<<"     ["<<i<<"] "<< Result_partial_Solve->asub(i,bsize);
+                oss <<"     ["<<i<<"] "<< Result_partial_Solve->asub(i,bsize);
             }
-            std::cout<<std::endl;
+            oss << "\n";
 
-            std::cout<<" after complete resolution OUT :";
+            oss <<" after complete resolution OUT :";
             for (Index i=MinIdBloc_OUT; i<=MaxIdBloc_OUT; i++)
             {
-                std::cout<<"     ["<<i<<"] "<<Result->asub(i,bsize);
+                oss <<"     ["<<i<<"] "<<Result->asub(i,bsize);
             }
-            std::cout<<std::endl;
+            oss << "\n";
         }
+        msg_info() << oss.str();
+
         delete(Result_partial_Solve);
         delete(Result);
         delete(DR);

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
@@ -109,10 +109,11 @@ void BTDLinearSolver<Matrix,Vector>::invert(SubMatrix& Inv, const BlocType& m)
 template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
 {
+    const bool verbose = d_verbose.getValue();
 
-    msg_info_when(this->f_verbose.getValue()) << "BTDLinearSolver, invert Matrix = "<< M ;
+    msg_info_when(verbose) << "BTDLinearSolver, invert Matrix = "<< M ;
 
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
     const Index nb = M.rowSize() / bsize;
     if (nb == 0) return;
     //alpha.resize(nb);
@@ -120,9 +121,9 @@ void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
     lambda.resize(nb-1);
     B.resize(nb);
 
-    /////////////////////////// subpartSolve init ////////////
+    /////////////////////////// d_subpartSolve init ////////////
 
-    if(subpartSolve.getValue() )
+    if(d_subpartSolve.getValue() )
     {
         this->init_partial_inverse(nb,bsize);
     }
@@ -132,9 +133,9 @@ void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
     M.getAlignedSubMatrix(0,0,bsize,bsize,A);
     M.getAlignedSubMatrix(0,1,bsize,bsize,C);
     invert(alpha_inv[0],A);
-    msg_info_when(this->f_verbose.getValue()) << "alpha_inv[0] = " << alpha_inv[0] ;
+    msg_info_when(verbose) << "alpha_inv[0] = " << alpha_inv[0] ;
     lambda[0] = alpha_inv[0]*C;
-    msg_info_when(this->f_verbose.getValue()) << "lambda[0] = " << lambda[0] ;
+    msg_info_when(verbose) << "lambda[0] = " << lambda[0] ;
 
     for (Index i=1; i<nb; ++i)
     {
@@ -145,13 +146,13 @@ void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
         BlocType Temp2= A - Temp1;
         invert(alpha_inv[i], Temp2);
 
-        msg_info_when(this->f_verbose.getValue()) << "alpha_inv["<<i<<"] = " << alpha_inv[i] ;
+        msg_info_when(verbose) << "alpha_inv["<<i<<"] = " << alpha_inv[i] ;
         if (i<nb-1)
         {
             M.getAlignedSubMatrix((i  ),(i+1),bsize,bsize,C);
             lambda[i] = alpha_inv[i]*C;
 
-            msg_info_when(this->f_verbose.getValue()) << "lambda["<<i<<"] = " << lambda[i] ;
+            msg_info_when(verbose) << "lambda["<<i<<"] = " << lambda[i] ;
         }
     }
     nBlockComputedMinv.resize(nb);
@@ -164,7 +165,7 @@ void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
 
     nBlockComputedMinv[nb-1] = 1;
 
-    if(subpartSolve.getValue() )
+    if(d_subpartSolve.getValue() )
     {
         SubMatrix iHi; // bizarre: pb compilation avec SubMatrix nHn_1 = B[i] *alpha_inv[i];
         my_identity(iHi, bsize);
@@ -202,7 +203,7 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
 
     // the block is computed now :
     // 1. all the diagonal block between N and i need to be computed
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
     sofa::SignedIndex i0 = i;
     while (nBlockComputedMinv[i0]==0)
         ++i0;
@@ -217,7 +218,7 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
             Minv.asub((i0  ),(i0-1),bsize,bsize) = Minv.asub((i0  ),(i0  ),bsize,bsize)*(-(lambda[i0-1].t()));
             ++nBlockComputedMinv[i0];
 
-            if(subpartSolve.getValue() )
+            if(d_subpartSolve.getValue() )
             {
                 // store -L[i0-1].t() H structure
                 SubMatrix iHi_1;
@@ -233,7 +234,7 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
         // compute bloc (i0-1,i0-1)  : //Minv[i0-1][i0-1] = inv(M[i0-1][i0-1]) + L[i0-1] * Minv[i0][i0-1]
         Minv.asub((i0-1),(i0-1),bsize,bsize) = alpha_inv[i0-1] - lambda[i0-1]*Minv.asub((i0  ),(i0-1),bsize,bsize);
 
-        if(subpartSolve.getValue() )
+        if(d_subpartSolve.getValue() )
         {
             // store Id in H structure
             SubMatrix iHi;
@@ -255,7 +256,7 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
     /////////////// ADD : Calcul pour faire du partial_solve //////////
     // first iHj is initiallized to iHj0+1 (that is supposed to be already computed)
     SubMatrix iHj ;
-    if(subpartSolve.getValue() )
+    if(d_subpartSolve.getValue() )
     {
 
 
@@ -279,7 +280,7 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
         // compute bloc (i0,j0)
         // Minv[i][j0] = Minv[i][j0+1] * (-L[j0].t)
         Minv.asub((i0  ),(j0  ),bsize,bsize) = Minv.asub((i0  ),(j0+1),bsize,bsize)*(-lambda[j0].t());
-        if(subpartSolve.getValue() )
+        if(d_subpartSolve.getValue() )
         {
             // iHj0 = iHj0+1 * (-L[j0].t)
             iHj = iHj * -lambda[j0].t();
@@ -296,7 +297,7 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
 template<class Matrix, class Vector>
 double BTDLinearSolver<Matrix,Vector>::getMinvElement(Index i, Index j)
 {
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
     if (i < j)
     {
         // lower diagonal
@@ -309,9 +310,11 @@ double BTDLinearSolver<Matrix,Vector>::getMinvElement(Index i, Index j)
 template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::solve (Matrix& /*M*/, Vector& x, Vector& b)
 {
-    msg_info_when(this->f_verbose.getValue() ) << "solve, b = "<< b;
+    const bool verbose = d_verbose.getValue();
 
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    msg_info_when(verbose) << "solve, b = "<< b;
+
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
     const Index nb = b.size() / bsize;
     if (nb == 0) return;
 
@@ -326,7 +329,7 @@ void BTDLinearSolver<Matrix,Vector>::solve (Matrix& /*M*/, Vector& x, Vector& b)
     }
 
     // x is the solution of the system
-    msg_info_when(this->f_verbose.getValue()) << "solve, solution = "<<x;
+    msg_info_when(verbose) << "solve, solution = "<<x;
 
 }
 
@@ -390,7 +393,7 @@ template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::init_partial_solve()
 {
 
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
     const Index nb = this->linearSystem.systemRHVector->size() / bsize;
 
     //TODO => optimisation ??
@@ -432,8 +435,8 @@ void BTDLinearSolver<Matrix,Vector>::init_partial_solve()
 template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::bwdAccumulateRHinBloc(Index indMaxBloc)
 {
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
-    const bool showProblem = problem.getValue();
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
+    const bool showProblem = d_problem.getValue();
 
     Index b=indMaxBloc;
 
@@ -487,10 +490,10 @@ void BTDLinearSolver<Matrix,Vector>::bwdAccumulateRHinBloc(Index indMaxBloc)
 template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::bwdAccumulateLHGlobal( )
 {
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
     _acc_lh_bloc =  bwdContributionOnLH.asub(current_bloc, bsize);
 
-    const bool showProblem = problem.getValue();
+    const bool showProblem = d_problem.getValue();
 
     while( current_bloc > 0)
     {
@@ -528,10 +531,10 @@ void BTDLinearSolver<Matrix,Vector>::bwdAccumulateLHGlobal( )
 template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::fwdAccumulateRHGlobal(Index indMinBloc)
 {
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
     _acc_rh_bloc =fwdContributionOnRH.asub(current_bloc, bsize);
 
-    const bool showProblem = problem.getValue();
+    const bool showProblem = d_problem.getValue();
 
     while( current_bloc< indMinBloc)
     {
@@ -567,8 +570,8 @@ template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::fwdComputeLHinBloc(Index indMaxBloc)
 {
 
-    const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
-    const bool showProblem = problem.getValue();
+    const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
+    const bool showProblem = d_problem.getValue();
 
     Index b;
 
@@ -603,7 +606,7 @@ template<class Matrix, class Vector>
 void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex&  Iin , bool NewIn)  ///*Matrix& M, Vector& result, Vector& rh, */
 {
 
-    const bool showProblem = problem.getValue();
+    const bool showProblem = d_problem.getValue();
 
     Index MinIdBloc_OUT = Iout.front();
     Index MaxIdBloc_OUT = Iout.back();
@@ -647,7 +650,7 @@ void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex& 
         fwdAccumulateRHGlobal(MinIdBloc_OUT);
 
         // debug
-        if (problem.getValue())
+        if (d_problem.getValue())
             dmsg_info_when(showProblem) << " new current_bloc = " << current_bloc;
     }
 
@@ -661,9 +664,9 @@ void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex& 
         dmsg_info_when(showProblem) << "  new _indMaxFwdLHComputed = " << _indMaxFwdLHComputed;
     }
     // debug: test
-    if (verification.getValue())
+    if (d_verification.getValue())
     {
-        const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
+        const Index bsize = Matrix::getSubMatrixDim(d_blockSize.getValue());
         Vector *Result_partial_Solve = new Vector();
         (*Result_partial_Solve) = (*this->linearSystem.systemLHVector);
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
@@ -121,7 +121,7 @@ void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
     lambda.resize(nb-1);
     B.resize(nb);
 
-    /////////////////////////// d_subpartSolve init ////////////
+    /////////////////////////// subpartSolve init ////////////
 
     if(d_subpartSolve.getValue() )
     {

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
@@ -688,9 +688,9 @@ void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex& 
             normR += (Result->asub(i,bsize)).norm();
         }
 
-        std::ostringstream oss;
         if (normDR > ((1.0e-7)*normR + 1.0e-20) )
         {
+            std::ostringstream oss;
             oss <<"++++++++++++++++ WARNING +++++++++++\n \n Found solution for bloc OUT :";
             for (Index i=MinIdBloc_OUT; i<=MaxIdBloc_OUT; i++)
             {
@@ -704,8 +704,8 @@ void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex& 
                 oss <<"     ["<<i<<"] "<<Result->asub(i,bsize);
             }
             oss << "\n";
+            msg_warning() << oss.str();
         }
-        msg_info() << oss.str();
 
         delete(Result_partial_Solve);
         delete(Result);

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/config.h.in
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/config.h.in
@@ -58,3 +58,11 @@ namespace sofa::component::linearsolver::direct
     SOFA_ATTRIBUTE_DISABLED( \
     "v22.06 (PR#2725)", "v22.12", "It is no longer possible to export the linear system matrix from within SparseLDLSolver. Instead, use the component GlobalSystemMatrixExporter.")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_COMPONENT_LINEARSOLVER_DIRECT
+#define SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME(msg)
+#else
+#define SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME(msg) \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v22.06", "v22.12", msg)
+#endif // SOFA_ATTRIBUTE_DISABLED__BTDLINEARSOLVER_DATANAME


### PR DESCRIPTION
Originally it was to get rid of the std::cout (and its associated tests) in the partial_solve functions, but I ended up renaming the Data because it was bothering me.
(and remove one because it is not used at all)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
