### PR TITLE
[Topology.Container.Grid] trivial optimization in GridTopology

### DIFF
--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.cpp
@@ -344,14 +344,16 @@ void GridTopology::computePointList()
 
 GridTopology::Index GridTopology::getIndex( int i, int j, int k ) const
 {
-    return Index(d_n.getValue()[0]* ( d_n.getValue()[1]*k + j ) + i);
+    const auto& n = d_n.getValue();
+    return Index(n[0]* ( n[1]*k + j ) + i);
 }
 
 
 sofa::type::Vec3 GridTopology::getPoint(Index i) const
 {
-    int x = i%d_n.getValue()[0]; i/=d_n.getValue()[0];
-    int y = i%d_n.getValue()[1]; i/=d_n.getValue()[1];
+    const auto& n = d_n.getValue();
+    int x = i%n[0]; i/=n[0];
+    int y = i%n[1]; i/=n[1];
     int z = int(i);
 
     return getPointInGrid(x,y,z);
@@ -359,9 +361,11 @@ sofa::type::Vec3 GridTopology::getPoint(Index i) const
 
 sofa::type::Vec3 GridTopology::getPointInGrid(int i, int j, int k) const
 {
+    const auto& spoints = seqPoints.getValue();
+
     Index id = this->getIndex(i, j, k);
-    if (id < seqPoints.getValue().size())
-        return seqPoints.getValue()[id];
+    if (id < spoints.size())
+        return spoints[id];
     else
         return sofa::type::Vec3();
 }
@@ -369,8 +373,10 @@ sofa::type::Vec3 GridTopology::getPointInGrid(int i, int j, int k) const
 
 GridTopology::Hexa GridTopology::getHexaCopy(Index i)
 {
-    int x = i%(d_n.getValue()[0]-1); i/=(d_n.getValue()[0]-1);
-    int y = i%(d_n.getValue()[1]-1); i/=(d_n.getValue()[1]-1);
+    const auto& n = d_n.getValue();
+
+    int x = i%(n[0]-1); i/=(n[0]-1);
+    int y = i%(n[1]-1); i/=(n[1]-1);
     int z = int(i);
     return getHexahedron(x,y,z);
 }
@@ -386,27 +392,29 @@ GridTopology::Hexa GridTopology::getHexahedron(int x, int y, int z)
 
 GridTopology::Quad GridTopology::getQuadCopy(Index i)
 {
-    if (d_n.getValue()[0] == 1)
+    const auto& n = d_n.getValue();
+
+    if (n[0] == 1)
     {
-        int y = i%(d_n.getValue()[1]-1);
-        i/=(d_n.getValue()[1]-1);
-        int z = i%(d_n.getValue()[2]-1);
+        int y = i%(n[1]-1);
+        i/=(n[1]-1);
+        int z = i%(n[2]-1);
 
         return getQuad(1,y,z);
     }
-    else if (d_n.getValue()[1] == 1)
+    else if (n[1] == 1)
     {
-        int x = i%(d_n.getValue()[0]-1);
-        i/=(d_n.getValue()[0]-1);
-        int z = i%(d_n.getValue()[2]-1);
+        int x = i%(n[0]-1);
+        i/=(n[0]-1);
+        int z = i%(n[2]-1);
 
         return getQuad(x,1,z);
     }
     else
     {
-        int x = i%(d_n.getValue()[0]-1);
-        i/=(d_n.getValue()[0]-1);
-        int y = i%(d_n.getValue()[1]-1);
+        int x = i%(n[0]-1);
+        i/=(n[0]-1);
+        int y = i%(n[1]-1);
 
         return getQuad(x,y,1);
     }
@@ -414,10 +422,12 @@ GridTopology::Quad GridTopology::getQuadCopy(Index i)
 
 GridTopology::Quad GridTopology::getQuad(int x, int y, int z)
 {
-    if (d_n.getValue()[2] == 1)
+    const auto& n = d_n.getValue();
+
+    if (n[2] == 1)
         return Quad(point(x, y, 1), point(x+1, y, 1),
                 point(x+1, y+1, 1), point(x, y+1, 1));
-    else if (d_n.getValue()[1] == 1)
+    else if (n[1] == 1)
         return Quad(point(x, 1, z), point(x+1, 1, z),
                 point(x+1, 1, z+1), point(x, 1, z+1));
     else

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.h
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.h
@@ -173,7 +173,11 @@ public:
     /// Get Point index in Grid, will call method @sa getIndex
     Index point(int x, int y, int z) const { return getIndex(x,y,z); }
     /// Get Hexa index in Grid
-    Index hexa(int x, int y, int z) const { return x+(d_n.getValue()[0]-1)*(y+(d_n.getValue()[1]-1)*z); }
+    Index hexa(int x, int y, int z) const 
+    { 
+        const auto& n = d_n.getValue();
+        return x+(n[0]-1)*(y+(n[1]-1)*z); 
+    }
     /// Get Cube index, similar to \sa hexa method
     Index cube(int x, int y, int z) const { return hexa(x,y,z); }
 


### PR DESCRIPTION
Just call getValue once and use the const ref afterwards.

This is particularly showing for the function getIndex() which is called a lot of times (really a lot)

Release mode (full optim), MSVC and scene from Components/topology/RegularGridTopology.scn:
before:  `5000 iterations done in 22.5747 s ( 221.487 FPS).`
after  : `5000 iterations done in 20.7355 s ( 241.132 FPS).`
so 10% speedup

But the optimization is more  effective the more complex  the mesh is
(I changed the mesh in the previous scene with a liver with 500K triangles and the speed up was like around 30%)


In any case, it shows that `getValue()` is not really "free" and must be called only once if the value is needed more than one time, especially in the "hot" functions.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
