### PR TITLE
[Constraint.Lagrangian] Make class abstract and add key function

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
@@ -51,4 +51,7 @@ unsigned int ConstraintProblem::getProblemId()
     return problemId;
 }
 
+ConstraintSolverImpl::~ConstraintSolverImpl()
+{}
+
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -65,7 +65,9 @@ protected:
 class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API ConstraintSolverImpl : public sofa::core::behavior::ConstraintSolver
 {
 public:
-    SOFA_CLASS(ConstraintSolverImpl, sofa::core::behavior::ConstraintSolver);
+    SOFA_ABSTRACT_CLASS(ConstraintSolverImpl, sofa::core::behavior::ConstraintSolver)
+
+    ~ConstraintSolverImpl() override;
 
     virtual ConstraintProblem* getConstraintProblem() = 0;
 


### PR DESCRIPTION
Should fix a failing unit test: https://ci.inria.fr/sofa-ci-dev/job/sofa-framework/job/master/CI_CONFIG=macos_clang,CI_PLUGINS=options,CI_TYPE=release/3799/testReport/UnitTests/

The [dynamic_cast](https://github.com/sofa-framework/SofaPython3/blob/05195cd49b6db0dd028f1163ac407d459f6156f6/bindings/Modules/src/SofaPython3/SofaConstraintSolver/Binding_ConstraintSolver.cpp#L69) failed in:
```cpp
py::cast(dynamic_cast<ConstraintSolverImpl*>(object));
```

This is due to the lack of key function in the class ConstraintSolverImpl

See 
https://github.com/android/ndk/issues/533#issuecomment-335977747






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
