### PR TITLE
[cmake] Introduce CMake presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ CMakeLists.txt.user*
 
 # custom cmake file
 custom.cmake
+CMakeUserPresets.json
 
 # caching dirs (clangd, ccls....)
 .cache

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,380 @@
+{
+  "version": 1,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default_base",
+      "displayName": "Default Config",
+      "description": "Build with default plugins/modules",
+      "hidden": true,
+      "cacheVariables": {
+        "SOFA_BUILD_TESTS": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "SOFA_ENABLE_LEGACY_HEADERS": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "SOFA_BUILD_TUTORIALS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "SOFA_BUILD_ADD_SCENES": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "SOFA_BUILD_ADD_SHADERS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_COLLISIONOBBCAPSULE": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAHIGHORDER": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_CIMGPLUGIN": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_ARTICULATEDSYSTEMPLUGIN": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFAEULERIANFLUID": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFASPHFLUID": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFADISTANCEGRID": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAIMPLICITFIELD": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_MULTITHREADING": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_DIFFUSIONSOLVER": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAPYTHON": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_IMAGE": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFANEWMAT": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_COMPLIANT": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAPYTHON3": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_CGALPLUGIN": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_FLEXIBLE": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_REGISTRATION": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_BULLETCOLLISIONDETECTION": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_PREASSEMBLEDMASS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_INVERTIBLEFVM": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_MESHSTEPLOADER": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_PLUGINEXAMPLE": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_MANIFOLDTOPOLOGIES": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_OPTITRACKNATNET": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SIXENSEHYDRA": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAOPENCL": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_XITACT": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_HAPTION": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_MANUALMAPPING": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_PERSISTENTCONTACT": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SENSABLE": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SENSABLEEMULATION": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAHAPI": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_THMPGSPATIALHASHING": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFACARVING": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_RIGIDSCALE": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_LEAPMOTION": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_GEOMAGIC": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAASSIMP": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAMATRIX": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_OPENCTMPLUGIN": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_BEAMADAPTER": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_PSL": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAPARDISOSOLVER": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFACUDA": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFASIMPLEGUI": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_VOLUMETRICRENDERING": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "APPLICATION_SCENECHECKING": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "APPLICATION_RUNSOFA": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "APPLICATION_REGRESSION": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "LIBRARY_SOFA_GUI_HEADLESSRECORDER": {
+          "type": "BOOL",
+          "value": "OFF"
+        }
+      }
+    },
+    {
+      "name": "minimal_base",
+      "displayName": "Minimal Config",
+      "description": "Build with as few plugins/modules as possible",
+      "hidden": true,
+      "inherits": "default_base",
+      "cacheVariables": {
+        "PLUGIN_CIMGPLUGIN": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_SOFAMATRIX": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PLUGIN_ARTICULATEDSYSTEMPLUGIN": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "APPLICATION_SCENECHECKING": {
+          "type": "BOOL",
+          "value": "OFF"
+        }
+      }
+    },
+    {
+      "name": "full_base",
+      "displayName": "Full Config",
+      "description": "Build with as much plugins/modules as possible",
+      "hidden": true,
+      "inherits": "default_base",
+      "cacheVariables": {
+        "SOFA_BUILD_TUTORIALS": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_BEAMADAPTER": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_DIFFUSIONSOLVER": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_GEOMAGIC": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_IMAGE": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_INVERTIBLEFVM": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_MANIFOLDTOPOLOGIES": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_MANUALMAPPING": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_MULTITHREADING": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_OPTITRACKNATNET": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_PLUGINEXAMPLE": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_REGISTRATION": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SENSABLEEMULATION": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFACARVING": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFACUDA": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFADISTANCEGRID": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFAEULERIANFLUID": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFAGLFW": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "APPLICATION_RUNSOFAGLFW": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFAIMGUI": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFAIMPLICITFIELD": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFASIMPLEGUI": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_SOFASPHFLUID": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "PLUGIN_COLLISIONOBBCAPSULE": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "APPLICATION_REGRESSION": {
+          "type": "BOOL",
+          "value": "ON"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
See doc https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html

It gives 3 different presets similarly to what we are used to on the CI. The idea is the same (3 different config) but it cannot mimic it perfectly. For example, the CI checks if dependencies are available before setting a variable. It is not possible with presets.

An example of CMakeUserPresets.json I use: https://gist.github.com/alxbilger/bee1135fbe222943906d0f595699c1a3






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
