### PR TITLE
[Topology] Add function in BaseMeshTopology to compute all topology containers

### DIFF
--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -532,7 +532,6 @@ void MeshTopology::init()
     const auto triangles = sofa::helper::getReadAccessor(d_seqTriangles);
     const auto edges = sofa::helper::getReadAccessor(d_seqEdges);
 
-
     // looking for upper topology
     if (!hexahedra.empty())
         m_upperElementType = geometry::ElementType::HEXAHEDRON;
@@ -585,6 +584,65 @@ void MeshTopology::initContainers()
 
         nbPoints = n;
     }
+
+
+    if (!hexahedra.empty()) // Create hexahedron cross element buffers.
+    {
+        createHexahedraAroundVertexArray();
+
+        if (!quads.empty())
+        {
+            createQuadsInHexahedronArray();
+            createHexahedraAroundQuadArray();
+        }
+
+        if (!edges.empty())
+        {
+            createEdgesInHexahedronArray();
+            createHexahedraAroundEdgeArray();
+        }
+    }
+    if (!tetrahedra.empty()) // Create tetrahedron cross element buffers.
+    {
+        createTetrahedraAroundVertexArray();
+
+        if (!triangles.empty())
+        {
+            createTrianglesInTetrahedronArray();
+            createTetrahedraAroundTriangleArray();
+        }
+
+        if (!edges.empty())
+        {
+            createEdgesInTetrahedronArray();
+            createTetrahedraAroundEdgeArray();
+        }
+    }
+    if (!quads.empty()) // Create triangle cross element buffers.
+    {
+        createQuadsAroundVertexArray();
+
+        if (!edges.empty())
+        {
+            createEdgesInQuadArray();
+            createQuadsAroundEdgeArray();
+        }
+    }
+    if (!triangles.empty()) // Create triangle cross element buffers.
+    {
+        createTrianglesAroundVertexArray();
+
+        if (!edges.empty())
+        {
+            createEdgesInTriangleArray();
+            createTrianglesAroundEdgeArray();
+        }
+    }
+    if (!edges.empty())
+    {
+        createEdgesAroundVertexArray();
+    }
+
 
     if(edges.empty() )
     {

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -547,10 +547,10 @@ void MeshTopology::init()
         m_upperElementType = sofa::geometry::ElementType::POINT;
 
 
-    initContainers();
+    computeCrossElementBuffers();
 }
 
-void MeshTopology::initContainers()
+void MeshTopology::computeCrossElementBuffers()
 {
     const auto hexahedra = sofa::helper::getReadAccessor(seqHexahedra);
     const auto tetrahedra = sofa::helper::getReadAccessor(seqTetrahedra);

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -524,7 +524,6 @@ MeshTopology::MeshTopology()
 
 void MeshTopology::init()
 {
-
     BaseMeshTopology::init();
 
     const auto hexahedra = sofa::helper::getReadAccessor(d_seqHexahedra);
@@ -548,6 +547,17 @@ void MeshTopology::init()
     else
         m_upperElementType = sofa::geometry::ElementType::POINT;
 
+
+    initContainers();
+}
+
+void MeshTopology::initContainers()
+{
+    const auto hexahedra = sofa::helper::getReadAccessor(seqHexahedra);
+    const auto tetrahedra = sofa::helper::getReadAccessor(seqTetrahedra);
+    const auto quads = sofa::helper::getReadAccessor(seqQuads);
+    const auto triangles = sofa::helper::getReadAccessor(seqTriangles);
+    const auto edges = sofa::helper::getReadAccessor(seqEdges);
 
     // compute the number of points, if the topology is charged from the scene or if it was loaded from a MeshLoader without any points data.
     if (nbPoints==0)

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -552,11 +552,11 @@ void MeshTopology::init()
 
 void MeshTopology::computeCrossElementBuffers()
 {
-    const auto hexahedra = sofa::helper::getReadAccessor(seqHexahedra);
-    const auto tetrahedra = sofa::helper::getReadAccessor(seqTetrahedra);
-    const auto quads = sofa::helper::getReadAccessor(seqQuads);
-    const auto triangles = sofa::helper::getReadAccessor(seqTriangles);
-    const auto edges = sofa::helper::getReadAccessor(seqEdges);
+    const auto hexahedra = sofa::helper::getReadAccessor(d_seqHexahedra);
+    const auto tetrahedra = sofa::helper::getReadAccessor(d_seqTetrahedra);
+    const auto quads = sofa::helper::getReadAccessor(d_seqQuads);
+    const auto triangles = sofa::helper::getReadAccessor(d_seqTriangles);
+    const auto edges = sofa::helper::getReadAccessor(d_seqEdges);
 
     // compute the number of points, if the topology is charged from the scene or if it was loaded from a MeshLoader without any points data.
     if (nbPoints==0)

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -545,9 +545,6 @@ void MeshTopology::init()
         m_upperElementType = sofa::geometry::ElementType::EDGE;
     else
         m_upperElementType = sofa::geometry::ElementType::POINT;
-
-
-    computeCrossElementBuffers();
 }
 
 void MeshTopology::computeCrossElementBuffers()

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -545,6 +545,8 @@ void MeshTopology::init()
         m_upperElementType = sofa::geometry::ElementType::EDGE;
     else
         m_upperElementType = sofa::geometry::ElementType::POINT;
+
+    computeCrossElementBuffers();
 }
 
 void MeshTopology::computeCrossElementBuffers()

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -546,17 +546,6 @@ void MeshTopology::init()
     else
         m_upperElementType = sofa::geometry::ElementType::POINT;
 
-    computeCrossElementBuffers();
-}
-
-void MeshTopology::computeCrossElementBuffers()
-{
-    const auto hexahedra = sofa::helper::getReadAccessor(d_seqHexahedra);
-    const auto tetrahedra = sofa::helper::getReadAccessor(d_seqTetrahedra);
-    const auto quads = sofa::helper::getReadAccessor(d_seqQuads);
-    const auto triangles = sofa::helper::getReadAccessor(d_seqTriangles);
-    const auto edges = sofa::helper::getReadAccessor(d_seqEdges);
-
     // compute the number of points, if the topology is charged from the scene or if it was loaded from a MeshLoader without any points data.
     if (nbPoints==0)
     {
@@ -584,6 +573,46 @@ void MeshTopology::computeCrossElementBuffers()
         nbPoints = n;
     }
 
+
+    if(edges.empty() )
+    {
+        if(d_seqEdges.getParent() != nullptr )
+        {
+            d_seqEdges.delInput(d_seqEdges.getParent());
+        }
+        const EdgeUpdate::SPtr edgeUpdate = sofa::core::objectmodel::New<EdgeUpdate>(this);
+        edgeUpdate->setName("edgeUpdate");
+        this->addSlave(edgeUpdate);
+    }
+    if(triangles.empty() )
+    {
+        if(d_seqTriangles.getParent() != nullptr)
+        {
+            d_seqTriangles.delInput(d_seqTriangles.getParent());
+        }
+        const TriangleUpdate::SPtr triangleUpdate = sofa::core::objectmodel::New<TriangleUpdate>(this);
+        triangleUpdate->setName("triangleUpdate");
+        this->addSlave(triangleUpdate);
+    }
+    if(quads.empty() )
+    {
+        if(d_seqQuads.getParent() != nullptr )
+        {
+            d_seqQuads.delInput(d_seqQuads.getParent());
+        }
+        const QuadUpdate::SPtr quadUpdate = sofa::core::objectmodel::New<QuadUpdate>(this);
+        quadUpdate->setName("quadUpdate");
+        this->addSlave(quadUpdate);
+    }
+}
+
+void MeshTopology::computeCrossElementBuffers()
+{
+    const auto hexahedra = sofa::helper::getReadAccessor(d_seqHexahedra);
+    const auto tetrahedra = sofa::helper::getReadAccessor(d_seqTetrahedra);
+    const auto quads = sofa::helper::getReadAccessor(d_seqQuads);
+    const auto triangles = sofa::helper::getReadAccessor(d_seqTriangles);
+    const auto edges = sofa::helper::getReadAccessor(d_seqEdges);
 
     if (!hexahedra.empty()) // Create hexahedron cross element buffers.
     {
@@ -640,38 +669,6 @@ void MeshTopology::computeCrossElementBuffers()
     if (!edges.empty())
     {
         createEdgesAroundVertexArray();
-    }
-
-
-    if(edges.empty() )
-    {
-        if(d_seqEdges.getParent() != nullptr )
-        {
-            d_seqEdges.delInput(d_seqEdges.getParent());
-        }
-        const EdgeUpdate::SPtr edgeUpdate = sofa::core::objectmodel::New<EdgeUpdate>(this);
-        edgeUpdate->setName("edgeUpdate");
-        this->addSlave(edgeUpdate);
-    }
-    if(triangles.empty() )
-    {
-        if(d_seqTriangles.getParent() != nullptr)
-        {
-            d_seqTriangles.delInput(d_seqTriangles.getParent());
-        }
-        const TriangleUpdate::SPtr triangleUpdate = sofa::core::objectmodel::New<TriangleUpdate>(this);
-        triangleUpdate->setName("triangleUpdate");
-        this->addSlave(triangleUpdate);
-    }
-    if(quads.empty() )
-    {
-        if(d_seqQuads.getParent() != nullptr )
-        {
-            d_seqQuads.delInput(d_seqQuads.getParent());
-        }
-        const QuadUpdate::SPtr quadUpdate = sofa::core::objectmodel::New<QuadUpdate>(this);
-        quadUpdate->setName("quadUpdate");
-        this->addSlave(quadUpdate);
     }
 }
 

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.cpp
@@ -492,6 +492,7 @@ MeshTopology::MeshTopology()
     , d_seqTetrahedra(initData(&d_seqTetrahedra, "tetrahedra", "List of tetrahedron indices"))
     , d_seqHexahedra(initData(&d_seqHexahedra, "hexahedra", "List of hexahedron indices"))
     , d_seqUVs(initData(&d_seqUVs, "uv", "List of uv coordinates"))
+    , d_computeAllBuffers(initData(&d_computeAllBuffers, false, "computeAllBuffers", "Option to compute all crossed topology buffers at init. False by default"))
     , nbPoints(0)
     , validTetrahedra(false), validHexahedra(false)
     , revision(0)
@@ -545,6 +546,12 @@ void MeshTopology::init()
         m_upperElementType = sofa::geometry::ElementType::EDGE;
     else
         m_upperElementType = sofa::geometry::ElementType::POINT;
+
+    // If true, will compute all crossed element buffers such as triangleAroundEdges, EdgesIntriangle, etc.
+    if (d_computeAllBuffers.getValue())
+    {
+        computeCrossElementBuffers();
+    }
 
     // compute the number of points, if the topology is charged from the scene or if it was loaded from a MeshLoader without any points data.
     if (nbPoints==0)

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
@@ -86,6 +86,9 @@ protected:
 public:
     void init() override;
 
+    /// Method called by component Init method. Will create all the topology buffers
+    void initContainers() override;
+
     Size getNbPoints() const override;
 
     void setNbPoints(Size  n) override;

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
@@ -87,7 +87,7 @@ public:
     void init() override;
 
     /// Method called by component Init method. Will create all the topology buffers
-    void initContainers() override;
+    void computeCrossElementBuffers() override;
 
     Size getNbPoints() const override;
 

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
@@ -351,6 +351,7 @@ public:
     Data<SeqTetrahedra>      d_seqTetrahedra; ///< List of tetrahedron indices
     Data<SeqHexahedra>	   d_seqHexahedra; ///< List of hexahedron indices
     Data<SeqUV>	d_seqUVs; ///< List of uv coordinates
+    Data<bool> d_computeAllBuffers ///< Option to call method computeCrossElementBuffers. False by default
 
 protected:
     Size  nbPoints;

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/MeshTopology.h
@@ -351,7 +351,7 @@ public:
     Data<SeqTetrahedra>      d_seqTetrahedra; ///< List of tetrahedron indices
     Data<SeqHexahedra>	   d_seqHexahedra; ///< List of hexahedron indices
     Data<SeqUV>	d_seqUVs; ///< List of uv coordinates
-    Data<bool> d_computeAllBuffers ///< Option to call method computeCrossElementBuffers. False by default
+    Data<bool> d_computeAllBuffers; ///< Option to call method computeCrossElementBuffers. False by default
 
 protected:
     Size  nbPoints;

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
@@ -77,10 +77,10 @@ void EdgeSetTopologyContainer::init()
 
     // only init if edges are present at init.
     if (!m_edge.empty())
-        initContainers();
+        computeCrossElementBuffers();
 }
 
-void EdgeSetTopologyContainer::initContainers()
+void EdgeSetTopologyContainer::computeCrossElementBuffers()
 {
     // force computation of neighborhood elements
     createEdgesAroundVertexArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
@@ -77,10 +77,10 @@ void EdgeSetTopologyContainer::init()
 
     // only init if edges are present at init.
     if (!m_edge.empty())
-        initTopology();
+        initContainers();
 }
 
-void EdgeSetTopologyContainer::initTopology()
+void EdgeSetTopologyContainer::initContainers()
 {
     // force computation of neighborhood elements
     createEdgesAroundVertexArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.h
@@ -100,7 +100,7 @@ public:
     /// Dynamic Topology API
     /// @{
     /// Method called by component Init method. Will create all the topology neighborhood buffers.
-    void initContainers() override;
+    void computeCrossElementBuffers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.h
@@ -100,7 +100,7 @@ public:
     /// Dynamic Topology API
     /// @{
     /// Method called by component Init method. Will create all the topology neighborhood buffers.
-    void initTopology();
+    void initContainers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
@@ -83,12 +83,12 @@ void HexahedronSetTopologyContainer::init()
     }
 
     if (!m_hexahedron.empty())
-        initContainers();
+        computeCrossElementBuffers();
 }
 
-void HexahedronSetTopologyContainer::initContainers()
+void HexahedronSetTopologyContainer::computeCrossElementBuffers()
 {
-    QuadSetTopologyContainer::initContainers();
+    QuadSetTopologyContainer::computeCrossElementBuffers();
 
     // Create tetrahedron cross element buffers.
     createQuadsInHexahedronArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
@@ -83,12 +83,12 @@ void HexahedronSetTopologyContainer::init()
     }
 
     if (!m_hexahedron.empty())
-        initTopology();
+        initContainers();
 }
 
-void HexahedronSetTopologyContainer::initTopology()
+void HexahedronSetTopologyContainer::initContainers()
 {
-    QuadSetTopologyContainer::initTopology();
+    QuadSetTopologyContainer::initContainers();
 
     // Create tetrahedron cross element buffers.
     createQuadsInHexahedronArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.h
@@ -222,8 +222,8 @@ public:
     /// Dynamic Topology API
     /// @{
 
-    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see QuadSetTopologyContainer::initContainers()
-    void initContainers() override;
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see QuadSetTopologyContainer::computeCrossElementBuffers()
+    void computeCrossElementBuffers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.h
@@ -222,8 +222,8 @@ public:
     /// Dynamic Topology API
     /// @{
 
-    /// Method called by component Init method. Will create all the topology neighborhood buffers and call @see TriangleSetTopologyContainer::initTopology()
-    void initTopology();
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see QuadSetTopologyContainer::initContainers()
+    void initContainers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
@@ -72,13 +72,13 @@ void QuadSetTopologyContainer::init()
 
     // only init if triangles are present at init.
     if (!m_quads.empty())
-        initTopology();
+        initContainers();
 }
 
-void QuadSetTopologyContainer::initTopology()
+void QuadSetTopologyContainer::initContainers()
 {
     // Force creation of Edge Neighborhood buffers.
-    EdgeSetTopologyContainer::initTopology();
+    EdgeSetTopologyContainer::initContainers();
 
     // Create triangle cross element buffers.
     createEdgesInQuadArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
@@ -72,13 +72,13 @@ void QuadSetTopologyContainer::init()
 
     // only init if triangles are present at init.
     if (!m_quads.empty())
-        initContainers();
+        computeCrossElementBuffers();
 }
 
-void QuadSetTopologyContainer::initContainers()
+void QuadSetTopologyContainer::computeCrossElementBuffers()
 {
     // Force creation of Edge Neighborhood buffers.
-    EdgeSetTopologyContainer::initContainers();
+    EdgeSetTopologyContainer::computeCrossElementBuffers();
 
     // Create triangle cross element buffers.
     createEdgesInQuadArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.h
@@ -144,8 +144,8 @@ public:
 
     /// Dynamic Topology API
     /// @{
-    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see EdgeSetTopologyContainer::initContainers()
-    void initContainers() override;
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see EdgeSetTopologyContainer::computeCrossElementBuffers()
+    void computeCrossElementBuffers() override;
 
     /** \brief Checks if the topology is coherent
     *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.h
@@ -144,8 +144,8 @@ public:
 
     /// Dynamic Topology API
     /// @{
-    /// Method called by component Init method. Will create all the topology neighborhood buffers and call @see EdgeSetTopologyContainer::initTopology()
-    void initTopology();
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see EdgeSetTopologyContainer::initContainers()
+    void initContainers() override;
 
     /** \brief Checks if the topology is coherent
     *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
@@ -79,12 +79,12 @@ void TetrahedronSetTopologyContainer::init()
     }
 
     if (!m_tetrahedron.empty())
-        initTopology();
+        initContainers();
 }
 
-void TetrahedronSetTopologyContainer::initTopology()
+void TetrahedronSetTopologyContainer::initContainers()
 {
-    TriangleSetTopologyContainer::initTopology();
+    TriangleSetTopologyContainer::initContainers();
 
     // Create tetrahedron cross element buffers.
     createTrianglesInTetrahedronArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
@@ -79,12 +79,12 @@ void TetrahedronSetTopologyContainer::init()
     }
 
     if (!m_tetrahedron.empty())
-        initContainers();
+        computeCrossElementBuffers();
 }
 
-void TetrahedronSetTopologyContainer::initContainers()
+void TetrahedronSetTopologyContainer::computeCrossElementBuffers()
 {
-    TriangleSetTopologyContainer::initContainers();
+    TriangleSetTopologyContainer::computeCrossElementBuffers();
 
     // Create tetrahedron cross element buffers.
     createTrianglesInTetrahedronArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.h
@@ -193,8 +193,8 @@ public:
     /// Dynamic Topology API
     /// @{
 
-    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see TriangleSetTopologyContainer::initContainers()
-    void initContainers() override;
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see TriangleSetTopologyContainer::computeCrossElementBuffers()
+    void computeCrossElementBuffers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.h
@@ -193,8 +193,8 @@ public:
     /// Dynamic Topology API
     /// @{
 
-    /// Method called by component Init method. Will create all the topology neighborhood buffers and call @see TriangleSetTopologyContainer::initTopology()
-    void initTopology();
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see TriangleSetTopologyContainer::initContainers()
+    void initContainers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
@@ -73,13 +73,13 @@ void TriangleSetTopologyContainer::init()
 
     // only init if triangles are present at init.
     if (!m_triangle.empty())
-        initTopology();
+        initContainers();
 }
 
-void TriangleSetTopologyContainer::initTopology()
+void TriangleSetTopologyContainer::initContainers()
 {
     // Force creation of Edge Neighborhood buffers.
-    EdgeSetTopologyContainer::initTopology();
+    EdgeSetTopologyContainer::initContainers();
 
     // Create triangle cross element buffers.
     createEdgesInTriangleArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
@@ -73,13 +73,13 @@ void TriangleSetTopologyContainer::init()
 
     // only init if triangles are present at init.
     if (!m_triangle.empty())
-        initContainers();
+        computeCrossElementBuffers();
 }
 
-void TriangleSetTopologyContainer::initContainers()
+void TriangleSetTopologyContainer::computeCrossElementBuffers()
 {
     // Force creation of Edge Neighborhood buffers.
-    EdgeSetTopologyContainer::initContainers();
+    EdgeSetTopologyContainer::computeCrossElementBuffers();
 
     // Create triangle cross element buffers.
     createEdgesInTriangleArray();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.h
@@ -151,8 +151,8 @@ public:
 
     /// Dynamic Topology API
     /// @{
-    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see EdgeSetTopologyContainer::initContainers()
-    void initContainers() override;
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see EdgeSetTopologyContainer::computeCrossElementBuffers()
+    void computeCrossElementBuffers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.h
@@ -151,8 +151,8 @@ public:
 
     /// Dynamic Topology API
     /// @{
-    /// Method called by component Init method. Will create all the topology neighborhood buffers and call @see EdgeSetTopologyContainer::initTopology()
-    void initTopology();
+    /// Method called by component Init method. Will create all the topology neighboorhood buffers and call @see EdgeSetTopologyContainer::initContainers()
+    void initContainers() override;
 
     /** \brief Checks if the topology is coherent
      *

--- a/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -23,7 +23,6 @@
 #include <sofa/helper/io/MeshTopologyLoader.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/core/objectmodel/BaseNode.h>
-
 namespace sofa::core::topology
 {
 

--- a/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.h
@@ -86,7 +86,7 @@ public:
     void init() override;
 
     /// Method to be overriden by child class to create all the topology buffers
-    virtual void initContainers() {}
+    virtual void computeCrossElementBuffers() {}
 
     /// Load the topology from a file.
     ///

--- a/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.h
@@ -85,6 +85,9 @@ protected:
 public:
     void init() override;
 
+    /// Method to be overriden by child class to create all the topology buffers
+    virtual void initContainers() {}
+
     /// Load the topology from a file.
     ///
     /// The default implementation supports the following formats: obj, gmsh, mesh (custom simple text file), xs3 (deprecated description of mass-springs networks).

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
@@ -132,7 +132,7 @@ void ParallelBVHNarrowPhase::initializeTopology(sofa::core::topology::BaseMeshTo
     auto insertionIt = m_initializedTopology.insert(topology);
     if (insertionIt.second)
     {
-        // We need to make sure All topology buffers are well created.
+        // We need to make sure all topology buffers are well created.
         // Those arrays cannot be created on the fly later, in a concurrent environment,
         // due to possible race conditions.
         topology->computeCrossElementBuffers();

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
@@ -132,22 +132,7 @@ void ParallelBVHNarrowPhase::initializeTopology(sofa::core::topology::BaseMeshTo
     auto insertionIt = m_initializedTopology.insert(topology);
     if (insertionIt.second)
     {
-        // The following calls force the creation of some topology arrays before the concurrent computing.
-        // Those arrays cannot be created on the fly, in a concurrent environment,
-        // due to possible race conditions.
-        // Depending on the scene graph, it is possible that those calls are not enough.
-        if (topology->getNbPoints())
-        {
-            topology->getTrianglesAroundVertex(0);
-        }
-        if (topology->getNbTriangles())
-        {
-            topology->getEdgesInTriangle(0);
-        }
-        if (topology->getNbEdges())
-        {
-            topology->getTrianglesAroundEdge(0);
-        }
+        topology->initContainers();
     }
 }
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
@@ -132,6 +132,9 @@ void ParallelBVHNarrowPhase::initializeTopology(sofa::core::topology::BaseMeshTo
     auto insertionIt = m_initializedTopology.insert(topology);
     if (insertionIt.second)
     {
+        // We need to make sure All topology buffers are well created.
+        // Those arrays cannot be created on the fly later, in a concurrent environment,
+        // due to possible race conditions.
         topology->computeCrossElementBuffers();
     }
 }

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBVHNarrowPhase.cpp
@@ -132,7 +132,7 @@ void ParallelBVHNarrowPhase::initializeTopology(sofa::core::topology::BaseMeshTo
     auto insertionIt = m_initializedTopology.insert(topology);
     if (insertionIt.second)
     {
-        topology->initContainers();
+        topology->computeCrossElementBuffers();
     }
 }
 


### PR DESCRIPTION
This PR add a commun API in Topology container to compute the Cross Element Buffers. I.e TriangleId around edges, vertices or edgeId inside triangle, etc..

- Add the method `computeCrossElementBuffers` as virtual in `BaseMeshTopology`.
- Rename method `initTopology `already present in **XXSetTopologyContainer** classes into `computeCrossElementBuffers` which override the base method and is called by default at init.
- Also add Override method implementation in `MeshTopology`. But it is not called at init by default as several scenes were crashing due to Mesh that have not consistent cross element buffers. 
Data<bool> d_computeAllBuffers can be specified in scene to force those buffers computation at init.
- Fix use case in `ParallelBVHNarrowPhase`

This should fix #2063 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
