### PR TITLE
[StateContainer] Optimize vector operations

### DIFF
--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -32,6 +32,7 @@
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <sofa/helper/accessor.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/defaulttype/DataTypeOperations.h>
 
 #ifdef SOFA_DUMP_VISITOR_INFO
 #include <sofa/simulation/Visitor.h>
@@ -1786,15 +1787,15 @@ void MechanicalObject<DataTypes>::vOp(const core::ExecParams* params, core::VecI
             {
                 helper::WriteOnlyAccessor< Data<VecCoord> >vv( *this->write(core::VecCoordId(v)) );
                 vv.resize(d_size.getValue());
-                for (unsigned int i=0; i<vv.size(); i++)
-                    vv[i] = Coord();
+
+                sofa::defaulttype::resetDataTypeVec(vv.wref());
             }
             else
             {
                 helper::WriteOnlyAccessor< Data<VecDeriv> >vv( *this->write(core::VecDerivId(v)) );
                 vv.resize(d_size.getValue());
-                for (unsigned int i=0; i<vv.size(); i++)
-                    vv[i] = Deriv();
+
+                sofa::defaulttype::resetDataTypeVec(vv.wref());
             }
         }
         else
@@ -1858,17 +1859,13 @@ void MechanicalObject<DataTypes>::vOp(const core::ExecParams* params, core::VecI
             {
                 helper::WriteOnlyAccessor< Data<VecCoord> > vv(*this->write(core::VecCoordId(v)) );
                 helper::ReadAccessor< Data<VecCoord> > va(*this->read(core::ConstVecCoordId(a)) );
-                vv.resize(va.size());
-                for (unsigned int i=0; i<vv.size(); i++)
-                    vv[i] = va[i];
+                vv.wref() = va.ref();
             }
             else
             {
                 helper::WriteOnlyAccessor< Data<VecDeriv> > vv(*this->write(core::VecDerivId(v)) );
                 helper::ReadAccessor< Data<VecDeriv> > va(*this->read(core::ConstVecDerivId(a)) );
-                vv.resize(va.size());
-                for (unsigned int i=0; i<vv.size(); i++)
-                    vv[i] = va[i];
+                vv.wref() = va.ref();
             }
         }
         else
@@ -2484,8 +2481,7 @@ void MechanicalObject<DataTypes>::resetForce(const core::ExecParams* params, cor
 
     {
         helper::WriteOnlyAccessor< Data<VecDeriv> > f( *this->write(fid) );
-        for (unsigned i = 0; i < f.size(); ++i)
-            f[i].clear();
+        sofa::defaulttype::resetDataTypeVec(f.wref());
     }
 }
 
@@ -2496,10 +2492,7 @@ void MechanicalObject<DataTypes>::resetAcc(const core::ExecParams* params, core:
 
     {
         helper::WriteOnlyAccessor< Data<VecDeriv> > a( *this->write(aId) );
-        for (unsigned i = 0; i < a.size(); ++i)
-        {
-            a[i] = Deriv();
-        }
+        sofa::defaulttype::resetDataTypeVec(a.wref());
     }
 }
 

--- a/Sofa/framework/DefaultType/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC_ROOT "src/sofa/defaulttype")
 set(HEADER_FILES
     ${SRC_ROOT}/AbstractTypeInfo.h
     ${SRC_ROOT}/DataTypeInfo.h
+    ${SRC_ROOT}/DataTypeOperations.h
     ${SRC_ROOT}/MapMapSparseMatrix.h
     ${SRC_ROOT}/MapMapSparseMatrixEigenUtils.h
     ${SRC_ROOT}/MatrixExporter.h

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/DataTypeOperations.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/DataTypeOperations.h
@@ -28,11 +28,13 @@ namespace sofa::defaulttype
 {
 
 /// Function resetting all the element of a container with its default constructor value type
-template<class Vec, typename = void>
+template<class Vec>
 void resetDataTypeVec(Vec& vec)
 {
     for (auto& v : vec)
-        v = {};
+    {
+        v = typename Vec::value_type{};
+    }
 }
 
 using sofa::type::Vec;

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/DataTypeOperations.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/DataTypeOperations.h
@@ -1,0 +1,96 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/config.h>
+#include <sofa/type/vector.h>
+#include <sofa/type/Vec.h>
+
+namespace sofa::defaulttype
+{
+
+/// Function resetting all the element of a container with its default constructor value type
+template<class Vec, typename = void>
+void resetDataTypeVec(Vec& vec)
+{
+    for (auto& v : vec)
+        v = {};
+}
+
+using sofa::type::Vec;
+using sofa::type::vector;
+
+/// In case of a vector<Vec>, zero can be set directly with memset on all the memory space for a faster reset
+template < sofa::Size N, typename ValueType>
+void resetVecTypeVec(vector<Vec<N, ValueType> >& vec)
+{
+    std::memset(vec.data(), 0, sizeof(ValueType) * N * vec.size());
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<6, float> > >(vector<Vec<6, float> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<6, double> > >(vector<Vec<6, double> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<3, float> > >(vector<Vec<3, float> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<3, double> > >(vector<Vec<3, double> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<2, float> > >(vector<Vec<2, float> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<2, double> > >(vector<Vec<2, double> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<1, float> > >(vector<Vec<1, float> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+template <>
+inline void resetDataTypeVec<vector<Vec<1, double> > >(vector<Vec<1, double> >& vec)
+{
+    resetVecTypeVec(vec);
+}
+
+}


### PR DESCRIPTION
Introduce a free function doing a simple loop in the general case, and use memset in the vector<Vec> case

The operator = on the vector object is faster than the loop

Performance improvements validated by https://github.com/alxbilger/SofaBenchmark/pull/29





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
