### PR TITLE
[SofaValidation] is a plugin, not a collection

### DIFF
--- a/applications/collections/deprecated/CMakeLists.txt
+++ b/applications/collections/deprecated/CMakeLists.txt
@@ -59,7 +59,7 @@ sofa_add_subdirectory(collection modules/SofaMiscMapping SofaMiscMapping ON WHEN
 sofa_add_subdirectory(collection modules/SofaMiscCollision SofaMiscCollision ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 
 sofa_add_subdirectory(collection modules/SofaHaptics SofaHaptics ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
-sofa_add_subdirectory(collection modules/SofaValidation SofaValidation ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
+sofa_add_subdirectory(plugin modules/SofaValidation SofaValidation ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 sofa_add_subdirectory(collection modules/SofaGeneralObjectInteraction SofaGeneralObjectInteraction ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 
 

--- a/applications/collections/deprecated/modules/SofaValidation/CMakeLists.txt
+++ b/applications/collections/deprecated/modules/SofaValidation/CMakeLists.txt
@@ -55,7 +55,7 @@ sofa_create_package_with_targets(
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
-    RELOCATABLE "collections"
+    RELOCATABLE "plugins"
 )
 
 ## Tests


### PR DESCRIPTION
SofaValidation seems to be a true plugin and not a collection.
This PR does not move it from the `collection` folder.

Question:
- Should the module decide by itself what type of module (plugin, collection etc) it is?

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
