### PR TITLE
[SofaCarving] Fix bug in CarvingManager when searching for target collision model

### DIFF
--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -88,14 +88,8 @@ void CarvingManager::init()
     if (d_surfaceModelPath.getValue().empty())
     {
         // We look for a CollisionModel identified with the CarvingSurface Tag.
-        std::vector<core::CollisionModel*> models;
-        getContext()->get<core::CollisionModel>(&models, core::objectmodel::Tag("CarvingSurface"), core::objectmodel::BaseContext::SearchRoot);
+        getContext()->get<core::CollisionModel>(&m_surfaceCollisionModels, core::objectmodel::Tag("CarvingSurface"), core::objectmodel::BaseContext::SearchRoot);
 
-        for (size_t i=0;i<models.size();++i)
-        {
-            core::CollisionModel* m = models[i];
-            m_surfaceCollisionModels.push_back(m);
-        }
     }
     else
     {

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -90,15 +90,10 @@ void CarvingManager::init()
         // We look for a CollisionModel identified with the CarvingSurface Tag.
         std::vector<core::CollisionModel*> models;
         getContext()->get<core::CollisionModel>(&models, core::objectmodel::Tag("CarvingSurface"), core::objectmodel::BaseContext::SearchRoot);
-    
-        // If topological mapping, iterate into child Node to find mapped topology
-	    sofa::core::topology::TopologicalMapping* topoMapping;
+
         for (size_t i=0;i<models.size();++i)
         {
             core::CollisionModel* m = models[i];
-            m->getContext()->get(topoMapping);
-            if (topoMapping == NULL) continue;
-                        
             m_surfaceCollisionModels.push_back(m);
         }
     }
@@ -188,8 +183,8 @@ void CarvingManager::doCarve()
 
             if (c.value < d_carvingDistance.getValue())
             {
-                auto triangleIdx = (c.elem.first.getCollisionModel() == m_toolCollisionModel ? c.elem.second.getIndex() : c.elem.first.getIndex());
-                elemsToRemove.push_back(triangleIdx);
+                auto elementIdx = (c.elem.first.getCollisionModel() == m_toolCollisionModel ? c.elem.second.getIndex() : c.elem.first.getIndex());
+                elemsToRemove.push_back(elementIdx);
             }
         }
 


### PR DESCRIPTION
I removed the check for a present topological mapping.
With the check a simple setup like

```
TriangleSetTopologyContainer
TriangleSetTopologyModifier
MechanicalObject
TriangleCollisionModel with tag CarvingSurface
```

is not recognized as a valid model for carving.

Cheers,
Paul

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
