### PR TITLE
[Regression] Add HexahedronFEMForceFieldAndMass to regression tests

### DIFF
--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -21,6 +21,7 @@ Components/constraint/FrictionContact.scn 100 1e-4 0 1
 Components/forcefield/BeamFEMForceField.scn 100 1e-4 0 1
 Components/forcefield/FastTriangularBendingSprings.scn 100 1e-4 0 1
 Components/forcefield/HexahedronFEMForceField.scn 300 1e-4 0 1
+Components/forcefield/HexahedronFEMForceFieldAndMass.scn 100 1e-4 0 1
 Components/forcefield/MeshSpringForceField.scn 300 1e-4 0 1
 Components/forcefield/QuadBendingFEMForceField.scn 300 1e-4 0 1
 Components/forcefield/TetrahedralCorotationalFEMForceField.scn 300 1e-4 0 1


### PR DESCRIPTION
[ci-depends-on https://github.com/sofa-framework/Regression/pull/37]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
