### PR TITLE
[Config] Option to enable interprocedural optimization

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -138,7 +138,7 @@ if (IS_IPO_SUPPORTED)
     # Focus on max speed with link-time optimization
     option(SOFA_ENABLE_LINK_TIME_OPTIMIZATION "Enable interprocedural optimization" OFF)
     if (SOFA_ENABLE_LINK_TIME_OPTIMIZATION)
-        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE PARENT_SCOPE)
     endif()
 else()
     message(STATUS "IPO / LTO not supported: <${IPO_ERROR}>")
@@ -204,11 +204,6 @@ if(WIN32)
 
     if(MSVC_TOOLSET_VERSION GREATER 140) # > VS 2015
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "/Zc:__cplusplus")
-    endif()
-
-    if(SOFA_ENABLE_LINK_TIME_OPTIMIZATION)
-        list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE "/GL")
-        list(APPEND SOFACONFIG_LINK_OPTIONS_RELEASE "/LTCG")
     endif()
 
     # Experimental: compilation with MSVC/Clang-cl

--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -130,6 +130,20 @@ set(SOFACONFIG_LINK_OPTIONS "")
 set(SOFACONFIG_LINK_OPTIONS_DEBUG "")
 set(SOFACONFIG_LINK_OPTIONS_RELEASE "")
 
+include(CheckIPOSupported)
+check_ipo_supported(RESULT IS_IPO_SUPPORTED OUTPUT IPO_ERROR)
+
+## Link-time optimization
+if (IS_IPO_SUPPORTED)
+    # Focus on max speed with link-time optimization
+    option(SOFA_ENABLE_LINK_TIME_OPTIMIZATION "Enable interprocedural optimization" OFF)
+    if (SOFA_ENABLE_LINK_TIME_OPTIMIZATION)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    endif()
+else()
+    message(STATUS "IPO / LTO not supported: <${IPO_ERROR}>")
+endif()
+
 ## GCC-specific
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     ## Find out the version of g++ (and save it in GCXX_VERSION)
@@ -192,14 +206,10 @@ if(WIN32)
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "/Zc:__cplusplus")
     endif()
 
-    # Focus on max speed in Release Mode with link-time optimization
-    option(SOFA_ENABLE_LINK_TIME_OPTIMIZATION "Enable LTCG IN release mode (MSVC only for now) [Warning, use a lot of disk space!]" OFF)
-
     if(SOFA_ENABLE_LINK_TIME_OPTIMIZATION)
         list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE "/GL")
         list(APPEND SOFACONFIG_LINK_OPTIONS_RELEASE "/LTCG")
     endif()
-
 
     # Experimental: compilation with MSVC/Clang-cl
     if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")


### PR DESCRIPTION
IPO option was already available for MSVC. This PR is the CMake way to enable it.
~~However, it does not seem to apply on my setup with MSVC. That's why I kept the `/GL` and `/LTCG` compilation options.~~



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
