### PR TITLE
[image] Fix CMake warning from deprecated function

### DIFF
--- a/applications/plugins/image/image_gui/CMakeLists.txt
+++ b/applications/plugins/image/image_gui/CMakeLists.txt
@@ -43,4 +43,9 @@ add_definitions("-DSOFA_BUILD_IMAGE_GUI")
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${MOC_HEADER_FILES} ${MOC_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} image ${OPENGL_LIBRARIES} SofaGuiQt)
 
-sofa_install_targets(image ${PROJECT_NAME} ${PROJECT_NAME})
+sofa_add_targets_to_package(
+    PACKAGE_NAME image
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+    INCLUDE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+    INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
+    )


### PR DESCRIPTION
The warning was:
``` cmake
CMake Warning at Sofa/framework/Config/cmake/SofaMacrosInstall.cmake:1031 (message):
  Deprecated macro.  Use 'sofa_add_targets_to_package' instead.
Call Stack (most recent call first):
  applications/plugins/image/image_gui/CMakeLists.txt:46 (sofa_install_targets)
```





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
