### PR TITLE
[GUI/runSofa] Cmake: tweaks and fixes

### DIFF
--- a/Sofa/CMakeLists.txt
+++ b/Sofa/CMakeLists.txt
@@ -11,4 +11,4 @@ option(SOFA_WITH_OPENGL "Compile Sofa with OpenGL support. This will define the 
 sofa_add_subdirectory(library GL Sofa.GL ON WHEN_TO_SHOW "SOFA_WITH_OPENGL" VALUE_IF_HIDDEN OFF)
 
 # GUI
-sofa_add_subdirectory(library GUI Sofa.GUI ON)
+add_subdirectory(GUI)

--- a/Sofa/GUI/CMakeLists.txt
+++ b/Sofa/GUI/CMakeLists.txt
@@ -28,26 +28,32 @@ if(TARGET ${PROJECT_NAME}.HeadlessRecorder)
     list(APPEND SOFAGUI_TARGETS ${PROJECT_NAME}.HeadlessRecorder)
 endif()
 
-if(SOFAGUI_MISSINGTARGETS)
-    message("${PROJECT_NAME}: package and library will not be created because some dependencies are missing or disabled: ${SOFAGUI_MISSINGTARGETS}")
-    return()
+option(LIBRARY_SOFA_GUI "Build the Sofa.Gui library." ON)
+
+if(LIBRARY_SOFA_GUI)
+
+    if(SOFAGUI_MISSINGTARGETS)
+        message("${PROJECT_NAME}: package and library will not be created because some dependencies are missing or disabled: ${SOFAGUI_MISSINGTARGETS}")
+        return()
+    endif()
+
+    set(HEADER_FILES
+        ${SOFAGUI_SOURCE_DIR}/config.h.in
+        ${SOFAGUI_SOURCE_DIR}/init.h
+    )
+    set(SOURCE_FILES
+        ${SOFAGUI_SOURCE_DIR}/init.cpp
+    )
+
+    add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFAGUI_TARGETS})
+
+    sofa_create_package_with_targets(
+        PACKAGE_NAME ${PROJECT_NAME}
+        PACKAGE_VERSION ${Sofa_VERSION}
+        TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+        INCLUDE_SOURCE_DIR "src"
+        INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
+    )
+
 endif()
-
-set(HEADER_FILES
-    ${SOFAGUI_SOURCE_DIR}/config.h.in
-    ${SOFAGUI_SOURCE_DIR}/init.h
-)
-set(SOURCE_FILES
-    ${SOFAGUI_SOURCE_DIR}/init.cpp
-)
-
-add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFAGUI_TARGETS})
-
-sofa_create_package_with_targets(
-    PACKAGE_NAME ${PROJECT_NAME}
-    PACKAGE_VERSION ${Sofa_VERSION}
-    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
-    INCLUDE_SOURCE_DIR "src"
-    INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
-)

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -280,7 +280,7 @@ sofa_create_package_with_targets(
 # Tests
 # If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
 cmake_dependent_option(SOFA_SIMULATION_CORE_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
-if(SOFA_SIMULATION_GRAPH_BUILD_TESTS)
+if(SOFA_SIMULATION_CORE_BUILD_TESTS)
     add_subdirectory(test)
     add_subdirectory(simutest)
 endif()

--- a/applications/projects/runSofa/CMakeLists.txt
+++ b/applications/projects/runSofa/CMakeLists.txt
@@ -24,8 +24,8 @@ sofa_find_package(Sofa.Component.Playback QUIET)
 
 sofa_find_package(Sofa.Simulation.Graph REQUIRED)
 sofa_find_package(Sofa.GUI.Common REQUIRED)
-sofa_find_package(Sofa.GUI.Qt QUIET)
 sofa_find_package(SceneChecking REQUIRED)
+sofa_find_package(SofaGui REQUIRED)
 
 set(HEADER_FILES
     runSofaValidation.h
@@ -62,8 +62,9 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC "CONFIG_PLUGIN_FILENAME=${_con
 target_compile_definitions(${PROJECT_NAME} PUBLIC "DEFAULT_CONFIG_PLUGIN_FILENAME=${_defaultConfigPluginFileName}")
 
 target_link_libraries(${PROJECT_NAME} Sofa.Simulation.Graph)
-target_link_libraries(${PROJECT_NAME} SofaGui)
+target_link_libraries(${PROJECT_NAME} Sofa.GUI.Common)
 target_link_libraries(${PROJECT_NAME} SceneChecking)
+target_link_libraries(${PROJECT_NAME} SofaGui)
 
 if(Sofa.Component.Playback_FOUND)
     target_link_libraries(${PROJECT_NAME} Sofa.Component.Playback)

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -55,7 +55,6 @@ using sofa::helper::system::FileSystem;
 using sofa::gui::common::GUIManager;
 
 #include <SofaGui/initSofaGui.h>
-#include <sofa/gui/batch/BatchGUI.h>  // For the default number of iterations
 
 using sofa::core::ExecParams ;
 
@@ -65,7 +64,6 @@ using sofa::helper::Utils;
 using sofa::simulation::graph::DAGSimulation;
 using sofa::helper::system::SetDirectory;
 using sofa::core::objectmodel::BaseNode ;
-using sofa::gui::batch::BatchGUI;
 
 #include <sofa/gui/common/BaseGUI.h>
 using sofa::gui::common::BaseGUI;


### PR DESCRIPTION
The goal was to be able to set the minimal requirements to get Sofa.Component + runSofa + batch only, and not having seemingly unrelated dependency.

Fixes:
 - runSofa needed absolutely Sofa.Gui.Qt but not using it
 - not possible to compile Sofa.Gui.Common without having to compile Sofa.Gui (which should be possible)

and cmake cleanups here and there.

\+ an other unrelated fix by repairing the typo for simulation core tests ; the consequence was that simulation.core.tests was always activated even if sofa_build_tests was off

This PR is a preliminary step to have SofaGui totally deprecated (and not used anymore by runSofa)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
