### PR TITLE
[ExternalBehaviorModel] Without compatibility layer

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -30,7 +30,7 @@ sofa_add_subdirectory(plugin Flexible Flexible EXTERNAL)         # Depends on im
 sofa_add_subdirectory(plugin Registration Registration EXTERNAL) # Depends on image, SofaPython, SofaGui and SofaDistanceGrid
 sofa_add_subdirectory(plugin BulletCollisionDetection BulletCollisionDetection) # Depends on Compliant and LMConstraint
 sofa_add_subdirectory(plugin PreassembledMass PreassembledMass) # Depends on Flexible and Compliant
-sofa_add_subdirectory(plugin ExternalBehaviorModel ExternalBehaviorModel)
+sofa_add_subdirectory(plugin ExternalBehaviorModel ExternalBehaviorModel OFF WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 sofa_add_subdirectory(plugin InvertibleFVM InvertibleFVM EXTERNAL)
 sofa_add_subdirectory(plugin MeshSTEPLoader MeshSTEPLoader)
 sofa_add_subdirectory(plugin PluginExample PluginExample EXTERNAL)

--- a/applications/plugins/ExternalBehaviorModel/CMakeLists.txt
+++ b/applications/plugins/ExternalBehaviorModel/CMakeLists.txt
@@ -14,16 +14,15 @@ set(SOURCE_FILES
 )
 
 
-sofa_find_package(SofaBaseLinearSolver REQUIRED)
-sofa_find_package(SofaBaseMechanics REQUIRED)
-sofa_find_package(SofaBaseTopology REQUIRED)
-sofa_find_package(SofaBoundaryCondition REQUIRED)
+sofa_find_package(Sofa.Component.LinearSolver.Iterative REQUIRED)
+sofa_find_package(Sofa.Component.Topology REQUIRED)
+sofa_find_package(Sofa.Component.Constraint.Projective REQUIRED)
 sofa_find_package(SofaGraphComponent REQUIRED)
-sofa_find_package(SofaImplicitOdeSolver REQUIRED)
-sofa_find_package(SofaSimpleFem REQUIRED)
+sofa_find_package(Sofa.Component.ODESolver.Backward REQUIRED)
+sofa_find_package(Sofa.Component.SolidMechanics.FEM.Elastic REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SofaBaseLinearSolver SofaBaseMechanics SofaBaseTopology SofaBoundaryCondition SofaGraphComponent SofaImplicitOdeSolver SofaSimpleFem)
+target_link_libraries(${PROJECT_NAME} Sofa.Component.LinearSolver.Iterative SofaBaseMechanics Sofa.Component.Topology Sofa.Component.Constraint.Projective SofaGraphComponent Sofa.Component.ODESolver.Backward Sofa.Component.SolidMechanics.FEM.Elastic)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_${PROJECT_NAME}")
 
 sofa_create_package_with_targets(

--- a/applications/plugins/ExternalBehaviorModel/CMakeLists.txt
+++ b/applications/plugins/ExternalBehaviorModel/CMakeLists.txt
@@ -22,7 +22,7 @@ sofa_find_package(Sofa.Component.ODESolver.Backward REQUIRED)
 sofa_find_package(Sofa.Component.SolidMechanics.FEM.Elastic REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} Sofa.Component.LinearSolver.Iterative SofaBaseMechanics Sofa.Component.Topology Sofa.Component.Constraint.Projective SofaGraphComponent Sofa.Component.ODESolver.Backward Sofa.Component.SolidMechanics.FEM.Elastic)
+target_link_libraries(${PROJECT_NAME} Sofa.Component.LinearSolver.Iterative Sofa.Component.Topology Sofa.Component.Constraint.Projective SofaGraphComponent Sofa.Component.ODESolver.Backward Sofa.Component.SolidMechanics.FEM.Elastic)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_${PROJECT_NAME}")
 
 sofa_create_package_with_targets(

--- a/applications/plugins/ExternalBehaviorModel/ExternalBehaviorModelConfig.cmake.in
+++ b/applications/plugins/ExternalBehaviorModel/ExternalBehaviorModelConfig.cmake.in
@@ -2,13 +2,12 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
-find_package(SofaBaseLinearSolver REQUIRED)
-find_package(SofaBaseMechanics REQUIRED)
-find_package(SofaBaseTopology REQUIRED)
-find_package(SofaBoundaryCondition REQUIRED)
+find_package(Sofa.Component.LinearSolver.Iterative REQUIRED)
+find_package(Sofa.Component.Topology REQUIRED)
+find_package(Sofa.Component.Constraint.Projective REQUIRED)
 find_package(SofaGraphComponent REQUIRED)
-find_package(SofaImplicitOdeSolver REQUIRED)
-find_package(SofaSimpleFem REQUIRED)
+find_package(Sofa.Component.ODESolver.Backward REQUIRED)
+find_package(Sofa.Component.SolidMechanics.FEM.Elastic REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/applications/plugins/ExternalBehaviorModel/FEMGridBehaviorModel.h
+++ b/applications/plugins/ExternalBehaviorModel/FEMGridBehaviorModel.h
@@ -31,10 +31,9 @@
 
 
 // internal stuff, here it is using SOFA components that could be replaced by any library
-#include <SofaBaseTopology/MeshTopology.h>
-#include <SofaSimpleFem/HexahedronFEMForceField.h>
-#include <SofaBaseMechanics/UniformMass.h>
-#include <SofaBaseTopology/RegularGridTopology.h>
+#include <sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h>
+#include <sofa/component/mass/UniformMass.h>
+#include <sofa/component/topology/container/grid/RegularGridTopology.h>
 #include <sofa/simulation/Node.h>
 
 
@@ -132,8 +131,8 @@ protected:
     /// @name internal sofa stuff that could be replaced by any library
     /// @{
     typename Dofs::SPtr m_internalDofs;
-    component::topology::RegularGridTopology::SPtr m_internalTopology;
-    typename component::forcefield::HexahedronFEMForceField<DataTypes>::SPtr m_internalForceField;
+    sofa::component::topology::container::grid::RegularGridTopology::SPtr m_internalTopology;
+    typename sofa::component::solidmechanics::fem::elastic::HexahedronFEMForceField<DataTypes>::SPtr m_internalForceField;
     typename component::mass::UniformMass<DataTypes>::SPtr m_internalMass;
     sofa::simulation::Node::SPtr m_internalNode;
 

--- a/applications/plugins/ExternalBehaviorModel/FEMGridBehaviorModel.inl
+++ b/applications/plugins/ExternalBehaviorModel/FEMGridBehaviorModel.inl
@@ -29,9 +29,9 @@
 
 
 // internal model includes (here SOFA but could be any library)
-#include <SofaBoundaryCondition/FixedConstraint.h>
-#include <SofaImplicitOdeSolver/EulerImplicitSolver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
+#include <sofa/component/constraint/projective/FixedConstraint.h>
+#include <sofa/component/odesolver/backward/EulerImplicitSolver.h>
+#include <sofa/component/linearsolver/iterative/CGLinearSolver.h>
 #include <sofa/simulation/InitVisitor.h>
 #include <sofa/simulation/AnimateVisitor.h>
 #include <sofa/simulation/AnimateEndEvent.h>
@@ -73,7 +73,7 @@ void FEMGridBehaviorModel<DataTypes>::init()
 
     m_internalNode = simulation::Node::create("internal hidden node"); //sofa::simulation::getSimulation()->createNewGraph("internal hidden node");
 
-    m_internalTopology = sofa::core::objectmodel::New< component::topology::RegularGridTopology >();
+    m_internalTopology = sofa::core::objectmodel::New< sofa::component::topology::container::grid::RegularGridTopology >();
     m_internalTopology->setSize(_subdivisions.getValue()+1,_subdivisions.getValue()+1,_subdivisions.getValue()+1);
 
     m_internalDofs = sofa::core::objectmodel::New< Dofs >();
@@ -94,7 +94,7 @@ void FEMGridBehaviorModel<DataTypes>::init()
 
     m_internalTopology->setPos( min[0], max[0], min[1], max[1], min[2], max[2] );
 
-    m_internalForceField = sofa::core::objectmodel::New< component::forcefield::HexahedronFEMForceField<DataTypes> >();
+    m_internalForceField = sofa::core::objectmodel::New< sofa::component::solidmechanics::fem::elastic::HexahedronFEMForceField<DataTypes> >();
     m_internalForceField->setYoungModulus( _youngModulus.getValue() );
     m_internalForceField->setPoissonRatio( _poissonRatio.getValue() );
 
@@ -104,12 +104,12 @@ void FEMGridBehaviorModel<DataTypes>::init()
 
 
     // to constrain certain internal dof to exposed sofa dofs. Here there are exactly at the same place, they could be interpolated
-    typename component::projectiveconstraintset::FixedConstraint<DataTypes>::SPtr constraint = sofa::core::objectmodel::New< component::projectiveconstraintset::FixedConstraint<DataTypes> >();
-    typename component::odesolver::EulerImplicitSolver::SPtr odesolver = sofa::core::objectmodel::New< component::odesolver::EulerImplicitSolver >();
+    typename sofa::component::constraint::projective::FixedConstraint<DataTypes>::SPtr constraint = sofa::core::objectmodel::New< sofa::component::constraint::projective::FixedConstraint<DataTypes> >();
+    typename sofa::component::odesolver::backward::EulerImplicitSolver::SPtr odesolver = sofa::core::objectmodel::New< sofa::component::odesolver::backward::EulerImplicitSolver >();
     odesolver->f_rayleighStiffness.setValue(0);
     odesolver->f_rayleighMass.setValue(0);
     odesolver->f_velocityDamping.setValue(0);
-    typename component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix,component::linearsolver::GraphScatteredVector>::SPtr cg = sofa::core::objectmodel::New< component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix,component::linearsolver::GraphScatteredVector> >();
+    typename sofa::component::linearsolver::iterative::CGLinearSolver<component::linearsolver::GraphScatteredMatrix,component::linearsolver::GraphScatteredVector>::SPtr cg = sofa::core::objectmodel::New< sofa::component::linearsolver::iterative::CGLinearSolver<component::linearsolver::GraphScatteredMatrix,component::linearsolver::GraphScatteredVector> >();
     cg->d_maxIter.setValue(100);
     cg->d_smallDenominatorThreshold.setValue(1e-10);
     cg->d_tolerance.setValue(1e-10);


### PR DESCRIPTION

Also, I made `ExternalBehaviorModel` depends on `SOFA_ENABLE_LEGACY_HEADERS`, since it depends on `SofaGraphComponent` which also depends on `SOFA_ENABLE_LEGACY_HEADERS`


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
