### PR TITLE
[Core, LinearSolver.Direct] Introduce PartialLinearSolver Interface

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
@@ -26,6 +26,7 @@
 
 #include <sofa/core/behavior/OdeSolver.h>
 #include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/behavior/PartialLinearSolver.h>
 
 #include <sofa/type/Mat.h>
 #include <sofa/type/Vec.h>
@@ -150,6 +151,8 @@ private:
     linearalgebra::BaseVector* systemRHVector_buf;
     linearalgebra::BaseVector* systemLHVector_buf;
 
+    // cache to call Partial Linear Solver API from the Linear Solver
+    sofa::core::behavior::PartialLinearSolver* m_partialLinearSolver{ nullptr };
 
     // par un vecteur de listes precaclues pour chaque contrainte
     std::vector< ListIndex > Vec_I_list_dof;   // vecteur donnant la liste des indices des dofs par block de contrainte

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -556,7 +556,7 @@ void LinearSolverConstraintCorrection<DataTypes>::resetForUnbuiltResolution(doub
     }
 
     // Init the internal data of the solver for partial solving
-    m_partialLinearSolver->init_partial_solve();
+    m_partialLinearSolver->initPartialSolve();
 
 
     ///////// new : precalcul des liste d'indice ///////
@@ -586,7 +586,7 @@ void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(doub
 
     last_disp = begin;
 
-    m_partialLinearSolver->partial_solve(Vec_I_list_dof[last_disp], Vec_I_list_dof[last_force], _new_force);
+    m_partialLinearSolver->partialSolve(Vec_I_list_dof[last_disp], Vec_I_list_dof[last_force], _new_force);
 
     _new_force = false;
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
@@ -46,7 +46,7 @@ class BTDLinearSolver : public sofa::component::linearsolver::MatrixLinearSolver
 public:
     SOFA_CLASS2(SOFA_TEMPLATE2(BTDLinearSolver, Matrix, Vector), 
                 SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver, Matrix, Vector),
-                sofa::core::behavior::PartialLinearSolver,
+                sofa::core::behavior::PartialLinearSolver
     );
 
     Data<bool> f_verbose; ///< Dump system state at each iteration

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
@@ -23,6 +23,7 @@
 #include <sofa/component/linearsolver/direct/config.h>
 
 #include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/behavior/PartialLinearSolver.h>
 #include <sofa/component/linearsolver/iterative/MatrixLinearSolver.h>
 #include <sofa/linearalgebra/SparseMatrix.h>
 #include <sofa/linearalgebra/BTDMatrix.h>
@@ -40,7 +41,7 @@ namespace sofa::component::linearsolver::direct
 /// http://www.cfd-online.com/Wiki/Tridiagonal_matrix_algorithm_-_TDMA_(Thomas_algorithm)
 /// http://www4.ncsu.edu/eos/users/w/white/www/white/ma580/chap2.5.PDF
 template<class Matrix, class Vector>
-class BTDLinearSolver : public sofa::component::linearsolver::MatrixLinearSolver<Matrix,Vector>
+class BTDLinearSolver : public sofa::component::linearsolver::MatrixLinearSolver<Matrix,Vector>, public sofa::core::behavior::PartialLinearSolver
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE2(BTDLinearSolver, Matrix, Vector), SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver, Matrix, Vector));
@@ -117,8 +118,6 @@ public:
     /// Solve Mx=b
     void solve (Matrix& /*M*/, Vector& x, Vector& b) override;
 
-
-
     /// Multiply the inverse of the system matrix by the transpose of the given matrix, and multiply the result with the given matrix J
     ///
     /// @param result the variable where the result will be added
@@ -126,24 +125,10 @@ public:
     /// @return false if the solver does not support this operation, of it the system matrix is not invertible
     bool addJMInvJt(linearalgebra::BaseMatrix* result, linearalgebra::BaseMatrix* J, SReal fact) override;
 
-
-    /// Init the partial solve
     void init_partial_solve() override;
-
-    using MatrixLinearSolver<Matrix,Vector>::partial_solve;
-    /// partial solve :
-    /// b is accumulated
-    /// db is a sparse vector that is added to b
-    /// partial_x is a sparse vector (with sparse map given) that provide the result of M x = b+db
-    /// Solve Mx=b
-    //void partial_solve_old(ListIndex&  Iout, ListIndex&  Iin , bool NewIn);
     void partial_solve(ListIndex&  Iout, ListIndex&  Iin , bool NewIn) override;
 
-
-
     void init_partial_inverse(const Index &nb, const Index &bsize);
-
-
 
     template<class RMatrix, class JMatrix>
     bool addJMInvJt(RMatrix& result, JMatrix& J, double fact);

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
@@ -125,8 +125,8 @@ public:
     /// @return false if the solver does not support this operation, of it the system matrix is not invertible
     bool addJMInvJt(linearalgebra::BaseMatrix* result, linearalgebra::BaseMatrix* J, SReal fact) override;
 
-    void init_partial_solve() override;
-    void partial_solve(ListIndex&  Iout, ListIndex&  Iin , bool NewIn) override;
+    void initPartialSolve() override;
+    void partialSolve(ListIndex&  Iout, ListIndex&  Iin , bool NewIn) override;
 
     void init_partial_inverse(const Index &nb, const Index &bsize);
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
@@ -44,7 +44,10 @@ template<class Matrix, class Vector>
 class BTDLinearSolver : public sofa::component::linearsolver::MatrixLinearSolver<Matrix,Vector>, public sofa::core::behavior::PartialLinearSolver
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE2(BTDLinearSolver, Matrix, Vector), SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver, Matrix, Vector));
+    SOFA_CLASS2(SOFA_TEMPLATE2(BTDLinearSolver, Matrix, Vector), 
+                SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver, Matrix, Vector),
+                sofa::core::behavior::PartialLinearSolver,
+    );
 
     Data<bool> f_verbose; ///< Dump system state at each iteration
     Data<bool> problem; ///< display debug informations about subpartSolve computation

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.inl
@@ -171,7 +171,7 @@ void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
         H.insert( make_pair(  IndexPair(nb-1, nb-1), iHi  ) );
 
         // on calcule les blocks diagonaux jusqu'au bout!!
-        // TODO : ajouter un compteur "first_block" qui évite de descendre les déplacements jusqu'au block 0 dans partial_solve si ce block n'a pas été appelé
+        // TODO : ajouter un compteur "first_block" qui évite de descendre les déplacements jusqu'au block 0 dans partialSolve si ce block n'a pas été appelé
         computeMinvBlock(0, 0);
     }
 }
@@ -252,7 +252,7 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
     SignedIndex j0 = i-nBlockComputedMinv[i];
 
 
-    /////////////// ADD : Calcul pour faire du partial_solve //////////
+    /////////////// ADD : Calcul pour faire du partialSolve //////////
     // first iHj is initiallized to iHj0+1 (that is supposed to be already computed)
     SubMatrix iHj ;
     if(subpartSolve.getValue() )
@@ -387,7 +387,7 @@ void BTDLinearSolver<Matrix,Vector>::init_partial_inverse(const Index &/*nb*/, c
 }
 
 template<class Matrix, class Vector>
-void BTDLinearSolver<Matrix,Vector>::init_partial_solve()
+void BTDLinearSolver<Matrix,Vector>::initPartialSolve()
 {
 
     const Index bsize = Matrix::getSubMatrixDim(f_blockSize.getValue());
@@ -605,7 +605,7 @@ void BTDLinearSolver<Matrix,Vector>::fwdComputeLHinBloc(Index indMaxBloc)
 }
 
 template<class Matrix, class Vector>
-void BTDLinearSolver<Matrix,Vector>::partial_solve(ListIndex&  Iout, ListIndex&  Iin , bool NewIn)  ///*Matrix& M, Vector& result, Vector& rh, */
+void BTDLinearSolver<Matrix,Vector>::partialSolve(ListIndex&  Iout, ListIndex&  Iin , bool NewIn)  ///*Matrix& M, Vector& result, Vector& rh, */
 {
 
     Index MinIdBloc_OUT = Iout.front();

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
@@ -295,6 +295,9 @@ public:
 
 protected:
 
+    SOFA_ATTRIBUTE_DISABLED("v22.06", "v22.12", "LinearSolver does not offer any partial_solve anymore. Please refer to core::behavior::PartialLinearSolver if you wish to use partial solving features.")
+    virtual void partial_solve(Matrix& /*M*/, Vector& /*partial_solution*/, Vector& /*sparse_rh*/, ListIndex& /* indices_solution*/, ListIndex& /* indices input */) = delete;
+
     class TempVectorContainer
     {
     public:

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
@@ -295,14 +295,6 @@ public:
 
 protected:
 
-    using BaseMatrixLinearSolver<Matrix, Vector>::partial_solve;
-
-    /// newPartially solve the system
-    virtual void partial_solve(Matrix& /*M*/, Vector& /*partial_solution*/, Vector& /*sparse_rh*/, ListIndex& /* indices_solution*/, ListIndex& /* indices input */)
-    {
-        msg_info()<<" WARNING : partial_solve is not implemented for this solver";
-    }
-
     class TempVectorContainer
     {
     public:

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -84,6 +84,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/behavior/PairInteractionProjectiveConstraintSet.h
     ${SRC_ROOT}/behavior/PairInteractionProjectiveConstraintSet.inl
     ${SRC_ROOT}/behavior/PairStateAccessor.h
+    ${SRC_ROOT}/behavior/PartialLinearSolver.h
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.h
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.inl
     ${SRC_ROOT}/behavior/RotationFinder.h

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -223,6 +223,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/behavior/PairInteractionConstraint.cpp
     ${SRC_ROOT}/behavior/PairInteractionForceField.cpp
     ${SRC_ROOT}/behavior/PairInteractionProjectiveConstraintSet.cpp
+    ${SRC_ROOT}/behavior/PartialLinearSolver.cpp
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.cpp
     ${SRC_ROOT}/behavior/SingleMatrixAccessor.cpp
     ${SRC_ROOT}/behavior/fwd.cpp

--- a/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
@@ -74,12 +74,6 @@ public:
     /// Solve the system as constructed using the previous methods
     virtual void solveSystem() = 0;
 
-    ///
-    virtual void init_partial_solve() { msg_warning() << "partial_solve is not implemented yet."; }
-
-    ///
-    virtual void partial_solve(std::list<linearalgebra::BaseMatrix::Index>& /*I_last_Disp*/, std::list<linearalgebra::BaseMatrix::Index>& /*I_last_Dforce*/, bool /*NewIn*/) { msg_warning() << "partial_solve is not implemented yet"; }
-
     /// Invert the system, this method is optional because it's called when solveSystem() is called for the first time
     virtual void invertSystem() {}
 
@@ -163,8 +157,6 @@ public:
 
     /// Ask the solver to no longer update the system matrix
     virtual void freezeSystemMatrix() { frozen = true; }
-
-
 
 protected:
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
@@ -74,6 +74,12 @@ public:
     /// Solve the system as constructed using the previous methods
     virtual void solveSystem() = 0;
 
+    SOFA_ATTRIBUTE_DISABLED("v22.06", "v22.12", "LinearSolver does not offer any partial_solve anymore. Please refer to core::behavior::PartialLinearSolver if you wish to use partial solving features.")
+    virtual void init_partial_solve() = delete;
+
+    SOFA_ATTRIBUTE_DISABLED("v22.06", "v22.12", "LinearSolver does not offer any partial_solve anymore. Please refer to core::behavior::PartialLinearSolver if you wish to use partial solving features.")
+    virtual void partial_solve(std::list<linearalgebra::BaseMatrix::Index>& /*I_last_Disp*/, std::list<linearalgebra::BaseMatrix::Index>& /*I_last_Dforce*/, bool /*NewIn*/) = delete;
+
     /// Invert the system, this method is optional because it's called when solveSystem() is called for the first time
     virtual void invertSystem() {}
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.cpp
@@ -21,34 +21,13 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/core/config.h>
-#include <sofa/core/objectmodel/BaseObject.h>
-
-#include <list>
+#include <sofa/core/behavior/PartialLinearSolver.h>
 
 namespace sofa::core::behavior
 {
 
-/**
- *  \brief Interface describing partial linear solvers API
- *
- */
-class SOFA_CORE_API PartialLinearSolver : public virtual sofa::core::objectmodel::BaseObject
+PartialLinearSolver::~PartialLinearSolver()
 {
-public:
-    SOFA_ABSTRACT_CLASS(PartialLinearSolver, objectmodel::BaseObject);
-
-    ~PartialLinearSolver() override;
-
-    /// Init the partial solve
-    virtual void initPartialSolve() = 0;
-    
-    /// partial solve :
-    /// b is accumulated
-    /// db is a sparse vector that is added to b
-    /// partial_x is a sparse vector (with sparse map given) that provide the result of M x = b+db
-    /// Solve Mx=b
-    virtual void partialSolve(std::list<sofa::SignedIndex>& /*I_last_Disp*/, std::list<sofa::SignedIndex>& /*I_last_Dforce*/, bool /*NewIn*/) = 0;
-};
+}
 
 } // namespace sofa::core::behavior

--- a/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.h
@@ -41,7 +41,6 @@ public:
     /// Init the partial solve
     virtual void init_partial_solve() = 0;
     
-    /// Init the partial solve
     /// partial solve :
     /// b is accumulated
     /// db is a sparse vector that is added to b

--- a/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/config.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+
+#include <list>
+
+namespace sofa::core::behavior
+{
+
+/**
+ *  \brief Interface describing partial linear solvers API
+ *
+ */
+class PartialLinearSolver : public virtual sofa::core::objectmodel::BaseObject
+{
+public:
+    SOFA_ABSTRACT_CLASS(PartialLinearSolver, objectmodel::BaseObject);
+
+    /// Init the partial solve
+    virtual void init_partial_solve() = 0;
+    
+    /// Init the partial solve
+    /// partial solve :
+    /// b is accumulated
+    /// db is a sparse vector that is added to b
+    /// partial_x is a sparse vector (with sparse map given) that provide the result of M x = b+db
+    /// Solve Mx=b
+    virtual void partial_solve(std::list<sofa::SignedIndex>& /*I_last_Disp*/, std::list<sofa::SignedIndex>& /*I_last_Dforce*/, bool /*NewIn*/) = 0;
+};
+
+} // namespace sofa::core::behavior

--- a/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PartialLinearSolver.h
@@ -39,14 +39,14 @@ public:
     SOFA_ABSTRACT_CLASS(PartialLinearSolver, objectmodel::BaseObject);
 
     /// Init the partial solve
-    virtual void init_partial_solve() = 0;
+    virtual void initPartialSolve() = 0;
     
     /// partial solve :
     /// b is accumulated
     /// db is a sparse vector that is added to b
     /// partial_x is a sparse vector (with sparse map given) that provide the result of M x = b+db
     /// Solve Mx=b
-    virtual void partial_solve(std::list<sofa::SignedIndex>& /*I_last_Disp*/, std::list<sofa::SignedIndex>& /*I_last_Dforce*/, bool /*NewIn*/) = 0;
+    virtual void partialSolve(std::list<sofa::SignedIndex>& /*I_last_Disp*/, std::list<sofa::SignedIndex>& /*I_last_Dforce*/, bool /*NewIn*/) = 0;
 };
 
 } // namespace sofa::core::behavior


### PR DESCRIPTION
As far as I could see, BTDLinearSolver is the only linear solver which can partially solve system; this is the only solver which implements `init_partial_solve()` and `partial_solve()` from core::LinearSolver.

Problems are:
- It seems to me that this API was introduced in core::LinearSolver only for this class and for linearsolverconstraintcorrection
- All the Linear Solvers will have partial_solve and init_partial_solve() in their codebase and will display msg_warn() "does not support partial_solve" only at run-time, which means there is no way to know at compile-time that a linear solver does not support partial solving.

So I set the partial solving API in an interface (crudely called PartialLinearSolver, name can be gladly changed), and is implemented only by BTDLinearSolver.
As for LinearSolverConstraintCorrection, it will check at construction if the given linearsolver is able to handle partialsolving (by dynamic_cast sadly) and if not, can warn the user that the linear solver is not usable and will be in "incorrect" state afterwards, instead of printing "partial_solve not implemented" while simulating....

A nice side-effect is that linear solvers libs will be slightly smaller, as all instanciations of all linear solvers (except btd then) do not contain init_partial_solve() and partial_solve()  functions anymore.

EDIT: it is even worse, linear solvers not implementing partial_solve does a "msg_info()" so w/o printLog off, users wont even know why the ConstraintSolver/ConstraintCorrections is not doing its job....
See unit tests on LCPForceFieldback, it is using SparseLDLSolver (not implementing partial_solve) and the tests do not throw any warning, even if it is using LCPConstraintSolver and LinearSolverConstraintCorrection

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
