### PR TITLE
[Topology_test] Add tests in EdgeSetTopology_test to check topological changes

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/tests/EdgeSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/EdgeSetTopology_test.cpp
@@ -33,17 +33,36 @@ using namespace sofa::testing;
 class EdgeSetTopology_test : public BaseTest
 {
 public:
+    using Edge = EdgeSetTopologyContainer::Edge;
+    using EdgeID = EdgeSetTopologyContainer::EdgeID;
+    using EdgesAroundVertex = EdgeSetTopologyContainer::EdgesAroundVertex;
+
+    /// Method to test @sa EdgeSetTopologyContainer creation and initialisation buffers without inputs.
     bool testEmptyContainer();
+
+    /// Method to test @sa EdgeSetTopologyContainer Edge creation and initialisation with a mesh as input.
     bool testEdgeBuffers();
+
+    /// Method to test @sa EdgeSetTopologyContainer EdgesAroundVertex creation and initialisation with a mesh as input.
     bool testVertexBuffers();
+
+    /// Method to test @sa EdgeSetTopologyContainer checkTopology method.
     bool checkTopology();
 private:
+    /// <summary>
+    /// Method to factorize the creation and loading of the @sa m_scene and retrieve Topology container @sa m_topoCon
+    /// </summary>
+    /// <param name="filename">Path string of the mesh to load</param>
+    /// <returns>Bool True if loaded success</returns>
     bool loadTopologyContainer(const std::string& filename);
 
+    /// Pointer to the basic scene created with a topology for the tests
     std::unique_ptr<fake_TopologyScene> m_scene;
+    
+    /// Pointer to the topology container created in the scene @sa m_scene
     EdgeSetTopologyContainer::SPtr m_topoCon = nullptr;
 
-
+    /// GroundTruth values of reference mesh used in test: square1_edges.obj
     int nbrEdge = 45;
     int nbrVertex = 20;
 };
@@ -106,12 +125,12 @@ bool EdgeSetTopology_test::testEdgeBuffers()
 
 
     //// check edge buffer
-    const sofa::type::vector<EdgeSetTopologyContainer::Edge>& edges = m_topoCon->getEdgeArray();
+    const sofa::type::vector<Edge>& edges = m_topoCon->getEdgeArray();
     if (edges.empty())
         return false;
     
     // check edge 
-    const EdgeSetTopologyContainer::Edge& edge0 = edges[0];
+    const Edge& edge0 = edges[0];
     EXPECT_EQ(edge0.size(), 2u);
     
     for (int i = 0; i<2; ++i)
@@ -128,11 +147,11 @@ bool EdgeSetTopology_test::testEdgeBuffers()
 
 
     // Check edge buffer access    
-    const EdgeSetTopologyContainer::Edge& edge1 = m_topoCon->getEdge(1);
+    const Edge& edge1 = m_topoCon->getEdge(1);
     for (int i = 0; i<2; ++i)
         EXPECT_EQ(edge1[i], edgeTruth1[i]);
 
-    const EdgeSetTopologyContainer::Edge& edge2 = m_topoCon->getEdge(1000);
+    const Edge& edge2 = m_topoCon->getEdge(1000);
     for (int i = 0; i<2; ++i)
         EXPECT_EQ(edge2[i], sofa::InvalidID);
 
@@ -146,7 +165,7 @@ bool EdgeSetTopology_test::testVertexBuffers()
         return false;
 
     // create and check vertex buffer
-    const sofa::type::vector< EdgeSetTopologyContainer::EdgesAroundVertex >& edgeAroundVertices = m_topoCon->getEdgesAroundVertexArray();
+    const sofa::type::vector< EdgesAroundVertex >& edgeAroundVertices = m_topoCon->getEdgesAroundVertexArray();
 
     //// check only the vertex buffer size: Full test on vertics are done in PointSetTopology_test
     EXPECT_EQ(m_topoCon->d_initPoints.getValue().size(), nbrVertex);
@@ -154,8 +173,8 @@ bool EdgeSetTopology_test::testVertexBuffers()
     
     // check EdgesAroundVertex buffer access
     EXPECT_EQ(edgeAroundVertices.size(), nbrVertex);
-    const EdgeSetTopologyContainer::EdgesAroundVertex& edgeAVertex = edgeAroundVertices[0];
-    const EdgeSetTopologyContainer::EdgesAroundVertex& edgeAVertexM = m_topoCon->getEdgesAroundVertex(0);
+    const EdgesAroundVertex& edgeAVertex = edgeAroundVertices[0];
+    const EdgesAroundVertex& edgeAVertexM = m_topoCon->getEdgesAroundVertex(0);
     
     EXPECT_EQ(edgeAVertex.size(), edgeAVertexM.size());
     for (size_t i = 0; i < edgeAVertex.size(); i++)

--- a/Sofa/Component/Topology/Container/Dynamic/tests/EdgeSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/EdgeSetTopology_test.cpp
@@ -31,7 +31,9 @@
 using namespace sofa::component::topology::container::dynamic;
 using namespace sofa::testing;
 
-
+/// <summary>
+/// Class to test @sa EdgeSetTopologyContainer and @sa EdgeSetTopologyModifier methods
+/// </summary>
 class EdgeSetTopology_test : public BaseTest
 {
 public:
@@ -290,7 +292,7 @@ bool EdgeSetTopology_test::testRemovingEdges()
     
     EXPECT_EQ(m_topoCon->getNbEdges(), nbr);
     EXPECT_EQ(m_topoCon->getNbPoints(), nbrVertex - 1);
-        
+
     return true;
 }
 

--- a/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/fake_TopologyScene.h
+++ b/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/fake_TopologyScene.h
@@ -57,6 +57,8 @@ public:
         sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Constant");
         sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Dynamic");
 
+        createObject(m_root, "DefaultAnimationLoop");
+
         std::string loaderType = "MeshOBJLoader";
         if (m_topoType == TopologyElementType::TETRAHEDRON || m_topoType == TopologyElementType::HEXAHEDRON)
             loaderType = "MeshGmshLoader";

--- a/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/fake_TopologyScene.h
+++ b/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/fake_TopologyScene.h
@@ -56,6 +56,7 @@ public:
         sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
         sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Constant");
         sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Dynamic");
+        sofa::simpleapi::importPlugin("Sofa.Component.Mass");
 
         createObject(m_root, "DefaultAnimationLoop");
 
@@ -104,6 +105,16 @@ public:
 
             createObject(m_root, topoType + "SetTopologyModifier", { { "name", "topoMod" } });
             createObject(m_root, topoType + "SetGeometryAlgorithms", { { "name", "topoGeo" } });
+
+            // Add some mechanical components
+            createObject(m_root, "MeshMatrixMass");
+
+            if (m_topoType == TopologyElementType::EDGE) {
+                sofa::simpleapi::importPlugin("Sofa.Component.SolidMechanics.Spring");
+                createObject(m_root, "VectorSpringForceField", { {"useTopology", "true"} });
+            }
+                
+                
         }
 
         m_simu->init(m_root.get());
@@ -114,7 +125,7 @@ public:
     /// Method to get acces to node containing the meshLoader and the toplogy container.
     sofa::simulation::Node::SPtr getNode() { return m_root; }
 
-protected:
+private:
     /// Simulation object
     sofa::simulation::Simulation::SPtr m_simu;
     /// Node containing the topology


### PR DESCRIPTION
- Add tests on add/remove edges/vertices using EdgeSetTopologyModifier methods
- Update FakeTopology_Scene to add mechanical Components with TopologyData
- Add test to check TopologyData and TopologyHandler registration
- Some cleaning, factorization and documentation in EdgeSetTopology_test code


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
