### PR TITLE
[all] Removal of datatype info from Data.h (step 2)

### DIFF
--- a/Sofa/framework/Config/src/sofa/config.h.in
+++ b/Sofa/framework/Config/src/sofa/config.h.in
@@ -238,6 +238,12 @@ class DeprecatedAndRemoved {};
         "v21.12 (PR#2292)", "v22.06", \
         "Use the Messaging API instead of using SofaOStream and sout/serr/sendl.")
 
+#define SOFA_ATTRIBUTE_DEPRECATED__DATA_TYPEINFOAPI(msg) \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v22.12 (PR#XXXX)", "v22.12", \
+        "BaseData typeinfo API has changed. " msg)
+
+
 /**********************************************/
 
 #define SOFA_DECL_CLASS(name) // extern "C" { int sofa_concat(class_,name) = 0; }

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
@@ -308,13 +308,15 @@ public:
     DataLink<BaseData> parentData;
 
     /// Helper method to decode the type name to a more readable form if possible
+    SOFA_ATTRIBUTE_DEPRECATED__DATA_TYPEINFOAPI("Use sofa::helper::NameDecoder::decodeTypeName(t) instead.")
     static std::string decodeTypeName(const std::type_info& t);
 
     /// Helper method to get the type name of type T
     template<class T>
+    SOFA_ATTRIBUTE_DEPRECATED__DATA_TYPEINFOAPI("Use sofa::helper::NameDecoder::decodeTypeName(t) or .... instead.")
     static std::string typeName(const T* = nullptr)
     {
-        if (defaulttype::DataTypeInfo<T>::ValidInfo)
+        if constexpr (defaulttype::DataTypeInfo<T>::ValidInfo)
             return defaulttype::DataTypeName<T>::name();
         else
             return decodeTypeName(typeid(T));


### PR DESCRIPTION
In  https://github.com/sofa-framework/sofa/pull/1605, https://github.com/sofa-framework/sofa/pull/1611 and https://github.com/sofa-framework/sofa/pull/1632 were layed-out typeInfo subsystem refactoring.

The general objective was to remove the "magic" and ODR violation of existing code.
The migration to the new system was postpone while NG refactoring & cleaning was progressing. 
Now it is done, let's go to deploy it.

So in this step we are starting to use the new subsystem for "selected" type while printing a deprecation message for type that have not been migrated; 

The PR shoul'nt break anything. 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
