### PR TITLE
[Sofa.Core] Add missing #include

### DIFF
--- a/Sofa/framework/Core/simutest/objectmodel/BaseLink_simutest.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/BaseLink_simutest.cpp
@@ -35,7 +35,10 @@ using sofa::core::objectmodel::BaseObject;
 #include <sofa/core/PathResolver.h>
 using sofa::core::PathResolver;
 
+#include <sofa/defaulttype/RigidTypes.h>
 using sofa::defaulttype::Rigid3Types;
+
+#include <sofa/defaulttype/VecTypes.h>
 using sofa::defaulttype::Vec3Types;
 
 namespace

--- a/Sofa/framework/Core/simutest/objectmodel/Base_test.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/Base_test.cpp
@@ -30,7 +30,10 @@ using sofa::simulation::Node ;
 #include <sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::BaseObject;
 
+#include <sofa/defaulttype/RigidTypes.h>
 using sofa::defaulttype::Rigid3Types;
+
+#include <sofa/defaulttype/VecTypes.h>
 using sofa::defaulttype::Vec3Types;
 
 namespace customns

--- a/Sofa/framework/Core/simutest/objectmodel/PathResolver_simutest.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/PathResolver_simutest.cpp
@@ -33,7 +33,10 @@ using sofa::core::objectmodel::BaseObject;
 #include <sofa/core/PathResolver.h>
 using sofa::core::PathResolver;
 
+#include <sofa/defaulttype/RigidTypes.h>
 using sofa::defaulttype::Rigid3Types;
+
+#include <sofa/defaulttype/VecTypes.h>
 using sofa::defaulttype::Vec3Types;
 
 namespace

--- a/Sofa/framework/Core/src/sofa/core/State.h
+++ b/Sofa/framework/Core/src/sofa/core/State.h
@@ -24,7 +24,8 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/BaseState.h>
-#include <sofa/defaulttype/fwd.h>
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/defaulttype/RigidTypes.h>
 namespace sofa
 {
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintCorrection.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintCorrection.h
@@ -23,6 +23,7 @@
 
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/MultiVecId.h>
+#include <sofa/linearalgebra/BaseMatrix.h>
 
 namespace sofa::core::behavior
 {

--- a/Sofa/framework/Core/src/sofa/core/behavior/MechanicalState.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/MechanicalState.h
@@ -22,7 +22,10 @@
 #pragma once
 
 #include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/defaulttype/typeinfo/TypeInfo_RigidTypes.h>
+#include <sofa/defaulttype/typeinfo/TypeInfo_VecTypes.h>
 #include <sofa/core/State.h>
+#include <sofa/helper/StringUtils.h>
 
 namespace sofa::core::behavior
 {

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
@@ -28,6 +28,8 @@
 #include <sofa/core/PathResolver.h>
 using sofa::core::PathResolver;
 
+#include <sofa/defaulttype/AbstractTypeInfo.h>
+
 #include <sofa/helper/logging/Messaging.h>
 using sofa::helper::logging::MessageDispatcher ;
 using sofa::helper::logging::Message ;

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -28,6 +28,7 @@
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/core/objectmodel/TagSet.h>
 #include <list>
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/core/sptr.h>
 
 #include <deque>


### PR DESCRIPTION
It is not obvious they as the missing one as in fact already included from one of the base header (Data/BaseData).






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
