### PR TITLE
[SofaCarving] Some cleaning in carvingManager to use link instead of string and clean warning in scenes

### DIFF
--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "CarvingManager.h"
+#include <SofaCarving/CarvingManager.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/collision/DetectionOutput.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
@@ -81,9 +81,6 @@ void CarvingManager::init()
         m_surfaceCollisionModels.push_back(getContext()->get<core::CollisionModel>(d_surfaceModelPath.getValue()));
     }
 
-    m_intersectionMethod = getContext()->get<core::collision::Intersection>();
-    m_detectionNP = getContext()->get<core::collision::NarrowPhaseDetection>();
-
     m_carvingReady = true;
 
     if (m_toolCollisionModel == nullptr) { 
@@ -96,8 +93,7 @@ void CarvingManager::init()
         m_carvingReady = false; 
     }
 
-    if (m_intersectionMethod == nullptr) { msg_error() << "m_intersectionMethod not found. Add an Intersection method in your scene."; m_carvingReady = false; }
-    if (m_detectionNP == nullptr) { msg_error() << "NarrowPhaseDetection not found. Add a NarrowPhaseDetection method in your scene."; m_carvingReady = false; }
+    if (l_detectionNP.get()) { msg_error() << "NarrowPhaseDetection not found. Add a NarrowPhaseDetection method in your scene."; m_carvingReady = false; }
     
     if (m_carvingReady) { msg_info() << "CarvingManager: init OK."; }
 }
@@ -115,7 +111,7 @@ void CarvingManager::doCarve()
         return;
 
     // get the collision output
-    const core::collision::NarrowPhaseDetection::DetectionOutputMap& detectionOutputs = m_detectionNP->getDetectionOutputs();
+    const core::collision::NarrowPhaseDetection::DetectionOutputMap& detectionOutputs = l_detectionNP.get()->getDetectionOutputs();
     if (detectionOutputs.size() == 0)
         return;
 

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -34,22 +34,16 @@
 #include <sofa/gui/component/performer/TopologicalChangeManager.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
 
-namespace sofa
+namespace sofa::component::collision
 {
 
-namespace component
-{
-
-namespace collision
-{
-
-int CarvingManagerClass = core::RegisterObject("Manager handling carving operations between a tool and an object.")
+const int CarvingManagerClass = core::RegisterObject("Manager handling carving operations between a tool and an object.")
 .add< CarvingManager >()
 ;
 
 
 CarvingManager::CarvingManager()
-    : d_toolModelPath( initData(&d_toolModelPath, "toolModelPath", "Tool model path"))
+    : l_toolModel(initLink("toolModel", "link to the carving collision model, if not set, manager wi will search for a collision model with tag: CarvingTool"))
     , d_surfaceModelPath( initData(&d_surfaceModelPath, "surfaceModelPath", "TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path"))
     , d_carvingDistance( initData(&d_carvingDistance, 0.0, "carvingDistance", "Collision distance at which cavring will start. Equal to contactDistance by default."))
     , d_active( initData(&d_active, false, "active", "Activate this object.\nNote that this can be dynamically controlled by using a key") )
@@ -58,30 +52,22 @@ CarvingManager::CarvingManager()
     , d_mouseEvent( initData(&d_mouseEvent, true, "mouseEvent", "Activate carving with middle mouse button") )
     , d_omniEvent( initData(&d_omniEvent, true, "omniEvent", "Activate carving with omni button") )
     , d_activatorName(initData(&d_activatorName, "button1", "activatorName", "Name to active the script event parsing. Will look for 'pressed' or 'release' keyword. For example: 'button1_pressed'"))
-    , m_toolCollisionModel(nullptr)
-    , m_intersectionMethod(nullptr)
-    , m_detectionNP(nullptr)
-    , m_carvingReady(false)
 {
     this->f_listening.setValue(true);
 }
 
 
-CarvingManager::~CarvingManager()
-{
-}
-
 
 void CarvingManager::init()
 {
     // Search for collision model corresponding to the tool.
-    if (d_toolModelPath.getValue().empty())
+    if (l_toolModel.empty())
     {
-        m_toolCollisionModel = getContext()->get<core::CollisionModel>(core::objectmodel::Tag("CarvingTool"), core::objectmodel::BaseContext::SearchDown);
+        m_toolCollisionModel = getContext()->get<core::CollisionModel>(core::objectmodel::Tag("CarvingTool"), core::objectmodel::BaseContext::SearchRoot);
     }
     else
     {
-        m_toolCollisionModel = getContext()->get<core::CollisionModel>(d_toolModelPath.getValue());
+        m_toolCollisionModel = l_toolModel.get();
     }
 
     // Search for the surface collision model.
@@ -89,7 +75,6 @@ void CarvingManager::init()
     {
         // We look for a CollisionModel identified with the CarvingSurface Tag.
         getContext()->get<core::CollisionModel>(&m_surfaceCollisionModels, core::objectmodel::Tag("CarvingSurface"), core::objectmodel::BaseContext::SearchRoot);
-
     }
     else
     {
@@ -252,8 +237,4 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
 
 }
 
-} // namespace collision
-
-} // namespace component
-
-} // namespace sofa
+} // namespace sofa::component::collision

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -61,7 +61,7 @@ CarvingManager::CarvingManager()
 void CarvingManager::init()
 {
     // Search for collision model corresponding to the tool.
-    if (l_toolModel.empty())
+    if (l_toolModel.get())
     {
         m_toolCollisionModel = getContext()->get<core::CollisionModel>(core::objectmodel::Tag("CarvingTool"), core::objectmodel::BaseContext::SearchRoot);
     }

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -43,7 +43,8 @@ const int CarvingManagerClass = core::RegisterObject("Manager handling carving o
 
 
 CarvingManager::CarvingManager()
-    : l_toolModel(initLink("toolModel", "link to the carving collision model, if not set, manager will search for a collision model with tag: CarvingTool"))
+    : l_toolModel(initLink("toolModel", "link to the carving collision model, if not set, manager will search for a collision model with tag: CarvingTool."))
+    , l_detectionNP(initLink("narrowPhaseDetection", "link to the narrow Phase Detection component, if not set, manager will search for it in root Node."))
     , d_surfaceModelPath( initData(&d_surfaceModelPath, "surfaceModelPath", "TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path"))
     , d_carvingDistance( initData(&d_carvingDistance, 0.0, "carvingDistance", "Collision distance at which cavring will start. Equal to contactDistance by default."))
     , d_active( initData(&d_active, false, "active", "Activate this object.\nNote that this can be dynamically controlled by using a key") )
@@ -68,8 +69,6 @@ void CarvingManager::init()
         auto toolCollisionModel = getContext()->get<core::CollisionModel>(core::objectmodel::Tag("CarvingTool"), core::objectmodel::BaseContext::SearchRoot);
         if (toolCollisionModel != nullptr)
             l_toolModel.set(toolCollisionModel);
-
-
     }
 
     // Search for the surface collision model.
@@ -104,9 +103,9 @@ void CarvingManager::init()
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
     }
 
-    if (l_detectionNP.get()) 
+    if (l_detectionNP.get() == nullptr)
     { 
-        msg_error() << "NarrowPhaseDetection not found. Add a NarrowPhaseDetection method in your scene."; 
+        msg_error() << "NarrowPhaseDetection not found. Add a NarrowPhaseDetection method in your scene and link it using narrowPhaseDetection field."; 
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
     }
 }

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -43,7 +43,7 @@ const int CarvingManagerClass = core::RegisterObject("Manager handling carving o
 
 
 CarvingManager::CarvingManager()
-    : l_toolModel(initLink("toolModel", "link to the carving collision model, if not set, manager wi will search for a collision model with tag: CarvingTool"))
+    : l_toolModel(initLink("toolModel", "link to the carving collision model, if not set, manager will search for a collision model with tag: CarvingTool"))
     , d_surfaceModelPath( initData(&d_surfaceModelPath, "surfaceModelPath", "TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path"))
     , d_carvingDistance( initData(&d_carvingDistance, 0.0, "carvingDistance", "Collision distance at which cavring will start. Equal to contactDistance by default."))
     , d_active( initData(&d_active, false, "active", "Activate this object.\nNote that this can be dynamically controlled by using a key") )

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -118,6 +118,7 @@ void CarvingManager::doCarve()
     sofa::helper::ScopedAdvancedTimer timer("CarvingElems");
 
     // loop on the contact to get the one between the CarvingSurface and the CarvingTool collision model
+    const SReal& carvDist = d_carvingDistance.getValue();
     const ContactVector* contacts = NULL;
     for (core::collision::NarrowPhaseDetection::DetectionOutputMap::const_iterator it = detectionOutputs.begin(); it != detectionOutputs.end(); ++it)
     {
@@ -156,7 +157,7 @@ void CarvingManager::doCarve()
         {
             const ContactVector::value_type& c = (*contacts)[j];
 
-            if (c.value < d_carvingDistance.getValue())
+            if (c.value < carvDist)
             {
                 auto elementIdx = (c.elem.first.getCollisionModel() == m_toolCollisionModel ? c.elem.second.getIndex() : c.elem.first.getIndex());
                 elemsToRemove.push_back(elementIdx);

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -99,9 +99,6 @@ public:
     Data < std::string > d_activatorName;
     
 protected:
-    /// Pointer to the tool collision model
-    core::CollisionModel* m_toolCollisionModel = nullptr;
-
     // Pointer to the target object collision model
     std::vector<core::CollisionModel*> m_surfaceCollisionModels;
 

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -34,13 +34,7 @@
 
 #include <fstream>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace collision
+namespace sofa::component::collision
 {
 
 /**
@@ -53,12 +47,8 @@ class SOFA_SOFACARVING_API CarvingManager : public core::behavior::BaseControlle
 {
 public:
 	SOFA_CLASS(CarvingManager,sofa::core::behavior::BaseController);
-
-	typedef defaulttype::Vec3Types DataTypes;
-    typedef DataTypes::Coord Coord;
-    typedef DataTypes::Real Real;
     
-    typedef type::vector<core::collision::DetectionOutput> ContactVector;
+    using ContactVector = type::vector<core::collision::DetectionOutput>;
     
     /// Sofa API init method of the component
     void init() override;
@@ -77,17 +67,22 @@ protected:
     CarvingManager();
 
     /// Default destructor
-    ~CarvingManager() override;
+    ~CarvingManager() override {};
 
 
 public:
     /// Tool model path
+    // link to the forceFeedBack component, if not set will search through graph and take first one encountered
+    SingleLink<CarvingManager, core::CollisionModel, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_toolModel;
+
+    //SingleLink<CarvingManager, core::CollisionModel, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_surfaceModel;
+
     Data < std::string > d_toolModelPath; 
     /// TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path
     Data < std::string > d_surfaceModelPath;
 
     /// Collision distance at which cavring will start. Equal to contactDistance by default.
-    Data < Real > d_carvingDistance;
+    Data < SReal > d_carvingDistance;
     
     ///< Activate this object. Note that this can be dynamically controlled by using a key
     Data < bool > d_active;
@@ -104,25 +99,21 @@ public:
     
 protected:
     /// Pointer to the tool collision model
-    core::CollisionModel* m_toolCollisionModel;
+    core::CollisionModel* m_toolCollisionModel = nullptr;
 
     // Pointer to the target object collision model
     std::vector<core::CollisionModel*> m_surfaceCollisionModels;
 
     // Pointer to the scene intersection Method component
-    core::collision::Intersection* m_intersectionMethod;
+    core::collision::Intersection* m_intersectionMethod = nullptr;
     // Pointer to the scene detection Method component (Narrow phase only)
-    core::collision::NarrowPhaseDetection* m_detectionNP;
+    core::collision::NarrowPhaseDetection* m_detectionNP = nullptr;
 
     // Bool to store the information if component has well be init and can be used.
-    bool m_carvingReady;
+    bool m_carvingReady = false;
     
 };
 
-} // namespace collision
-
-} // namespace component
-
-} // namespace sofa
+} // namespace sofa::component::collision
 
 #endif

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -51,8 +51,6 @@ public:
     
     /// Sofa API init method of the component
     void init() override;
-    /// Sofa API reset method of the component
-    void reset() override;
 
     /// Method to handle various event like keyboard or omni.
     void handleEvent(sofa::core::objectmodel::Event* event) override;
@@ -101,10 +99,7 @@ public:
 protected:
     // Pointer to the target object collision model
     std::vector<core::CollisionModel*> m_surfaceCollisionModels;
-
-    // Bool to store the information if component has been initialized and can be used.
-    bool m_carvingReady = false;
-    
+   
 };
 
 } // namespace sofa::component::collision

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -75,8 +75,6 @@ public:
     // link to the forceFeedBack component, if not set will search through graph and take first one encountered
     SingleLink<CarvingManager, core::CollisionModel, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_toolModel;
 
-    //SingleLink<CarvingManager, core::CollisionModel, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_surfaceModel;
-
     Data < std::string > d_toolModelPath; 
     /// TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path
     Data < std::string > d_surfaceModelPath;

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -75,8 +75,6 @@ public:
     // link to the scene detection Method component (Narrow phase only)
     SingleLink<CarvingManager, core::collision::NarrowPhaseDetection, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_detectionNP;
 
-
-    Data < std::string > d_toolModelPath; 
     /// TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path
     Data < std::string > d_surfaceModelPath;
 

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_COLLISION_CARVINGMANAGER_H
-#define SOFA_COMPONENT_COLLISION_CARVINGMANAGER_H
+#pragma once
 
 #include <SofaCarving/config.h>
 #include <sofa/core/behavior/MechanicalState.h>
@@ -75,6 +74,10 @@ public:
     // link to the forceFeedBack component, if not set will search through graph and take first one encountered
     SingleLink<CarvingManager, core::CollisionModel, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_toolModel;
 
+    // link to the scene detection Method component (Narrow phase only)
+    SingleLink<CarvingManager, core::collision::NarrowPhaseDetection, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_detectionNP;
+
+
     Data < std::string > d_toolModelPath; 
     /// TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path
     Data < std::string > d_surfaceModelPath;
@@ -102,16 +105,9 @@ protected:
     // Pointer to the target object collision model
     std::vector<core::CollisionModel*> m_surfaceCollisionModels;
 
-    // Pointer to the scene intersection Method component
-    core::collision::Intersection* m_intersectionMethod = nullptr;
-    // Pointer to the scene detection Method component (Narrow phase only)
-    core::collision::NarrowPhaseDetection* m_detectionNP = nullptr;
-
     // Bool to store the information if component has been initialized and can be used.
     bool m_carvingReady = false;
     
 };
 
 } // namespace sofa::component::collision
-
-#endif

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -79,7 +79,7 @@ public:
     /// TriangleSetModel or SphereCollisionModel<sofa::defaulttype::Vec3Types> path
     Data < std::string > d_surfaceModelPath;
 
-    /// Collision distance at which cavring will start. Equal to contactDistance by default.
+    /// Collision distance at which carving will start. Equal to contactDistance by default.
     Data < SReal > d_carvingDistance;
     
     ///< Activate this object. Note that this can be dynamically controlled by using a key

--- a/applications/plugins/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/CarvingManager.h
@@ -107,7 +107,7 @@ protected:
     // Pointer to the scene detection Method component (Narrow phase only)
     core::collision::NarrowPhaseDetection* m_detectionNP = nullptr;
 
-    // Bool to store the information if component has well be init and can be used.
+    // Bool to store the information if component has been initialized and can be used.
     bool m_carvingReady = false;
     
 };

--- a/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
+++ b/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
@@ -65,10 +65,11 @@ bool SofaCarving_test::createScene(const std::string& carvingDistance)
     m_root->setDt(0.01);
 
     // create collision pipeline
+    createObject(m_root, "DefaultAnimationLoop", { { "name","DefaultAnimationLoop " } });
     createObject(m_root, "CollisionPipeline", { { "name","Collision Pipeline" } });
     createObject(m_root, "BruteForceBroadPhase", { { "name","Broad Phase Detection" } });
     createObject(m_root, "BVHNarrowPhase", { { "name","Narrow Phase Detection" } });
-    createObject(m_root, "CollisionResponse", {
+    createObject(m_root, "DefaultContactManager", {
         { "name", "Contact Manager" },
         { "response", "PenalityContactForceField" }
     });

--- a/applications/plugins/SofaCarving/examples/CarvingTool.scn
+++ b/applications/plugins/SofaCarving/examples/CarvingTool.scn
@@ -1,24 +1,26 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.05" showBoundingTree="0" gravity="0 0 0">
-    <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
-    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
-    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
-    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
-    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
-    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
-    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
-    <RequiredPlugin name="Sofa.Component.Mapping.NonLinear"/> <!-- Needed to use components [RigidMapping] -->  
-    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
-    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
-    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader, MeshOBJLoader] -->  
-    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
-    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint, LinearMovementConstraint] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, TriangleCollisionModel] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
+    <Node name="RequiredPlugins">
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, TriangleCollisionModel] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint, LinearMovementConstraint] -->  
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader, MeshOBJLoader] -->  
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
+        <RequiredPlugin name="Sofa.Component.Mapping.NonLinear"/> <!-- Needed to use components [RigidMapping] -->  
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
+        <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
+        <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
+    <Node/>
 
   <VisualStyle displayFlags="" />
   <DefaultPipeline verbose="0" />

--- a/applications/plugins/SofaCarving/examples/CarvingTool.scn
+++ b/applications/plugins/SofaCarving/examples/CarvingTool.scn
@@ -1,11 +1,24 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.05" showBoundingTree="0" gravity="0 0 0">
-  <RequiredPlugin name="SofaOpenglVisual"/>
-  <RequiredPlugin name="Carving" pluginName="SofaCarving" />
-  <RequiredPlugin name='SofaGeneralSimpleFem'/>
-  <RequiredPlugin name='SofaTopologyMapping'/>
-  <RequiredPlugin name='SofaEngine'/>
-  <RequiredPlugin name='SofaImplicitOdeSolver'/>
+    <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
+    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
+    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
+    <RequiredPlugin name="Sofa.Component.Mapping.NonLinear"/> <!-- Needed to use components [RigidMapping] -->  
+    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
+    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
+    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader, MeshOBJLoader] -->  
+    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
+    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint, LinearMovementConstraint] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, TriangleCollisionModel] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
 
   <VisualStyle displayFlags="" />
   <DefaultPipeline verbose="0" />

--- a/applications/plugins/SofaCarving/examples/CarvingTool.scn
+++ b/applications/plugins/SofaCarving/examples/CarvingTool.scn
@@ -22,59 +22,63 @@
         <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
     </Node>
 
-  <VisualStyle displayFlags="" />
-  <DefaultPipeline verbose="0" />
-  <BruteForceBroadPhase/>
-    <BVHNarrowPhase/>
-  <DefaultContactManager response="PenalityContactForceField" />
-  <MinProximityIntersection name="Proximity" alarmDistance="0.08" contactDistance="0.05" useSurfaceNormals="false"/>
+    <VisualStyle displayFlags="" />
+    <DefaultAnimationLoop />
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase name="narrowPhase"/>
+    <DefaultContactManager response="PenalityContactForceField" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.08" contactDistance="0.05" useSurfaceNormals="false"/>
 
-  <CarvingManager active="true" carvingDistance="-0.01"/>
+    <CarvingManager active="true" carvingDistance="-0.01" narrowPhaseDetection="@narrowPhase" toolModel="@Instrument/CollisionModel/ParticleModel"/>
 
-  <Node name="TT">
-    <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-    <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-    <MeshGmshLoader filename="mesh/cylinder_8x30x6.msh" name="loader" scale="100"/>
-    <MechanicalObject src="@loader" name="Volume" />
-    <include href="Objects/TetrahedronSetTopology.xml" src="@loader" />
-    <DiagonalMass massDensity="0.5" />
-	
-    <BoxROI name="ROI1" box="-1 -1 -1 1 1 0.01" drawBoxes="1" />
-    <FixedConstraint indices="@ROI1.indices" />
-	
-    <TetrahedralCorotationalFEMForceField name="CFEM" youngModulus="160" poissonRatio="0.3" method="large" />
-	
-    <Node name="T">
-      <include href="Objects/TriangleSetTopology.xml" />
-      <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
-      <TriangleCollisionModel tags="CarvingSurface"/>
-      <Node name="Visu">
-        <OglModel name="Visual" material="Default Diffuse 1 0 1 0 1 Ambient 0 1 1 1 1 Specular 1 1 1 0 1 Emissive 0 1 1 0 1 Shininess 1 100"/>
-        <IdentityMapping input="@../../Volume" output="@Visual" />
-      </Node>
-    </Node>
-  </Node>
+    <Node name="TT">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <MeshGmshLoader filename="mesh/cylinder_8x30x6.msh" name="loader" scale="100"/>
+        <MechanicalObject src="@loader" name="Volume" />
+        <TetrahedronSetTopologyContainer  name="Container" src="@loader"/>
+        <TetrahedronSetTopologyModifier   name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
+        <DiagonalMass massDensity="0.5" />
 
-  <Node 	name="Instrument"  >
-    <EulerImplicitSolver name="cg_odesolver" printLog="false" />
-    <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <BoxROI name="ROI1" box="-1 -1 -1 1 1 0.01" drawBoxes="1" />
+        <FixedConstraint indices="@ROI1.indices" />
 
-    <MechanicalObject template="Rigid3d" name="instrumentState" tags="Omni" rotation="90 45 0" translation="0 0 1"/>
-    <UniformMass template="Rigid3d" name="mass"  totalMass="0.05" />
-    <LinearMovementConstraint template="Rigid3d" keyTimes="0 2" movements="0 0 0   0 0 0
-										      0 0 0   0 0 0" />
-    <Node 	name="VisualModel" >
-      <MeshOBJLoader name="meshLoader_0" filename="mesh/dental_instrument_light.obj" scale3d="1 1 1" translation="-0.412256 -0.067639 3.35" rotation="180 0 150" handleSeams="1" />
-      <OglModel template="ExtVec3f"  name="InstrumentVisualModel" src="@meshLoader_0" material="Default Diffuse 1 1 0.2 0.2 1 Ambient 1 0.2 0.04 0.04 1 Specular 0 1 0.2 0.2 1 Emissive 0 1 0.2 0.2 1 Shininess 0 45" />
-      <RigidMapping template="Rigid,ExtVec3f" name="MM->VM mapping"  input="@instrumentState"  output="@InstrumentVisualModel" />
-    </Node>
-	
-    <Node 	name="CollisionModel"  >
-      <MechanicalObject template="Vec3d" name="Particle"  position="-0.2 -0.2 -0.2" />
-      <PointCollisionModel name="ParticleModel" contactStiffness="2" tags="CarvingTool" />
-      <RigidMapping template="Rigid,Vec3d" name="MM->CM mapping"  input="@instrumentState"  output="@Particle" />
+        <TetrahedralCorotationalFEMForceField name="CFEM" youngModulus="160" poissonRatio="0.3" method="large" />
+
+        <Node name="T">
+            <TriangleSetTopologyContainer  name="Container"/>
+            <TriangleSetTopologyModifier   name="Modifier" />
+            <TriangleSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <TriangleCollisionModel tags="CarvingSurface"/>
+            <Node name="Visu">
+                <OglModel name="Visual" material="Default Diffuse 1 0 1 0 1 Ambient 0 1 1 1 1 Specular 1 1 1 0 1 Emissive 0 1 1 0 1 Shininess 1 100"/>
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
     </Node>
 
-  </Node>
+    <Node name="Instrument"  >
+        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
 
+        <MechanicalObject template="Rigid3d" name="instrumentState" tags="Omni" rotation="90 45 0" translation="0 0 1"/>
+        <UniformMass template="Rigid3d" name="mass"  totalMass="0.05" />
+        <LinearMovementConstraint template="Rigid3d" keyTimes="0 2" movements="0 0 0   0 0 0
+                                          0 0 0   0 0 0" />
+        <Node name="VisualModel" >
+            <MeshOBJLoader name="meshLoader_0" filename="mesh/dental_instrument_light.obj" scale3d="1 1 1" translation="-0.412256 -0.067639 3.35" rotation="180 0 150" handleSeams="1" />
+            <OglModel template="Vec3d"  name="InstrumentVisualModel" src="@meshLoader_0" material="Default Diffuse 1 1 0.2 0.2 1 Ambient 1 0.2 0.04 0.04 1 Specular 0 1 0.2 0.2 1 Emissive 0 1 0.2 0.2 1 Shininess 0 45" />
+            <RigidMapping template="Rigid3d,Vec3d" name="MM->VM mapping"  input="@instrumentState"  output="@InstrumentVisualModel" />
+        </Node>
+
+        <Node name="CollisionModel"  >
+            <MechanicalObject template="Vec3d" name="Particle"  position="-0.2 -0.2 -0.2" />
+            <PointCollisionModel name="ParticleModel" contactStiffness="2" tags="CarvingTool" />
+            <RigidMapping template="Rigid3d,Vec3d" name="MM->CM mapping"  input="@instrumentState"  output="@Particle" />
+        </Node>
+    </Node>
+    
 </Node>

--- a/applications/plugins/SofaCarving/examples/CarvingTool.scn
+++ b/applications/plugins/SofaCarving/examples/CarvingTool.scn
@@ -20,7 +20,7 @@
         <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
         <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
         <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
-    <Node/>
+    </Node>
 
   <VisualStyle displayFlags="" />
   <DefaultPipeline verbose="0" />

--- a/applications/plugins/SofaCarving/examples/SimpleCarving.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving.scn
@@ -21,43 +21,48 @@
         <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
     </Node>
 
-  <VisualStyle displayFlags="showCollisionModels" />
-  
-  <DefaultPipeline verbose="0" />
-  <BruteForceBroadPhase/>
-  <BVHNarrowPhase/>
-  <DefaultContactManager response="PenalityContactForceField" />
-  <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.02"/>
-  
-  <CarvingManager active="true" carvingDistance="0.0"/>
+    <VisualStyle displayFlags="showCollisionModels" />
 
-  <EulerImplicitSolver name="EulerImplicit"  rayleighStiffness="0.1" rayleighMass="0.1" />
-  <CGLinearSolver name="CG Solver" iterations="25" tolerance="1e-9" threshold="1e-9"/>
-  
-  <Node name="Cylinder">
-	<MeshGmshLoader filename="mesh/cylinder.msh" name="loader" />
-    <MechanicalObject src="@loader" name="Volume" />
-    <include href="Objects/TetrahedronSetTopology.xml" src="@loader" />
-    <DiagonalMass massDensity="0.01" />
-	<BoxROI name="ROI1" box="-1 -1 -1 1 1 0.01" drawBoxes="1" />
-    <FixedConstraint indices="@ROI1.indices" />
-    <TetrahedralCorotationalFEMForceField name="CFEM" youngModulus="300" poissonRatio="0.3" method="large" />
-    <Node name="Surface">
-      <include href="Objects/TriangleSetTopology.xml" />
-      <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
-      <TriangleCollisionModel name="triangleCol" tags="CarvingSurface"/>
-	  <PointCollisionModel name="pointCol" tags="CarvingSurface"/>
-      <Node name="Visu">
-        <OglModel name="Visual" material="Default Diffuse 1 0 1 0 0.75 Ambient 0 1 1 1 1 Specular 1 1 1 0 1 Emissive 0 1 1 0 1 Shininess 1 100"/>
-        <IdentityMapping input="@../../Volume" output="@Visual" />
-      </Node>
+    <DefaultAnimationLoop />
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager response="PenalityContactForceField" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.02"/>
+
+    <CarvingManager active="true" carvingDistance="0.0"/>
+
+    <EulerImplicitSolver name="EulerImplicit"  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <CGLinearSolver name="CG Solver" iterations="25" tolerance="1e-9" threshold="1e-9"/>
+
+    <Node name="Cylinder">
+        <MeshGmshLoader filename="mesh/cylinder.msh" name="loader" />
+        <MechanicalObject src="@loader" name="Volume" />
+        <TetrahedronSetTopologyContainer  name="Container" src="@loader"/>
+        <TetrahedronSetTopologyModifier   name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
+        <DiagonalMass massDensity="0.01" />
+        <BoxROI name="ROI1" box="-1 -1 -1 1 1 0.01" drawBoxes="1" />
+        <FixedConstraint indices="@ROI1.indices" />
+        <TetrahedralCorotationalFEMForceField name="CFEM" youngModulus="300" poissonRatio="0.3" method="large" />
+        <Node name="Surface">
+            <TriangleSetTopologyContainer  name="Container"/>
+            <TriangleSetTopologyModifier   name="Modifier" />
+            <TriangleSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <TriangleCollisionModel name="triangleCol" tags="CarvingSurface"/>
+            <PointCollisionModel name="pointCol" tags="CarvingSurface"/>
+            <Node name="Visu">
+                <OglModel name="Visual" material="Default Diffuse 1 0 1 0 0.75 Ambient 0 1 1 1 1 Specular 1 1 1 0 1 Emissive 0 1 1 0 1 Shininess 1 100"/>
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
     </Node>
-  </Node>
 
-  
-  <Node name="carvingElement">
-		<MechanicalObject name="Particles" template="Vec3d" position="0 0 1.4" velocity="0 0 0"/>
-		<UniformMass name="Mass" totalMass="1.0" />
-		<SphereCollisionModel radius="0.02" tags="CarvingTool"/>
-  </Node>
+
+    <Node name="carvingElement">
+        <MechanicalObject name="Particles" template="Vec3d" position="0 0 1.4" velocity="0 0 0"/>
+        <UniformMass name="Mass" totalMass="1.0" />
+        <SphereCollisionModel radius="0.02" tags="CarvingTool"/>
+    </Node>
 </Node>

--- a/applications/plugins/SofaCarving/examples/SimpleCarving.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving.scn
@@ -19,7 +19,7 @@
         <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
         <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
         <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
-    <Node/>
+    </Node>
 
   <VisualStyle displayFlags="showCollisionModels" />
   

--- a/applications/plugins/SofaCarving/examples/SimpleCarving.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving.scn
@@ -1,23 +1,25 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.01" showBoundingTree="0" gravity="0 0 -0.9">
-    <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
-    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
-    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
-    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
-    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
-    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
-    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
-    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
-    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
-    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
-    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
-    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, SphereCollisionModel, TriangleCollisionModel] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
+    <Node name="RequiredPlugins">
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, SphereCollisionModel, TriangleCollisionModel] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
+        <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
+        <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
+    <Node/>
 
   <VisualStyle displayFlags="showCollisionModels" />
   

--- a/applications/plugins/SofaCarving/examples/SimpleCarving.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving.scn
@@ -1,11 +1,23 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.01" showBoundingTree="0" gravity="0 0 -0.9">
-  <RequiredPlugin name="SofaOpenglVisual"/>
-  <RequiredPlugin name="Carving" pluginName="SofaCarving" />
-  <RequiredPlugin name='SofaGeneralSimpleFem'/> 
-  <RequiredPlugin name='SofaTopologyMapping'/>
-  <RequiredPlugin name='SofaEngine'/>
-  <RequiredPlugin name='SofaImplicitOdeSolver'/>
+    <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
+    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
+    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
+    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
+    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
+    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
+    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
+    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, SphereCollisionModel, TriangleCollisionModel] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
 
   <VisualStyle displayFlags="showCollisionModels" />
   

--- a/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
@@ -19,7 +19,7 @@
         <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
         <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
         <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
-    <Node/>
+    </Node>
 
   <VisualStyle displayFlags="showCollisionModels" />
   

--- a/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
@@ -1,23 +1,25 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.01" showBoundingTree="0" gravity="0 0 -0.9">
-    <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
-    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
-    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
-    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
-    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
-    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
-    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
-    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
-    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
-    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
-    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
-    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, SphereCollisionModel, TriangleCollisionModel] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
+    <Node name="RequiredPlugins">
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, SphereCollisionModel, TriangleCollisionModel] -->  
+        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
+        <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
+        <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
+    <Node/>
 
   <VisualStyle displayFlags="showCollisionModels" />
   

--- a/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
@@ -21,43 +21,47 @@
         <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
     </Node>
 
-  <VisualStyle displayFlags="showCollisionModels" />
-  
-  <DefaultPipeline verbose="0" />
-  <BruteForceBroadPhase/>
-  <BVHNarrowPhase/>
-  <DefaultContactManager response="PenalityContactForceField" />
-  <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.02"/>
-  
-  <CarvingManager active="true" carvingDistance="-0.02"/>
+    <VisualStyle displayFlags="showCollisionModels" />
 
-  <EulerImplicitSolver name="EulerImplicit"  rayleighStiffness="0.1" rayleighMass="0.1" />
-  <CGLinearSolver name="CG Solver" iterations="25" tolerance="1e-9" threshold="1e-9"/>
-  
-  <Node name="Cylinder">
-	<MeshGmshLoader filename="mesh/cylinder.msh" name="loader" />
-    <MechanicalObject src="@loader" name="Volume" />
-    <include href="Objects/TetrahedronSetTopology.xml" src="@loader" />
-    <DiagonalMass massDensity="0.01" />
-	<BoxROI name="ROI1" box="-1 -1 -1 1 1 0.01" drawBoxes="1" />
-    <FixedConstraint indices="@ROI1.indices" />
-    <TetrahedralCorotationalFEMForceField name="CFEM" youngModulus="300" poissonRatio="0.3" method="large" />
-    <Node name="Surface">
-      <include href="Objects/TriangleSetTopology.xml" />
-      <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
-      <TriangleCollisionModel name="triangleCol" tags="CarvingSurface"/>
-	  <PointCollisionModel name="pointCol" tags="CarvingSurface"/>
-      <Node name="Visu">
-        <OglModel name="Visual" material="Default Diffuse 1 0 1 0 0.75 Ambient 0 1 1 1 1 Specular 1 1 1 0 1 Emissive 0 1 1 0 1 Shininess 1 100"/>
-        <IdentityMapping input="@../../Volume" output="@Visual" />
-      </Node>
+    <DefaultAnimationLoop />
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager response="PenalityContactForceField" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.02"/>
+
+    <CarvingManager active="true" carvingDistance="-0.02"/>
+
+    <EulerImplicitSolver name="EulerImplicit"  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <CGLinearSolver name="CG Solver" iterations="25" tolerance="1e-9" threshold="1e-9"/>
+
+    <Node name="Cylinder">
+        <MeshGmshLoader filename="mesh/cylinder.msh" name="loader" />
+        <MechanicalObject src="@loader" name="Volume" />
+        <TetrahedronSetTopologyContainer  name="Container" src="@loader"/>
+        <TetrahedronSetTopologyModifier   name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
+        <DiagonalMass massDensity="0.01" />
+        <BoxROI name="ROI1" box="-1 -1 -1 1 1 0.01" drawBoxes="1" />
+        <FixedConstraint indices="@ROI1.indices" />
+        <TetrahedralCorotationalFEMForceField name="CFEM" youngModulus="300" poissonRatio="0.3" method="large" />
+        <Node name="Surface">
+            <TriangleSetTopologyContainer  name="Container"/>
+            <TriangleSetTopologyModifier   name="Modifier" />
+            <TriangleSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <TriangleCollisionModel name="triangleCol" tags="CarvingSurface"/>
+            <PointCollisionModel name="pointCol" tags="CarvingSurface"/>
+            <Node name="Visu">
+                <OglModel name="Visual" material="Default Diffuse 1 0 1 0 0.75 Ambient 0 1 1 1 1 Specular 1 1 1 0 1 Emissive 0 1 1 0 1 Shininess 1 100"/>
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
     </Node>
-  </Node>
 
-  
-  <Node name="carvingElement">
-		<MechanicalObject name="Particles" template="Vec3d" position="0 0 1.4" velocity="0 0 0"/>
-		<UniformMass name="Mass" totalMass="1.0" />
-		<SphereCollisionModel radius="0.02" tags="CarvingTool"/>
-  </Node>
+    <Node name="carvingElement">
+        <MechanicalObject name="Particles" template="Vec3d" position="0 0 1.4" velocity="0 0 0"/>
+        <UniformMass name="Mass" totalMass="1.0" />
+        <SphereCollisionModel radius="0.02" tags="CarvingTool"/>
+    </Node>
 </Node>

--- a/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
+++ b/applications/plugins/SofaCarving/examples/SimpleCarving_withPenetration.scn
@@ -1,11 +1,23 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.01" showBoundingTree="0" gravity="0 0 -0.9">
-  <RequiredPlugin name="SofaOpenglVisual"/>
-  <RequiredPlugin name="Carving" pluginName="SofaCarving" />
-  <RequiredPlugin name='SofaGeneralSimpleFem'/> 
-  <RequiredPlugin name='SofaTopologyMapping'/>
-  <RequiredPlugin name='SofaEngine'/>
-  <RequiredPlugin name='SofaImplicitOdeSolver'/>
+    <RequiredPlugin name="SofaCarving"/> <!-- Needed to use components [CarvingManager] -->  
+    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
+    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->  
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms, TetrahedronSetTopologyContainer, TetrahedronSetTopologyModifier, TriangleSetGeometryAlgorithms, TriangleSetTopologyContainer, TriangleSetTopologyModifier] -->  
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->  
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass, UniformMass] -->  
+    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
+    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
+    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
+    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->  
+    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [PointCollisionModel, SphereCollisionModel, TriangleCollisionModel] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase, BruteForceBroadPhase, DefaultPipeline] -->  
 
   <VisualStyle displayFlags="showCollisionModels" />
   


### PR DESCRIPTION
- Update CarvingManager to use SingleLink instead of string path.
- Clean warnings in scenes
- Clean warnings in tests
- remove reset method
- use componentState value instead of bool m_carvingReady



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
