### PR TITLE
[Constraint.Lagrangian] Remove merge option from BilateralInteractionConstraint

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -104,6 +104,9 @@ protected:
     Data<bool> keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
     std::vector<Vec3d> prevForces;
 
+    SOFA_ATTRIBUTE_DEPRECATED("v22.12", "v23.06", "Data activateAtIteration has been deprecated, please use the Data d_activate instead and an engine or a script to change the behavior at the right step (see PR #3327).")
+    Data<int> activateAtIteration; ///< activate constraint at specified interation (0 = always enabled, -1=disabled)
+
     // grouped square constraints
     bool squareXYZ[3];
     Deriv dfree_square_total;
@@ -119,6 +122,17 @@ public:
     void bwdInit() override {}
 
     void reinit() override;
+
+    /// Temporary function to warn the user when old attribute names are used
+    void parse(sofa::core::objectmodel::BaseObjectDescription* arg) override
+    {
+        Inherit::parse(arg);
+
+        if (arg->getAttribute("activateAtIteration"))
+        {
+            msg_warning() << "input data 'activateAtIteration' has been deprecated, please use 'activate' instead and an engine or a script to change the behavior at the right step (see PR #3327).";
+        }
+    }
 
     void buildConstraintMatrix(const ConstraintParams* cParams,
                                        DataMatrixDeriv &c1, DataMatrixDeriv &c2,

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -99,17 +99,15 @@ protected:
 
     Data<double> d_numericalTolerance; ///< a real value specifying the tolerance during the constraint solving. (default=0.0001
     Data<bool> d_activate; ///< bool to control constraint activation
-    Data<bool> merge; ///< TEST: merge the bilateral constraints in a unique constraint
-    Data<bool> derivative; ///< TEST: derivative
     Data<bool> keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
     std::vector<Vec3d> prevForces;
 
-    SOFA_ATTRIBUTE_DEPRECATED("v22.12", "v23.06", "Data activateAtIteration has been deprecated, please use the Data d_activate instead and an engine or a script to change the behavior at the right step (see PR #3327).")
+    SOFA_ATTRIBUTE_DEPRECATED("v22.12", "v23.06", "Data 'activateAtIteration' has been deprecated, please use the Data d_activate instead and an engine or a script to change the behavior at the right step (see PR #3327).")
     Data<int> activateAtIteration; ///< activate constraint at specified interation (0 = always enabled, -1=disabled)
-
-    // grouped square constraints
-    bool squareXYZ[3];
-    Deriv dfree_square_total;
+    SOFA_ATTRIBUTE_DEPRECATED("v22.12", "v23.06", "Data 'merge' has been deprecated. Its behavior was unused, undocumented, untested, and unclear (see PR #3328).")
+    Data<bool> merge; ///< TEST: merge the bilateral constraints in a unique constraint
+    SOFA_ATTRIBUTE_DEPRECATED("v22.12", "v23.06", "Data 'derivative' has been deprecated. Its behavior was unused, undocumented, untested, and unclear (see PR #3328).")
+    Data<bool> derivative; ///< TEST: derivative
 
     BilateralInteractionConstraint(MechanicalState* object1, MechanicalState* object2) ;
     BilateralInteractionConstraint(MechanicalState* object) ;
@@ -130,7 +128,15 @@ public:
 
         if (arg->getAttribute("activateAtIteration"))
         {
-            msg_warning() << "input data 'activateAtIteration' has been deprecated, please use 'activate' instead and an engine or a script to change the behavior at the right step (see PR #3327).";
+            msg_warning() << "input Data 'activateAtIteration' has been deprecated, please use 'activate' instead and an engine or a script to change the behavior at the right step (see PR #3327).";
+        }
+        else if (arg->getAttribute("merge"))
+        {
+            msg_warning() << "input Data 'merge' has been deprecated. Its behavior was unused, undocumented, untested, and unclear (see PR #3328).";
+        }
+        else if (arg->getAttribute("derivative"))
+        {
+            msg_warning() << "input Data 'derivative' has been deprecated. Its behavior was unused, undocumented, untested, and unclear (see PR #3328).";
         }
     }
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -130,11 +130,11 @@ public:
         {
             msg_warning() << "input data 'activateAtIteration' has been deprecated, please use the boolean data 'activate' instead and an engine or a script to change the behavior at the right step (see PR #3327).";
         }
-        else if (arg->getAttribute("merge"))
+        if (arg->getAttribute("merge"))
         {
             msg_warning() << "input Data 'merge' has been deprecated. Its behavior was unused, undocumented, untested, and unclear (see PR #3328).";
         }
-        else if (arg->getAttribute("derivative"))
+        if (arg->getAttribute("derivative"))
         {
             msg_warning() << "input Data 'derivative' has been deprecated. Its behavior was unused, undocumented, untested, and unclear (see PR #3328).";
         }

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -98,7 +98,7 @@ protected:
     VecCoord initialDifference;
 
     Data<double> d_numericalTolerance; ///< a real value specifying the tolerance during the constraint solving. (default=0.0001
-    Data<int> activateAtIteration; ///< activate constraint at specified interation (0 = always enabled, -1=disabled)
+    Data<bool> d_activate; ///< bool to control constraint activation
     Data<bool> merge; ///< TEST: merge the bilateral constraints in a unique constraint
     Data<bool> derivative; ///< TEST: derivative
     Data<bool> keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
@@ -107,10 +107,6 @@ protected:
     // grouped square constraints
     bool squareXYZ[3];
     Deriv dfree_square_total;
-
-
-    bool activated;
-    int iteration;
 
     BilateralInteractionConstraint(MechanicalState* object1, MechanicalState* object2) ;
     BilateralInteractionConstraint(MechanicalState* object) ;

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -124,8 +124,6 @@ public:
 
     void reinit() override;
 
-    void reset() override;
-
     void buildConstraintMatrix(const ConstraintParams* cParams,
                                        DataMatrixDeriv &c1, DataMatrixDeriv &c2,
                                        unsigned int &cIndex,

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -101,10 +101,6 @@ void BilateralInteractionConstraint<DataTypes>::reinit()
     activated = (activateAtIteration.getValue() >= 0 && activateAtIteration.getValue() <= iteration);
 }
 
-template<class DataTypes>
-void BilateralInteractionConstraint<DataTypes>::reset(){
-    init();
-}
 
 template<class DataTypes>
 void BilateralInteractionConstraint<DataTypes>::buildConstraintMatrix(const ConstraintParams*, DataMatrixDeriv &c1_d, DataMatrixDeriv &c2_d, unsigned int &constraintId

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -49,7 +49,7 @@ BilateralInteractionConstraint<DataTypes>::BilateralInteractionConstraint(Mechan
 
     , d_numericalTolerance(initData(&d_numericalTolerance, 0.0001, "numericalTolerance",
                                     "a real value specifying the tolerance during the constraint solving. (optional, default=0.0001)") )
-    , d_activate( initData(&d_activate, true, "activate", "controle constraint activation (true by default)"))
+    , d_activate( initData(&d_activate, true, "activate", "control constraint activation (true by default)"))
 
     //TODO(dmarchal): what do TEST means in the following ? should it be renamed (EXPERIMENTAL FEATURE) and when those Experimental feature will become official feature ?
     , merge(initData(&merge,false, "merge", "TEST: merge the bilateral constraints in a unique constraint"))


### PR DESCRIPTION
based on PR #3327 

- Remove option `merge` which was added as a test in 2011 and never finished. According to a quick test on example. The behavior is less stable when activating the option with the same speed.

**Result of BilateralConstraint between 2 deformable models.** 
Current behavior: single constraint working fine
![RemovingBilateralInteractionConstraint_00000001](https://user-images.githubusercontent.com/21199245/191688055-b0f0af8a-a657-4d9f-b477-6d712542a48a.png)

Result when activating merge option: Some vibration and constraint is duplicated
![RemovingBilateralInteractionConstraint_00000002](https://user-images.githubusercontent.com/21199245/191688314-22cd8674-ce2c-40d9-a6c1-f77267cbb471.png)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
