### PR TITLE
[SolidMechanics][Spring] Implement applyRemovedEdges for SpringForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.h
@@ -119,6 +119,7 @@ protected:
     void initializeTopologyHandler(sofa::core::topology::TopologySubsetIndices& indices, core::topology::BaseMeshTopology* topology, sofa::Index mstateId);
     void updateTopologyIndicesFromSprings();
     void applyRemovedPoints(const sofa::core::topology::PointsRemoved* pointsRemoved, sofa::Index mstateId);
+    void applyRemovedEdges(const sofa::core::topology::EdgesRemoved* edgesRemoved, sofa::Index mstateId);
 
 protected:
     bool maskInUse;

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
@@ -268,14 +268,18 @@ void SpringForceField<DataTypes>::initializeTopologyHandler(sofa::core::topology
                 applyRemovedPoints(pointsRemoved, mstateId);
             });
 
-        indices.linkToEdgeDataArray();  
-        indices.addTopologyEventCallBack(core::topology::TopologyChangeType::EDGESREMOVED,
-            [this, mstateId](const core::topology::TopologyChange* change)
-            {
-                const auto* edgesRemoved = static_cast<const core::topology::EdgesRemoved*>(change);
-                msg_info(this) << "Removed edges: [" << edgesRemoved->getArray() << "]";
-                applyRemovedEdges(edgesRemoved, mstateId);
-            });
+        if (topology->getTopologyType() == sofa::core::topology::TopologyElementType::EDGE)
+        {
+            indices.linkToEdgeDataArray();  
+            indices.addTopologyEventCallBack(core::topology::TopologyChangeType::EDGESREMOVED,
+                [this, mstateId](const core::topology::TopologyChange* change)
+                {
+                    const auto* edgesRemoved = static_cast<const core::topology::EdgesRemoved*>(change);
+                    msg_info(this) << "Removed edges: [" << edgesRemoved->getArray() << "]";
+                    applyRemovedEdges(edgesRemoved, mstateId);
+                });
+        }
+        
         indices.addTopologyEventCallBack(core::topology::TopologyChangeType::ENDING_EVENT,
             [this](const core::topology::TopologyChange*)
             {


### PR DESCRIPTION
Hi,
`SpringForceField` currently only implements `applyRemovedPoints`.
If a point is removed from the topology, the springs are removed correctly.
If only an edge is removed, the springs are not changed.

https://user-images.githubusercontent.com/29635054/188287191-cebd8b7d-b66d-4f25-90f7-e7b90efa2098.mp4

The PR is marked as WIP, because I need help on correctly registering the component to listen for `core::topology::TopologyChangeType::EDGESREMOVED`.
The current code compiles fine, but the code of `applyRemovedEdges` is never reached.

Could someone give me a hint on what is missing? :)

Cheers,
Paul
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
