### PR TITLE
[All] Compilation with "/fpermissive-" (MSVC)

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -164,6 +164,8 @@ private:
     void unspecializedInit() ;
 };
 
+template<>
+SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API void BilateralInteractionConstraint<Rigid3Types>::bwdInit();
 
 #if !defined(SOFA_COMPONENT_CONSTRAINTSET_BILATERALINTERACTIONCONSTRAINT_CPP)
 extern template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API BilateralInteractionConstraint< Vec3Types >;

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.h
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.h
@@ -100,11 +100,12 @@ void DisplacementTransformEngine<defaulttype::Rigid3Types,type::Mat4x4 >::mult( 
 template < class DataTypes >
 class DisplacementMatrixEngine : public DisplacementTransformEngine<DataTypes, type::Mat4x4>
 {
-
 public:
     SOFA_CLASS( SOFA_TEMPLATE( DisplacementMatrixEngine, DataTypes ),SOFA_TEMPLATE2( DisplacementTransformEngine, DataTypes, type::Mat4x4 ) );
 
     typedef DisplacementTransformEngine<DataTypes, type::Mat4x4> Inherit;
+    using Inherit::initData;
+
     typedef typename DataTypes::Real Real;
     typedef typename DataTypes::Coord Coord; // rigid
     typedef typename DataTypes::VecCoord VecCoord;

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/BTDLinearSolver.h
@@ -45,6 +45,9 @@ class BTDLinearSolver : public sofa::component::linearsolver::MatrixLinearSolver
 public:
     SOFA_CLASS(SOFA_TEMPLATE2(BTDLinearSolver, Matrix, Vector), SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver, Matrix, Vector));
 
+    using Inherit = sofa::component::linearsolver::MatrixLinearSolver<Matrix, Vector>;
+    using Inherit::initData;
+
     Data<bool> d_verbose; ///< Dump system state at each iteration
     Data<bool> d_problem; ///< display debug informations about subpartSolve computation
     Data<bool> d_subpartSolve; ///< Allows for the computation of a subpart of the system
@@ -98,7 +101,7 @@ public:
     Vector Y;
 protected:
     BTDLinearSolver()
-        : d_verbose( initData(&d_verbose,false,"verbose","Dump system state at each iteration") )
+        : d_verbose(initData(&d_verbose,false,"verbose","Dump system state at each iteration") )
         , d_problem(initData(&d_problem, false,"showProblem", "display debug informations about subpartSolve computation") )
         , d_subpartSolve(initData(&d_subpartSolve, false,"subpartSolve", "Allows for the computation of a subpart of the system") )
         , d_verification(initData(&d_verification, false,"verification", "verification of the subpartSolve"))

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/CholeskySolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/CholeskySolver.h
@@ -45,6 +45,7 @@ public:
     typedef TVector Vector;
     typedef typename Vector::Real Real;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    using Inherit::initData;
 
     Data<bool> f_verbose; ///< Dump system state at each iteration
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenDirectSparseSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenDirectSparseSolver.h
@@ -47,6 +47,9 @@ public:
     SOFA_ABSTRACT_CLASS(SOFA_TEMPLATE2(EigenDirectSparseSolver, TBlockType, EigenSolver),
         SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver, Matrix, Vector));
 
+    using Inherit = sofa::component::linearsolver::MatrixLinearSolver<Matrix, Vector>;
+    using Inherit::initData;
+
     using NaturalOrderSolver = typename EigenSolver::NaturalOrderSolver;
     using AMDOrderSolver     = typename EigenSolver::AMDOrderSolver;
     using COLAMDOrderSolver  = typename EigenSolver::COLAMDOrderSolver;

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/PrecomputedLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/PrecomputedLinearSolver.h
@@ -77,6 +77,8 @@ public:
     SOFA_CLASS(SOFA_TEMPLATE2(PrecomputedLinearSolver,TMatrix,TVector),SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver,TMatrix,TVector));
 
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    using Inherit::initData;
+
     typedef typename TMatrix::Real Real;
     typedef typename PrecomputedLinearSolverInternalData<TMatrix,TVector>::TBaseMatrix TBaseMatrix;
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SVDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SVDLinearSolver.h
@@ -47,6 +47,7 @@ public:
     typedef TVector Vector;
     typedef typename TVector::Real Real;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    using Inherit::initData;
 
     Data<bool> f_verbose; ///< Dump system state at each iteration
     Data<Real> f_minSingularValue; ///< Thershold under which a singular value is set to 0, for the stabilization of ill-conditioned system.

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseCholeskySolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseCholeskySolver.h
@@ -42,6 +42,9 @@ public:
     typedef TMatrix Matrix;
     typedef TVector Vector;
 
+    typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix, TVector> Inherit;
+    using Inherit::initData;
+
     SparseCholeskySolver();
     ~SparseCholeskySolver() override;
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolverImpl.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolverImpl.h
@@ -138,6 +138,7 @@ class SparseLDLSolverImpl : public sofa::component::linearsolver::MatrixLinearSo
 public :
     SOFA_CLASS(SOFA_TEMPLATE3(SparseLDLSolverImpl,TMatrix,TVector,TThreadManager),SOFA_TEMPLATE3(sofa::component::linearsolver::MatrixLinearSolver,TMatrix,TVector,TThreadManager));
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector, TThreadManager> Inherit;
+    using Inherit::initData;
 
     typedef TMatrix Matrix;
     typedef TVector Vector;

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
@@ -69,7 +69,8 @@ public:
     typedef TVector Vector;
     typedef typename Matrix::Real Real;
 
-    typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector,TThreadManager> Inherit;
+    typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector,TThreadManager> Inherit;    
+    using Inherit::initData;
 
     Data<bool> f_verbose; ///< Dump system state at each iteration
     Data<double> f_tol; ///< tolerance of factorization

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.h
@@ -39,6 +39,7 @@ public:
     typedef TVector Vector;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
     using Real = typename Matrix::Real;
+    using Inherit::initData;
 
     Data<unsigned> d_maxIter; ///< maximum number of iterations of the Conjugate Gradient solution
     Data<Real> d_tolerance; ///< desired precision of the Conjugate Gradient Solution (ratio of current residual norm over initial residual norm)

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
@@ -54,7 +54,7 @@ template<class Matrix, class Vector>
 class BaseMatrixLinearSolver : public sofa::core::behavior::LinearSolver
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE2(BaseMatrixLinearSolver,Matrix,Vector), sofa::core::behavior::LinearSolver);
+    SOFA_ABSTRACT_CLASS(SOFA_TEMPLATE2(BaseMatrixLinearSolver,Matrix,Vector), sofa::core::behavior::LinearSolver);
 
     virtual void invert(Matrix& M) = 0;
 

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MinResLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MinResLinearSolver.h
@@ -43,6 +43,8 @@ public:
     typedef TMatrix Matrix;
     typedef TVector Vector;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    using Inherit::initData;
+
     Data<unsigned> f_maxIter; ///< maximum number of iterations of the Conjugate Gradient solution
     Data<double> f_tolerance; ///< desired precision of the Conjugate Gradient Solution (ratio of current residual norm over initial residual norm)
     Data<bool> f_verbose; ///< Dump system state at each iteration

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/ShewchukPCGLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/ShewchukPCGLinearSolver.h
@@ -41,6 +41,7 @@ public:
     typedef TMatrix Matrix;
     typedef TVector Vector;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    using Inherit::initData;
 
     Data<unsigned> f_maxIter; ///< maximum number of iterations of the Conjugate Gradient solution
     Data<double> f_tolerance; ///< desired precision of the Conjugate Gradient Solution (ratio of current residual norm over initial residual norm)

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/JacobiPreconditioner.h
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/JacobiPreconditioner.h
@@ -42,6 +42,8 @@ public:
     typedef TMatrix Matrix;
     typedef TVector Vector;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    using Inherit::initData;
+
     Data<bool> f_verbose; ///< Dump system state at each iteration
 protected:
     JacobiPreconditioner();

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
@@ -94,6 +94,7 @@ public:
     typedef typename PrecomputedWarpPreconditionerInternalData<TDataTypes>::TBaseVector TVector;
     typedef typename PrecomputedWarpPreconditionerInternalData<TDataTypes>::TBaseMatrix TBaseMatrix;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    using Inherit::initData;
 
     SOFA_CLASS(SOFA_TEMPLATE(PrecomputedWarpPreconditioner,TDataTypes),SOFA_TEMPLATE2(sofa::component::linearsolver::MatrixLinearSolver,TMatrix,TVector));
     typedef TDataTypes DataTypes;

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/SSORPreconditioner.h
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/SSORPreconditioner.h
@@ -50,6 +50,7 @@ public:
     typedef TThreadManager ThreadManager;
     typedef SReal Real;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector,TThreadManager> Inherit;
+    using Inherit::initData;
 
     Data<bool> f_verbose; ///< Dump system state at each iteration
     Data<double> f_omega; ///< Omega coefficient

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/WarpPreconditioner.h
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/WarpPreconditioner.h
@@ -47,6 +47,7 @@ public:
     typedef TVector Vector;
     typedef typename TMatrix::Real Real;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector,ThreadManager> Inherit;
+    using Inherit::initData;
     typedef sofa::type::MatNoInit<3, 3, Real> Transformation;
     typedef TMatrix TRotationMatrix;
     typedef typename Inherit::JMatrixType JMatrixType;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShader.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShader.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/gl/component/shader/OglShader.h>
+#include <sofa/simulation/Node.h>
 #include <sofa/gl/component/shader/CompositingVisualLoop.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>


### PR DESCRIPTION
MSVC got recently a flag "/fpermissive-" to have a strict conformance with C++ standard (and is enabled by default if c++20 is specified)

-> https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170

It would force the code made with msvc to be more similar to the one made with gcc/clang.

By curiosity, I tried to enable it on SOFA master and got some errors:
 - some initData not recognized (and the SOFA_CLASS and its `using Base::initData` does not work ??)
 - a fwd declaration of a Link was not possible anymore (because Node is not known at that time)
 - lastly a symbol was made twice, due to both the specialization in cpp, and the {} in the header file.

To discuss:
 - should we add an option to make the compilation with MSVC on strict conformance (add the flag  "/fpermissive-" to CXX_FLAGS)
 - should we even make it by default ? (this could be quite breaking)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
