### PR TITLE
[Constraint.lagrangian] Fix BilateralInteractionConstraint double init and clean some Data

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -130,7 +130,7 @@ public:
 
         if (arg->getAttribute("activateAtIteration"))
         {
-            msg_warning() << "input data 'activateAtIteration' has been deprecated, please use 'activate' instead and an engine or a script to change the behavior at the right step (see PR #3327).";
+            msg_warning() << "input data 'activateAtIteration' has been deprecated, please use the boolean data 'activate' instead and an engine or a script to change the behavior at the right step (see PR #3327).";
         }
     }
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -104,6 +104,9 @@ protected:
     Data<bool> keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
     std::vector<Vec3d> prevForces;
 
+    SOFA_ATTRIBUTE_DEPRECATED("v22.12", "v23.06", "Data activateAtIteration has been deprecated, please use the Data d_activate instead and an engine or a script to change the behavior at the right step (see PR #3327).")
+    Data<int> activateAtIteration; ///< activate constraint at specified interation (0 = always enabled, -1=disabled)
+
     // grouped square constraints
     bool squareXYZ[3];
     Deriv dfree_square_total;
@@ -119,6 +122,17 @@ public:
     void bwdInit() override {}
 
     void reinit() override;
+
+    /// Temporary function to warn the user when old attribute names are used
+    void parse(sofa::core::objectmodel::BaseObjectDescription* arg) override
+    {
+        Inherit::parse(arg);
+
+        if (arg->getAttribute("activateAtIteration"))
+        {
+            msg_warning() << "input data 'activateAtIteration' has been deprecated, please use 'activate' instead and an engine or a script to change the behavior at the right step (see PR #3327).";
+        }
+    }
 
     void buildConstraintMatrix(const ConstraintParams* cParams,
                                        DataMatrixDeriv &c1, DataMatrixDeriv &c2,

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -98,7 +98,7 @@ protected:
     VecCoord initialDifference;
 
     Data<double> d_numericalTolerance; ///< a real value specifying the tolerance during the constraint solving. (default=0.0001
-    Data<int> activateAtIteration; ///< activate constraint at specified interation (0 = always enabled, -1=disabled)
+    Data<bool> d_activate; ///< bool to control constraint activation
     Data<bool> merge; ///< TEST: merge the bilateral constraints in a unique constraint
     Data<bool> derivative; ///< TEST: derivative
     Data<bool> keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
@@ -107,10 +107,6 @@ protected:
     // grouped square constraints
     bool squareXYZ[3];
     Deriv dfree_square_total;
-
-
-    bool activated;
-    int iteration;
 
     BilateralInteractionConstraint(MechanicalState* object1, MechanicalState* object2) ;
     BilateralInteractionConstraint(MechanicalState* object) ;

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -124,8 +124,6 @@ public:
 
     void reinit() override;
 
-    void reset() override;
-
     void buildConstraintMatrix(const ConstraintParams* cParams,
                                        DataMatrixDeriv &c1, DataMatrixDeriv &c2,
                                        unsigned int &cIndex,

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -101,10 +101,6 @@ void BilateralInteractionConstraint<DataTypes>::reinit()
     activated = (activateAtIteration.getValue() >= 0 && activateAtIteration.getValue() <= iteration);
 }
 
-template<class DataTypes>
-void BilateralInteractionConstraint<DataTypes>::reset(){
-    init();
-}
 
 template<class DataTypes>
 void BilateralInteractionConstraint<DataTypes>::buildConstraintMatrix(const ConstraintParams*, DataMatrixDeriv &c1_d, DataMatrixDeriv &c2_d, unsigned int &constraintId

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -49,7 +49,7 @@ BilateralInteractionConstraint<DataTypes>::BilateralInteractionConstraint(Mechan
 
     , d_numericalTolerance(initData(&d_numericalTolerance, 0.0001, "numericalTolerance",
                                     "a real value specifying the tolerance during the constraint solving. (optional, default=0.0001)") )
-    , d_activate( initData(&d_activate, true, "activate", "controle constraint activation (true by default)"))
+    , d_activate( initData(&d_activate, true, "activate", "control constraint activation (true by default)"))
 
     //TODO(dmarchal): what do TEST means in the following ? should it be renamed (EXPERIMENTAL FEATURE) and when those Experimental feature will become official feature ?
     , merge(initData(&merge,false, "merge", "TEST: merge the bilateral constraints in a unique constraint"))


### PR DESCRIPTION
- Remove reset method which was calling a second time init at start
- Replace activateAtIteration and all mechanism of iteration count by a single activate Data<bool>



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
