### PR TITLE
[Topology] Update getLastElementIndex in TopologySubsetIndices

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/topology/BaseTopologyData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseTopologyData.h
@@ -119,7 +119,7 @@ public:
     }
 
     /// Return the last element index of the topolgy buffer this Data is linked to. @sa m_lastElementIndex
-    Index getLastElementIndex() const { return m_lastElementIndex; }
+    virtual Index getLastElementIndex() const { return m_lastElementIndex; }
 
 protected:
     /// Pointer to the Topology this TopologyData is depending on

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -163,6 +163,9 @@ void TopologySubsetData <TopologyElementType, VecT>::remove(const sofa::type::ve
 {
     helper::WriteOnlyAccessor<Data<container_type> > data = this;
     
+    // Update last element index before removing elements. Warn is sent before updating Topology buffer
+    Index lastTopoElemId = this->getLastElementIndex();
+    
     // check for each element index to remove if it concern this subsetData
     for (Index elemId : index)
     {
@@ -187,12 +190,15 @@ void TopologySubsetData <TopologyElementType, VecT>::remove(const sofa::type::ve
         }
 
         // Need to check if last element index is in the map. If yes need to replace that value to follow topological changes
-        dataId = this->indexOfElement(this->m_lastElementIndex);
+        if (lastTopoElemId == sofa::InvalidID)
+            continue;
+
+        dataId = this->indexOfElement(lastTopoElemId);
         if (dataId != sofa::InvalidID)
         {
             updateLastIndex(dataId, elemId);
         }
-        this->m_lastElementIndex--;
+        lastTopoElemId--;
     }
 }
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
@@ -51,6 +51,11 @@ void TopologySubsetIndices::createTopologyHandler(sofa::core::topology::BaseMesh
     this->Inherit::createTopologyHandler(_topology);
 }
 
+Index TopologySubsetIndices::getLastElementIndex() const
+{
+    auto nbr = Index(m_topology->getNbPoints());
+    return (nbr == 0) ? sofa::InvalidID : nbr - 1;
+}
 
 void TopologySubsetIndices::swapPostProcess(Index i1, Index i2)
 {

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
@@ -49,6 +49,8 @@ public:
 
     void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology) override;
 
+    Index getLastElementIndex() const override;
+
 protected:
     void swapPostProcess(Index i1, Index i2) override;
 


### PR DESCRIPTION
TopologySubsetIndices can be initialized before their corresponding TopologyContainer is total init depending on the component graph order.
Therefor the member `m_lastElementIndex` used to store the size of the TopologyBuffer could be set to 0.

Override the method `getLastElementIndex() ` in `TopologySubsetIndices` (and put it in const) to get the number of points as a TopologySubsetIndices is always used on the Point topology. This method is called before removing elements to make sure we use and up to date value of m_lastElementIndex before doing any process.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
