### PR TITLE
[Sofa.Core] Make some functions non-virtual

### DIFF
--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.h
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.h
@@ -122,6 +122,11 @@ public:
     // inputs
     Data< type::vector< sofa::type::Vec<3,Real> > > d_scales; ///< scale matrices
     type::vector<Matrix4x4> SxInverses;  ///< inverse initial positions
+
+    static std::string GetCustomTemplateName()
+    {
+        return DataTypes::Name();
+    }
 };
 
 } // namespace sofa::component::engine::transform

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.h
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.h
@@ -68,9 +68,10 @@ public:
     void init() override;   // compute the inverse matrices
     void doUpdate() override; // compute the displacements wrt original positions
 
-    // To simplify the template name in the xml file
-    virtual std::string getTemplateName() const override { return templateName(this); }
-    static std::string templateName(const DisplacementTransformEngine<DataTypes,OutputType>* = nullptr) { return DataTypes::Name()+std::string(",")+defaulttype::DataTypeInfo<OutputType>::name(); }
+    static std::string GetCustomTemplateName()
+    {
+        return DataTypes::Name()+std::string(",")+defaulttype::DataTypeInfo<OutputType>::name();
+    }
 
 protected:
     type::vector<OutputType> inverses;  ///< inverse initial positions
@@ -117,10 +118,6 @@ public:
     void init() override;   // compute the inverse matrices
     void reinit() override; // compute S*inverse and store it once and for all.
     void doUpdate() override; // compute the displacements wrt original positions
-
-    // To simplify the template name in the xml file
-    virtual std::string getTemplateName() const override { return templateName(this); }
-    static std::string templateName(const DisplacementMatrixEngine<DataTypes>* = nullptr) { return DataTypes::Name(); }
 
     // inputs
     Data< type::vector< sofa::type::Vec<3,Real> > > d_scales; ///< scale matrices

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/ProjectiveTransformEngine.h
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/ProjectiveTransformEngine.h
@@ -62,16 +62,6 @@ public:
 
     void doUpdate() override;
 
-    virtual std::string getTemplateName() const override
-    {
-        return templateName(this);
-    }
-
-    static std::string templateName(const ProjectiveTransformEngine<DataTypes>* = nullptr)
-    {
-        return DataTypes::Name();
-    }
-
 protected:
     Data<VecCoord> f_inputX;   ///< input position
     Data<VecCoord> f_outputX;  ///< output position: Z=focal_distance

--- a/Sofa/Component/Engine/Transform/tests/TransformEngine_test.cpp
+++ b/Sofa/Component/Engine/Transform/tests/TransformEngine_test.cpp
@@ -134,11 +134,11 @@ namespace
 // Define the list of DataTypes to instanciate
 using ::testing::Types;
 typedef Types<
-	defaulttype::Vec1Types,
-	defaulttype::Vec2Types,
+    defaulttype::Vec1Types,
+    defaulttype::Vec2Types,
     defaulttype::Vec3Types,
-	defaulttype::Rigid2Types,
-	defaulttype::Rigid3Types
+    defaulttype::Rigid2Types,
+    defaulttype::Rigid3Types
 > DataTypes; // the types to instanciate.
 
 // Test suite for all the instanciations

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -121,26 +121,20 @@ public:
     void setName(const std::string& n, int counter);
 
     /// Get the type name of this object (i.e. class and template types)
-    /// Since #PR 1283, the signature has changed to "final" so it is not possible
-    /// to override the getTypeName() method.
-    virtual std::string getTypeName() const ;
+    std::string getTypeName() const ;
 
     /// Get the class name of this object
-    /// Since #PR 1283, the signature has changed to "final" so it is not possible
-    /// to override the getClassName() method. To specify custom class name you need
-    /// to implement a single static std::string GetCustomClassName(){} method.
-    virtual std::string getClassName() const ;
+    /// To specify custom class name you need to implement a single
+    /// static std::string GetCustomClassName(){} method.
+    std::string getClassName() const ;
 
     /// Get the template type names (if any) used to instantiate this object
-    /// Since #PR 1283, the signature has changed to "final" so it is not possible
-    /// to override the getClassName() method. To specify custom class name you need
-    /// to implement a single static std::string GetCustomTemplateName(){} method.
-    virtual std::string getTemplateName() const ;
+    /// To specify custom class name you need to implement a single
+    /// static std::string GetCustomTemplateName(){} method.
+    std::string getTemplateName() const ;
 
     /// Get the template type names (if any) used to instantiate this object
-    /// Since #PR 1283, the signature has changed to "final" so it is not possible
-    /// to override the getNameSpaceName() method.
-    virtual std::string getNameSpaceName() const ;
+    std::string getNameSpaceName() const ;
 
     /// Set the source filename (where the component is implemented)
     void setDefinitionSourceFileName(const std::string& sourceFileName);

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -124,12 +124,13 @@ public:
     std::string getTypeName() const ;
 
     /// Get the class name of this object
-    /// To specify custom class name you need to implement a single
+    /// To specify custom static class name you need to implement a single
     /// static std::string GetCustomClassName(){} method.
-    std::string getClassName() const ;
+    /// Override only if the class name cannot be known at compile-time (e.g. Python).
+    virtual std::string getClassName() const ;
 
     /// Get the template type names (if any) used to instantiate this object
-    /// To specify custom class name you need to implement a single
+    /// To specify custom static template name you need to implement a single
     /// static std::string GetCustomTemplateName(){} method.
     std::string getTemplateName() const ;
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -132,7 +132,7 @@ public:
     /// Get the template type names (if any) used to instantiate this object
     /// To specify custom static template name you need to implement a single
     /// static std::string GetCustomTemplateName(){} method.
-    std::string getTemplateName() const ;
+    virtual std::string getTemplateName() const final;
 
     /// Get the template type names (if any) used to instantiate this object
     std::string getNameSpaceName() const ;

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfo.h
@@ -126,8 +126,6 @@ struct DefaultDataTypeInfo
     {
     }
 
-    // mtournier: wtf is this supposed to do?
-    // mtournier: wtf is this not returning &type?
     static const void* getValuePtr(const DataType& /*type*/)
     {
         return nullptr;

--- a/applications/plugins/MeshSTEPLoader/SingleComponent.h
+++ b/applications/plugins/MeshSTEPLoader/SingleComponent.h
@@ -57,12 +57,7 @@ public:
         return core::DataEngine::canCreate(obj, context, arg);
     }
 
-    virtual std::string getTemplateName() const override
-    {
-        return templateName(this);
-    }
-
-    static std::string templateName(const SingleComponent<DataTypes>*)
+    static std::string GetCustomTemplateName()
     {
         return "int";
     }

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
@@ -81,15 +81,10 @@ namespace sofa
 
 			void handleEvent( core::objectmodel::Event* event ) override;
 
-            virtual std::string getTemplateName() const  override
-            { 
-                return templateName(this);
-            }
-
-            static std::string templateName(const DataExchange<DataTypes>* = nullptr)
-            { 
-                return sofa::defaulttype::DataTypeName<DataTypes>::name();
-            }
+			static std::string GetCustomTemplateName()
+			{
+				return sofa::defaulttype::DataTypeName<DataTypes>::name();
+			}
 
 			template<class T>
 			static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)

--- a/applications/plugins/MultiThreading/src/MultiThreading/MeanComputation.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/MeanComputation.h
@@ -70,16 +70,6 @@ namespace sofa
 
                 void handleEvent(core::objectmodel::Event* event) override;
 
-                virtual std::string getTemplateName() const override
-                {
-                    return templateName(this);
-                }
-
-                static std::string templateName(const MeanComputation<DataTypes>* = NULL)
-                {
-                    return DataTypes::Name();
-                }
-
             private:
 
                 Data<VecCoord> d_result; ///< Result: mean computed from the input values


### PR DESCRIPTION
They are not meant to be overriden because there is another mechanism to have a custom class name or template name. As stated in the removed comments, it should have been final. But they could be non-virtual because Base is the top-level base class.

Note this is breaking. For example, SoftRobots is affected.

[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/298]
[ci-depends-on https://github.com/sofa-framework/Registration/pull/4]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
