### PR TITLE
[Sofa.Core] Refactor BaseObject::canCreate & BaseObject::create

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/Multi2Mapping.h
+++ b/Sofa/framework/Core/src/sofa/core/Multi2Mapping.h
@@ -222,35 +222,14 @@ public:
     /// mapping.
     template<class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        std::string input1 = arg->getAttribute("input1","");
-        std::string input2 = arg->getAttribute("input2","");
-        std::string output = arg->getAttribute("output","");
-        if (!input1.empty() && !PathResolver::CheckPaths(context, LinkFromModels1::DestType::GetClass(), input1))
+    {        
+        if( !IsRequiredLinkPathPointingToCompatibleObject("input1", LinkFromModels1::DestType::GetClass(), context, arg)  )
             return false;
-        if (!input2.empty() && !PathResolver::CheckPaths(context, LinkFromModels2::DestType::GetClass(), input2))
+        if( !IsRequiredLinkPathPointingToCompatibleObject("input2", LinkFromModels2::DestType::GetClass(), context, arg)  )
             return false;
-        if (output.empty() || !PathResolver::CheckPaths(context, LinkToModels::DestType::GetClass(), output))
+        if( !IsRequiredLinkPathPointingToCompatibleObject("output", LinkToModels::DestType::GetClass(), context, arg)  )
             return false;
-
         return BaseMapping::canCreate(obj, context, arg);
-    }
-    /// Construction method called by ObjectFactory.
-    ///
-    /// This implementation read the input and output attributes to
-    /// find the input and output models of this mapping.
-    template<class T>
-    static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
-        if (context)
-            context->addObject(obj);
-
-        if (arg)
-            obj->parse(arg);
-
-        return obj;
     }
 
 protected:

--- a/Sofa/framework/Core/src/sofa/core/MultiMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/MultiMapping.h
@@ -210,50 +210,11 @@ public:
     template<class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
     {
-        std::string input  = arg->getAttribute("input","");
-        if (input.empty()) {
-            arg->logError("The 'input' data attribute is empty. It should contain a valid path "
-                          "to one or more mechanical states of type '" + std::string(TIn::Name()) + "'.");
+        if( !IsRequiredLinkPathPointingToCompatibleObject("input", LinkFromModels::DestType::GetClass(), context, arg) )
             return false;
-
-        } else if (!PathResolver::CheckPaths(context, LinkFromModels::DestType::GetClass(), input)) {
-            arg->logError("The 'input' data attribute does not contain a valid path to one or more mechanical "
-                          "states of type '" + std::string(TIn::Name()) + "'.");
+        if( !IsRequiredLinkPathPointingToCompatibleObject("output", LinkToModels::DestType::GetClass(), context, arg) )
             return false;
-        }
-
-        std::string output = arg->getAttribute("output","");
-        if (output.empty()) {
-            arg->logError("The 'output' data attribute is empty. It should contain a valid path "
-                          "to one or more mechanical states. of type '" + std::string(TOut::Name()) + "'.");
-            return false;
-        } else if (!PathResolver::CheckPaths(context, LinkToModels::DestType::GetClass(), output)) {
-            arg->logError("The 'output' data attribute does not contain a valid path to one or more mechanical "
-                          "states of type '" + std::string(TOut::Name()) + "'.");
-            return false;
-        }
-
         return BaseMapping::canCreate(obj, context, arg);
-    }
-
-    /// Construction method called by ObjectFactory.
-    ///
-    /// This implementation read the input and output attributes to
-    /// find the input and output models of this mapping.
-    template<class T>
-    static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
-        if (context)
-            context->addObject(obj);
-
-        if (arg)
-        {
-            obj->parse(arg);
-        }
-
-        return obj;
     }
 
 protected:

--- a/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionConstraint.h
@@ -105,20 +105,6 @@ public:
             , const DataVecCoord1 &x1, const DataVecCoord2 &x2) = 0;
 
 
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T* p0, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = core::behavior::BaseInteractionConstraint::create(p0, context, arg);
-
-        if (arg)
-        {
-            obj->parse(arg);
-        }
-
-        return obj;
-    }
-
     //TODO(dmarchal: 20/04/2020): Have a carefull look that we really want this customize pattern and it is not
     // a bug.
     /// Overriding this function is needed otherwise the template returned would be of type DataTypes1::Name()+","+DataType2::Name().

--- a/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionConstraint.h
@@ -126,30 +126,6 @@ public:
         return BaseInteractionConstraint::canCreate(obj, context, arg);
     }
 
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T* p0, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = core::behavior::BaseInteractionConstraint::create(p0, context, arg);
-
-        if (arg)
-        {
-            std::string object1 = arg->getAttribute("object1","");
-            std::string object2 = arg->getAttribute("object2","");
-            if (!object1.empty())
-            {
-                arg->setAttribute("object1", object1);
-            }
-            if (!object2.empty())
-            {
-                arg->setAttribute("object2", object2);
-            }
-            obj->parse(arg);
-        }
-
-        return obj;
-    }
-
     using Inherit2::getMechModel1;
     using Inherit2::getMechModel2;
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionForceField.h
@@ -184,33 +184,6 @@ public:
         return BaseInteractionForceField::canCreate(obj, context, arg);
     }
 
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T* /*p0*/, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
-        if (context)
-            context->addObject(obj);
-
-        if (arg)
-        {
-            std::string object1 = arg->getAttribute("object1","");
-            std::string object2 = arg->getAttribute("object2","");
-            if (!object1.empty())
-            {
-                arg->setAttribute("object1", object1);
-            }
-            if (!object2.empty())
-            {
-                arg->setAttribute("object2", object2);
-            }
-            obj->parse(arg);
-        }
-
-        return obj;
-    }
-
     template<class T>
     static std::string shortName(const T* ptr = nullptr, objectmodel::BaseObjectDescription* arg = nullptr)
     {

--- a/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
@@ -143,33 +143,6 @@ public:
         return BaseInteractionProjectiveConstraintSet::canCreate(obj, context, arg);
     }
 
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T* /*p0*/, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
-        if (context)
-            context->addObject(obj);
-
-        if (arg)
-        {
-            std::string object1 = arg->getAttribute("object1","");
-            std::string object2 = arg->getAttribute("object2","");
-            if (!object1.empty())
-            {
-                arg->setAttribute("object1", object1);
-            }
-            if (!object2.empty())
-            {
-                arg->setAttribute("object2", object2);
-            }
-            obj->parse(arg);
-        }
-
-        return obj;
-    }
-
     using Inherit2::getMechModel1;
     using Inherit2::getMechModel2;
 };

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
@@ -28,7 +28,6 @@
 #include <sofa/helper/TagFactory.h>
 #include <iostream>
 
-
 namespace sofa
 {
 
@@ -369,6 +368,14 @@ std::string BaseObject::getPathName() const {
     result += getName();
     return result;
 }
+
+BaseObject::SPtr BaseObject::AddObjectToContextAndParse(BaseObject::SPtr obj, BaseContext* context, BaseObjectDescription* arg)
+{
+    if (context) context->addObject(obj);
+    if (arg) obj->parse(arg);
+    return obj;
+}
+
 
 } // namespace objectmodel
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
@@ -376,6 +376,32 @@ BaseObject::SPtr BaseObject::AddObjectToContextAndParse(BaseObject::SPtr obj, Ba
     return obj;
 }
 
+bool BaseObject::IsRequiredLinkPathPointingToCompatibleObject(const std::string& linkPath, const BaseClass* type, BaseContext* context, BaseObjectDescription* arg)
+{
+    std::string output = arg->getAttribute("linkPath");
+    if (output.empty()) {
+        arg->logError("The '"+linkPath+"' data attribute is empty. It should contain a valid path "
+                      "to one or more object of type '" + type->typeName + "'.");
+        return false;
+    } else if (!PathResolver::CheckPaths(context, type, output)) {
+        arg->logError("The '"+linkPath+"' data attribute does not contain a valid path to one or more object of type '" + type->typeName + "'.");
+        return false;
+    }
+    return true;    
+}
+
+bool BaseObject::IsRequiredObjectInContext(const ClassInfo& typeOfRequiredObject, BaseContext* context, BaseObjectDescription* arg)
+{
+    if( !context->getObject(typeOfRequiredObject) )
+    {
+        arg->logError(std::string("No object with the datatype '") + typeOfRequiredObject.name() +
+                      "' found in the context node.");
+        return false; 
+    }
+    return true;
+}
+
+
 
 } // namespace objectmodel
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
@@ -65,14 +65,15 @@ public:
     {
         return true;
     }
-
+    static bool IsRequiredLinkPathPointingToCompatibleObject(const std::string& linkPath, const BaseClass* type, BaseContext*, BaseObjectDescription* arg);
+    static bool IsRequiredObjectInContext(const ClassInfo& typeOfRequiredObject, BaseContext* context, BaseObjectDescription* arg);
+    
     /// Construction method called by ObjectFactory.
     template<class T>
     static BaseObject::SPtr create(T*, BaseContext* context, BaseObjectDescription* arg)
     {
         return AddObjectToContextAndParse(sofa::core::objectmodel::New<T>(), context, arg);
     }
-
     static BaseObject::SPtr AddObjectToContextAndParse(BaseObject::SPtr obj, BaseContext* context, BaseObjectDescription* arg);
 
     /// Parse the given description to assign values to this object's fields and potentially other parameters

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
@@ -51,7 +51,6 @@ public:
 
 protected:
     BaseObject();
-
     ~BaseObject() override;
 
 public:
@@ -69,13 +68,12 @@ public:
 
     /// Construction method called by ObjectFactory.
     template<class T>
-    static typename T::SPtr create(T*, BaseContext* context, BaseObjectDescription* arg)
+    static BaseObject::SPtr create(T*, BaseContext* context, BaseObjectDescription* arg)
     {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-        if (context) context->addObject(obj);
-        if (arg) obj->parse(arg);
-        return obj;
+        return AddObjectToContextAndParse(sofa::core::objectmodel::New<T>(), context, arg);
     }
+
+    static BaseObject::SPtr AddObjectToContextAndParse(BaseObject::SPtr obj, BaseContext* context, BaseObjectDescription* arg);
 
     /// Parse the given description to assign values to this object's fields and potentially other parameters
     void parse ( BaseObjectDescription* arg ) override;

--- a/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevAngleCollisionMonitor.h
+++ b/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevAngleCollisionMonitor.h
@@ -57,13 +57,12 @@ public:
     void eval() override;
 
     /// Retrieve the associated MechanicalState (First model)
-    core::behavior::MechanicalState<DataTypes>* getMState1() { return mstate1; }
-    core::behavior::BaseMechanicalState* getMechModel1() { return mstate1; }
+    core::behavior::MechanicalState<DataTypes>* getMState1() { return mstate1.get(); }
+    core::behavior::BaseMechanicalState* getMechModel1() { return mstate1.get(); }
 
     /// Retrieve the associated MechanicalState (Second model)
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMState2() { return mstate2; }
-    core::behavior::BaseMechanicalState* getMechModel2() { return mstate2; }
-
+    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMState2() { return mstate2.get(); }
+    core::behavior::BaseMechanicalState* getMechModel2() { return mstate2.get(); }
 
     /// Pre-construction check method called by ObjectFactory.
     /// Check that DataTypes matches the MechanicalState.
@@ -85,26 +84,12 @@ public:
         return core::objectmodel::BaseObject::canCreate(obj, context, arg);
     }
 
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T* tObj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = core::objectmodel::BaseObject::create(tObj, context, arg);
-
-        if (arg && (arg->getAttribute("object1") || arg->getAttribute("object2")))
-        {
-            obj->mstate1 = dynamic_cast<core::behavior::MechanicalState<DataTypes>*>(arg->findObject(arg->getAttribute("object1","..")));
-            obj->mstate2 = dynamic_cast<core::behavior::MechanicalState<defaulttype::Vec3Types>*>(arg->findObject(arg->getAttribute("object2","..")));
-        }
-
-        return obj;
-    }
-
 protected:
     /// First model mechanical state
-    core::behavior::MechanicalState<DataTypes> *mstate1;
+    SingleLink<DevAngleCollisionMonitor<DataTypes>, core::behavior::MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH> mstate1;
+
     /// Second model mechanical state
-    core::behavior::MechanicalState<defaulttype::Vec3Types> *mstate2;
+    SingleLink<DevAngleCollisionMonitor<DataTypes>, core::behavior::MechanicalState<sofa::defaulttype::Vec3Types>, BaseLink::FLAG_STOREPATH> mstate2;
 
     /// Point model of first object
     sofa::component::collision::geometry::PointCollisionModel<sofa::defaulttype::Vec3Types> *pointsCM;

--- a/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevAngleCollisionMonitor.inl
+++ b/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevAngleCollisionMonitor.inl
@@ -32,6 +32,8 @@ DevAngleCollisionMonitor<DataTypes>::DevAngleCollisionMonitor()
     , surfaceCM(nullptr)
     , intersection(nullptr)
     , narrowPhaseDetection(nullptr)
+    , mstate1(initLink("object1", "link to the first state container to monitor"))
+    , mstate2(initLink("object2", "link to the second state container to monitor"))
 {
 }
 

--- a/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevTensionMonitor.h
+++ b/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevTensionMonitor.h
@@ -42,7 +42,7 @@ public:
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::Coord Coord;
 protected:
-    DevTensionMonitor() { };
+    DevTensionMonitor();
     virtual ~DevTensionMonitor() { };
 public:
     void init() override;
@@ -71,22 +71,8 @@ public:
         return core::objectmodel::BaseObject::canCreate(obj, context, arg);
     }
 
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T* tObj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = core::objectmodel::BaseObject::create(tObj, context, arg);
-
-        if (arg && (arg->getAttribute("object")))
-        {
-            obj->mstate = dynamic_cast<core::behavior::MechanicalState<DataTypes>*>(arg->findObject(arg->getAttribute("object","..")));
-        }
-
-        return obj;
-    }
-
 protected:
-    core::behavior::MechanicalState<DataTypes> *mstate;
+    SingleLink<DevTensionMonitor<DataTypes>, core::behavior::MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH> mstate;
 };
 
 

--- a/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevTensionMonitor.inl
+++ b/applications/collections/deprecated/modules/SofaValidation/src/SofaValidation/DevTensionMonitor.inl
@@ -26,6 +26,13 @@ namespace sofa::component::misc
 {
 
 template <class DataTypes>
+DevTensionMonitor<DataTypes>::DevTensionMonitor() :
+    mstate(initLink("object", "link to the state container to monitor"))
+{
+        
+};
+
+template <class DataTypes>
 void DevTensionMonitor<DataTypes>::init()
 {
 }


### PR DESCRIPTION
The current process of constructing object is very complex, error prone and generates a lot of duplicated code. 
To clean a bit in this PR is:
1) moving the common code into dedicated and opaque method: 
BaseObject::IsRequiredLinkPathPointingToCompatibleObject...
BaseObject::IsRequiredComponentInContext....
BaseObject::AddObjectToContextAndParse

2) remove the create or canCreate method that I think where doing nothing more than the default ones (please check).

3) to update to new signature It was needed to update some rare component. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
