### PR TITLE
[Constraint.Lagrangian.Solver] fixes verbose GenericConstraintSolver

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -1142,7 +1142,7 @@ void GenericConstraintProblem::NNCG(GenericConstraintSolver* solver, int iterati
     {
         if(!constraintsResolutions[i])
         {
-            msg_error("GenericConstraintSolver") << "Bad size of constraintsResolutions in GenericConstraintProblem" ;
+            msg_error(solver) << "Bad size of constraintsResolutions in GenericConstraintProblem" ;
             break;
         }
         constraintsResolutions[i]->init(i, w, force);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -822,7 +822,7 @@ void GenericConstraintProblem::gaussSeidel(SReal timeout, GenericConstraintSolve
 
     sofa::helper::AdvancedTimer::valSet("GS iterations", currentIterations);
 
-    result_output(force, error, iterCount, convergence);
+    result_output(solver, force, error, iterCount, convergence);
 
     if(showGraphs)
     {
@@ -1064,7 +1064,7 @@ void GenericConstraintProblem::unbuiltGaussSeidel(SReal timeout, GenericConstrai
 
     sofa::helper::AdvancedTimer::valSet("GS iterations", currentIterations);
 
-    result_output(force, error, iter, convergence);
+    result_output(solver, force, error, iter, convergence);
 
     if(showGraphs)
     {
@@ -1223,7 +1223,7 @@ void GenericConstraintProblem::NNCG(GenericConstraintSolver* solver, int iterati
         }
     }
 
-    result_output(force, error, iterCount, convergence);
+    result_output(solver, force, error, iterCount, convergence);
 }
 
 void GenericConstraintProblem::gaussSeidel_increment(bool measureError, SReal *dfree, SReal *force, SReal **w, SReal tol, SReal *d, int dim, bool& constraintsAreVerified, SReal& error, sofa::type::vector<SReal>& tabErrors) const
@@ -1306,7 +1306,7 @@ void GenericConstraintProblem::gaussSeidel_increment(bool measureError, SReal *d
     }
 }
 
-void GenericConstraintProblem::result_output(SReal *force, SReal error, int iterCount, bool convergence)
+void GenericConstraintProblem::result_output(GenericConstraintSolver *solver, SReal *force, SReal error, int iterCount, bool convergence)
 {
     currentError = error;
     currentIterations = iterCount+1;
@@ -1315,11 +1315,11 @@ void GenericConstraintProblem::result_output(SReal *force, SReal error, int iter
 
     if(!convergence)
     {
-        msg_info("GenericConstraintSolver") << "No convergence : error = " << error ;
+        msg_info(solver) << "No convergence : error = " << error ;
     }
     else
     {
-        msg_info("GenericConstraintSolver") << "Convergence after " << currentIterations << " iterations " ;
+        msg_info(solver) << "Convergence after " << currentIterations << " iterations " ;
     }
 
     for(int i=0; i<dimension; i += constraintsResolutions[i]->getNbLines())

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -77,7 +77,7 @@ public:
     void NNCG(GenericConstraintSolver* solver = nullptr, int iterationNewton = 1);
 
     void gaussSeidel_increment(bool measureError, SReal *dfree, SReal *force, SReal **w, SReal tol, SReal *d, int dim, bool& constraintsAreVerified, SReal& error, sofa::type::vector<SReal>& tabErrors) const;
-    void result_output(SReal *force, SReal error, int iterCount, bool convergence);
+    void result_output(GenericConstraintSolver* solver, SReal *force, SReal error, int iterCount, bool convergence);
 
     int getNumConstraints();
     int getNumConstraintGroups();


### PR DESCRIPTION
Fixes the verbosity introduced in #3053. 
These messages should be associated with the solver object, so that they are only printed if `printLog` is set to true.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
