### PR TITLE
[Sofa.Helper] RAII for DrawTool state life cycle

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/DirectSAPNarrowPhase.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/DirectSAPNarrowPhase.cpp
@@ -372,7 +372,7 @@ void DirectSAPNarrowPhase::draw(const core::visual::VisualParams* vparams)
     if (!d_draw.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::RGBAColor> colors;
@@ -442,7 +442,6 @@ void DirectSAPNarrowPhase::draw(const core::visual::VisualParams* vparams)
     }
 
     vparams->drawTool()->drawLines(vertices, 3, colors);
-    vparams->drawTool()->restoreLastState();
 }
 
 inline void DSAPBox::show()const

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/RayTraceNarrowPhase.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/RayTraceNarrowPhase.cpp
@@ -234,7 +234,7 @@ void RayTraceNarrowPhase::draw (const core::visual::VisualParams* vparams)
     if (!bDraw.getValue ())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     constexpr sofa::type::RGBAColor color = sofa::type::RGBAColor::magenta();
@@ -265,7 +265,7 @@ void RayTraceNarrowPhase::draw (const core::visual::VisualParams* vparams)
         }
     }
     vparams->drawTool()->drawLines(vertices,3,color);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::collision::detection::algorithm

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayModel.cpp
@@ -101,11 +101,11 @@ void RayCollisionModel::draw(const core::visual::VisualParams* vparams, Index in
     const Vector3& p1 = r.origin();
     const Vector3 p2 = p1 + r.direction()*r.l();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
     constexpr sofa::type::RGBAColor color = sofa::type::RGBAColor::magenta();
     vparams->drawTool()->drawLine(p1,p2,color);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 void RayCollisionModel::draw(const core::visual::VisualParams* vparams)

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronModel.cpp
@@ -145,7 +145,7 @@ void TetrahedronCollisionModel::addTetraToDraw(const Tetrahedron& t, std::vector
 
 void TetrahedronCollisionModel::draw(const core::visual::VisualParams* vparams, Index index)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     std::vector<sofa::type::Vector3> tetraVertices;
     std::vector<sofa::type::Vector3> normalVertices;
@@ -156,12 +156,12 @@ void TetrahedronCollisionModel::draw(const core::visual::VisualParams* vparams, 
     const auto c = getColor4f();
     vparams->drawTool()->drawTetrahedra(tetraVertices, sofa::type::RGBAColor(c[0], c[1], c[2], c[3]));
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 void TetrahedronCollisionModel::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     if (mstate && m_topology && vparams->displayFlags().getShowCollisionModels())
     {
         if (vparams->displayFlags().getShowWireFrame())
@@ -193,7 +193,7 @@ void TetrahedronCollisionModel::draw(const core::visual::VisualParams* vparams)
     if (getPrevious()!=nullptr && vparams->displayFlags().getShowBoundingCollisionModels())
         getPrevious()->draw(vparams);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 void TetrahedronCollisionModel::computeBoundingTree(int maxDepth)

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeModel.cpp
@@ -42,7 +42,7 @@ TriangleOctreeModel::TriangleOctreeModel ()
 
 void TriangleOctreeModel::draw (const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     TriangleCollisionModel<sofa::defaulttype::Vec3Types>::draw(vparams);
     if (isActive () && vparams->displayFlags().getShowCollisionModels ())
@@ -63,7 +63,7 @@ void TriangleOctreeModel::draw (const core::visual::VisualParams* vparams)
             vparams->drawTool()->setPolygonMode(0, false);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 void TriangleOctreeModel::computeBoundingTree(int maxDepth)

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -787,7 +787,7 @@ void PrecomputedConstraintCorrection< DataTypes >::draw(const core::visual::Visu
     if (!vparams->displayFlags().getShowBehaviorModels() || !m_rotations.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     using sofa::core::behavior::RotationFinder;
 
@@ -826,7 +826,7 @@ void PrecomputedConstraintCorrection< DataTypes >::draw(const core::visual::Visu
 
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -514,7 +514,7 @@ void BilateralInteractionConstraint<DataTypes>::draw(const core::visual::VisualP
 {
     if (!vparams->displayFlags().getShowInteractionForceFields()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     constexpr sofa::type::RGBAColor colorActive = sofa::type::RGBAColor::magenta();
@@ -535,7 +535,7 @@ void BilateralInteractionConstraint<DataTypes>::draw(const core::visual::VisualP
 
     vparams->drawTool()->drawPoints(vertices, 10, (activated) ? colorActive : colorNotActive);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 //TODO(dmarchal): implementing keyboard interaction behavior directly in a component is not a valid

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingConstraint.inl
@@ -196,7 +196,7 @@ void SlidingConstraint<DataTypes>::draw(const core::visual::VisualParams* vparam
     if (!vparams->displayFlags().getShowInteractionForceFields())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     vparams->drawTool()->disableLighting();
 
@@ -220,7 +220,7 @@ void SlidingConstraint<DataTypes>::draw(const core::visual::VisualParams* vparam
     vertices.push_back(DataTypes::getCPos((this->mstate2->read(core::ConstVecCoordId::position())->getValue())[d_m2b.getValue()]));
     vparams->drawTool()->drawLines(vertices, 1, color);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::constraint::lagrangian::model

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
@@ -391,7 +391,7 @@ void UnilateralInteractionConstraint<DataTypes>::draw(const core::visual::Visual
 {
     if (!vparams->displayFlags().getShowInteractionForceFields()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::Vector3> redVertices;
@@ -418,7 +418,7 @@ void UnilateralInteractionConstraint<DataTypes>::draw(const core::visual::Visual
     vparams->drawTool()->drawLines(otherVertices, 3, otherColors);
 
 
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -1321,7 +1321,7 @@ void LCPConstraintSolver::draw(const core::visual::VisualParams* vparams)
     constexpr int merge_spatial_shift = 0; // merge_spatial_step/2
     const int merge_local_levels = this->merge_local_levels.getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // from http://colorexplorer.com/colormatch.aspx
     const unsigned int colors[72]= { 0x2F2FBA, 0x111145, 0x2FBA8C, 0x114534, 0xBA8C2F, 0x453411, 0x2F72BA, 0x112A45,
@@ -1417,7 +1417,6 @@ void LCPConstraintSolver::draw(const core::visual::VisualParams* vparams)
         coordFact *= merge_spatial_step;
 
     }
-    vparams->drawTool()->saveLastState();
 
 }
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AttachConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AttachConstraint.inl
@@ -608,7 +608,7 @@ void AttachConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     const SetIndexArray & indices1 = f_indices1.getValue();
@@ -637,7 +637,7 @@ void AttachConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams
         vertices.push_back(sofa::type::Vector3(x2[indices2[i]][0],x2[indices2[i]][1],x2[indices2[i]][2]));
     }
     vparams->drawTool()->drawLines(vertices,1,color2);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.cpp
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.cpp
@@ -69,7 +69,7 @@ void FixedConstraint<Rigid3Types>::draw(const core::visual::VisualParams* vparam
     if (!this->isActive()) return;
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const SetIndexArray & indices = d_indices.getValue();
     const VecCoord& x = mstate->read(core::ConstVecCoordId::position())->getValue();
@@ -100,7 +100,7 @@ void FixedConstraint<Rigid3Types>::draw(const core::visual::VisualParams* vparam
     else
         vparams->drawTool()->drawSpheres(points, (float)d_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template <>
@@ -111,7 +111,7 @@ void FixedConstraint<Rigid2Types>::draw(const core::visual::VisualParams* vparam
     if (!this->isActive()) return;
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const SetIndexArray& indices = d_indices.getValue();
     const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
@@ -132,7 +132,7 @@ void FixedConstraint<Rigid2Types>::draw(const core::visual::VisualParams* vparam
     }
 
     vparams->drawTool()->drawPoints(vertices, 10, color);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
@@ -353,7 +353,7 @@ void FixedConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (!d_showObject.getValue()) return;
     if (!this->isActive()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     const SetIndexArray & indices = d_indices.getValue();
@@ -404,7 +404,7 @@ void FixedConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
         vparams->drawTool()->drawSpheres(points, (float)d_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
@@ -177,7 +177,7 @@ void FixedTranslationConstraint<DataTypes>::draw(const core::visual::VisualParam
         return;
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::Vector3> vertices;
@@ -208,7 +208,7 @@ void FixedTranslationConstraint<DataTypes>::draw(const core::visual::VisualParam
         }
     }
     vparams->drawTool()->drawPoints(vertices, 10, color);
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
@@ -226,7 +226,7 @@ void HermiteSplineConstraint<DataTypes>::draw(const core::visual::VisualParams* 
     Real dt = (Real) this->getContext()->getDt();
     Real DT = m_tEnd.getValue() - m_tBegin.getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::Vector3> vertices;
@@ -265,7 +265,7 @@ void HermiteSplineConstraint<DataTypes>::draw(const core::visual::VisualParams* 
     vertices.push_back(mx1 + mdx1*0.1);
 
     vparams->drawTool()->drawLines(vertices, 1.0, sofa::type::RGBAColor::red());
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
@@ -396,7 +396,7 @@ void LinearMovementConstraint<DataTypes>::draw(const core::visual::VisualParams*
     if (!vparams->displayFlags().getShowBehaviorModels() || m_keyTimes.getValue().size() == 0)
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     constexpr sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
 
     if (showMovement.getValue())
@@ -458,7 +458,7 @@ void LinearMovementConstraint<DataTypes>::draw(const core::visual::VisualParams*
         vparams->drawTool()->drawPoints(points, 10, color);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearVelocityConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearVelocityConstraint.inl
@@ -316,7 +316,7 @@ template <class TDataTypes>
 void LinearVelocityConstraint<TDataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     if (!vparams->displayFlags().getShowBehaviorModels() || d_keyTimes.getValue().size() == 0 ) return;
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     vparams->drawTool()->disableLighting();
 
@@ -338,7 +338,7 @@ void LinearVelocityConstraint<TDataTypes>::draw(const core::visual::VisualParams
 
     vparams->drawTool()->drawLines(vertices, 1.0, color);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
@@ -213,7 +213,7 @@ void ParabolicConstraint<DataTypes>::projectJacobianMatrix(const core::Mechanica
 template <class DataTypes>
 void ParabolicConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
 
@@ -260,7 +260,7 @@ void ParabolicConstraint<DataTypes>::draw(const core::visual::VisualParams* vpar
 
     vparams->drawTool()->drawPoints(vertices, 5.0, color);
 
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.inl
@@ -450,7 +450,7 @@ void PartialLinearMovementConstraint<DataTypes>::applyConstraint(const core::Mec
 template <class DataTypes>
 void PartialLinearMovementConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (!vparams->displayFlags().getShowBehaviorModels() || m_keyTimes.getValue().size() == 0)
         return;
@@ -491,6 +491,6 @@ void PartialLinearMovementConstraint<DataTypes>::draw(const core::visual::Visual
         vparams->drawTool()->drawPoints(vertices, 10, color);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectDirectionConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectDirectionConstraint.inl
@@ -244,7 +244,7 @@ void ProjectDirectionConstraint<DataTypes>::draw(const core::visual::VisualParam
     if (!this->isActive()) return;
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const Indices & indices = f_indices.getValue();
 
@@ -270,7 +270,7 @@ void ProjectDirectionConstraint<DataTypes>::draw(const core::visual::VisualParam
         }
         vparams->drawTool()->drawSpheres(points, (float)f_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
     }
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToLineConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToLineConstraint.inl
@@ -248,7 +248,7 @@ void ProjectToLineConstraint<DataTypes>::draw(const core::visual::VisualParams* 
     if (!this->isActive()) return;
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const Indices & indices = f_indices.getValue();
 
@@ -277,7 +277,7 @@ void ProjectToLineConstraint<DataTypes>::draw(const core::visual::VisualParams* 
         }
         vparams->drawTool()->drawSpheres(points, (float)f_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
     }
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPlaneConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPlaneConstraint.inl
@@ -242,7 +242,7 @@ void ProjectToPlaneConstraint<DataTypes>::draw(const core::visual::VisualParams*
     if (!this->isActive()) return;
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const Indices & indices = f_indices.getValue();
 
@@ -270,7 +270,7 @@ void ProjectToPlaneConstraint<DataTypes>::draw(const core::visual::VisualParams*
         vparams->drawTool()->drawSpheres(points, (float)f_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPointConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPointConstraint.inl
@@ -287,7 +287,7 @@ void ProjectToPointConstraint<DataTypes>::draw(const core::visual::VisualParams*
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     const SetIndexArray & indices = f_indices.getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if( f_drawSize.getValue() == 0) // old classical drawing by points
     {
@@ -326,7 +326,7 @@ void ProjectToPointConstraint<DataTypes>::draw(const core::visual::VisualParams*
         vparams->drawTool()->drawSpheres(points, (float)f_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
+++ b/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
@@ -399,7 +399,7 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::draw(const core::visual::Visu
     if (!this->mstate)
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -482,7 +482,7 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::draw(const core::visual::Visu
         vparams->drawTool()->setPolygonMode(0, false);
 
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/ClusteringEngine.inl
+++ b/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/ClusteringEngine.inl
@@ -368,7 +368,7 @@ void ClusteringEngine<DataTypes>::draw(const core::visual::VisualParams* vparams
         if(this->mstate==nullptr)
             return;
 
-        vparams->drawTool()->saveLastState();
+        const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
         const VecCoord& currentPositions = this->mstate->read(core::ConstVecCoordId::position())->getValue();
         ReadAccessor< Data< VVI > > clust = this->d_cluster;
@@ -398,7 +398,7 @@ void ClusteringEngine<DataTypes>::draw(const core::visual::VisualParams* vparams
                 }
         }
         vparams->drawTool()->drawLines(vertices, 1.0, colors);
-        vparams->drawTool()->restoreLastState();
+
     }
 }
 

--- a/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
+++ b/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
@@ -696,7 +696,7 @@ void Distances< DataTypes >::getNeighbors ( const core::topology::BaseMeshTopolo
 template<class DataTypes>
 void Distances< DataTypes >::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     // Display the distance on each hexa of the grid
     if ( showDistanceMap.getValue() )
     {
@@ -712,7 +712,7 @@ void Distances< DataTypes >::draw(const core::visual::VisualParams* vparams)
             vparams->drawTool()->draw3DText(tmpPt, showTextScaleFactor.getValue(), color, oss.str().c_str());
         }
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/ExtrudeSurface.inl
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/ExtrudeSurface.inl
@@ -209,7 +209,7 @@ void ExtrudeSurface<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (!vparams->displayFlags().getShowBehaviorModels() || !isVisible.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     if (vparams->displayFlags().getShowWireFrame())
@@ -264,7 +264,7 @@ void ExtrudeSurface<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
     
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::engine::generate

--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/RandomPointDistributionInSurface.inl
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/RandomPointDistributionInSurface.inl
@@ -251,7 +251,7 @@ void RandomPointDistributionInSurface<DataTypes>::draw(const core::visual::Visua
     if (!vparams->displayFlags().getShowBehaviorModels() || !isVisible.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     
     const VecCoord& in = f_inPoints.getValue();
     const VecCoord& out = f_outPoints.getValue();
@@ -273,7 +273,7 @@ void RandomPointDistributionInSurface<DataTypes>::draw(const core::visual::Visua
         vparams->drawTool()->drawPoints(vertices, 5.0, sofa::type::RGBAColor::blue());
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::engine::generate

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/MeshROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/MeshROI.inl
@@ -593,7 +593,7 @@ void MeshROI<DataTypes>::draw(const VisualParams* vparams)
     if (!vparams->displayFlags().getShowBehaviorModels() && !this->d_drawSize.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     vparams->drawTool()->disableLighting();
 
@@ -740,7 +740,7 @@ void MeshROI<DataTypes>::draw(const VisualParams* vparams)
         vparams->drawTool()->drawLines(vertices, drawSize, sofa::type::RGBAColor(0.4f, 0.4f, 1.0f, 1.0f));
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::engine::select

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PairBoxRoi.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PairBoxRoi.inl
@@ -184,7 +184,7 @@ void PairBoxROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
 
     constexpr sofa::type::RGBAColor color(1.0f, 0.4f, 0.4f, 1.0f);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     /// Draw inclusive box
     if( p_drawInclusiveBox.getValue())
     {
@@ -228,7 +228,7 @@ void PairBoxROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
         }
         vparams->drawTool()->drawPoints(vertices, pointsWidth, color);
     }
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.inl
@@ -396,7 +396,7 @@ void PlaneROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     vparams->drawTool()->disableLighting();
 
@@ -534,7 +534,7 @@ void PlaneROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
         vparams->drawTool()->drawLines(vertices, _drawSize.getValue(), color);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::engine::select

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.inl
@@ -249,7 +249,7 @@ void ProximityROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     constexpr const sofa::type::RGBAColor& color = sofa::type::RGBAColor::cyan();
 
@@ -286,7 +286,7 @@ void ProximityROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
         vparams->drawTool()->drawPoints(vertices, 5.0, color);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::engine::select

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SphereROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SphereROI.inl
@@ -450,7 +450,7 @@ void SphereROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord* x0 = &f_X0.getValue();
     constexpr const sofa::type::RGBAColor& color = sofa::type::RGBAColor::cyan();
@@ -571,7 +571,7 @@ void SphereROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
         vparams->drawTool()->drawLines(vertices, _drawSize.getValue(), color);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.inl
@@ -784,7 +784,7 @@ void SubsetTopology<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord* x0 = &f_X0.getValue();
     constexpr const sofa::type::RGBAColor& color = sofa::type::RGBAColor::cyan();
@@ -868,7 +868,7 @@ void SubsetTopology<DataTypes>::draw(const core::visual::VisualParams* vparams)
         }
         vparams->drawTool()->drawLines(vertices, 1.0, color);
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.inl
@@ -402,7 +402,7 @@ void ValuesFromPositions<DataTypes>::updateVectors(TempData &_data)
 template <class DataTypes>
 void ValuesFromPositions<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (p_drawVectors.getValue())
     {
@@ -440,7 +440,7 @@ void ValuesFromPositions<DataTypes>::draw(const core::visual::VisualParams* vpar
         vparams->drawTool()->drawLines(vertices, 1.0, colors);
 
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::engine::select

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/SmoothMeshEngine.inl
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/SmoothMeshEngine.inl
@@ -162,7 +162,7 @@ void SmoothMeshEngine<DataTypes>::draw(const core::visual::VisualParams* vparams
     if (!vparams->displayFlags().getShowVisualModels() || m_topology == nullptr) return;
 
     using sofa::type::Vec;
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     bool wireframe=vparams->displayFlags().getShowWireFrame();
 
@@ -214,7 +214,7 @@ void SmoothMeshEngine<DataTypes>::draw(const core::visual::VisualParams* vparams
     if (wireframe)
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::engine::transform

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/TransformPosition.inl
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/TransformPosition.inl
@@ -472,7 +472,7 @@ void TransformPosition<DataTypes>::doUpdate()
 template <class DataTypes>
 void TransformPosition<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (f_drawInput.getValue())
     {
@@ -491,7 +491,7 @@ void TransformPosition<DataTypes>::draw(const core::visual::VisualParams* vparam
             points.push_back(out[i]);
         vparams->drawTool()->drawPoints(points, (float)f_pointSize.getValue(), sofa::type::RGBAColor(0.2f, 0.8f, 0.2f, 1.0f));
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.inl
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.inl
@@ -656,7 +656,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::draw(const core::visual::VisualP
     if (! vparams->displayFlags().getShowBehaviorModels()) return;
     if (mstate==nullptr) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = mstate->read(core::ConstVecCoordId::position())->getValue();
     const Real& scale = this->draw_rotations_scale.getValue();
@@ -679,7 +679,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::draw(const core::visual::VisualP
         q.fromMatrix(RotMat);
         vparams->drawTool()->drawFrame(DataTypes::getCPos(x[pid]), q, sofa::type::Vector3(scale,scale,scale));
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::linearsolver::preconditioner

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BeamLinearMapping.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BeamLinearMapping.inl
@@ -260,7 +260,7 @@ template <class TIn, class TOut>
 void BeamLinearMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
 {
     if (!vparams->displayFlags().getShowMappings()) return;
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     std::vector< sofa::type::Vector3 > points;
     sofa::type::Vector3 point;
 
@@ -272,7 +272,7 @@ void BeamLinearMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparam
     }
 
     vparams->drawTool()->drawPoints(points, 7, sofa::type::RGBAColor::yellow());
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/CenterOfMassMapping.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/CenterOfMassMapping.inl
@@ -139,7 +139,7 @@ void CenterOfMassMapping<TIn, TOut>::draw(const core::visual::VisualParams* vpar
 {
     if (!vparams->displayFlags().getShowMapping()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const typename Out::VecCoord &X = this->toModel->read(core::ConstVecCoordId::position())->getValue();
 
@@ -157,7 +157,7 @@ void CenterOfMassMapping<TIn, TOut>::draw(const core::visual::VisualParams* vpar
 
     vparams->drawTool()->drawLines(points, 1, sofa::type::RGBAColor::yellow());
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::mapping::linear

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/LineSetSkinningMapping.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/LineSetSkinningMapping.inl
@@ -192,7 +192,7 @@ void LineSetSkinningMapping<TIn, TOut>::draw(const core::visual::VisualParams* v
     if (!vparams->displayFlags().getShowMappings())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     const OutVecCoord& xto = this->toModel->read(core::ConstVecCoordId::position())->getValue();

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SkinningMapping.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SkinningMapping.inl
@@ -349,7 +349,7 @@ void SkinningMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
     sofa::helper::ReadAccessor<Data<type::vector<sofa::type::SVector<InReal> > > > m_weights  ( weight );
     sofa::helper::ReadAccessor<Data<type::vector<sofa::type::SVector<unsigned int> > > > index ( f_index );
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::RGBAColor> colorVector;
@@ -426,7 +426,7 @@ void SkinningMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
             vparams->drawTool()->drawPoints(vertices,10,colorVector);
         }
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
@@ -354,7 +354,7 @@ void DistanceMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
 {
     if( !vparams->displayFlags().getShowMechanicalMappings() ) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     typename core::behavior::MechanicalState<In>::ReadVecCoord pos = this->getFromModel()->readPositions();
     const SeqEdges& links = l_topology->getEdges();
@@ -380,7 +380,7 @@ void DistanceMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
             vparams->drawTool()->drawCylinder( p0, p1, (float)d_showObjectScale.getValue(), d_color.getValue() );
         }
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 ///////////////////////////////////////////////////////

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
@@ -271,7 +271,7 @@ void SquareDistanceMapping<TIn, TOut>::draw(const core::visual::VisualParams* vp
 {
     if( !vparams->displayFlags().getShowMechanicalMappings() ) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     typename core::behavior::MechanicalState<In>::ReadVecCoord pos = this->getFromModel()->readPositions();
     const SeqEdges& links = l_topology->getEdges();
@@ -298,7 +298,7 @@ void SquareDistanceMapping<TIn, TOut>::draw(const core::visual::VisualParams* vp
         }
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::mapping::nonlinear

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -2323,7 +2323,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::draw(const core::visual::Visua
         totalMass += vertexMass[i] * m_massLumpingCoeff;
     }
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
     sofa::type::RGBAColor color = sofa::type::RGBAColor::white();
 
@@ -2345,7 +2345,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::draw(const core::visual::Visua
         }
     }
     vparams->drawTool()->drawLines(vertices,5,color);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/ConicalForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/ConicalForceField.inl
@@ -171,7 +171,7 @@ void ConicalForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
     const Real b = (Real)tan((a/180*M_PI)) * h;
     const Coord c = coneCenter.getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     vparams->drawTool()->enableBlending();
     vparams->drawTool()->enableLighting();
@@ -183,7 +183,7 @@ void ConicalForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
     vparams->drawTool()->disableBlending();
     vparams->drawTool()->disableBlending();
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<class DataTypes>

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/ConstantForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/ConstantForceField.inl
@@ -477,7 +477,7 @@ void ConstantForceField<DataTypes>::draw(const core::visual::VisualParams* vpara
 
     if (!vparams->displayFlags().getShowForceFields() || (aSC <= 0.0)) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecIndex& indices = d_indices.getValue();
     const VecDeriv& f = d_forces.getValue();
@@ -568,7 +568,7 @@ void ConstantForceField<DataTypes>::draw(const core::visual::VisualParams* vpara
         }
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::mechanicalload

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/EdgePressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/EdgePressureForceField.inl
@@ -415,7 +415,7 @@ void EdgePressureForceField<DataTypes>::draw(const core::visual::VisualParams* v
     if (!p_showForces.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const SReal aSC = arrowSizeCoef.getValue();
 
@@ -442,7 +442,7 @@ void EdgePressureForceField<DataTypes>::draw(const core::visual::VisualParams* v
 
     vparams->drawTool()->drawLines(vertices, 1, color);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::mechanicalload

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/EllipsoidForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/EllipsoidForceField.inl
@@ -169,7 +169,7 @@ void EllipsoidForceField<DataTypes>::draw(const core::visual::VisualParams* vpar
 {
     if (!vparams->displayFlags().getShowForceFields()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     Real cx=0, cy=0, cz=0;
     DataTypes::get(cx, cy, cz, center.getValue());
@@ -184,7 +184,7 @@ void EllipsoidForceField<DataTypes>::draw(const core::visual::VisualParams* vpar
 	vparams->drawTool()->drawEllipsoid(vCenter, radii);
     vparams->drawTool()->disableLighting();
 
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/InteractionEllipsoidForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/InteractionEllipsoidForceField.inl
@@ -358,7 +358,7 @@ void InteractionEllipsoidForceField<DataTypes1, DataTypes2>::draw(const core::vi
 
     if (!bDraw.getValue()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     sofa::type::RGBAColor colorValue;
     std::vector<sofa::type::Vector3> vertices;
 
@@ -415,7 +415,7 @@ void InteractionEllipsoidForceField<DataTypes1, DataTypes2>::draw(const core::vi
     }
     vparams->drawTool()->drawLines(vertices,1,colorValue);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/OscillatingTorsionPressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/OscillatingTorsionPressureForceField.inl
@@ -297,7 +297,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::selectTrianglesFromString(
 template<class DataTypes>
 void OscillatingTorsionPressureForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (!p_showForces.getValue())
         return;
@@ -326,7 +326,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::draw(const core::visual::V
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<class DataTypes>

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/PlaneForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/PlaneForceField.inl
@@ -316,7 +316,7 @@ void PlaneForceField<DataTypes>::drawPlane(const core::visual::VisualParams* vpa
     points.push_back(corners[0]);
     points.push_back(corners[2]);
     points.push_back(corners[3]);
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     vparams->drawTool()->setPolygonMode(2,false); //Cull Front face
 
@@ -350,7 +350,7 @@ void PlaneForceField<DataTypes>::drawPlane(const core::visual::VisualParams* vpa
         }
     }
     vparams->drawTool()->drawLines(pointsLine, 1, sofa::type::RGBAColor(1,0,0,1));
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template <class DataTypes>

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/QuadPressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/QuadPressureForceField.inl
@@ -222,7 +222,7 @@ bool QuadPressureForceField<DataTypes>::isPointInPlane(Coord p)
 template<class DataTypes>
 void QuadPressureForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (!p_showForces.getValue())
         return;
@@ -249,7 +249,6 @@ void QuadPressureForceField<DataTypes>::draw(const core::visual::VisualParams* v
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->saveLastState();
 }
 
 } // namespace sofa::component::mechanicalload

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SphereForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SphereForceField.inl
@@ -183,7 +183,7 @@ void SphereForceField<DataTypes>::draw(const core::visual::VisualParams* vparams
 {
     if (!vparams->displayFlags().getShowForceFields()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     type::Vec3d center;
     DataTypes::get(center[0], center[1], center[2], sphereCenter.getValue());
@@ -194,7 +194,7 @@ void SphereForceField<DataTypes>::draw(const core::visual::VisualParams* vparams
     vparams->drawTool()->drawSphere(center, (float)(r*0.99) );
     vparams->drawTool()->disableLighting();
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<class DataTypes>

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.inl
@@ -494,7 +494,7 @@ void SurfacePressureForceField<DataTypes>::draw(const core::visual::VisualParams
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -524,7 +524,7 @@ void SurfacePressureForceField<DataTypes>::draw(const core::visual::VisualParams
         vparams->drawTool()->drawLines(points, 1, color);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<>

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.inl
@@ -241,7 +241,7 @@ void TrianglePressureForceField<DataTypes>::draw(const core::visual::VisualParam
     if (!p_showForces.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -273,7 +273,7 @@ void TrianglePressureForceField<DataTypes>::draw(const core::visual::VisualParam
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<class DataTypes>

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
@@ -637,7 +637,7 @@ void BeamFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
@@ -657,7 +657,7 @@ void BeamFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
     vparams->drawTool()->drawLines(points[1], 1, sofa::type::RGBAColor::green());
     vparams->drawTool()->drawLines(points[2], 1, sofa::type::RGBAColor::blue());
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<class DataTypes>

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -602,7 +602,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::draw(const core::visual::
     if (!this->mstate) return;
     if (!f_drawing.getValue()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
@@ -654,7 +654,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::draw(const core::visual::
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedralFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedralFEMForceField.inl
@@ -632,7 +632,7 @@ void HexahedralFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
     std::vector<sofa::type::RGBAColor> colorVector;
     std::vector<sofa::type::Vector3> vertices;
@@ -727,7 +727,7 @@ void HexahedralFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         vertices.push_back(DataTypes::getCPos(p0));
     }
     vparams->drawTool()->drawQuads(vertices,colorVector);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
@@ -1261,7 +1261,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::draw(const core::visual::V
     if (!this->mstate) return;
     if (!f_drawing.getValue()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
@@ -1310,7 +1310,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::draw(const core::visual::V
         vparams->drawTool()->setPolygonMode(0,false);
 
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -1788,7 +1788,7 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
 
     bool drawVonMisesStress = (_showVonMisesStressPerNode.getValue() || _showVonMisesStressPerElement.getValue()) && isComputeVonMisesStressMethodSet();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
     {
@@ -1962,7 +1962,7 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
         vparams->drawTool()->drawLines(points[2], 5, sofa::type::RGBAColor::blue());
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangleFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangleFEMForceField.inl
@@ -536,7 +536,7 @@ void TriangleFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vp
     if (!vparams->displayFlags().getShowForceFields())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     if (vparams->displayFlags().getShowWireFrame())
@@ -563,7 +563,7 @@ void TriangleFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vp
     }
     vparams->drawTool()->drawTriangles(vertices, colorVector);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularAnisotropicFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularAnisotropicFEMForceField.inl
@@ -311,7 +311,7 @@ void TriangularAnisotropicFEMForceField<DataTypes>::draw(const core::visual::Vis
 
     if (showFiber.getValue() && lfd.size() >= (unsigned)m_topology->getNbTriangles())
     {
-        vparams->drawTool()->saveLastState();
+        const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
         constexpr sofa::type::RGBAColor color = sofa::type::RGBAColor::black();
         std::vector<sofa::type::Vector3> vertices;
 
@@ -335,7 +335,7 @@ void TriangularAnisotropicFEMForceField<DataTypes>::draw(const core::visual::Vis
             }
         }
         vparams->drawTool()->drawLines(vertices,1,color);
-        vparams->drawTool()->restoreLastState();
+
     }
     localFiberDirection.endEdit();
 }

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
@@ -1199,7 +1199,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         return;
     }
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -1326,7 +1326,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         colorVector.clear();
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
@@ -572,7 +572,7 @@ void StandardTetrahedralFEMForceField<DataTypes>::draw(const core::visual::Visua
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
@@ -584,7 +584,7 @@ void StandardTetrahedralFEMForceField<DataTypes>::draw(const core::visual::Visua
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0,false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<class DataTypes>

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/TetrahedronHyperelasticityFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/TetrahedronHyperelasticityFEMForceField.inl
@@ -689,7 +689,7 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::draw(const core::visual
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
@@ -701,7 +701,7 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::draw(const core::visual
     if (vparams->displayFlags().getShowWireFrame())
           vparams->drawTool()->setPolygonMode(0,false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::fem::hyperelastic

--- a/Sofa/Component/SolidMechanics/FEM/NonUniform/src/sofa/component/solidmechanics/fem/nonuniform/HexahedronCompositeFEMForceFieldAndMass.inl
+++ b/Sofa/Component/SolidMechanics/FEM/NonUniform/src/sofa/component/solidmechanics/fem/nonuniform/HexahedronCompositeFEMForceFieldAndMass.inl
@@ -1555,7 +1555,7 @@ void HexahedronCompositeFEMForceFieldAndMass<T>::draw(const core::visual::Visual
 
     if( d_drawType.getValue() == -1 ) return HexahedronFEMForceFieldAndMassT::draw(vparams);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/AngularSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/AngularSpringForceField.inl
@@ -168,7 +168,7 @@ void AngularSpringForceField<DataTypes>::draw(const core::visual::VisualParams* 
     if (!vparams->displayFlags().getShowForceFields() || !drawSpring.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->setLightingEnabled(false);
 
     sofa::helper::ReadAccessor< DataVecCoord > p = this->mstate->read(core::VecCoordId::position());
@@ -180,7 +180,7 @@ void AngularSpringForceField<DataTypes>::draw(const core::visual::VisualParams* 
         vertices.push_back(p[index].getCenter());
     }
     vparams->drawTool()->drawLines(vertices,5,springColor.getValue());
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/FastTriangularBendingSprings.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/FastTriangularBendingSprings.inl
@@ -441,7 +441,7 @@ void FastTriangularBendingSprings<DataTypes>::draw(const core::visual::VisualPar
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/FrameSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/FrameSpringForceField.inl
@@ -175,7 +175,7 @@ void FrameSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vp
     const VecCoord& p1 =this->mstate1->read(core::ConstVecCoordId::position())->getValue();
     const VecCoord& p2 =this->mstate2->read(core::ConstVecCoordId::position())->getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::Vector3> vertices;
@@ -221,7 +221,7 @@ void FrameSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vp
     }
 
     vparams->drawTool()->drawLines(vertices, 1, colors);
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/GearSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/GearSpringForceField.inl
@@ -319,7 +319,7 @@ void GearSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vpa
 {
     if (!((this->mstate1 == this->mstate2)?vparams->displayFlags().getShowForceFields():vparams->displayFlags().getShowInteractionForceFields())) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& p1 =this->mstate1->read(core::ConstVecCoordId::position())->getValue();
     const VecCoord& p2 =this->mstate2->read(core::ConstVecCoordId::position())->getValue();
@@ -389,7 +389,7 @@ void GearSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vpa
         }
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/JointSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/JointSpringForceField.inl
@@ -363,7 +363,7 @@ void JointSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vp
     if (!((this->mstate1 == this->mstate2)?vparams->displayFlags().getShowForceFields():vparams->displayFlags().getShowInteractionForceFields())) return;
     const VecCoord& p1 = this->mstate1->read(core::ConstVecCoordId::position())->getValue();
     const VecCoord& p2 = this->mstate2->read(core::ConstVecCoordId::position())->getValue();
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     vparams->drawTool()->setLightingEnabled(true);
 
@@ -446,7 +446,7 @@ void JointSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vp
     }
     vparams->drawTool()->drawLines(vertices,1, colors);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template <class DataTypes>

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/MeshSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/MeshSpringForceField.inl
@@ -216,7 +216,7 @@ void MeshSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vpa
     if(this->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid || !mstate1 || !mstate2)
         return ;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if(vparams->displayFlags().getShowForceFields())
     {
@@ -270,7 +270,7 @@ void MeshSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vpa
             vparams->drawTool()->drawLines(points, float(drawSpringSize), sofa::type::RGBAColor{ float(R), float(G), float(B), 1.f });
         }
 
-        vparams->drawTool()->restoreLastState();
+
     }
 }
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialRestShapeSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialRestShapeSpringsForceField.inl
@@ -388,7 +388,7 @@ void PolynomialRestShapeSpringsForceField<DataTypes>::draw(const core::visual::V
         points.push_back(p0[ext_index]);
     }
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->setLightingEnabled(false);
 
     vparams->drawTool()->drawLines(points, 5, d_springColor.getValue());
@@ -405,7 +405,7 @@ void PolynomialRestShapeSpringsForceField<DataTypes>::draw(const core::visual::V
     }
 
     vparams->drawTool()->draw3DText_Indices(positions, float(scale), type::RGBAColor::white());
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialSpringsForceField.inl
@@ -336,7 +336,7 @@ void PolynomialSpringsForceField<DataTypes>::draw(const core::visual::VisualPara
     if (!((this->mstate1 == this->mstate2)?vparams->displayFlags().getShowForceFields():vparams->displayFlags().getShowInteractionForceFields()))
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& p1 =this->mstate1->read(core::ConstVecCoordId::position())->getValue();
     const VecCoord& p2 =this->mstate2->read(core::ConstVecCoordId::position())->getValue();
@@ -389,7 +389,7 @@ void PolynomialSpringsForceField<DataTypes>::draw(const core::visual::VisualPara
 
     vparams->drawTool()->drawPoints(positions, scale, color);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.inl
@@ -692,7 +692,7 @@ void QuadularBendingSprings<DataTypes>::draw(const core::visual::VisualParams* v
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -767,7 +767,7 @@ void QuadularBendingSprings<DataTypes>::draw(const core::visual::VisualParams* v
     }
     vparams->drawTool()->drawQuads(vertices, sofa::type::RGBAColor::red());
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RegularGridSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RegularGridSpringForceField.inl
@@ -439,7 +439,7 @@ void RegularGridSpringForceField<DataTypes>::draw(const core::visual::VisualPara
     assert(this->mstate1);
     assert(this->mstate2);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // Draw any custom springs
     this->StiffSpringForceField<DataTypes>::draw(vparams);
@@ -511,7 +511,7 @@ void RegularGridSpringForceField<DataTypes>::draw(const core::visual::VisualPara
     }
 
     vparams->drawTool()->drawLines(points, 1, sofa::type::RGBAColor(0.5,0.5,0.5,1));
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
@@ -424,7 +424,7 @@ void RestShapeSpringsForceField<DataTypes>::draw(const VisualParams *vparams)
     if (!vparams->displayFlags().getShowForceFields() || !d_drawSpring.getValue())
         return;  /// \todo put this in the parent class
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->setLightingEnabled(false);
 
     ReadAccessor< DataVecCoord > p0 = *getExtPosition();
@@ -454,7 +454,7 @@ void RestShapeSpringsForceField<DataTypes>::draw(const VisualParams *vparams)
 
     //todo(dmarchal) because of https://github.com/sofa-framework/sofa/issues/64
     vparams->drawTool()->drawLines(vertices,5, d_springColor.getValue());
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template<class DataTypes>

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangularBendingSprings.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangularBendingSprings.inl
@@ -534,7 +534,7 @@ void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams*
     if (!vparams->displayFlags().getShowForceFields()) {return;}
     if (!this->mstate) {return;}
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame()){
         vparams->drawTool()->setPolygonMode(0, true);
@@ -585,7 +585,7 @@ void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams*
         vparams->drawTool()->setPolygonMode(0, false);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangularBiquadraticSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangularBiquadraticSpringsForceField.inl
@@ -535,7 +535,7 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::draw(const core::visual:
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -567,7 +567,7 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::draw(const core::visual:
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangularQuadraticSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangularQuadraticSpringsForceField.inl
@@ -415,7 +415,7 @@ void TriangularQuadraticSpringsForceField<DataTypes>::draw(const core::visual::V
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -447,7 +447,7 @@ void TriangularQuadraticSpringsForceField<DataTypes>::draw(const core::visual::V
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TetrahedralTensorMassForceField.inl
+++ b/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TetrahedralTensorMassForceField.inl
@@ -465,7 +465,7 @@ void TetrahedralTensorMassForceField<DataTypes>::draw(const core::visual::Visual
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     if (vparams->displayFlags().getShowWireFrame())
@@ -488,7 +488,7 @@ void TetrahedralTensorMassForceField<DataTypes>::draw(const core::visual::Visual
         vertices.push_back(sofa::type::Vector3(x[c]));
     }
     vparams->drawTool()->drawTriangles(vertices,color);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::tensormass

--- a/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TriangularTensorMassForceField.inl
+++ b/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TriangularTensorMassForceField.inl
@@ -400,7 +400,7 @@ void TriangularTensorMassForceField<DataTypes>::draw(const core::visual::VisualP
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, true);
@@ -432,7 +432,7 @@ void TriangularTensorMassForceField<DataTypes>::draw(const core::visual::VisualP
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0, false);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::solidmechanics::tensormass

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.cpp
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.cpp
@@ -187,7 +187,7 @@ void MechanicalObject<defaulttype::Rigid3Types>::addFromBaseVectorSameSize(core:
 template<>
 void MechanicalObject<defaulttype::Rigid3Types>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->setLightingEnabled(false);
 
 	if (showIndices.getValue())
@@ -245,7 +245,7 @@ void MechanicalObject<defaulttype::Rigid3Types>::draw(const core::visual::Visual
             vparams->drawTool()->popMatrix();
         }
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::statecontainer

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -2718,7 +2718,7 @@ inline void MechanicalObject<DataTypes>::drawVectors(const core::visual::VisualP
 template <class DataTypes>
 inline void MechanicalObject<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->setLightingEnabled(false);
 
     if (showIndices.getValue())
@@ -2764,7 +2764,7 @@ inline void MechanicalObject<DataTypes>::draw(const core::visual::VisualParams* 
             break;
         }
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -2669,7 +2669,7 @@ SReal MeshTopology::getPosZ(Index i) const
 
 void MeshTopology::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // Draw Edges
     if(_drawEdges.getValue())
@@ -2777,7 +2777,7 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
         vparams->drawTool()->drawLines(pos, 1.0f, sofa::type::RGBAColor(1.0f,0.0f,0.0f,1.0f));
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } //namespace sofa::component::topology::container::constant

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
@@ -703,7 +703,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
 {
     PointSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // Draw Edges indices
     if (showEdgeIndices.getValue() && this->m_topology->getNbEdges() != 0)
@@ -751,7 +751,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         vparams->drawTool()->drawPoints(positions, 4.0f, _drawColor.getValue());
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
@@ -829,7 +829,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
 {
     QuadSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // Draw Hexa indices
     if (d_showHexaIndices.getValue() && this->m_topology->getNbHexahedra() != 0)
@@ -897,7 +897,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
             vparams->drawTool()->setPolygonMode(0, false);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.inl
@@ -272,7 +272,7 @@ bool PointSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const
 template<class DataTypes>
 void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (d_showPointIndices.getValue())
     {
@@ -296,7 +296,7 @@ void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParam
         vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
@@ -348,7 +348,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
 {
     EdgeSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // Draw Quads indices
     if (showQuadIndices.getValue() && this->m_topology->getNbQuads() != 0)
@@ -455,7 +455,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
             vparams->drawTool()->setPolygonMode(0, false);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
@@ -3243,7 +3243,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
 
     TriangleSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
     //Draw tetra indices
@@ -3344,7 +3344,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
             vparams->drawTool()->setPolygonMode(0, false);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
@@ -4832,7 +4832,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
 {
     EdgeSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // Draw Triangles indices
     if (showTriangleIndices.getValue() && this->m_topology->getNbTriangles() != 0)
@@ -4968,7 +4968,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
         vparams->drawTool()->drawLines(vertices,1.0f,colors);
     }
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/LineAxis.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/LineAxis.cpp
@@ -85,7 +85,7 @@ void LineAxis::drawVisual(const core::visual::VisualParams* vparams)
 
     const float s = d_size.getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     if(m_drawX)
@@ -112,7 +112,7 @@ void LineAxis::drawVisual(const core::visual::VisualParams* vparams)
             helper::visual::DrawTool::RGBAColor(0.0f, 0.0f, 1.0f, 1.0f));
     }
 
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/RecordedCamera.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/RecordedCamera.cpp
@@ -560,7 +560,7 @@ void RecordedCamera::drawRotation()
 
 void RecordedCamera::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     // Draw rotation path
     if(p_drawRotation.getValue())
@@ -615,7 +615,7 @@ void RecordedCamera::draw(const core::visual::VisualParams* vparams)
         }
         vparams->drawTool()->drawLines(vertices,1,color);
     }
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::visual

--- a/Sofa/Component/Visual/src/sofa/component/visual/Visual3DText.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/Visual3DText.cpp
@@ -65,11 +65,11 @@ void Visual3DText::drawTransparent(const core::visual::VisualParams* vparams)
     const type::Vec3f& pos = d_position.getValue();
     float scale = d_scale.getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableDepthTest();
     vparams->drawTool()->setLightingEnabled(true);
     vparams->drawTool()->draw3DText(pos,scale,d_color.getValue(),d_text.getValue().c_str());
-    vparams->drawTool()->restoreLastState();
+
 }
 
 } // namespace sofa::component::visual

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
@@ -196,12 +196,12 @@ void VisualGrid::drawVisual(const core::visual::VisualParams* vparams)
 {
     if (!d_draw.getValue()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     vparams->drawTool()->drawLines(m_drawnPoints, d_thickness.getValue(), d_color.getValue());
 
-    vparams->drawTool()->restoreLastState();
+
 
 }
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
@@ -118,7 +118,7 @@ void OglSceneFrame::draw(const core::visual::VisualParams* vparams)
 {
     if (!d_drawFrame.getValue()) return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     const Viewport& viewport = vparams->viewport();
 
@@ -190,7 +190,7 @@ void OglSceneFrame::draw(const core::visual::VisualParams* vparams)
     glMatrixMode(GL_MODELVIEW);
     vparams->drawTool()->popMatrix();
 
-    vparams->drawTool()->restoreLastState();
+
     glViewport(viewport[0],viewport[1],viewport[2],viewport[3]);
 
 }

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/InciseAlongPathPerformer.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/InciseAlongPathPerformer.cpp
@@ -271,7 +271,7 @@ void InciseAlongPathPerformer::draw(const core::visual::VisualParams* vparams)
     positions[0] = pointA;
     positions[positions.size()-1] = pointB;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
     constexpr sofa::type::RGBAColor color(0.3f, 0.8f, 0.3f, 1.0f);
     std::vector<sofa::type::Vector3> vertices;
@@ -281,7 +281,7 @@ void InciseAlongPathPerformer::draw(const core::visual::VisualParams* vparams)
         vertices.push_back(sofa::type::Vector3(positions[i][0], positions[i][1], positions[i][2]));
     }
     vparams->drawTool()->drawLines(vertices,1,color);
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/RemovePrimitivePerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/RemovePrimitivePerformer.inl
@@ -650,7 +650,7 @@ void RemovePrimitivePerformer<DataTypes>::draw(const core::visual::VisualParams*
 
     const VecCoord& X = mstateCollision->read(core::ConstVecCoordId::position())->getValue();
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::Vector3> vertices_quads;
@@ -731,7 +731,7 @@ void RemovePrimitivePerformer<DataTypes>::draw(const core::visual::VisualParams*
     vparams->drawTool()->drawQuads(vertices_quads, color);
     vparams->drawTool()->drawTriangles(vertices_triangles, color);
 
-    vparams->drawTool()->restoreLastState();
+
 }
 
 

--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -184,6 +184,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/logging/RoutingMessageHandler.cpp
     ${SRC_ROOT}/logging/ExceptionMessageHandler.cpp
     ${SRC_ROOT}/messaging/FileMessage.cpp
+    ${SRC_ROOT}/visual/DrawTool.cpp
     ${SRC_ROOT}/visual/Transformation.cpp
     ${SRC_ROOT}/visual/Trackball.cpp
 )

--- a/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.cpp
@@ -1,0 +1,44 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/visual/DrawTool.h>
+
+namespace sofa::helper::visual
+{
+
+DrawTool::StateLifeCycle::StateLifeCycle(DrawTool* drawTool)
+    : m_drawTool(drawTool)
+{
+    m_drawTool->saveLastState();
+}
+
+DrawTool::StateLifeCycle::~StateLifeCycle()
+{
+    m_drawTool->restoreLastState();
+}
+
+DrawTool::StateLifeCycle DrawTool::makeStateLifeCycle()
+{
+    // copy elision if compiler uses RVO
+    return StateLifeCycle{ this };
+}
+
+}

--- a/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.h
+++ b/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.h
@@ -39,7 +39,7 @@ namespace sofa::helper::visual
  *k
  */
 
-class DrawTool
+class SOFA_HELPER_API DrawTool
 {
 
 public:
@@ -208,6 +208,13 @@ public:
     virtual void saveLastState() = 0;
     virtual void restoreLastState() = 0;
 
+    struct StateLifeCycle;
+
+    /// Use RAII to bind state save and restore to the returned object: saveLastState is called
+    /// at object creation, and restoreLastState is called when the object is destroyed.
+    [[nodiscard]]
+    StateLifeCycle makeStateLifeCycle();
+
     /// @name Overlay methods
 
     /// draw 2D text at position (x,y) from top-left corner
@@ -226,6 +233,16 @@ public:
 
     /// Compatibility wrapper functions 
     using Vec4f = sofa::type::Vec4f;
+};
+
+struct SOFA_HELPER_API DrawTool::StateLifeCycle
+{
+    StateLifeCycle() = delete;
+    StateLifeCycle(const StateLifeCycle&) = delete;
+    StateLifeCycle(DrawTool* drawTool);
+    ~StateLifeCycle();
+private:
+    DrawTool* m_drawTool { nullptr };
 };
 
 } // namespace sofa::helper::visual

--- a/applications/plugins/ArticulatedSystemPlugin/src/ArticulatedSystemPlugin/ArticulatedSystemMapping.inl
+++ b/applications/plugins/ArticulatedSystemPlugin/src/ArticulatedSystemPlugin/ArticulatedSystemMapping.inl
@@ -547,7 +547,7 @@ void ArticulatedSystemMapping<TIn, TInRoot, TOut>::draw(const core::visual::Visu
 {
     if (vparams->displayFlags().getShowMappings())
     {
-        vparams->drawTool()->saveLastState();
+        const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
         std::vector< sofa::type::Vector3 > points;
         std::vector< sofa::type::Vector3 > pointsLine;
@@ -573,7 +573,7 @@ void ArticulatedSystemMapping<TIn, TInRoot, TOut>::draw(const core::visual::Visu
         vparams->drawTool()->drawPoints(points, 10, sofa::type::RGBAColor(1,0.5,0.5,1));
         vparams->drawTool()->drawLines(pointsLine, 1, sofa::type::RGBAColor::blue());
 
-        vparams->drawTool()->restoreLastState();
+
     }
 }
 } //namespace sofa::component::mapping


### PR DESCRIPTION
As discussed previously, state in DrawTool can be managed by RAII.

Note that this PR also highlights a few problems which have been fixed (saveLastState called but not restoreLastState, or saveLastState called twice).


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
