### PR TITLE
[Sofa.Type] Fix compile-time Mat and Vec

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -28,6 +28,7 @@
 #include <sofa/type/Vec.h>
 
 #include <iostream>
+#include <type_traits>
 
 namespace // anonymous
 {
@@ -35,7 +36,7 @@ namespace // anonymous
     constexpr real rabs(const real r)
     {
         if constexpr (std::is_signed<real>())
-            return std::abs(r);
+            return r < 0 ? -r : r;
         else
             return r;
     }

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -28,7 +28,6 @@
 #include <sofa/type/Vec.h>
 
 #include <iostream>
-#include <type_traits>
 
 namespace // anonymous
 {

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -32,16 +32,16 @@
 namespace // anonymous
 {
     template<typename real>
-    constexpr real rabs(const real r)
+    real rabs(const real r)
     {
         if constexpr (std::is_signed<real>())
-            return r < 0 ? -r : r;
+            return std::abs(r);
         else
             return r;
     }
 
     template<typename real>
-    constexpr real equalsZero(const real r, const real epsilon = std::numeric_limits<real>::epsilon())
+    real equalsZero(const real r, const real epsilon = std::numeric_limits<real>::epsilon())
     {
         return rabs(r) <= epsilon;
     }
@@ -65,8 +65,8 @@ public:
     typedef VecNoInit<C,real> LineNoInit;
     typedef Vec<L,real> Col;
 
-    static const Size nbLines = L;
-    static const Size nbCols  = C;
+    static constexpr Size nbLines = L;
+    static constexpr Size nbCols  = C;
 
     constexpr Mat() noexcept
     {
@@ -389,7 +389,7 @@ public:
     }
 
 
-    constexpr bool isSymmetric() const
+    bool isSymmetric() const
     {
         for (Size i=0; i<L; i++)
             for (Size j=i+1; j<C; j++)
@@ -397,7 +397,7 @@ public:
         return true;
     }
 
-    constexpr bool isDiagonal() const noexcept
+    bool isDiagonal() const noexcept
     {
         for (Size i=0; i<L; i++)
         {
@@ -799,7 +799,7 @@ constexpr real determinant(const Mat<3,2,real>& m) noexcept
 
 // one-norm of a 3 x 3 matrix
 template<class real>
-constexpr real oneNorm(const Mat<3,3,real>& A)
+real oneNorm(const Mat<3,3,real>& A)
 {
     real norm = 0.0;
     for (sofa::Size i=0; i<3; i++)
@@ -813,7 +813,7 @@ constexpr real oneNorm(const Mat<3,3,real>& A)
 
 // inf-norm of a 3 x 3 matrix
 template<class real>
-constexpr real infNorm(const Mat<3,3,real>& A)
+real infNorm(const Mat<3,3,real>& A)
 {
     real norm = 0.0;
     for (sofa::Size i=0; i<3; i++)
@@ -847,7 +847,7 @@ constexpr Vec<N,real> diagonal(const Mat<N,N,real>& m)
 
 /// Matrix inversion (general case).
 template<sofa::Size S, class real>
-[[nodiscard]] constexpr bool invertMatrix(Mat<S,S,real>& dest, const Mat<S,S,real>& from)
+[[nodiscard]] bool invertMatrix(Mat<S,S,real>& dest, const Mat<S,S,real>& from)
 {
     sofa::Size i{0}, j{0}, k{0};
     Vec<S, sofa::Size> r, c, row, col;

--- a/Sofa/framework/Type/src/sofa/type/Vec.h
+++ b/Sofa/framework/Type/src/sofa/type/Vec.h
@@ -42,7 +42,7 @@ namespace // anonymous
     constexpr real rabs(const real r)
     {
         if constexpr (std::is_signed<real>())
-            return std::abs(r);
+            return r < 0 ? -r : r;
         else
             return r;
     }
@@ -441,7 +441,7 @@ public:
     }
 
     /// Euclidean norm.
-    constexpr ValueType norm() const noexcept
+    ValueType norm() const noexcept
     {
         return ValueType(std::sqrt(norm2()));
     }
@@ -449,7 +449,7 @@ public:
     /// l-norm of the vector
     /// The type of norm is set by parameter l.
     /// Use l<0 for the infinite norm.
-    constexpr ValueType lNorm( int l ) const
+    ValueType lNorm( int l ) const
     {
         if( l==2 ) return norm(); // euclidian norm
         else if( l<0 ) // infinite norm
@@ -504,21 +504,21 @@ public:
 
     /// Normalize the vector.
     /// returns false iff the norm is too small
-    constexpr bool normalize(ValueType threshold=std::numeric_limits<ValueType>::epsilon()) noexcept
+    bool normalize(ValueType threshold=std::numeric_limits<ValueType>::epsilon()) noexcept
     {
         return normalizeWithNorm(norm(),threshold);
     }
 
     /// Normalize the vector with a failsafe.
     /// If the norm is too small, the vector becomes the failsafe.
-    constexpr void normalize(Vec<N,ValueType> failsafe, ValueType threshold=std::numeric_limits<ValueType>::epsilon()) noexcept
+    void normalize(Vec<N,ValueType> failsafe, ValueType threshold=std::numeric_limits<ValueType>::epsilon()) noexcept
     {
         if( !normalize(threshold) ) *this=failsafe;
     }
 
     /// Return the normalized vector.
     /// @warning 'this' is not normalized.
-    constexpr Vec<N,ValueType> normalized() const noexcept
+    Vec<N,ValueType> normalized() const noexcept
     {
         Vec<N,ValueType> r(*this);
         r.normalize();

--- a/Sofa/framework/Type/src/sofa/type/Vec.h
+++ b/Sofa/framework/Type/src/sofa/type/Vec.h
@@ -39,10 +39,10 @@ namespace sofa::type
 namespace // anonymous
 {
     template<typename real>
-    constexpr real rabs(const real r)
+    real rabs(const real r)
     {
         if constexpr (std::is_signed<real>())
-            return r < 0 ? -r : r;
+            return std::abs(r);
         else
             return r;
     }
@@ -526,7 +526,7 @@ public:
     }
 
     /// return true if norm()==1
-    constexpr bool isNormalized( ValueType threshold=std::numeric_limits<ValueType>::epsilon()*(ValueType)10 ) const
+    bool isNormalized( ValueType threshold=std::numeric_limits<ValueType>::epsilon()*(ValueType)10 ) const
     { 
         return rabs( norm2() - static_cast<ValueType>(1) ) <= threshold;
     }


### PR DESCRIPTION
- std::abs is constexpr only in c++23 
-> as stated in the standard... But gcc flagged it constexpr 🤫

- std::sqrt is not constexpr at all. Implementations exists though. For now, all functions relying on sqrt is not constexpr (norm methods)

Allows to compile https://github.com/alxbilger/SofaBenchmark/pull/27 (for mac and msvc then)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
