### PR TITLE
[Topology] Fix internal infinite update loop in TopologySubsetData remove process

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
@@ -74,7 +74,7 @@ public:
     * @param {Index} element index of the full Data vector to find in the vector map
     * @return {Index} position of the element in the vector map. return sofa::InvalidID if not found.
     */
-    virtual Index indexOfElement(Index index);
+    virtual Index indexOfElement(Index index) const;
 
     /// Swaps values of this subsetmap at indices i1 and i2. (only if i1 and i2 < subset size())
     void swap(Index i1, Index i2) override;

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -46,7 +46,7 @@ void TopologySubsetData <TopologyElementType, VecT>::swap(Index i1, Index i2)
     
     if (i1 >= data.size() || i2 >= data.size())
     {
-        msg_warning("TopologySubsetData") << "swap indices out of bouds: i1: " << i1 << " | i2: " << i2 << " out of data size: " << data.size();
+        msg_warning(this->getOwner()) << "TopologySubsetData: " << this->getName() << " swap indices out of bouds: i1: " << i1 << " | i2: " << i2 << " out of data size: " << data.size();
         this->endEdit();
         return;
     }
@@ -67,7 +67,7 @@ void TopologySubsetData <TopologyElementType, VecT>::setMap2Elements(const sofa:
 }
 
 template <typename TopologyElementType, typename VecT>
-Index TopologySubsetData <TopologyElementType, VecT>::indexOfElement(Index index)
+Index TopologySubsetData <TopologyElementType, VecT>::indexOfElement(Index index) const
 {    
     for (unsigned int i = 0; i < m_map2Elements.size(); ++i)
         if (index == m_map2Elements[i])
@@ -166,6 +166,9 @@ void TopologySubsetData <TopologyElementType, VecT>::remove(const sofa::type::ve
     // check for each element index to remove if it concern this subsetData
     for (Index elemId : index)
     {
+        if (data.size() == 0)
+            return;
+
         // Check if this element is inside the subset map
         Index dataId = this->indexOfElement(elemId);
         
@@ -216,7 +219,7 @@ void TopologySubsetData <TopologyElementType, VecT>::swapPostProcess(Index i1, I
 {
     if (i1 >= m_map2Elements.size() || i2 >= m_map2Elements.size())
     {
-        msg_warning("TopologySubsetData") << "swap indices out of bouds: i1: " << i1 << " | i2: " << i2 << " out of m_map2Elements size: " << m_map2Elements.size();
+        msg_warning(this->getOwner()) << "TopologySubsetData: " << this->getName() << " swap indices out of bouds: i1: " << i1 << " | i2: " << i2 << " out of m_map2Elements size: " << m_map2Elements.size();
         return;
     }
 
@@ -253,14 +256,14 @@ template <typename TopologyElementType, typename VecT>
 void TopologySubsetData <TopologyElementType, VecT>::addOnMovedPosition(const sofa::type::vector<Index>&,
     const sofa::type::vector<TopologyElementType>&)
 {
-    dmsg_error("TopologySubsetData") << "addOnMovedPosition event on topology subsetData is not yet handled.";
+    dmsg_error(this->getOwner()) << "TopologySubsetData: " << this->getName() << " addOnMovedPosition event on topology subsetData is not yet handled.";
 }
 
 
 template <typename TopologyElementType, typename VecT>
 void TopologySubsetData <TopologyElementType, VecT>::removeOnMovedPosition(const sofa::type::vector<Index>&)
 {
-    dmsg_error("TopologySubsetData") << "removeOnMovedPosition event on topology subsetData is not yet handled";
+    dmsg_error(this->getOwner()) << "TopologySubsetData: " << this->getName() << " removeOnMovedPosition event on topology subsetData is not yet handled";
 }
 
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -219,7 +219,7 @@ void TopologySubsetData <TopologyElementType, VecT>::swapPostProcess(Index i1, I
 {
     if (i1 >= m_map2Elements.size() || i2 >= m_map2Elements.size())
     {
-        msg_warning(this->getOwner()) << "TopologySubsetData: " << this->getName() << " swap indices out of bouds: i1: " << i1 << " | i2: " << i2 << " out of m_map2Elements size: " << m_map2Elements.size();
+        msg_warning(this->getOwner()) << "TopologySubsetData: " << this->getName() << " swap indices out of bounds: i1: " << i1 << " | i2: " << i2 << " out of m_map2Elements size: " << m_map2Elements.size();
         return;
     }
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -46,7 +46,7 @@ void TopologySubsetData <TopologyElementType, VecT>::swap(Index i1, Index i2)
     
     if (i1 >= data.size() || i2 >= data.size())
     {
-        msg_warning(this->getOwner()) << "TopologySubsetData: " << this->getName() << " swap indices out of bouds: i1: " << i1 << " | i2: " << i2 << " out of data size: " << data.size();
+        msg_warning(this->getOwner()) << "TopologySubsetData: " << this->getName() << " swap indices out of bounds: i1: " << i1 << " | i2: " << i2 << " out of data size: " << data.size();
         this->endEdit();
         return;
     }

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
@@ -34,9 +34,9 @@ TopologySubsetIndices::TopologySubsetIndices(const typename sofa::core::topology
 
 }
 
-Index TopologySubsetIndices::indexOfElement(Index index)
+Index TopologySubsetIndices::indexOfElement(Index index) const
 {
-    const container_type& data = this->getValue();
+    const container_type& data = m_value.getValue();
     for (Index idElem = 0; idElem < data.size(); idElem++)
     {
         if (data[idElem] == index)

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
@@ -45,7 +45,7 @@ public:
     /// Default Constructor to init Data
     explicit TopologySubsetIndices(const typename sofa::core::topology::BaseTopologyData< type::vector<Index> >::InitData& data);
     
-    Index indexOfElement(Index index) override;
+    Index indexOfElement(Index index) const override;
 
     void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology) override;
 


### PR DESCRIPTION
During remove process inside `TopologySubsetData`  the current Data was being modified but the method `TopologySubsetIndices::indexOfElement` was also called.
This method was using: 
`const container_type& data = this->getValue();`  which call updateIfDirty messing WriteAccessor in the caller method.
Fix it by using directly: `const container_type& data = m_value.getValue();`

The others modifications are just better logs for debug.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
