### PR TITLE
[Sofa.Core] Remove compilation warning because of un-used argument in BaseClass.h

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -307,6 +307,7 @@ struct TClassParents<void>
     }
     static const BaseClass* get(const std::size_t i)
     {
+        SOFA_UNUSED(i);
         return nullptr;
     }
 };


### PR DESCRIPTION







______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
