### PR TITLE
[SolidMechanics] Fix updating the internal spring indices of SpringForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
@@ -114,7 +114,7 @@ void SpringForceField<DataTypes>::applyRemovedPoints(const sofa::core::topology:
 
     if (tab.empty())
         return;
-    
+
     core::topology::BaseMeshTopology* modifiedTopology;
     if (mstateId == 0)
     {
@@ -152,7 +152,7 @@ void SpringForceField<DataTypes>::applyRemovedPoints(const sofa::core::topology:
         {
             springsValue.erase(springsValue.begin() + (*it));
         }
-        
+
         if (pntId == nbPoints) // no need to renumber springs as last pointId has just been removed
             continue;
 
@@ -473,6 +473,8 @@ void SpringForceField<DataTypes>::removeSpring(sofa::Index idSpring)
     sofa::type::vector<Spring>& springs = *this->springs.beginEdit();
     springs.erase(springs.begin() +idSpring );
     this->springs.endEdit();
+
+    updateTopologyIndicesFromSprings();
 }
 
 template <class DataTypes>


### PR DESCRIPTION
Hi,
at the moment, `springsIndices1` and `springsIndices2` are not updated, when calling `removeSpring` in `SpringForceField`.

Added a call to `updateTopologyIndicesFromSprings` in `removeSpring`

Cheers,
Paul

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
