### PR TITLE
[Simulation] Change LoadFromMemory signature to remove unused parameter Size

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/tests/DefaultPipeline_test.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/tests/DefaultPipeline_test.cpp
@@ -103,9 +103,7 @@ void TestDefaultPipeLine::checkDefaultPipelineWithNoAttributes()
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
-    root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    root = SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str());
     
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
@@ -128,9 +126,7 @@ void TestDefaultPipeLine::checkDefaultPipelineWithMissingIntersection()
              "  <DefaultContactManager/>                                                     \n"
              "</Node>                                                                        \n" ;
 
-    root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    root = SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -152,9 +148,7 @@ void TestDefaultPipeLine::checkDefaultPipelineWithMissingBroadPhase()
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
-    root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    root = SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -175,9 +169,7 @@ void TestDefaultPipeLine::checkDefaultPipelineWithMissingNarrowPhase()
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
-    root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    root = SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -198,9 +190,7 @@ void TestDefaultPipeLine::checkDefaultPipelineWithMissingContactManager()
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
-    root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    root = SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -221,9 +211,7 @@ int TestDefaultPipeLine::checkDefaultPipelineWithMonkeyValueForDepth(int dvalue)
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
-    root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    root = SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str());
     //EXPECT_NE( (root.get()), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 

--- a/Sofa/Component/Collision/Detection/Intersection/tests/LocalMinDistance_test.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/tests/LocalMinDistance_test.cpp
@@ -88,9 +88,7 @@ void TestLocalMinDistance::checkBasicIntersectionTests()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -119,9 +117,7 @@ void TestLocalMinDistance::checkMissingRequiredAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -144,9 +140,7 @@ void TestLocalMinDistance::checkAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -179,9 +173,7 @@ void TestLocalMinDistance::checkDoubleInit()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -209,9 +201,7 @@ void TestLocalMinDistance::checkInitReinit()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 

--- a/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
+++ b/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
@@ -430,9 +430,7 @@ void checkAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -460,9 +458,7 @@ void checkSceneWithVec3MechanicalModel()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -481,9 +477,7 @@ void checkSceneWithRigid3dMechanicalModel()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -503,9 +497,7 @@ void checkGracefulHandlingWhenMechanicalModelIsMissing()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 

--- a/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
@@ -127,9 +127,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
                 "</Node>                                                       ";
 
         EXPECT_MSG_EMIT(Error); // Unable to find a MechanicalObject for this component.
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.c_str());
         EXPECT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
@@ -157,9 +155,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
                 "   </Node>                                                    "
                 "</Node>                                                       ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.c_str());
         EXPECT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
@@ -203,9 +199,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
                 "   </Node>                                                    "
                 "</Node>                                                       ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.c_str());
         EXPECT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
         BaseObject* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");

--- a/Sofa/Component/Engine/Select/tests/MeshROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/MeshROI_test.cpp
@@ -79,9 +79,7 @@ struct MeshROI_test : public BaseSimulationTest,
         "   </Node>                                                        "
         "</Node>                                                           " ;
 
-        m_root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                  scene2.c_str(),
-                                                  scene2.size()) ;
+        m_root = SceneLoaderXML::loadFromMemory("testscene", scene2.c_str());
 
         ASSERT_NE(m_root, nullptr) ;
 
@@ -144,9 +142,7 @@ struct MeshROI_test : public BaseSimulationTest,
         "   </Node>                                                        "
         "</Node>                                                           " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                  scene1.c_str(),
-                                                  scene1.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.c_str());
         ASSERT_NE(root, nullptr) ;
 
         root->getChild("node")->getObject("MeshROI")->init();

--- a/Sofa/Component/Engine/Select/tests/PlaneROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/PlaneROI_test.cpp
@@ -80,9 +80,7 @@ struct PlaneROI_test : public BaseSimulationTest,
         "   </Node>                                                        "
         "</Node>                                                           " ;
 
-        m_node2 = SceneLoaderXML::loadFromMemory ("testscene",
-                                                  scene1.c_str(),
-                                                  scene1.size()) ;
+        m_node2 = SceneLoaderXML::loadFromMemory ("testscene", scene1.c_str());
     }
 
 

--- a/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
@@ -91,9 +91,7 @@ public:
                 "   <MeshExporter name='exporter1' format='"<< format <<"' printLog='true' filename='"<< filename << "' exportAtBegin='true' /> \n"
                 "</Node>                                                           \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene1.str().c_str(),
-                                                          scene1.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -123,9 +121,7 @@ public:
                 "   <MeshExporter name='exporterA' format='"<< format <<"' printLog='true' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
                 "</Node>                                                           \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene1.str().c_str(),
-                                                          scene1.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;

--- a/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
@@ -89,9 +89,7 @@ public:
                 "   <STLExporter name='exporter1' printLog='true' filename='"<< filename << "' exportAtBegin='true' /> \n"
                 "</Node>                                                           \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene1.str().c_str(),
-                                                          scene1.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) << scene1.str() ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -122,9 +120,7 @@ public:
                 "   <STLExporter name='exporterA' printLog='true' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
                 "</Node>                                                           \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene1.str().c_str(),
-                                                          scene1.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;

--- a/Sofa/Component/IO/Mesh/tests/VisualModelOBJExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/VisualModelOBJExporter_test.cpp
@@ -81,9 +81,7 @@ public:
                 "   <VisualModelOBJExporter name='exporter1' printLog='true' filename='"<< filename << "' exportAtBegin='true' /> \n"
                 "</Node>                                                           \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene1.str().c_str(),
-                                                          scene1.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene", scene1.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -109,9 +107,7 @@ public:
                 "   <VisualModelOBJExporter name='exporterA' printLog='true' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
                 "</Node>                                                           \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene1.str().c_str(),
-                                                          scene1.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene", scene1.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;

--- a/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
+++ b/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
@@ -160,9 +160,7 @@ public:
                 "   <DiagonalMass name='m_mass'/>                            "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -195,9 +193,7 @@ public:
                 "    <DiagonalMass name='m_mass' massDensity='1.0' />                                           "
                 "</Node>                                                                                        " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -228,9 +224,7 @@ public:
                 "    <DiagonalMass name='m_mass' totalMass='10'/>                                               "
                 "</Node>                                                                                        " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -260,9 +254,7 @@ public:
                 "    <DiagonalMass name='m_mass' massDensity='1.0' totalMass='10'/>                             "
                 "</Node>                                                                                        " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -292,9 +284,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -330,9 +320,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -362,9 +350,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -401,9 +387,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -434,9 +418,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -467,9 +449,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -500,9 +480,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -533,9 +511,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -572,9 +548,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -605,9 +579,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -632,9 +604,7 @@ public:
                  "   <DiagonalMass name='m_mass' filename='"<< filename <<"'/>      "
                  "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.str().c_str(),
-                                                          sofa::Size(scene.str().size())) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.str().c_str());
         ASSERT_NE(root.get(), nullptr) ;
 
         TheDiagonalMass* mass = root->getTreeObject<TheDiagonalMass>() ;
@@ -679,9 +649,7 @@ public:
             "    </Node>                                                                                        "
             "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation
@@ -752,9 +720,7 @@ public:
             "    </Node>                                                                                        "
             "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
         
         /// Init simulation
@@ -818,9 +784,7 @@ public:
             "    </Node>                                                                                        "
             "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation
@@ -908,9 +872,7 @@ public:
             "    </Node>                                                                                        "
             "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation
@@ -979,9 +941,7 @@ public:
             "    </Node>                                                                                        "
             "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation

--- a/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
+++ b/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
@@ -182,10 +182,8 @@ public:
                 "    <MeshMatrixMass name='m_mass' />                                                               "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
-
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
+    
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
@@ -224,10 +222,8 @@ public:
                 "    <MeshMatrixMass name='m_mass' totalMass='2.0' />                                               "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
-
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
+    
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
@@ -268,9 +264,7 @@ public:
                 "    <MeshMatrixMass name='m_mass' massDensity='1.0' />                                             "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -313,10 +307,8 @@ public:
                 "               vertexMass='1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1' />               "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
-
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
+    
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
@@ -364,10 +356,8 @@ public:
                 "    <MeshMatrixMass name='m_mass' massDensity='1.0' totalMass='2.0' />                             "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
-
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
+    
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
@@ -398,9 +388,7 @@ public:
                 "               vertexMass='1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1' />               "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -433,9 +421,7 @@ public:
                 "               vertexMass='1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1' />               "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -470,9 +456,7 @@ public:
                 "    <MeshMatrixMass name='m_mass' totalMass='-2.0' />                                              "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -503,9 +487,7 @@ public:
                 "    <MeshMatrixMass name='m_mass' massDensity='-1.0' />                                            "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -536,9 +518,7 @@ public:
                 "    <MeshMatrixMass name='m_mass' massDensity='1.0 4.0' />                                         "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -570,9 +550,7 @@ public:
                 "               vertexMass='1 -1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1' />              "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -603,9 +581,7 @@ public:
                 "    <MeshMatrixMass name='m_mass' lumping='1' vertexMass='1 2' />                                  "
                 "</Node>                                                                                            " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -640,9 +616,7 @@ public:
 
         /// Here : default totalMass value will be used since negative value is given
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -675,9 +649,7 @@ public:
 
         /// Here : totalMass value will be used due to concurrent data
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -720,9 +692,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -766,9 +736,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -806,9 +774,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -845,9 +811,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -890,9 +854,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -929,9 +891,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -969,9 +929,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1012,9 +970,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());   
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1051,9 +1007,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1090,9 +1044,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1129,9 +1081,7 @@ public:
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1167,9 +1117,7 @@ public:
                 "        <MeshMatrixMass name='m_mass' vertexMass='1.0 2.0' lumping='1' />                          "
                 "    </Node>                                                                                        "
                 "</Node>                                                                                            ";
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1210,9 +1158,7 @@ public:
 
         /// Here : default totalMass value will be used since negative value is given
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1251,9 +1197,7 @@ public:
 
         /// Here : totalMass value will be used due to concurrent data
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -1307,9 +1251,7 @@ public:
                     "    </Node>                                                                                        "
                     "</Node>                                                                                            ";
         }
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation
@@ -1466,9 +1408,7 @@ public:
                 "</Node>                                                                                            ";
         }
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation
@@ -1621,9 +1561,7 @@ public:
                     "</Node>                                                                                            ";
         }
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation
@@ -1754,9 +1692,7 @@ public:
                     "</Node>                                                                                            ";
         }
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation
@@ -1910,9 +1846,7 @@ public:
                 "</Node>                                                                                            ";
         }
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
-            scene.c_str(),
-            sofa::Size(scene.size()));
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
         ASSERT_NE(root.get(), nullptr);
 
         /// Init simulation

--- a/Sofa/Component/Mass/tests/UniformMass_test.cpp
+++ b/Sofa/Component/Mass/tests/UniformMass_test.cpp
@@ -126,9 +126,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass'/>                             "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -153,9 +151,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='mass' vertexMass='1.0 1.0 2.0 0.0 0.0 0.0 4.0 0.0 7.0 8.0 9.0'/>"
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -183,9 +179,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' totalMass='8.0'/>                             "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -208,9 +202,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' vertexMass='4.0' />                 "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -233,9 +225,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' totalMass='-8.0' />                 "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -258,9 +248,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' vertexMass='-4.0' />                 "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -283,9 +271,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' vertexMass='10.0' totalMass='8.0'/>                 "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -310,9 +296,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' vertexMass='4.0' totalMass='-8.0'/>                 "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -335,9 +319,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' vertexMass='-4.0' totalMass='8.0'/>                 "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -360,9 +342,7 @@ struct UniformMassTest :  public BaseTest
                 "   <UniformMass name='m_mass' totalMass='-8.0' vertexMass=-4.0/>   "
                 "</Node>                                                     " ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
-                                                          scene.c_str(),
-                                                          scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
 
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -383,8 +363,7 @@ struct UniformMassTest :  public BaseTest
                 "   <MechanicalObject template='Rigid3' position='0 0 0 1 0 0 1 0 0 0 1 0 0 1'/>                     "
                 "   <UniformMass filename='BehaviorModels/card.rigid'/>        "
                 "</Node>                                                     " ;
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadFromAValidFile",
-                                                          scene.c_str(), (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadFromAValidFile", scene.c_str());
         root->init(sofa::core::execparams::defaultInstance()) ;
 
         UniformMassRigid* mass = root->getTreeObject<UniformMassRigid>() ;
@@ -403,8 +382,7 @@ struct UniformMassTest :  public BaseTest
                 "   <MechanicalObject position='0 0 0'/>                     "
                 "   <UniformMass filename='BehaviorModels/card.rigid'/>        "
                 "</Node>                                                     " ;
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadFromAValidFile",
-                                                          scene.c_str(), (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadFromAValidFile", scene.c_str());
         root->init(sofa::core::execparams::defaultInstance()) ;
     }
 
@@ -415,8 +393,7 @@ struct UniformMassTest :  public BaseTest
                 "   <MechanicalObject position='0 0 0'/>                     "
                 "   <UniformMass filename='invalid_uniformmatrix.txt'/>        "
                 "</Node>                                                     " ;
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadFromAnInValidFile",
-                                                          scene.c_str(), (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadFromAnInValidFile", scene.c_str());
         root->init(sofa::core::execparams::defaultInstance()) ;
     }
 
@@ -427,8 +404,7 @@ struct UniformMassTest :  public BaseTest
                 "   <MechanicalObject position='0 0 0'/>                     "
                 "   <UniformMass filename='invalid_uniformmatrix.txt'/>        "
                 "</Node>                                                     " ;
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadFromAnInValidFile",
-                                                          scene.c_str(), (int)scene.size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadFromAnInValidFile", scene.c_str());
         root->init(sofa::core::execparams::defaultInstance()) ;
     }
 

--- a/Sofa/Component/MechanicalLoad/tests/ConstantForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/ConstantForceField_test.cpp
@@ -88,9 +88,7 @@ struct ConstantForceField_test : public BaseSimulationTest, NumericTest<typename
                  "   <ConstantForceField name='myForceField' indices='0' force='100.0 0.0 0'/>         \n"
                  "</Node>                                                                                                                                                               \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         EXPECT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -139,9 +137,7 @@ struct ConstantForceField_test : public BaseSimulationTest, NumericTest<typename
                          "   <ConstantForceField name='myForceField' "<< kv.first << "='"<< v.first << "'/>  \n"
                          "</Node>                                                                        \n" ;
 
-                Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                                  scene.str().c_str(),
-                                                                  scene.str().size()) ;
+                Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
                 ASSERT_NE(root.get(), nullptr) << "Problem to load scene: " << scene.str() ;
                 EXPECT_MSG_EMIT(Error) ;
                 root->init(sofa::core::execparams::defaultInstance());
@@ -173,9 +169,7 @@ struct ConstantForceField_test : public BaseSimulationTest, NumericTest<typename
                  "   <ConstantForceField name='myPlaneForceField'/>                              \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         EXPECT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -212,9 +206,7 @@ struct ConstantForceField_test : public BaseSimulationTest, NumericTest<typename
                  "   <ConstantForceField name='myPlaneForceField'/>                              \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;

--- a/Sofa/Component/MechanicalLoad/tests/PlaneForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/PlaneForceField_test.cpp
@@ -204,9 +204,7 @@ struct PlaneForceField_test : public BaseSimulationTest
                  "  </Node>                                                                      \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
         EXPECT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -241,9 +239,7 @@ struct PlaneForceField_test : public BaseSimulationTest
                  "  </Node>                                                                      \n"
                  "</Node>                                                                        \n" ;
 
-            Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                              scene.str().c_str(),
-                                                              scene.str().size()) ;
+            Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
             EXPECT_NE(root.get(), nullptr) ;
             root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -276,9 +272,7 @@ struct PlaneForceField_test : public BaseSimulationTest
                  "  </Node>                                                                      \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
         EXPECT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -309,9 +303,7 @@ struct PlaneForceField_test : public BaseSimulationTest
                  "  </Node>                                                                      \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         EXPECT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;

--- a/Sofa/Component/SceneUtility/tests/AddResourceRepository_test.cpp
+++ b/Sofa/Component/SceneUtility/tests/AddResourceRepository_test.cpp
@@ -58,8 +58,7 @@ struct AddResourceRepository_test : public BaseSimulationTest
         std::string scene = START_STR + addRepoStr + END_STR;
         std::cout << scene << std::endl;
 
-        m_root = sofa::simulation::SceneLoaderXML::loadFromMemory(
-                "scene", scene.c_str(), scene.size());
+        m_root = sofa::simulation::SceneLoaderXML::loadFromMemory("scene", scene.c_str());
 
         EXPECT_NE(m_root, nullptr);
     }

--- a/Sofa/Component/SceneUtility/tests/MakeAliasComponent_test.cpp
+++ b/Sofa/Component/SceneUtility/tests/MakeAliasComponent_test.cpp
@@ -100,9 +100,7 @@ TEST(MakeAliasComponent, checkGracefullHandlingOfMissingAttributes)
         "       <MakeAlias/>                                                 "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeAliasComponent* component = nullptr;
@@ -126,9 +124,7 @@ TEST(MakeAliasComponent, checkGracefullHandlingOfMissingTargetAttributes)
         "       <MakeAlias                            alias='NewName'/>      "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeAliasComponent* component = nullptr;
@@ -150,9 +146,7 @@ TEST(MakeAliasComponent, checkGracefullHandlingOfMissingAliasAttributes)
         "       <MakeAlias targetcomponent='MakeAlias'/>                     "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeAliasComponent* component = nullptr;
@@ -176,9 +170,7 @@ TEST(MakeAliasComponent, checkGracefullHandlingOfInvalidTargetName)
         "</Node>                                                             \n" ;
 
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeAliasComponent* component = nullptr;
@@ -200,9 +192,7 @@ TEST(MakeAliasComponent, checkValidBehavior)
         "       <MyAlias targetcomponent='MakeAlias' alias='ThirdName'/>     \n"
         "</Node>                                                             \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeAliasComponent* component = nullptr;

--- a/Sofa/Component/SceneUtility/tests/MakeDataAliasComponent_test.cpp
+++ b/Sofa/Component/SceneUtility/tests/MakeDataAliasComponent_test.cpp
@@ -99,9 +99,7 @@ TEST(MakeDataAliasComponent, checkGracefullHandlingOfMissingAttributes)
         "       <MakeDataAlias/>                                             "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeDataAliasComponent* component = nullptr;
@@ -125,9 +123,7 @@ TEST(MakeDataAliasComponent, checkGracefullHandlingOfMissingTargetAttributes)
         "       <MakeDataAlias                             alias='NewName'/>      "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeDataAliasComponent* component = nullptr;
@@ -151,9 +147,7 @@ TEST(MakeDataAliasComponent, checkGracefullHandlingOfMissingAliasAttributes)
         "       <MakeDataAlias targetcomponent='MakeAlias'/>                     "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeDataAliasComponent* component = nullptr;
@@ -176,9 +170,7 @@ TEST(MakeDataAliasComponent, checkGracefullHandlingOfInvalidTargetName)
         "       <MakeDataAlias componentname='InvalidComponentName' dataname='position' alias='rest_position'/> \n"
         "</Node>                                                             \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeDataAliasComponent* component = nullptr;
@@ -202,9 +194,7 @@ TEST(MakeDataAliasComponent, checkGracefullHandlingOfInvalidDataName)
         "       <MechanicalObject position='1 2 3 4'/>                                                           \n"
         "</Node>                                                             \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
     MakeDataAliasComponent* component = nullptr;
 
@@ -226,9 +216,7 @@ TEST(MakeDataAliasComponent, checkValidBehavior)
         "       <MechanicalObject myrest_position='1 2 3 '/>                                                 \n"
         "</Node>                                                             \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test",
-                                                       ascene.c_str(),
-                                                       ascene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test", ascene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MakeDataAliasComponent* component = nullptr;

--- a/Sofa/Component/SceneUtility/tests/MessageHandlerComponent_test.cpp
+++ b/Sofa/Component/SceneUtility/tests/MessageHandlerComponent_test.cpp
@@ -71,9 +71,7 @@ TEST(MessageHandlerComponent, simpleInit)
 
     sofa::simulation::setSimulation(new DAGSimulation());
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
     EXPECT_TRUE(root!=nullptr) ;
 
     MessageHandlerComponent* component = nullptr;
@@ -91,9 +89,7 @@ TEST(MessageHandlerComponent, missingHandler)
         "       <MessageHandlerComponent/>                   "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
 
     MessageHandlerComponent* component = nullptr;
     root->getTreeObject(component) ;
@@ -109,9 +105,7 @@ TEST(MessageHandlerComponent, invalidHandler)
         "       <MessageHandlerComponent handler='thisisinvalid'/>           "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
 
     MessageHandlerComponent* component = nullptr;
     root->getTreeObject(component) ;
@@ -127,9 +121,7 @@ TEST(MessageHandlerComponent, clangHandler)
         "       <MessageHandlerComponent handler='clang'/>                   "
         "</Node>                                                             " ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1",
-                                                       scene.c_str(),
-                                                       scene.size() ) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("test1", scene.c_str());
 
     MessageHandlerComponent* component = nullptr;
     root->getTreeObject(component) ;

--- a/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
+++ b/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
@@ -69,9 +69,7 @@ public:
                  "  <OglLabel name='label1' color='0 0 0 0' selectContrastingColor='true' />     \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(nullptr, root.get()) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -102,9 +100,7 @@ public:
                  "  <OglLabel name='label1' color='contrast' printLog='true'/>                   \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(nullptr, root.get()) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -131,9 +127,7 @@ public:
                  "  <OglLabel name='label1'/>                                                    \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;

--- a/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
+++ b/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
@@ -64,9 +64,7 @@ void TestClipPlane::checkClipPlaneValidAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -98,9 +96,7 @@ void TestClipPlane::checkClipPlaneAttributesValues(const std::string& dataname, 
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 

--- a/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
@@ -74,9 +74,7 @@ void checkAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 

--- a/Sofa/GL/Component/Shader/tests/Light_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/Light_test.cpp
@@ -77,9 +77,7 @@ void TestLight::checkLightMissingLightManager(const std::string& lighttype)
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -104,9 +102,7 @@ void TestLight::checkPositionalLightValidAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -147,9 +143,7 @@ void TestLight::checkDirectionalLightValidAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
@@ -193,9 +187,7 @@ void TestLight::checkSpotLightValidAttributes()
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+    Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 

--- a/Sofa/framework/Helper/simutest/AdvancedTimer_test.cpp
+++ b/Sofa/framework/Helper/simutest/AdvancedTimer_test.cpp
@@ -54,9 +54,7 @@ protected:
 				 "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
 				 "</Node>                                                                        \n" ;
 
-		root = SceneLoaderXML::loadFromMemory ("testscene",
-											scene.str().c_str(),
-											scene.str().size()) ;
+		root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 	}
 
 public:

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderPHP.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderPHP.cpp
@@ -96,7 +96,7 @@ sofa::simulation::Node::SPtr SceneLoaderPHP::doLoad(const std::string& filename,
         if (out == "")
             return nullptr;
     }
-    root = SceneLoaderXML::loadFromMemory(filename.c_str(), out.c_str(), (unsigned int)out.size());
+    root = SceneLoaderXML::loadFromMemory(filename.c_str(), out.c_str());
 
     return root;
 }

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.cpp
@@ -136,17 +136,23 @@ Node::SPtr SceneLoaderXML::processXML(xml::BaseElement* xml, const char *filenam
 }
 
 /// Load from a string in memory
-Node::SPtr SceneLoaderXML::loadFromMemory ( const char *filename, const char *data, unsigned int size )
+Node::SPtr SceneLoaderXML::loadFromMemory(const char* filename, const char* data)
 {
     notifyLoadingSceneBefore();
 
-    xml::BaseElement* xml = xml::loadFromMemory (filename, data, size );
+    xml::BaseElement* xml = xml::loadFromMemory(filename, data);
 
     Node::SPtr root = processXML(xml, filename);
 
     delete xml;
     notifyLoadingSceneAfter(root);
     return root;
+}
+
+Node::SPtr SceneLoaderXML::loadFromMemory ( const char *filename, const char *data, unsigned int size )
+{
+    SOFA_UNUSED(size);
+    return loadFromMemory(filename, data);
 }
 
 

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.h
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.h
@@ -47,6 +47,9 @@ public:
     static NodeSPtr processXML(xml::BaseElement* xml, const char *filename);
 
     /// load a scene from memory (typically : an xml into a string)
+    static NodeSPtr loadFromMemory(const char* filename, const char* data);
+
+    SOFA_ATTRIBUTE_DEPRECATED("v22.12 (PR#)", "v23.06", "loadFromMemory with 3 arguments specifying the size has been deprecated. Use loadFromMemory(const char* filename, const char* data).")
     static NodeSPtr loadFromMemory ( const char *filename, const char *data, unsigned int size );
 
     /// get the file type description

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/XML.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/XML.cpp
@@ -231,7 +231,7 @@ BaseElement* processXMLLoading(const char *filename, const TiXmlDocument &doc, b
     return graph;
 }
 
-BaseElement* loadFromMemory(const char *filename, const char *data, unsigned int /*size*/ )
+BaseElement* loadFromMemory(const char* filename, const char* data)
 {
     TiXmlDocument doc; // the resulting document tree
 
@@ -240,10 +240,16 @@ BaseElement* loadFromMemory(const char *filename, const char *data, unsigned int
     doc.Parse(data);
     if (doc.Error())
     {
-        msg_error("XMLParser") << "Failed to open " << filename << "\n" << doc.ErrorDesc() << " at line " << doc.ErrorRow() << " row " << doc.ErrorCol() ;
+        msg_error("XMLParser") << "Failed to open " << filename << "\n" << doc.ErrorDesc() << " at line " << doc.ErrorRow() << " row " << doc.ErrorCol();
         return nullptr;
     }
     return processXMLLoading(filename, doc, true);
+}
+
+BaseElement* loadFromMemory(const char *filename, const char *data, unsigned int size )
+{
+    SOFA_UNUSED(size);
+    return loadFromMemory(filename, data);
 }
 
 BaseElement* loadFromFile(const char *filename)

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/XML.h
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/XML.h
@@ -32,7 +32,10 @@ SOFA_SIMULATION_COMMON_API BaseElement* processXMLLoading(const char *filename, 
 
 SOFA_SIMULATION_COMMON_API BaseElement* loadFromFile(const char *filename);
 
-SOFA_SIMULATION_COMMON_API BaseElement* loadFromMemory(const char *filename, const char *data, unsigned int size );
+SOFA_ATTRIBUTE_DEPRECATED("v22.12 (PR#)", "v23.06", "loadFromMemory with 3 arguments specifying the size has been deprecated. Use loadFromMemory(const char* filename, const char* data).")
+SOFA_SIMULATION_COMMON_API BaseElement* loadFromMemory(const char* filename, const char* data, unsigned int size);
+
+SOFA_SIMULATION_COMMON_API BaseElement* loadFromMemory(const char *filename, const char *data);
 
 
 SOFA_SIMULATION_COMMON_API bool save(const char *filename, BaseElement* root);

--- a/Sofa/framework/Simulation/Core/test/RequiredPlugin_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/RequiredPlugin_test.cpp
@@ -45,9 +45,7 @@ struct RequiredPlugin_test : public BaseSimulationTest
                  "   <RequiredPlugin name=\"notExist\" pluginName=\"SofaNotExist\" />            \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
@@ -63,9 +61,7 @@ struct RequiredPlugin_test : public BaseSimulationTest
                  "   <RequiredPlugin />            \n"
                  "</Node>                                                                        \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size()) ;
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;

--- a/Sofa/framework/Testing/src/sofa/testing/BaseSimulationTest.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/BaseSimulationTest.cpp
@@ -55,7 +55,7 @@ BaseSimulationTest::SceneInstance::SceneInstance(const std::string& type, const 
         simulation::setSimulation(new simulation::graph::DAGSimulation()) ;
 
     simulation = simulation::getSimulation() ;
-    root = SceneLoaderXML::loadFromMemory("dynamicscene", desc.c_str(), desc.size()) ;
+    root = SceneLoaderXML::loadFromMemory("dynamicscene", desc.c_str()) ;
 }
 
 BaseSimulationTest::SceneInstance BaseSimulationTest::SceneInstance::LoadFromFile(const std::string& filename)

--- a/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
+++ b/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
@@ -93,8 +93,7 @@ struct SceneChecker_test : public BaseSimulationTest
               << "</Node>                                                           \n";
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size());
+                                                          scene.str().c_str());
         EXPECT_MSG_NOEMIT(Error);
 
         ASSERT_NE(root.get(), nullptr);
@@ -140,8 +139,7 @@ struct SceneChecker_test : public BaseSimulationTest
               << "</Node>                                                         \n";
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size());
+                                                          scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -182,9 +180,7 @@ struct SceneChecker_test : public BaseSimulationTest
               << "      <ComponentDeprecated />                                   \n"
               << "</Node>                                                         \n";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -227,9 +223,7 @@ struct SceneChecker_test : public BaseSimulationTest
         SceneCheckerVisitor checker(sofa::core::execparams::defaultInstance());
         checker.addCheck( SceneCheckUsingAlias::newSPtr() );
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                          scene.str().c_str(),
-                                                          scene.str().size());
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 


### PR DESCRIPTION
Method LoadFromMemory to load an XML as a string is taking a parameter size which is unused and generate conversion warnings in tests.

- Add method depreciation
- Update all tests compiled in my setup.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
