### PR TITLE
[CMake] FIX out-of-tree SofaGui and runSofa locations

### DIFF
--- a/applications/collections/deprecated/SofaGui/CMakeLists.txt
+++ b/applications/collections/deprecated/SofaGui/CMakeLists.txt
@@ -66,5 +66,5 @@ sofa_create_package_with_targets(
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
-    RELOCATABLE "collections"
+#    RELOCATABLE "collections" # disabled because we need SofaGui installed at root for backward compat
     )

--- a/applications/collections/deprecated/modules/SofaGuiCommon/CMakeLists.txt
+++ b/applications/collections/deprecated/modules/SofaGuiCommon/CMakeLists.txt
@@ -21,5 +21,5 @@ sofa_create_package_with_targets(
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR ${PROJECT_NAME}
-    RELOCATABLE "../../collections" # under SofaGui
+    RELOCATABLE "collections"
 )

--- a/applications/collections/deprecated/modules/SofaGuiQt/CMakeLists.txt
+++ b/applications/collections/deprecated/modules/SofaGuiQt/CMakeLists.txt
@@ -19,5 +19,5 @@ sofa_create_package_with_targets(
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR ${PROJECT_NAME}
-    RELOCATABLE "../../collections" # under SofaGui
+    RELOCATABLE "collections"
 )

--- a/applications/projects/runSofa/CMakeLists.txt
+++ b/applications/projects/runSofa/CMakeLists.txt
@@ -85,8 +85,8 @@ install(FILES "${CMAKE_BINARY_DIR}/etc/installed${PROJECT_NAME}.ini" DESTINATION
 install(DIRECTORY "resources/" DESTINATION "share/sofa/gui/runSofa" COMPONENT resources)
 
 sofa_add_targets_to_package(
-    PACKAGE_NAME SofaGui
+    PACKAGE_NAME Sofa.GUI
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
-    INCLUDE_INSTALL_DIR "SofaGui/runSofa"
+    INCLUDE_INSTALL_DIR "Sofa.GUI/runSofa"
     )


### PR DESCRIPTION
Should fix out-of-tree errors like https://github.com/guparan/SofaPython3/runs/7896706218?check_suite_focus=true
To be backported asap.

[ci-depends-on https://github.com/sofa-framework/SofaGLFW/pull/57]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
