### PR TITLE
[Helper] Reorganize accessors files and add tests

### DIFF
--- a/Sofa/framework/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Core/test/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.12)
 project(Sofa.Core_test)
 
 set(SOURCE_FILES
+    accessor/ReadAccessor.cpp
+    accessor/WriteAccessor.cpp
     collision/NarrowPhaseDetection_test.cpp
     loader/MeshLoader_test.cpp
     objectmodel/AspectPool_test.cpp

--- a/Sofa/framework/Core/test/accessor/ReadAccessor.cpp
+++ b/Sofa/framework/Core/test/accessor/ReadAccessor.cpp
@@ -19,10 +19,36 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
+#include <gtest/gtest.h>
 
-#include <sofa/helper/accessor/ReadAccessor.h>
-#include <sofa/helper/accessor/ReadAccessorVector.h>
-#include <sofa/helper/accessor/WriteAccessor.h>
-#include <sofa/helper/accessor/WriteAccessorVector.h>
-#include <sofa/helper/accessor/WriteOnlyAccessor.h>
+#include <sofa/type/vector.h>
+#include <sofa/core/objectmodel/Data.h>
+
+namespace sofa
+{
+
+TEST(ReadAccessor, DataPrimitiveTypes)
+{
+    const Data<float> float_value { 12.f };
+    const sofa::helper::ReadAccessor float_accessor(float_value);
+    EXPECT_FLOAT_EQ(float_accessor.ref(), 12.f);
+
+    const Data<std::size_t> size_t_value = 8;
+    const sofa::helper::ReadAccessor size_t_accessor(size_t_value);
+    EXPECT_EQ(size_t_accessor.ref(), 8);
+}
+
+TEST(ReadAccessor, DataVectorTypes)
+{
+    const Data<sofa::type::vector<float> > vector { sofa::type::vector<float> { 0.f, 1.f, 2.f, 3.f, 4.f} };
+    const sofa::helper::ReadAccessor accessor(vector);
+
+    EXPECT_EQ(accessor.size(), vector.getValue().size());
+    EXPECT_EQ(accessor.size(), 5);
+    EXPECT_EQ(accessor.empty(), vector.getValue().empty());
+    EXPECT_EQ(accessor.begin(), vector.getValue().begin());
+    EXPECT_EQ(accessor.end(), vector.getValue().end());
+}
+
+
+}

--- a/Sofa/framework/Core/test/accessor/WriteAccessor.cpp
+++ b/Sofa/framework/Core/test/accessor/WriteAccessor.cpp
@@ -1,0 +1,83 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+
+#include <sofa/core/objectmodel/Data.h>
+#include <sofa/type/vector.h>
+
+namespace sofa
+{
+
+TEST(WriteAccessor, PrimitiveTypes)
+{
+    Data<float> float_value { 12.f };
+    sofa::helper::WriteAccessor float_accessor(float_value);
+    EXPECT_FLOAT_EQ(float_accessor.ref(), 12.f);
+    float_accessor.wref() = 14.f;
+    EXPECT_FLOAT_EQ(float_accessor.ref(), 14.f);
+    EXPECT_FLOAT_EQ(float_accessor, 14.f);
+    EXPECT_FLOAT_EQ(float_value.getValue(), 14.f);
+
+    Data<std::size_t> size_t_value { 8 };
+    sofa::helper::WriteAccessor size_t_accessor(size_t_value);
+    EXPECT_EQ(size_t_accessor.ref(), 8);
+    size_t_accessor.wref() = 9;
+    EXPECT_EQ(size_t_accessor.ref(), 9);
+    EXPECT_EQ(size_t_accessor, 9);
+    EXPECT_EQ(size_t_value.getValue(), 9);
+}
+
+TEST(WriteAccessor, VectorTypes)
+{
+    Data<sofa::type::vector<float> > vector { sofa::type::vector<float> { 0.f, 1.f, 2.f, 3.f, 4.f} };
+    sofa::helper::WriteAccessor accessor(vector);
+
+    EXPECT_EQ(accessor.size(), vector.getValue().size());
+    EXPECT_EQ(accessor.size(), 5);
+    EXPECT_EQ(accessor.empty(), vector.getValue().empty());
+    EXPECT_EQ(accessor.begin(), vector.getValue().begin());
+    EXPECT_EQ(accessor.end(), vector.getValue().end());
+
+    for(auto& v : accessor)
+    {
+        ++v;
+    }
+
+    EXPECT_FLOAT_EQ(vector.getValue()[0], 1.f);
+    EXPECT_FLOAT_EQ(vector.getValue()[1], 2.f);
+    EXPECT_FLOAT_EQ(vector.getValue()[2], 3.f);
+    EXPECT_FLOAT_EQ(vector.getValue()[3], 4.f);
+    EXPECT_FLOAT_EQ(vector.getValue()[4], 5.f);
+
+    EXPECT_FLOAT_EQ(accessor[0], 1.f);
+    EXPECT_FLOAT_EQ(accessor[1], 2.f);
+    EXPECT_FLOAT_EQ(accessor[2], 3.f);
+    EXPECT_FLOAT_EQ(accessor[3], 4.f);
+    EXPECT_FLOAT_EQ(accessor[4], 5.f);
+
+    accessor[3] = 6.f;
+    EXPECT_FLOAT_EQ(accessor[3], 6.f);
+    EXPECT_FLOAT_EQ(vector.getValue()[3], 6.f);
+}
+
+
+}

--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -51,6 +51,11 @@ set(HEADER_FILES
     ${SRC_ROOT}/hash.h
     ${SRC_ROOT}/init.h
     ${SRC_ROOT}/integer_id.h
+    ${SRC_ROOT}/accessor/ReadAccessor.h
+    ${SRC_ROOT}/accessor/ReadAccessorVector.h
+    ${SRC_ROOT}/accessor/WriteAccessor.h
+    ${SRC_ROOT}/accessor/WriteAccessorVector.h
+    ${SRC_ROOT}/accessor/WriteOnlyAccessor.h
     ${SRC_ROOT}/io/BaseFileAccess.h
     ${SRC_ROOT}/io/FileAccess.h
     ${SRC_ROOT}/io/File.h

--- a/Sofa/framework/Helper/src/sofa/helper/accessor.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor.h
@@ -22,7 +22,5 @@
 #pragma once
 
 #include <sofa/helper/accessor/ReadAccessor.h>
-#include <sofa/helper/accessor/ReadAccessorVector.h>
 #include <sofa/helper/accessor/WriteAccessor.h>
-#include <sofa/helper/accessor/WriteAccessorVector.h>
 #include <sofa/helper/accessor/WriteOnlyAccessor.h>

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessor.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessor.h
@@ -21,8 +21,53 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/helper/accessor/ReadAccessor.h>
-#include <sofa/helper/accessor/ReadAccessorVector.h>
-#include <sofa/helper/accessor/WriteAccessor.h>
-#include <sofa/helper/accessor/WriteAccessorVector.h>
-#include <sofa/helper/accessor/WriteOnlyAccessor.h>
+#include <ostream>
+
+namespace sofa::helper
+{
+
+
+/** A ReadAccessor is a proxy class, holding a reference to a given container
+ *  and providing access to its data, using an unified interface (similar to
+ *  std::vector), hiding API differences within containers.
+ *
+ *  Other advantadges of using a ReadAccessor are :
+ *
+ *  - It can be faster that the default methods and operators of the container,
+ *  as verifications and changes notifications can be handled in the accessor's
+ *  constructor and destructor instead of at each item access.
+ *
+ *  - No modifications to the container will be done by mistake
+ *
+ *  - Accesses can be logged for debugging or task dependencies analysis.
+ *
+ *  The default implementation provides only minimal set of methods and
+ *  operators, sufficient for scalar types but which should be overloaded for
+ *  more complex types.
+ *  Various template specializations are typically used, especially for core::objectmodel::Data<T>
+ */
+template<class T, class Enable = void>
+class ReadAccessor
+{
+public:
+    typedef T container_type;
+    typedef T value_type;
+    typedef value_type& reference;
+    typedef value_type* pointer;
+    typedef const value_type& const_reference;
+    typedef const value_type* const_pointer;
+
+protected:
+    const container_type* vref;
+
+public:
+    explicit ReadAccessor(const container_type& container) : vref(&container) {}
+
+    const_reference ref() const { return *vref; }
+
+    operator  const_reference () const { return  *vref; }
+    const_pointer   operator->() const { return vref; }
+    const_reference operator* () const { return  *vref; }
+};
+
+}

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessor.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessor.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-#include <ostream>
+#include <sofa/helper/accessor/ReadAccessorVector.h>
 
 namespace sofa::helper
 {
@@ -68,6 +68,17 @@ public:
     operator  const_reference () const { return  *vref; }
     const_pointer   operator->() const { return vref; }
     const_reference operator* () const { return  *vref; }
+};
+
+template<class VectorLikeType>
+class ReadAccessor<VectorLikeType,
+                   std::enable_if_t<sofa::type::trait::is_vector<VectorLikeType>::value> >
+    : public ReadAccessorVector< VectorLikeType >
+{
+public:
+    typedef ReadAccessorVector< VectorLikeType > Inherit;
+    typedef typename Inherit::container_type container_type;
+    ReadAccessor(const container_type& c) : Inherit(c) {}
 };
 
 }

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessorVector.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessorVector.h
@@ -29,7 +29,7 @@ namespace sofa::helper
 ////////////////////////// ReadAccessor for wrapping around vector like object //////////////////////
 /// ReadAccessor implementation class for vector types
 template<class T>
-class ReadAccessor<T, std::enable_if_t<sofa::type::trait::is_vector<T>::value > >
+class ReadAccessorVector
 {
 public:
     typedef T container_type;
@@ -45,7 +45,7 @@ protected:
     const container_type* vref;
 
 public:
-    ReadAccessor(const container_type& container) : vref(&container) {}
+    ReadAccessorVector(const container_type& container) : vref(&container) {}
 
     bool empty() const { return vref->empty(); }
     Size size() const { return vref->size(); }

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessorVector.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/ReadAccessorVector.h
@@ -21,8 +21,45 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/helper/accessor/ReadAccessor.h>
-#include <sofa/helper/accessor/ReadAccessorVector.h>
-#include <sofa/helper/accessor/WriteAccessor.h>
-#include <sofa/helper/accessor/WriteAccessorVector.h>
-#include <sofa/helper/accessor/WriteOnlyAccessor.h>
+#include <sofa/type/trait/is_vector.h>
+#include <iosfwd>
+
+namespace sofa::helper
+{
+////////////////////////// ReadAccessor for wrapping around vector like object //////////////////////
+/// ReadAccessor implementation class for vector types
+template<class T>
+class ReadAccessor<T, std::enable_if_t<sofa::type::trait::is_vector<T>::value > >
+{
+public:
+    typedef T container_type;
+    typedef const T const_container_type;
+    typedef typename container_type::Size Size;
+    typedef typename container_type::value_type value_type;
+    typedef typename container_type::reference reference;
+    typedef typename container_type::const_reference const_reference;
+    typedef typename container_type::iterator iterator;
+    typedef typename container_type::const_iterator const_iterator;
+
+protected:
+    const container_type* vref;
+
+public:
+    ReadAccessor(const container_type& container) : vref(&container) {}
+
+    bool empty() const { return vref->empty(); }
+    Size size() const { return vref->size(); }
+    const_reference operator[](Size i) const { return (*vref)[i]; }
+
+    const_iterator begin() const { return vref->begin(); }
+    const_iterator end() const { return vref->end(); }
+
+    ///////// Access the container for reading ////////////////
+    operator const_container_type& () const { return  *vref; }
+    const_container_type* operator->() const { return vref; }
+    const_container_type& operator* () const { return  *vref; }
+    const_container_type& ref() const { return *vref; }          ///< this duplicate operator* (remove ?)
+    ///////////////////////////////////////////////////////////
+};
+
+}

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessor.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessor.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-#include <iosfwd>
+#include <sofa/helper/accessor/WriteAccessorVector.h>
 
 namespace sofa::helper
 {
@@ -79,6 +79,17 @@ public:
     {
         vref = &v;
     }
+};
+
+template<class VectorLikeType>
+class WriteAccessor<VectorLikeType,
+                    std::enable_if_t<sofa::type::trait::is_vector<VectorLikeType>::value>>
+    : public WriteAccessorVector< VectorLikeType >
+{
+public:
+    typedef WriteAccessorVector< VectorLikeType > Inherit;
+    typedef typename Inherit::container_type container_type;
+    WriteAccessor(container_type& c) : Inherit(c) {}
 };
 
 }

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessor.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessor.h
@@ -1,0 +1,84 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <iosfwd>
+
+namespace sofa::helper
+{
+
+
+/** A WriteAccessor is a proxy class, holding a reference to a given container
+ *  and providing access to its data, using an unified interface (similar to
+ *  std::vector), hiding API differences within some containers.
+ *
+ *  Other advantadges of using a WriteAccessor are :
+ *
+ *  - It can be faster that the default methods and operators of the container,
+ *  as verifications and changes notifications can be handled in the accessor's
+ *  constructor and destructor instead of at each item access.
+ *
+ *  - Accesses can be logged for debugging or task dependencies analysis.
+ *
+ *  The default implementation provides only minimal set of methods and
+ *  operators, sufficient for scalar types but which should be overloaded for
+ *  more complex types.
+ *  Various template specializations are typically used, especially for core::objectmodel::Data<T>
+ */
+template<class T, class Enable = void>
+class WriteAccessor
+{
+public:
+    static_assert(!std::is_const_v<T>, "Trying to have write access on a const type");
+
+    typedef T container_type;
+    typedef T value_type;
+    typedef value_type& reference;
+    typedef value_type* pointer;
+    typedef const value_type& const_reference;
+    typedef const value_type* const_pointer;
+
+protected:
+    container_type* vref;
+
+public:
+    explicit WriteAccessor(container_type& container) : vref(&container) {}
+
+    const_reference ref() const { return *vref; }
+    reference wref() { return *vref; }
+
+    operator  const_reference () const { return  *vref; }
+    const_pointer   operator->() const { return vref; }
+    const_reference operator* () const { return  *vref; }
+
+    operator  reference () { return  *vref; }
+    pointer   operator->() { return vref; }
+    reference operator* () { return  *vref; }
+
+    template<class T2>
+    void operator=(const T2& v)
+    {
+        vref = &v;
+    }
+};
+
+}

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessorVector.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessorVector.h
@@ -21,18 +21,14 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/type/trait/is_vector.h>
-
 namespace sofa::helper
 {
 
 /// WriteAccessor implementation class for vector types
 template<class T>
-class WriteAccessor<T, std::enable_if_t<sofa::type::trait::is_vector<T>::value> >
+class WriteAccessorVector
 {
 public:
-    static_assert(!std::is_const_v<T>, "Trying to have write access on a const type");
-
     typedef T container_type;
     typedef const T const_container_type;
     typedef typename container_type::Size Size;
@@ -46,7 +42,7 @@ protected:
     container_type* vref;
 
 public:
-    WriteAccessor(container_type& container) : vref(&container) {}
+    WriteAccessorVector(container_type& container) : vref(&container) {}
 
     bool empty() const { return vref->empty(); }
     Size size() const { return vref->size(); }

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessorVector.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessorVector.h
@@ -1,0 +1,84 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/type/trait/is_vector.h>
+
+namespace sofa::helper
+{
+
+/// WriteAccessor implementation class for vector types
+template<class T>
+class WriteAccessor<T, std::enable_if_t<sofa::type::trait::is_vector<T>::value> >
+{
+public:
+    static_assert(!std::is_const_v<T>, "Trying to have write access on a const type");
+
+    typedef T container_type;
+    typedef const T const_container_type;
+    typedef typename container_type::Size Size;
+    typedef typename container_type::value_type value_type;
+    typedef typename container_type::reference reference;
+    typedef typename container_type::const_reference const_reference;
+    typedef typename container_type::iterator iterator;
+    typedef typename container_type::const_iterator const_iterator;
+
+protected:
+    container_type* vref;
+
+public:
+    WriteAccessor(container_type& container) : vref(&container) {}
+
+    bool empty() const { return vref->empty(); }
+    Size size() const { return vref->size(); }
+
+    const_reference operator[](Size i) const { return (*vref)[i]; }
+    reference operator[](Size i) { return (*vref)[i]; }
+
+    const_iterator begin() const { return vref->begin(); }
+    iterator begin() { return vref->begin(); }
+    const_iterator end() const { return vref->end(); }
+    iterator end() { return vref->end(); }
+
+    void clear() { vref->clear(); }
+    void resize(Size s, bool /*init*/ = true) { vref->resize(s); }
+    void reserve(Size s) { vref->reserve(s); }
+    void push_back(const value_type& v) { vref->push_back(v); }
+
+    ////// Access the container in reading & writing //////
+    operator  container_type () { return  *vref; }
+    container_type* operator->() { return vref; }
+    container_type& operator* () { return  *vref; }
+    container_type& wref() { return *vref; }
+    ///////////////////////////////////////////////////////
+
+    ///////// Access the container for reading ////////////////
+    operator  const_container_type () const { return  *vref; }
+    const_container_type* operator->() const { return vref; }
+    const_container_type& operator* () const { return  *vref; }
+
+    /// this one duplicate operator*
+    const container_type& ref() const { return *vref; }
+    ///////////////////////////////////////////////////////////
+};
+
+}

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/WriteOnlyAccessor.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/WriteOnlyAccessor.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <sofa/helper/accessor/WriteAccessor.h>
-#include <sofa/helper/accessor/WriteAccessorVector.h>
 
 namespace sofa::helper
 {
@@ -38,6 +37,17 @@ protected:
 
 public:
     explicit WriteOnlyAccessor(container_type& container) : WriteAccessor<T, Enable>(container) {}
+};
+
+template<class VectorLikeType>
+class WriteOnlyAccessor<VectorLikeType,
+                        std::enable_if_t<sofa::type::trait::is_vector<VectorLikeType>::value> >
+    : public WriteAccessorVector< VectorLikeType >
+{
+public:
+    typedef WriteAccessorVector< VectorLikeType > Inherit;
+    typedef typename Inherit::container_type container_type;
+    WriteOnlyAccessor(container_type& c) : Inherit(c) {}
 };
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/accessor/WriteOnlyAccessor.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/WriteOnlyAccessor.h
@@ -21,8 +21,24 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/helper/accessor/ReadAccessor.h>
-#include <sofa/helper/accessor/ReadAccessorVector.h>
 #include <sofa/helper/accessor/WriteAccessor.h>
 #include <sofa/helper/accessor/WriteAccessorVector.h>
-#include <sofa/helper/accessor/WriteOnlyAccessor.h>
+
+namespace sofa::helper
+{
+
+/** Identical to WriteAccessor for default implementation, but different for some template specializations such as  core::objectmodel::Data<T>
+*/
+template<class T, class Enable = void>
+class WriteOnlyAccessor : public WriteAccessor<T, Enable>
+{
+protected:
+    typedef WriteAccessor<T> Inherit;
+    typedef typename Inherit::container_type container_type;
+
+public:
+    explicit WriteOnlyAccessor(container_type& container) : WriteAccessor<T, Enable>(container) {}
+};
+
+
+}

--- a/Sofa/framework/Helper/test/CMakeLists.txt
+++ b/Sofa/framework/Helper/test/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SOURCE_FILES
     narrow_cast_test.cpp
     TagFactory_test.cpp
     Utils_test.cpp
+    accessor/ReadAccessor.cpp
+    accessor/WriteAccessor.cpp
     io/MeshOBJ_test.cpp
     io/XspLoader_test.cpp
     io/STBImage_test.cpp

--- a/Sofa/framework/Helper/test/accessor/ReadAccessor.cpp
+++ b/Sofa/framework/Helper/test/accessor/ReadAccessor.cpp
@@ -19,10 +19,35 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
+#include <gtest/gtest.h>
 
-#include <sofa/helper/accessor/ReadAccessor.h>
-#include <sofa/helper/accessor/ReadAccessorVector.h>
-#include <sofa/helper/accessor/WriteAccessor.h>
-#include <sofa/helper/accessor/WriteAccessorVector.h>
-#include <sofa/helper/accessor/WriteOnlyAccessor.h>
+#include <sofa/helper/accessor.h>
+#include <sofa/type/vector.h>
+
+namespace sofa
+{
+
+TEST(ReadAccessor, PrimitiveTypes)
+{
+    const float float_value { 12.f };
+    const sofa::helper::ReadAccessor float_accessor(float_value);
+    EXPECT_FLOAT_EQ(float_accessor.ref(), 12.f);
+
+    const std::size_t size_t_value { 8 };
+    const sofa::helper::ReadAccessor size_t_accessor(size_t_value);
+    EXPECT_EQ(size_t_accessor.ref(), 8);
+}
+
+TEST(ReadAccessor, VectorTypes)
+{
+    const sofa::type::vector<float> vector { 0.f, 1.f, 2.f, 3.f, 4.f};
+    const sofa::helper::ReadAccessor accessor(vector);
+
+    EXPECT_EQ(accessor.size(), vector.size());
+    EXPECT_EQ(accessor.empty(), vector.empty());
+    EXPECT_EQ(accessor.begin(), vector.begin());
+    EXPECT_EQ(accessor.end(), vector.end());
+}
+
+
+}

--- a/Sofa/framework/Helper/test/accessor/WriteAccessor.cpp
+++ b/Sofa/framework/Helper/test/accessor/WriteAccessor.cpp
@@ -19,10 +19,64 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
+#include <gtest/gtest.h>
 
-#include <sofa/helper/accessor/ReadAccessor.h>
-#include <sofa/helper/accessor/ReadAccessorVector.h>
-#include <sofa/helper/accessor/WriteAccessor.h>
-#include <sofa/helper/accessor/WriteAccessorVector.h>
-#include <sofa/helper/accessor/WriteOnlyAccessor.h>
+#include <sofa/helper/accessor.h>
+#include <sofa/type/vector.h>
+
+namespace sofa
+{
+
+TEST(WriteAccessor, PrimitiveTypes)
+{
+    float float_value { 12.f };
+    sofa::helper::WriteAccessor float_accessor(float_value);
+    EXPECT_FLOAT_EQ(float_accessor.ref(), 12.f);
+    float_accessor.wref() = 14.f;
+    EXPECT_FLOAT_EQ(float_accessor.ref(), 14.f);
+    EXPECT_FLOAT_EQ(float_accessor, 14.f);
+    EXPECT_FLOAT_EQ(float_value, 14.f);
+
+    std::size_t size_t_value { 8 };
+    sofa::helper::WriteAccessor size_t_accessor(size_t_value);
+    EXPECT_EQ(size_t_accessor.ref(), 8);
+    size_t_accessor.wref() = 9;
+    EXPECT_EQ(size_t_accessor.ref(), 9);
+    EXPECT_EQ(size_t_accessor, 9);
+    EXPECT_EQ(size_t_value, 9);
+}
+
+TEST(WriteAccessor, VectorTypes)
+{
+    sofa::type::vector<float> vector { 0.f, 1.f, 2.f, 3.f, 4.f};
+    sofa::helper::WriteAccessor accessor(vector);
+
+    EXPECT_EQ(accessor.size(), vector.size());
+    EXPECT_EQ(accessor.empty(), vector.empty());
+    EXPECT_EQ(accessor.begin(), vector.begin());
+    EXPECT_EQ(accessor.end(), vector.end());
+
+    for(auto& v : accessor)
+    {
+        ++v;
+    }
+
+    EXPECT_FLOAT_EQ(vector[0], 1.f);
+    EXPECT_FLOAT_EQ(vector[1], 2.f);
+    EXPECT_FLOAT_EQ(vector[2], 3.f);
+    EXPECT_FLOAT_EQ(vector[3], 4.f);
+    EXPECT_FLOAT_EQ(vector[4], 5.f);
+
+    EXPECT_FLOAT_EQ(accessor[0], 1.f);
+    EXPECT_FLOAT_EQ(accessor[1], 2.f);
+    EXPECT_FLOAT_EQ(accessor[2], 3.f);
+    EXPECT_FLOAT_EQ(accessor[3], 4.f);
+    EXPECT_FLOAT_EQ(accessor[4], 5.f);
+
+    accessor[3] = 6.f;
+    EXPECT_FLOAT_EQ(accessor[3], 6.f);
+    EXPECT_FLOAT_EQ(vector[3], 6.f);
+}
+
+
+}


### PR DESCRIPTION
- Each accessor has its own file: 1 for the default class, 1 for the specialization for vector types. The specialization for Data is still in Data.h
- I added a compilation error in case the type is const while trying to create a `WriteAccessor` on it.
- I added unit tests for the default class, for the vector types specialization and for the Data specialization.
- I removed the deprecated `<<` and `>>` operators



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
