### PR TITLE
[sceneutility] Deprecate MakeAlias and MakeDataAlias

### DIFF
--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeAliasComponent.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeAliasComponent.cpp
@@ -44,6 +44,8 @@ void MakeAliasComponent::parse ( core::objectmodel::BaseObjectDescription* arg )
 {
     BaseObject::parse(arg) ;
 
+    msg_deprecated() << "This component is still usable but has been DEPRECATED since v22.12. You have until v23.06 to fix your scene.";
+
     const char* target=arg->getAttribute("targetcomponent") ;
     if(target==nullptr)
     {

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeAliasComponent.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeAliasComponent.h
@@ -38,7 +38,7 @@ namespace sofa::component::sceneutility::makealiascomponent
 /// for ease of use
 /// 
 /// A component to add alias to other components.
-class SOFA_COMPONENT_SCENEUTILITY_API MakeAliasComponent : public core::objectmodel::BaseObject
+class SOFA_ATTRIBUTE_DEPRECATED__MAKEALIASCOMPONENT() SOFA_COMPONENT_SCENEUTILITY_API MakeAliasComponent : public core::objectmodel::BaseObject
 {
 public:
     SOFA_CLASS(MakeAliasComponent, core::objectmodel::BaseObject);

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
@@ -59,6 +59,8 @@ void MakeDataAliasComponent::parse ( core::objectmodel::BaseObjectDescription* a
 {
     BaseObject::parse(arg) ;
 
+    msg_deprecated() << "This component is still usable but has been DEPRECATED since v22.12. You have until v23.06 to fix your scene.";
+
     const char* component=arg->getAttribute("componentname") ;
     if(component==nullptr)
     {

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
@@ -37,7 +37,7 @@ namespace sofa::component::sceneutility::makedataaliascomponent
 /// for ease of use
 
 /// A component to add alias to other components.
-class SOFA_COMPONENT_SCENEUTILITY_API MakeDataAliasComponent : public core::objectmodel::BaseObject
+class SOFA_ATTRIBUTE_DEPRECATED__MAKEALIASCOMPONENT() SOFA_COMPONENT_SCENEUTILITY_API MakeDataAliasComponent : public core::objectmodel::BaseObject
 {
 public:
     SOFA_CLASS(MakeDataAliasComponent, core::objectmodel::BaseObject);

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/config.h.in
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/config.h.in
@@ -31,6 +31,15 @@
 #  define SOFA_COMPONENT_SCENEUTILITY_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
 
+#ifdef SOFA_BUILD_SOFA_COMPONENT_SCENEUTILITY
+#define SOFA_ATTRIBUTE_DEPRECATED__MAKEALIASCOMPONENT()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__MAKEALIASCOMPONENT() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v22.12", "v23.06", \
+        "Aliases are not advised.")
+#endif
+
 namespace sofa::component::sceneutility
 {
 	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -767,6 +767,9 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
 
     { "OglGrid", Deprecated("v22.12", "v23.06")},
     { "OglLineAxis", Deprecated("v22.12", "v23.06")},
+
+    { "MakeAlias", Deprecated("v22.12", "v23.06")},
+    { "MakeDataAlias", Deprecated("v22.12", "v23.06")},
 };
 
 } // namespace sofa::helper::lifecycle


### PR DESCRIPTION
Because it is not used and not useful






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
