### PR TITLE
[DrawToolGL] Fix ill-formed drawLines with multiple colors

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
@@ -389,13 +389,10 @@ bool UnilateralInteractionConstraint<DataTypes>::isActive() const
 template<class DataTypes>
 void UnilateralInteractionConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-
     if (!vparams->displayFlags().getShowInteractionForceFields()) return;
 
     vparams->drawTool()->saveLastState();
-
     vparams->drawTool()->disableLighting();
-    vparams->drawTool()->saveLastState();
 
     std::vector<sofa::type::Vector3> redVertices;
     std::vector<sofa::type::Vector3> otherVertices;

--- a/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
+++ b/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
@@ -144,19 +144,25 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
         return drawLines(points, size, RGBAColor::red());
     }
 
-    glLineWidth(size);
-    if (getLightEnabled()) disableLighting();
-    glBegin(GL_LINES);
+    // gather lines with same colors
+    std::map<RGBAColor, std::vector<Vector3> > colorPointsMap;
+    for (std::size_t i = 0; i < colors.size(); ++i)
     {
-        for (std::size_t i=0; i<points.size()/2; ++i)
+        if (colorPointsMap.find(colors[i]) == colorPointsMap.end())
         {
-            setMaterial(colors[i]);
-            internalDrawLine(points[2*i],points[2*i+1], colors[i] );
-            resetMaterial(colors[i]);
+            colorPointsMap.insert({ colors[i] , {} });
         }
-    } glEnd();
-    if (getLightEnabled()) enableLighting();
-    glLineWidth(1);
+
+        colorPointsMap[colors[i]].push_back(points[2 * i]);
+        colorPointsMap[colors[i]].push_back(points[2 * i + 1]);
+    }
+
+    // call the drawLine method which takes only one color
+    for (auto [color, points] : colorPointsMap)
+    {
+        drawLines(points, size, color);
+    }
+
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
+++ b/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
@@ -148,17 +148,12 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
     std::map<RGBAColor, std::vector<Vector3> > colorPointsMap;
     for (std::size_t i = 0; i < colors.size(); ++i)
     {
-        if (colorPointsMap.find(colors[i]) == colorPointsMap.end())
-        {
-            colorPointsMap.insert({ colors[i] , {} });
-        }
-
         colorPointsMap[colors[i]].push_back(points[2 * i]);
         colorPointsMap[colors[i]].push_back(points[2 * i + 1]);
     }
 
     // call the drawLine method which takes only one color
-    for (auto [color, points] : colorPointsMap)
+    for (const auto& [color, points] : colorPointsMap)
     {
         drawLines(points, size, color);
     }


### PR DESCRIPTION
Got a GlError() somewhere else and finding where it came from was a pain...
It appears that drawLines (version with multiple colors) was incorrectly implemented, as it was calling setMaterial/resetMaterial between glBegin()/glEnd() and this is not possible apparently because those 2 functions call glDisable() and glDepthMask() and it is not possible to call them between glBegin/glEnd. (yes old OpenGL is... marvelous)

Anyway this PR regroups the lines per color and call the drawLine() with one color. Implementation with map is not nice IMO but all the DrawTool implementation itself is, anyway.

\+ UnilateralInteractionConstraint was calling twice saveLastState()


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
