### PR TITLE
[Sofa.Type] Fix/clean and speed up of Mat

### DIFF
--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectDirectionConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectDirectionConstraint.inl
@@ -156,7 +156,7 @@ void  ProjectDirectionConstraint<DataTypes>::reinit()
         }
         else           // unconstrained particle: set diagonal to identity block
         {
-            jacobian.insertBackBlock(i,i,Block::s_identity);
+            jacobian.insertBackBlock(i,i,Block::Identity());
         }
         i++;
     }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToLineConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToLineConstraint.inl
@@ -161,7 +161,7 @@ void  ProjectToLineConstraint<DataTypes>::updateJacobian()
         }
         else           // unconstrained particle: set diagonal to identity block
         {
-            jacobian.insertBackBlock(i,i,Block::s_identity);
+            jacobian.insertBackBlock(i,i,Block::Identity());
         }
         i++;
     }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPlaneConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPlaneConstraint.inl
@@ -164,7 +164,7 @@ void  ProjectToPlaneConstraint<DataTypes>::reinit()
         }
         else           // unconstrained particle: set diagonal to identity block
         {
-            jacobian.insertBackBlock(i,i,Block::s_identity); // only one block to create
+            jacobian.insertBackBlock(i,i,Block::Identity()); // only one block to create
         }
         i++;
     }

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/TransformMatrixEngine.cpp
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/TransformMatrixEngine.cpp
@@ -50,7 +50,7 @@ int RotateTransformMatrixEngineClass = core::RegisterObject("Compose the input t
  */
 
 AbstractTransformMatrixEngine::AbstractTransformMatrixEngine()
-    : d_inT ( initData (&d_inT, Matrix4::s_identity, "inT", "input transformation if any") )
+    : d_inT ( initData (&d_inT, Matrix4::Identity(), "inT", "input transformation if any") )
     , d_outT( initData (&d_outT, "outT", "output transformation") )
 {
     addInput(&d_inT);

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/TransformPosition.inl
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/TransformPosition.inl
@@ -42,7 +42,7 @@ TransformPosition<DataTypes>::TransformPosition()
     , f_translation(initData(&f_translation, "translation", "translation vector ") )
     , f_rotation(initData(&f_rotation, "rotation", "rotation vector ") )
     , f_scale(initData(&f_scale, Coord(1.0,1.0,1.0), "scale", "scale factor") )
-    , f_affineMatrix(initData(&f_affineMatrix, Mat4x4::s_identity, "matrix", "4x4 affine matrix") )
+    , f_affineMatrix(initData(&f_affineMatrix, Mat4x4::Identity(), "matrix", "4x4 affine matrix") )
     , f_method(initData(&f_method, "method", "transformation method either translation or scale or rotation or random or projectOnPlane") )
     , f_seed(initData(&f_seed, (long) 0, "seedValue", "the seed value for the random generator") )
     , f_maxRandomDisplacement(initData(&f_maxRandomDisplacement, (Real) 1.0, "maxRandomDisplacement", "the maximum displacement around initial position for the random transformation") )
@@ -177,7 +177,7 @@ void TransformPosition<DataTypes>::getTransfoFromTfm()
     if (stream)
     {
         std::string line;
-        Mat4x4 mat(Mat4x4::s_identity);
+        Mat4x4 mat(Mat4x4::Identity());
 
         bool found = false;
         while (getline(stream,line) && !found)
@@ -245,7 +245,7 @@ void TransformPosition<DataTypes>::getTransfoFromTrm()
     {
         std::string line;
         unsigned int nbLines = 0;
-        Mat4x4 mat(Mat4x4::s_identity);
+        Mat4x4 mat(Mat4x4::Identity());
 
         while (getline(stream,line))
         {
@@ -323,7 +323,7 @@ void TransformPosition<DataTypes>::getTransfoFromTxt()
     {
         std::string line;
         unsigned int nbLines = 0;
-        Mat4x4 mat(Mat4x4::s_identity);
+        Mat4x4 mat(Mat4x4::Identity());
 
         while (getline(stream,line))
         {

--- a/Sofa/framework/Core/src/sofa/core/loader/MeshLoader.cpp
+++ b/Sofa/framework/Core/src/sofa/core/loader/MeshLoader.cpp
@@ -71,8 +71,8 @@ MeshLoader::MeshLoader() : BaseLoader()
   , d_translation(initData(&d_translation, Vec3(), "translation", "Translation of the DOFs"))
   , d_rotation(initData(&d_rotation, Vec3(), "rotation", "Rotation of the DOFs"))
   , d_scale(initData(&d_scale, Vec3(1.0, 1.0, 1.0), "scale3d", "Scale of the DOFs in 3 dimensions"))
-  , d_transformation(initData(&d_transformation, type::Matrix4::s_identity, "transformation", "4x4 Homogeneous matrix to transform the DOFs (when present replace any)"))
-  , d_previousTransformation(type::Matrix4::s_identity )
+  , d_transformation(initData(&d_transformation, type::Matrix4::Identity(), "transformation", "4x4 Homogeneous matrix to transform the DOFs (when present replace any)"))
+  , d_previousTransformation(type::Matrix4::Identity() )
 {
     addAlias(&d_tetrahedra, "tetras");
     addAlias(&d_hexahedra, "hexas");
@@ -220,7 +220,7 @@ void MeshLoader::reinit()
     d_previousTransformation.identity();
 
 
-    if (transformation != type::Matrix4::s_identity)
+    if (transformation != type::Matrix4::Identity())
     {
         if (d_scale.getValue() != Vec3(1.0, 1.0, 1.0) || d_rotation.getValue() != Vec3(0.0, 0.0, 0.0) || d_translation.getValue() != Vec3(0.0, 0.0, 0.0))
         {
@@ -237,7 +237,7 @@ void MeshLoader::reinit()
                 type::Matrix4::transformScale(scale);
     }
 
-    if (transformation != type::Matrix4::s_identity)
+    if (transformation != type::Matrix4::Identity())
     {
         this->applyTransformation(transformation);
         d_previousTransformation.transformInvert(transformation);

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BTDMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BTDMatrix.h
@@ -91,11 +91,7 @@ public:
         }
         type::Mat<BSIZE,BSIZE,Real> operator*(const type::Mat<BSIZE,BSIZE,Real>& m)
         {
-            return type::Mat<BSIZE,BSIZE,Real>::operator*(m);
-        }
-        type::Mat<BSIZE,BSIZE,Real> operator*(const Block& m)
-        {
-            return type::Mat<BSIZE,BSIZE,Real>::operator*(m);
+            return sofa::type::operator*(*this, m);
         }
         type::Mat<BSIZE,BSIZE,Real> operator*(const TransposedBlock& mt)
         {

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BlocFullMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BlocFullMatrix.h
@@ -82,11 +82,7 @@ public:
         }
         type::Mat<BSIZE,BSIZE,Real> operator*(const type::Mat<BSIZE,BSIZE,Real>& m)
         {
-            return type::Mat<BSIZE,BSIZE,Real>::operator*(m);
-        }
-        type::Mat<BSIZE,BSIZE,Real> operator*(const Block& m)
-        {
-            return type::Mat<BSIZE,BSIZE,Real>::operator*(m);
+            return sofa::type::operator*(*this, m);
         }
         type::Mat<BSIZE,BSIZE,Real> operator*(const TransposedBlock& mt)
         {

--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOURCE_FILES
     ${SOFATYPESRC_ROOT}/DualQuat.cpp
     ${SOFATYPESRC_ROOT}/BoundingBox.cpp
     ${SOFATYPESRC_ROOT}/Frame.cpp
+    ${SOFATYPESRC_ROOT}/Mat.cpp
     ${SOFATYPESRC_ROOT}/Material.cpp
     ${SOFATYPESRC_ROOT}/PrimitiveGroup.cpp
     ${SOFATYPESRC_ROOT}/RGBAColor.cpp

--- a/Sofa/framework/Type/src/sofa/type/Mat.cpp
+++ b/Sofa/framework/Type/src/sofa/type/Mat.cpp
@@ -23,61 +23,6 @@
 
 namespace sofa::type
 {
-
-template<typename Real>
-constexpr Mat<3,3, Real> mult33(const Mat<3,3,Real>& m1, const Mat<3,3,Real>& m2)
-{
-    Mat<3,3,Real> r(NOINIT);
-
-    const auto A00 = m1[0][0];
-    const auto A01 = m1[0][1];
-    const auto A02 = m1[0][2];
-    const auto A10 = m1[1][0];
-    const auto A11 = m1[1][1];
-    const auto A12 = m1[1][2];
-    const auto A20 = m1[2][0];
-    const auto A21 = m1[2][1];
-    const auto A22 = m1[2][2];
-
-    const auto B00 = m2[0][0];
-    const auto B01 = m2[0][1];
-    const auto B02 = m2[0][2];
-    const auto B10 = m2[1][0];
-    const auto B11 = m2[1][1];
-    const auto B12 = m2[1][2];
-    const auto B20 = m2[2][0];
-    const auto B21 = m2[2][1];
-    const auto B22 = m2[2][2];
-
-    r[0][0] = A00 * B00 + A01 * B10 + A02 * B20;
-    r[0][1] = A00 * B01 + A01 * B11 + A02 * B21;
-    r[0][2] = A00 * B02 + A01 * B12 + A02 * B22;
-
-    r[1][0] = A10 * B00 + A11 * B10 + A12 * B20;
-    r[1][1] = A10 * B01 + A11 * B11 + A12 * B21;
-    r[1][2] = A10 * B02 + A11 * B12 + A12 * B22;
-
-    r[2][0] = A20 * B00 + A21 * B10 + A22 * B20;
-    r[2][1] = A20 * B01 + A21 * B11 + A22 * B21;
-    r[2][2] = A20 * B02 + A21 * B12 + A22 * B22;
-
-    return r;
-}
-
-template<>
-template<> SOFA_TYPE_API
-constexpr Mat<3,3,float> Mat<3,3,float>::operator*(const Mat<3,3,float>& m) const noexcept
-{
-    return mult33(*this, m);
-}
-
-template<>
-template<> SOFA_TYPE_API
-constexpr Mat<3,3,double> Mat<3,3,double>::operator*(const Mat<3,3,double>& m) const noexcept
-{
-    return mult33(*this, m);
-}
-
 template class SOFA_TYPE_API Mat<2, 2, SReal>;
 template class SOFA_TYPE_API Mat<2, 3, SReal>;
 template class SOFA_TYPE_API Mat<3, 3, SReal>;

--- a/Sofa/framework/Type/src/sofa/type/Mat.cpp
+++ b/Sofa/framework/Type/src/sofa/type/Mat.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_TYPE_MAT_CPP
 #include <sofa/type/Mat.h>
 
 namespace sofa::type

--- a/Sofa/framework/Type/src/sofa/type/Mat.cpp
+++ b/Sofa/framework/Type/src/sofa/type/Mat.cpp
@@ -1,0 +1,97 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/type/Mat.h>
+
+namespace sofa::type
+{
+
+template<typename Real>
+constexpr Mat<3,3, Real> mult33(const Mat<3,3,Real>& m1, const Mat<3,3,Real>& m2)
+{
+    Mat<3,3,Real> r(NOINIT);
+
+    const auto A00 = m1[0][0];
+    const auto A01 = m1[0][1];
+    const auto A02 = m1[0][2];
+    const auto A10 = m1[1][0];
+    const auto A11 = m1[1][1];
+    const auto A12 = m1[1][2];
+    const auto A20 = m1[2][0];
+    const auto A21 = m1[2][1];
+    const auto A22 = m1[2][2];
+
+    const auto B00 = m2[0][0];
+    const auto B01 = m2[0][1];
+    const auto B02 = m2[0][2];
+    const auto B10 = m2[1][0];
+    const auto B11 = m2[1][1];
+    const auto B12 = m2[1][2];
+    const auto B20 = m2[2][0];
+    const auto B21 = m2[2][1];
+    const auto B22 = m2[2][2];
+
+    r[0][0] = A00 * B00 + A01 * B10 + A02 * B20;
+    r[0][1] = A00 * B01 + A01 * B11 + A02 * B21;
+    r[0][2] = A00 * B02 + A01 * B12 + A02 * B22;
+
+    r[1][0] = A10 * B00 + A11 * B10 + A12 * B20;
+    r[1][1] = A10 * B01 + A11 * B11 + A12 * B21;
+    r[1][2] = A10 * B02 + A11 * B12 + A12 * B22;
+
+    r[2][0] = A20 * B00 + A21 * B10 + A22 * B20;
+    r[2][1] = A20 * B01 + A21 * B11 + A22 * B21;
+    r[2][2] = A20 * B02 + A21 * B12 + A22 * B22;
+
+    return r;
+}
+
+template<>
+template<> SOFA_TYPE_API
+constexpr Mat<3,3,float> Mat<3,3,float>::operator*(const Mat<3,3,float>& m) const noexcept
+{
+    return mult33(*this, m);
+}
+
+template<>
+template<> SOFA_TYPE_API
+constexpr Mat<3,3,double> Mat<3,3,double>::operator*(const Mat<3,3,double>& m) const noexcept
+{
+    return mult33(*this, m);
+}
+
+template class SOFA_TYPE_API Mat<2, 2, SReal>;
+template class SOFA_TYPE_API Mat<2, 3, SReal>;
+template class SOFA_TYPE_API Mat<3, 3, SReal>;
+template class SOFA_TYPE_API Mat<4, 4, SReal>;
+template class SOFA_TYPE_API Mat<6, 3, SReal>;
+template class SOFA_TYPE_API Mat<6, 6, SReal>;
+template class SOFA_TYPE_API Mat<8, 3, SReal>;
+template class SOFA_TYPE_API Mat<8, 8, SReal>;
+template class SOFA_TYPE_API Mat<9, 9, SReal>;
+template class SOFA_TYPE_API Mat<12, 3, SReal>;
+template class SOFA_TYPE_API Mat<12, 6, SReal>;
+template class SOFA_TYPE_API Mat<12, 12, SReal>;
+template class SOFA_TYPE_API Mat<20, 20, SReal>;
+template class SOFA_TYPE_API Mat<20, 32, SReal>;
+template class SOFA_TYPE_API Mat<24, 24, SReal>;
+template class SOFA_TYPE_API Mat<32, 20, SReal>;
+}

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -312,9 +312,9 @@ public:
 
     /// Returns the identity matrix
     template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
-    static constexpr const Mat<L,L,real>& Identity() noexcept
+    static const Mat<L,L,real>& Identity() noexcept
     {
-        static constexpr Mat<L,L,real> s_identity = []()
+        static Mat<L,L,real> s_identity = []()
         {
             Mat<L,L,real> id(NOINIT);
             id.identity();

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -56,7 +56,7 @@ class Mat : public fixed_array<VecNoInit<C,real>, L>
 {
 public:
 
-    enum { N = L*C };
+    static constexpr sofa::Size N = L * C;
 
     typedef typename fixed_array<real, N>::size_type Size;
 
@@ -276,44 +276,56 @@ public:
     }
 
     /// Special access to first line.
-    constexpr Line& x()  noexcept { static_assert(L >= 1, ""); return this->elems[0]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 1> >
+    constexpr Line& x()  noexcept { return this->elems[0]; }
     /// Special access to second line.
-    constexpr Line& y()  noexcept { static_assert(L >= 2, ""); return this->elems[1]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 2> >
+    constexpr Line& y()  noexcept { return this->elems[1]; }
     /// Special access to third line.
-    constexpr Line& z()  noexcept { static_assert(L >= 3, ""); return this->elems[2]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 3> >
+    constexpr Line& z()  noexcept { return this->elems[2]; }
     /// Special access to fourth line.
-    constexpr Line& w()  noexcept { static_assert(L >= 4, ""); return this->elems[3]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 4> >
+    constexpr Line& w()  noexcept { return this->elems[3]; }
 
     /// Special access to first line (read-only).
-    constexpr const Line& x() const noexcept { static_assert(L >= 1, ""); return this->elems[0]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 1> >
+    constexpr const Line& x() const noexcept { return this->elems[0]; }
     /// Special access to second line (read-only).
-    constexpr const Line& y() const noexcept { static_assert(L >= 2, ""); return this->elems[1]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 2> >
+    constexpr const Line& y() const noexcept { return this->elems[1]; }
     /// Special access to thrid line (read-only).
-    constexpr const Line& z() const noexcept { static_assert(L >= 3, ""); return this->elems[2]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 3> >
+    constexpr const Line& z() const noexcept { return this->elems[2]; }
     /// Special access to fourth line (read-only).
-    constexpr const Line& w() const noexcept { static_assert(L >= 4, ""); return this->elems[3]; }
+    template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 4> >
+    constexpr const Line& w() const noexcept { return this->elems[3]; }
 
     /// Set matrix to identity.
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     constexpr void identity() noexcept
     {
-        static_assert(L == C, "");
         clear();
         for (Size i=0; i<L; i++)
             this->elems[i][i]=1;
     }
 
     /// Returns the identity matrix
-    static Mat<L,L,real> Identity() noexcept
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
+    static constexpr const Mat<L,L,real>& Identity() noexcept
     {
-        static_assert(L == C, "");
-        Mat<L,L,real> id;
-        for (Size i=0; i<L; i++)
-            id[i][i]=1;
-        return id;
+        static constexpr Mat<L,L,real> s_identity = []()
+        {
+            Mat<L,L,real> id(NOINIT);
+            id.identity();
+            return id;
+        }();
+        return s_identity;
     }
 
     /// precomputed identity matrix of size (L,L)
-    static Mat<L, L, real> s_identity;
+    SOFA_ATTRIBUTE_DEPRECATED__STATIC_MATRIX_IDENTITY()
+    static const Mat<L, L, real>& s_identity;
 
     template<Size S>
     static bool canSelfTranspose(const Mat<S, S, real>& lhs, const Mat<S, S, real>& rhs) noexcept
@@ -359,9 +371,9 @@ public:
     }
 
     /// Transpose the square matrix.
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     constexpr void transpose() noexcept
     {
-        static_assert(L == C, "Cannot self-transpose a non-square matrix. Use transposed() instead");
         for (Size i=0; i<L; i++)
         {
             for (Size j=i+1; j<C; j++)
@@ -617,7 +629,8 @@ public:
 
 
     /// invert this
-    constexpr Mat<L,C,real> inverted() const
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
+    [[nodiscard]] constexpr Mat<L,C,real> inverted() const
     {
         static_assert(L == C, "Cannot invert a non-square matrix");
         Mat<L,C,real> m = *this;
@@ -630,9 +643,9 @@ public:
     }
 
     /// Invert square matrix m
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     [[nodiscard]] constexpr bool invert(const Mat<L,C,real>& m)
     {
-        static_assert(L == C, "Cannot invert a non-square matrix");
         if (&m == this)
         {
             Mat<L,C,real> mat = m;
@@ -642,6 +655,7 @@ public:
         return invertMatrix(*this, m);
     }
 
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     static Mat<L,C,real> transformTranslation(const Vec<C-1,real>& t) noexcept
     {
         Mat<L,C,real> m;
@@ -651,6 +665,7 @@ public:
         return m;
     }
 
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     static Mat<L,C,real> transformScale(real s) noexcept
     {
         Mat<L,C,real> m;
@@ -660,6 +675,7 @@ public:
         return m;
     }
 
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     static Mat<L,C,real> transformScale(const Vec<C-1,real>& s) noexcept
     {
         Mat<L,C,real> m;
@@ -715,6 +731,7 @@ public:
     }
 
     /// Invert transformation matrix m
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     constexpr bool transformInvert(const Mat<L,C,real>& m)
     {
         return transformInvertMatrix(*this, m);
@@ -723,9 +740,9 @@ public:
     /// for square matrices
     /// @warning in-place simple symmetrization
     /// this = ( this + this.transposed() ) / 2.0
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     constexpr void symmetrize() noexcept
     {
-        static_assert( C == L, "" );
         for(Size l=0; l<L; l++)
             for(Size c=l+1; c<C; c++)
                 this->elems[l][c] = this->elems[c][l] = ( this->elems[l][c] + this->elems[c][l] ) * 0.5f;
@@ -734,8 +751,8 @@ public:
 };
 
 
-template <sofa::Size L, sofa::Size C, typename real> 
-Mat<L, L, real> Mat<L, C, real>::s_identity = Mat<L, L, real>::Identity();
+template <sofa::Size L, sofa::Size C, typename real>
+const Mat<L, L, real>& Mat<L, C, real>::s_identity = Mat<L, L, real>::Identity();
 
 /// Same as Mat except the values are not initialized by default
 template <sofa::Size L, sofa::Size C, typename real>
@@ -956,6 +973,19 @@ template<class real>
     return true;
 }
 
+/// Matrix inversion (special case 1x1).
+template<class real>
+[[nodiscard]] constexpr bool invertMatrix(Mat<1,1,real>& dest, const Mat<1,1,real>& from)
+{
+    if (equalsZero(from[0][0]))
+    {
+        return false;
+    }
+
+    dest[0][0] = static_cast<real>(1.) / from[0][0];
+    return true;
+}
+
 /// Inverse Matrix considering the matrix as a transformation.
 template<sofa::Size S, class real>
 [[nodiscard]] constexpr bool transformInvertMatrix(Mat<S,S,real>& dest, const Mat<S,S,real>& from)
@@ -1113,5 +1143,13 @@ constexpr Mat<L,L,Real> tensorProduct(const Vec<L,Real>& a, const Vec<L,Real>& b
 
     return m;
 }
+
+template<>
+template<> SOFA_TYPE_API
+constexpr Mat<3,3,float> Mat<3,3,float>::operator*(const Mat<3,3,float>& m) const noexcept;
+
+template<>
+template<> SOFA_TYPE_API
+constexpr Mat<3,3,double> Mat<3,3,double>::operator*(const Mat<3,3,double>& m) const noexcept;
 
 } // namespace sofa::type

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -406,12 +406,19 @@ public:
     }
 
 
-    bool isSymmetric() const
+    [[nodiscard]] bool isSymmetric() const
     {
-        for (Size i=0; i<L; i++)
-            for (Size j=i+1; j<C; j++)
-                if( rabs( this->elems[i][j] - this->elems[j][i] ) > EQUALITY_THRESHOLD ) return false;
-        return true;
+        if constexpr (L == C)
+        {
+            for (Size i=0; i<L; i++)
+                for (Size j=i+1; j<C; j++)
+                    if( rabs( this->elems[i][j] - this->elems[j][i] ) > EQUALITY_THRESHOLD ) return false;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
     }
 
     bool isDiagonal() const noexcept

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -1251,4 +1251,25 @@ constexpr Mat<3,3,real> multTranspose(const Mat<3,3,real>& m1, const Mat<3,3,rea
     return r;
 }
 
+#if !defined(SOFA_TYPE_MAT_CPP)
+
+extern template class SOFA_TYPE_API Mat<2, 2, SReal>;
+extern template class SOFA_TYPE_API Mat<2, 3, SReal>;
+extern template class SOFA_TYPE_API Mat<3, 3, SReal>;
+extern template class SOFA_TYPE_API Mat<4, 4, SReal>;
+extern template class SOFA_TYPE_API Mat<6, 3, SReal>;
+extern template class SOFA_TYPE_API Mat<6, 6, SReal>;
+extern template class SOFA_TYPE_API Mat<8, 3, SReal>;
+extern template class SOFA_TYPE_API Mat<8, 8, SReal>;
+extern template class SOFA_TYPE_API Mat<9, 9, SReal>;
+extern template class SOFA_TYPE_API Mat<12, 3, SReal>;
+extern template class SOFA_TYPE_API Mat<12, 6, SReal>;
+extern template class SOFA_TYPE_API Mat<12, 12, SReal>;
+extern template class SOFA_TYPE_API Mat<20, 20, SReal>;
+extern template class SOFA_TYPE_API Mat<20, 32, SReal>;
+extern template class SOFA_TYPE_API Mat<24, 24, SReal>;
+extern template class SOFA_TYPE_API Mat<32, 20, SReal>;
+
+#endif
+
 } // namespace sofa::type

--- a/Sofa/framework/Type/src/sofa/type/fixed_array.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array.h
@@ -239,18 +239,6 @@ public:
         return in;
     }
 
-    constexpr inline bool operator < (const fixed_array& v ) const noexcept
-    {
-        for( size_type i=0; i<N; i++ )
-        {
-            if( elems[i]<v[i] )
-                return true;  // (*this)<v
-            else if( elems[i]>v[i] )
-                return false; // (*this)>v
-        }
-        return false; // (*this)==v
-    }
-
 private:
 
     // check range (may be private because it is static)
@@ -267,6 +255,28 @@ template<typename... Ts>
 constexpr auto make_array(Ts&&... ts) -> fixed_array<std::common_type_t<Ts...>, sizeof...(Ts)>
 {
     return { std::forward<Ts>(ts)... };
+}
+
+/// Checks if v1 is lexicographically less than v2. Similar to std::lexicographical_compare
+template<typename T, sofa::Size N>
+constexpr bool
+operator<(const fixed_array<T, N>& v1, const fixed_array<T, N>& v2 ) noexcept
+{
+    for( sofa::Size i=0; i<N; i++ )
+    {
+        if( v1[i] < v2[i] )
+            return true;
+        if( v2[i] < v1[i] )
+            return false;
+    }
+    return false;
+}
+
+template<typename T, sofa::Size N>
+constexpr bool
+operator>(const fixed_array<T, N>& v1, const fixed_array<T, N>& v2 ) noexcept
+{
+    return v2 < v1;
 }
 
 #ifndef FIXED_ARRAY_CPP

--- a/Sofa/framework/Type/test/CMakeLists.txt
+++ b/Sofa/framework/Type/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE_FILES
     vector_test.cpp
     MatTypes_test.cpp
     VecTypes_test.cpp
+    fixed_array_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/Sofa/framework/Type/test/MatTypes_test.cpp
+++ b/Sofa/framework/Type/test/MatTypes_test.cpp
@@ -51,8 +51,8 @@ TEST(MatTypesTest, lineAccess)
 
 TEST(MatTypesTest, mat3x3product)
 {
-    Matrix3 a{ Matrix3::Line{1., 2., 3.}, Matrix3::Line{4., 5., 6.}, Matrix3::Line{7., 8., 9.} };
-    const auto a2 = a * a;
+    static constexpr Matrix3 a{ Matrix3::Line{1., 2., 3.}, Matrix3::Line{4., 5., 6.}, Matrix3::Line{7., 8., 9.} };
+    static constexpr auto a2 = a * a;
 
     EXPECT_FLOATINGPOINT_EQ(a2[0][0], 30.)
     EXPECT_FLOATINGPOINT_EQ(a2[0][1], 36.)
@@ -65,6 +65,59 @@ TEST(MatTypesTest, mat3x3product)
     EXPECT_FLOATINGPOINT_EQ(a2[2][0], 102.)
     EXPECT_FLOATINGPOINT_EQ(a2[2][1], 126.)
     EXPECT_FLOATINGPOINT_EQ(a2[2][2], 150.)
+}
+
+TEST(MatTypesTest, multTranspose)
+{
+    sofa::type::Mat<3,4, int> a
+    {
+        sofa::type::Mat<3,4, int>::Line{1, 2, 3, 4},
+        sofa::type::Mat<3,4, int>::Line{5, 6, 7, 8},
+        sofa::type::Mat<3,4, int>::Line{9, 10, 11, 12}
+    };
+
+    sofa::type::Mat<3,2, int> b
+    {
+        sofa::type::Mat<3,2, int>::Line{1, 2},
+        sofa::type::Mat<3,2, int>::Line{3, 4},
+        sofa::type::Mat<3,2, int>::Line{5, 6}
+    };
+
+    sofa::type::Mat<4, 2, int> aTb = a.multTranspose(b);
+
+    EXPECT_EQ(aTb[0][0], 61);
+    EXPECT_EQ(aTb[0][1], 76);
+
+    EXPECT_EQ(aTb[1][0], 70);
+    EXPECT_EQ(aTb[1][1], 88);
+
+    EXPECT_EQ(aTb[2][0], 79);
+    EXPECT_EQ(aTb[2][1], 100);
+
+    EXPECT_EQ(aTb[3][0], 88);
+    EXPECT_EQ(aTb[3][1], 112);
+
+    sofa::type::Mat<3, 3, int> c
+    {
+        sofa::type::Mat<3, 3, int>::Line{1., 2., 3.},
+        sofa::type::Mat<3, 3, int>::Line{4., 5., 6.},
+        sofa::type::Mat<3, 3, int>::Line{7., 8., 9.}
+    };
+    sofa::type::Mat<3, 3, int> cTc = c.multTranspose(c);
+
+    EXPECT_EQ(cTc[0][0], 66);
+    EXPECT_EQ(cTc[0][1], 78);
+    EXPECT_EQ(cTc[0][2], 90);
+
+    EXPECT_EQ(cTc[1][0], 78);
+    EXPECT_EQ(cTc[1][1], 93);
+    EXPECT_EQ(cTc[1][2], 108);
+
+    EXPECT_EQ(cTc[2][0], 90);
+    EXPECT_EQ(cTc[2][1], 108);
+    EXPECT_EQ(cTc[2][2], 126);
+
+
 }
 
 void test_transformInverse(Matrix4 const& M)

--- a/Sofa/framework/Type/test/MatTypes_test.cpp
+++ b/Sofa/framework/Type/test/MatTypes_test.cpp
@@ -33,6 +33,40 @@ using namespace sofa::type;
 using namespace sofa::helper;
 using namespace sofa::defaulttype;
 
+TEST(MatTypesTest, lineAccess)
+{
+    Matrix2 mat2;
+
+    mat2.x();
+    mat2.y();
+    //mat2.z(); // z is not available due to the size of the matrix
+
+    Matrix3 mat3;
+
+    mat3.x();
+    mat3.y();
+    mat3.z();
+    //mat3.w(); // z is not available due to the size of the matrix
+}
+
+TEST(MatTypesTest, mat3x3product)
+{
+    Matrix3 a{ Matrix3::Line{1., 2., 3.}, Matrix3::Line{4., 5., 6.}, Matrix3::Line{7., 8., 9.} };
+    const auto a2 = a * a;
+
+    EXPECT_FLOATINGPOINT_EQ(a2[0][0], 30.)
+    EXPECT_FLOATINGPOINT_EQ(a2[0][1], 36.)
+    EXPECT_FLOATINGPOINT_EQ(a2[0][2], 42.)
+
+    EXPECT_FLOATINGPOINT_EQ(a2[1][0], 66.)
+    EXPECT_FLOATINGPOINT_EQ(a2[1][1], 81.)
+    EXPECT_FLOATINGPOINT_EQ(a2[1][2], 96.)
+
+    EXPECT_FLOATINGPOINT_EQ(a2[2][0], 102.)
+    EXPECT_FLOATINGPOINT_EQ(a2[2][1], 126.)
+    EXPECT_FLOATINGPOINT_EQ(a2[2][2], 150.)
+}
+
 void test_transformInverse(Matrix4 const& M)
 {
     Matrix4 M_inv;
@@ -212,4 +246,17 @@ TEST(MatTypesTest, tensorProduct)
     Mat<2, 2, SReal> M(Mat<2, 2, SReal>::Line(0.,  0.),
                        Mat<2, 2, SReal>::Line( 1., 2.));
     EXPECT_EQ(M, Mtest);
+}
+
+TEST(MatTypesTest, identity)
+{
+    const sofa::type::Mat<3, 3, SReal>& id = sofa::type::Mat<3, 3, SReal>::Identity();
+
+    for (sofa::Index i = 0; i < 3; ++i)
+    {
+        for (sofa::Index j = 0; j < 3; ++j)
+        {
+            EXPECT_FLOATINGPOINT_EQ(id(i,j), static_cast<SReal>(i == j))
+        }
+    }
 }

--- a/Sofa/framework/Type/test/fixed_array_test.cpp
+++ b/Sofa/framework/Type/test/fixed_array_test.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,33 +19,18 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
+#include <sofa/type/fixed_array.h>
+#include <gtest/gtest.h>
 
-#include <sofa/config.h>
+namespace sofa
+{
 
-#define SOFATYPE_VERSION @PROJECT_VERSION@
+TEST(fixed_array, operatorLess)
+{
+    sofa::type::fixed_array<sofa::Index, 2> edge1 { 0, 0};
+    sofa::type::fixed_array<sofa::Index, 2> edge2 { 1, 0};
+    EXPECT_LT(edge1, edge2);
+    EXPECT_GT(edge2, edge1);
+}
 
-#ifdef SOFA_BUILD_SOFA_TYPE
-#  define SOFA_TARGET @PROJECT_NAME@
-#  define SOFA_TYPE_API SOFA_EXPORT_DYNAMIC_LIBRARY
-#else
-#  define SOFA_TYPE_API SOFA_IMPORT_DYNAMIC_LIBRARY
-#endif
-
-#ifdef SOFA_BUILD_SOFA_TYPE
-#define SOFA_ATTRIBUTE_DEPRECATED__REBIND()
-#else
-#define SOFA_ATTRIBUTE_DEPRECATED__REBIND() \
-    SOFA_ATTRIBUTE_DEPRECATED( \
-        "v22.06", "v22.12", \
-        "As an alternative, use sofa::type::Rebind or sofa::type::rebind_to.")
-#endif
-
-#ifdef SOFA_BUILD_SOFA_TYPE
-#define SOFA_ATTRIBUTE_DEPRECATED__STATIC_MATRIX_IDENTITY()
-#else
-#define SOFA_ATTRIBUTE_DEPRECATED__STATIC_MATRIX_IDENTITY() \
-    SOFA_ATTRIBUTE_DEPRECATED( \
-        "v22.12", "v23.06", \
-        "As an alternative, use sofa::type::Mat<L,C,real>::Identity().")
-#endif
+}


### PR DESCRIPTION
Explicit instantiations of common `Mat` sizes led to compilation errors. For example, `z()` throws a `static_assert` for `Mat<2,2,>` because there is only 2 elements. Now, `x`, `y`, `z` and `w` are compiled conditionally. Other methods, such as `Identity`, `transpose` etc, are also concerned for squared matrices. The `static_assert` are therefore no longer useful. 

`Identity` has been changed so it is `static constexpr` and it returns a reference. So there is no need to compute the identity matrix each time it is called. `s_identity` is now deprecated. The static variable is now included in the `Identity` method. It is better for static initialization fiasco and required for a `constexpr` context. Also, `s_identity` does not make sense for rectangular matrices. Since it is not possible to conditionally add a class member, it is hidden in the conditionally compiled method `Identity`.

In `fixed_array`, the `operator<` is moved out of the class. This allows to compile this operator only when used, and not in explicit instantiations. This is necessary because the operator on `fixed_array<Vec3>` is not implemented (and does not make sense).

The 3x3 matrix product and the `multTranspose` operation are specialized for a speedup. https://github.com/alxbilger/SofaBenchmark was used. Results show that this implementation is closer to the Eigen implementation.

Unit tests are added.

[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/302]






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
