### PR TITLE
[Simulation.Core] Fix import of required plugins

### DIFF
--- a/Sofa/framework/Simulation/Core/simutest/NodeContext_test.cpp
+++ b/Sofa/framework/Simulation/Core/simutest/NodeContext_test.cpp
@@ -39,7 +39,8 @@ public:
 
     NodeContext_test()
     {
-
+        importPlugin("Sofa.Component.StateContainer");
+        importPlugin("Sofa.Component.SceneUtility");
     }
 
     void testGetNodeObjects()


### PR DESCRIPTION
https://github.com/sofa-framework/sofa/pull/3266 removed `importPlugin("SofaComponentAll") ;` in `NodeContext_test.cpp`, but did not replace it by anything else. I don't know why the CI did not detect it, but the problem can be seen in https://github.com/sofa-framework/sofa/pull/3280



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
