### PR TITLE
[all] Unit tests for getTemplateName in some components

### DIFF
--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.cpp
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/DisplacementMatrixEngine.cpp
@@ -71,4 +71,6 @@ int DisplacementMatrixEngineClass = core::RegisterObject("Converts a vector of R
     .add< DisplacementMatrixEngine<Rigid3Types> >()
 ;
 
+template class SOFA_COMPONENT_ENGINE_TRANSFORM_API DisplacementMatrixEngine<Rigid3Types>;
+
 } // namespace sofa::component::engine::transform

--- a/Sofa/Component/Engine/Transform/tests/CMakeLists.txt
+++ b/Sofa/Component/Engine/Transform/tests/CMakeLists.txt
@@ -5,8 +5,11 @@ project(Sofa.Component.Engine.Transform_test)
 set(SOURCE_FILES
     DifferenceEngine_test.cpp
     DilateEngine_test.cpp
+    DisplacementMatrixEngine_test.cpp
+    DisplacementTransformEngine_test.cpp
     Engine.Transform_DataUpdate_test.cpp
     IndexValueMapper_test.cpp
+    ProjectiveTransformEngine_test.cpp
     SmoothMeshEngine_test.cpp
     TransformEngine_test.cpp
 )

--- a/Sofa/Component/Engine/Transform/tests/DisplacementMatrixEngine_test.cpp
+++ b/Sofa/Component/Engine/Transform/tests/DisplacementMatrixEngine_test.cpp
@@ -19,28 +19,16 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <MultiThreading/MeanComputation.inl>
+#include <gtest/gtest.h>
+#include <sofa/component/engine/transform/DisplacementMatrixEngine.h>
 
-#include <sofa/core/ObjectFactory.h>
-
-#include <sofa/type/Vec.h>
-#include <sofa/defaulttype/VecTypes.h>
-
-namespace sofa::component::engine
+namespace sofa
 {
-
-int MeanComputationEngineClass = core::RegisterObject("Compute the mean of the input elements")
-        .add< MeanComputation<defaulttype::Vec3Types> >(true) // default template
-        .add< MeanComputation<defaulttype::Vec1Types> >()
-        .add< MeanComputation<defaulttype::Vec2Types> >()
-        .add< MeanComputation<defaulttype::Rigid2Types> >()
-        .add< MeanComputation<defaulttype::Rigid3Types> >()
-        ;
-
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec3Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec1Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid3Types >;
-
-} // namespace sofa::component::engine
+TEST(DisplacementMatrixEngine, getTemplateName)
+{
+    const auto engine = sofa::core::objectmodel::New<
+        sofa::component::engine::transform::DisplacementMatrixEngine<sofa::defaulttype::Rigid3Types>
+    >();
+    EXPECT_EQ(engine->getTemplateName(), "Rigid3d");
+}
+}

--- a/Sofa/Component/Engine/Transform/tests/DisplacementTransformEngine_test.cpp
+++ b/Sofa/Component/Engine/Transform/tests/DisplacementTransformEngine_test.cpp
@@ -19,28 +19,24 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <MultiThreading/MeanComputation.inl>
+#include <gtest/gtest.h>
+#include <sofa/component/engine/transform/DisplacementMatrixEngine.h>
 
-#include <sofa/core/ObjectFactory.h>
-
-#include <sofa/type/Vec.h>
-#include <sofa/defaulttype/VecTypes.h>
-
-namespace sofa::component::engine
+namespace sofa
 {
-
-int MeanComputationEngineClass = core::RegisterObject("Compute the mean of the input elements")
-        .add< MeanComputation<defaulttype::Vec3Types> >(true) // default template
-        .add< MeanComputation<defaulttype::Vec1Types> >()
-        .add< MeanComputation<defaulttype::Vec2Types> >()
-        .add< MeanComputation<defaulttype::Rigid2Types> >()
-        .add< MeanComputation<defaulttype::Rigid3Types> >()
-        ;
-
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec3Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec1Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid3Types >;
-
-} // namespace sofa::component::engine
+TEST(DisplacementTransformEngine, getTemplateName)
+{
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::component::engine::transform::DisplacementTransformEngine<sofa::defaulttype::Rigid3Types, sofa::type::Mat4x4>
+        >();
+        EXPECT_EQ(engine->getTemplateName(), "Rigid3d,Mat4x4d");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::component::engine::transform::DisplacementTransformEngine<sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types::Coord>
+        >();
+        EXPECT_EQ(engine->getTemplateName(), "Rigid3d,RigidCoord3d");
+    }
+}
+}

--- a/Sofa/Component/Engine/Transform/tests/ProjectiveTransformEngine_test.cpp
+++ b/Sofa/Component/Engine/Transform/tests/ProjectiveTransformEngine_test.cpp
@@ -19,28 +19,16 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <MultiThreading/MeanComputation.inl>
+#include <gtest/gtest.h>
+#include <sofa/component/engine/transform/ProjectiveTransformEngine.h>
 
-#include <sofa/core/ObjectFactory.h>
-
-#include <sofa/type/Vec.h>
-#include <sofa/defaulttype/VecTypes.h>
-
-namespace sofa::component::engine
+namespace sofa
 {
-
-int MeanComputationEngineClass = core::RegisterObject("Compute the mean of the input elements")
-        .add< MeanComputation<defaulttype::Vec3Types> >(true) // default template
-        .add< MeanComputation<defaulttype::Vec1Types> >()
-        .add< MeanComputation<defaulttype::Vec2Types> >()
-        .add< MeanComputation<defaulttype::Rigid2Types> >()
-        .add< MeanComputation<defaulttype::Rigid3Types> >()
-        ;
-
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec3Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec1Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid3Types >;
-
-} // namespace sofa::component::engine
+TEST(ProjectiveTransformEngine, getTemplateName)
+{
+    const auto engine = sofa::core::objectmodel::New<
+        sofa::component::engine::transform::ProjectiveTransformEngine<sofa::defaulttype::Vec3Types>
+    >();
+    EXPECT_EQ(engine->getTemplateName(), "Vec3d");
+}
+}

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -137,7 +137,7 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
             /// This alias results in "undefined" behavior.
             if( alias->second )
             {
-                deprecatedTemplates.push_back("The deprecated template '"+name+"' has been replaced by "+alias->first+". As they have different precisions this may result in undefined behavior. To remove this message, please update your scene to use the generic 'Vec3' templates or one of 'Vec3f/Vec3d' that match your the precision of your Sofa binary.");
+                deprecatedTemplates.push_back("The deprecated template '"+name+"' has been replaced by "+alias->first+".");
             }
 
             name = alias->first;

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
@@ -27,6 +27,8 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
+#include <sofa/defaulttype/DataTypeInfo.h>
+
 namespace sofa::defaulttype
 {
 
@@ -127,4 +129,13 @@ static RegisterTemplateAlias Vec3dAlias("Vec3d", sofa::defaulttype::Vec3Types::N
 static RegisterTemplateAlias Vec6dAlias("Vec6d", sofa::defaulttype::Vec6Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Rigid2dAlias("Rigid2d", sofa::defaulttype::Rigid2Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Rigid3dAlias("Rigid3d", sofa::defaulttype::Rigid3Types::Name(), isSRealFloat());
+
+// Compatibility aliases used previously in DataExchange (see PR#3380)
+static RegisterTemplateAlias floatAlias("float", sofa::defaulttype::DataTypeName<float>::name(), true);
+static RegisterTemplateAlias doubleAlias("double", sofa::defaulttype::DataTypeName<double>::name(), true);
+static RegisterTemplateAlias vector_intAlias("vector<int>", sofa::defaulttype::DataTypeName<sofa::type::vector<int> >::name(), true);
+static RegisterTemplateAlias vector_uintAlias("vector<unsigned_int>", sofa::defaulttype::DataTypeName<sofa::type::vector<unsigned int> >::name(), true);
+static RegisterTemplateAlias vector_floatAlias("vector<float>", sofa::defaulttype::DataTypeName<sofa::type::vector<float> >::name(), true);
+static RegisterTemplateAlias vector_doubleAlias("vector<double>", sofa::defaulttype::DataTypeName<sofa::type::vector<double> >::name(), true);
+
 } // namespace sofa::defaulttype

--- a/applications/plugins/MultiThreading/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/CMakeLists.txt
@@ -54,3 +54,11 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     RELOCATABLE "plugins"
     )
+
+# Tests
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(MULTITHREADING_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(MULTITHREADING_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
@@ -1,4 +1,25 @@
-#include "DataExchange.inl"
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <MultiThreading/DataExchange.inl>
 
 #include <MultiThreading/config.h>
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_MULTITHREADING_PLUGIN_DATAEXCHANGE_CPP
 #include <MultiThreading/DataExchange.inl>
 
 #include <MultiThreading/config.h>

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
@@ -35,28 +35,6 @@
 namespace sofa
 {
 
-
-	namespace defaulttype
-	{
-
-		template<> class DataTypeName< type::vector<sofa::type::Vec3d> > { public: static const std::string name() { return "vector<Vec3d>"; } };
-		template<> class DataTypeName< type::vector<sofa::type::Vec2d> > { public: static const std::string name() { return "vector<Vec2d>"; } };
-		template<> class DataTypeName< type::vector<double> > { public: static const std::string name() { return "vector<double>"; } };
-		template<> class DataTypeName< type::vector<sofa::type::Vec3f> > { public: static const std::string name() { return "vector<Vec3f>"; } };
-		template<> class DataTypeName< type::vector<sofa::type::Vec2f> > { public: static const std::string name() { return "vector<Vec2f>"; } };
-		template<> class DataTypeName< type::vector<float> > { public: static const std::string name() { return "vector<float>"; } };
-		template<> class DataTypeName<double> { public: static const std::string name() { return "double"; } };
-		template<> class DataTypeName<float> { public: static const std::string name() { return "float"; } };
-		template<> class DataTypeName< type::vector<int> > { public: static const std::string name() { return "vector<int>"; } };
-		template<> class DataTypeName< type::vector<unsigned int> > { public: static const std::string name() { return "vector<unsigned_int>"; } };
-		template<> class DataTypeName<bool> { public: static const std::string name() { return "bool"; } };
-		
-		//template<> struct DataTypeName< sofa::gpu::cuda::CudaVector<sofa::gpu::cuda::CudaVec2fTypes> > { static const std::string name() { return "cudavector<CudaVec2f>"; } };
-		
-
-	} // namespace defaulttype
-
-
 	namespace core
 	{
 
@@ -79,8 +57,6 @@ int DataExchangeClass = core::RegisterObject("DataExchange")
 .add< DataExchange< sofa::type::vector<int> > >()
 .add< DataExchange< sofa::type::vector<unsigned int> > >()
 .add< DataExchange< bool > >()
-
-//.add< DataExchange< sofa::gpu::cuda::CudaVector<sofa::gpu::cuda::CudaVec2fTypes> >()
 ;
 
 
@@ -101,9 +77,6 @@ template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< float >;
 template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<int> >;
 template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<unsigned int> >;
 template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< bool >;
-
-//template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::gpu::cuda::CudaVector<sofa::gpu::cuda::CudaVec2fTypes> >;
-
 
 
 	} // namespace core

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.cpp
@@ -38,19 +38,19 @@ namespace sofa
 	namespace defaulttype
 	{
 
-		template<> struct DataTypeName< type::vector<sofa::type::Vec3d> > { static const char* name() { return "vector<Vec3d>"; } };
-		template<> struct DataTypeName< type::vector<sofa::type::Vec2d> > { static const char* name() { return "vector<Vec2d>"; } };
-		template<> struct DataTypeName< type::vector<double> > { static const char* name() { return "vector<double>"; } };
-		template<> struct DataTypeName< type::vector<sofa::type::Vec3f> > { static const char* name() { return "vector<Vec3f>"; } };
-		template<> struct DataTypeName< type::vector<sofa::type::Vec2f> > { static const char* name() { return "vector<Vec2f>"; } };
-		template<> struct DataTypeName< type::vector<float> > { static const char* name() { return "vector<float>"; } };
-		template<> struct DataTypeName<double> { static const char* name() { return "double"; } };
-		template<> struct DataTypeName<float> { static const char* name() { return "float"; } };
-		template<> struct DataTypeName< type::vector<int> > { static const char* name() { return "vector<int>"; } };
-		template<> struct DataTypeName< type::vector<unsigned int> > { static const char* name() { return "vector<unsigned_int>"; } };
-		template<> struct DataTypeName<bool> { static const char* name() { return "bool"; } };
+		template<> class DataTypeName< type::vector<sofa::type::Vec3d> > { public: static const std::string name() { return "vector<Vec3d>"; } };
+		template<> class DataTypeName< type::vector<sofa::type::Vec2d> > { public: static const std::string name() { return "vector<Vec2d>"; } };
+		template<> class DataTypeName< type::vector<double> > { public: static const std::string name() { return "vector<double>"; } };
+		template<> class DataTypeName< type::vector<sofa::type::Vec3f> > { public: static const std::string name() { return "vector<Vec3f>"; } };
+		template<> class DataTypeName< type::vector<sofa::type::Vec2f> > { public: static const std::string name() { return "vector<Vec2f>"; } };
+		template<> class DataTypeName< type::vector<float> > { public: static const std::string name() { return "vector<float>"; } };
+		template<> class DataTypeName<double> { public: static const std::string name() { return "double"; } };
+		template<> class DataTypeName<float> { public: static const std::string name() { return "float"; } };
+		template<> class DataTypeName< type::vector<int> > { public: static const std::string name() { return "vector<int>"; } };
+		template<> class DataTypeName< type::vector<unsigned int> > { public: static const std::string name() { return "vector<unsigned_int>"; } };
+		template<> class DataTypeName<bool> { public: static const std::string name() { return "bool"; } };
 		
-		//template<> struct DataTypeName< sofa::gpu::cuda::CudaVector<sofa::gpu::cuda::CudaVec2fTypes> > { static const char* name() { return "cudavector<CudaVec2f>"; } };
+		//template<> struct DataTypeName< sofa::gpu::cuda::CudaVector<sofa::gpu::cuda::CudaVec2fTypes> > { static const std::string name() { return "cudavector<CudaVec2f>"; } };
 		
 
 	} // namespace defaulttype

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
@@ -22,7 +22,7 @@
 #ifndef SOFA_EXCHANGE_DATA_H
 #define SOFA_EXCHANGE_DATA_H
 
-
+#include <MultiThreading/config.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/objectmodel/BaseData.h>
 #include <sofa/core/State.h>
@@ -166,29 +166,23 @@ namespace sofa
 
 
 
+#if !defined(SOFA_MULTITHREADING_PLUGIN_DATAEXCHANGE_CPP)
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<sofa::type::Vec3d> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<sofa::type::Vec2d> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<double> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::Vec3d >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< double >;
 
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec3dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec2dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec1dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec6dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec3dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid3dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid2dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid3dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid3dTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid2dTypes >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<sofa::type::Vec3f> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<sofa::type::Vec2f> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<float> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::Vec3f >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< float >;
 
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec3fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::type::Vec2fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec1fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec6fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Vec3fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid3fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid2fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid3fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid3fTypes >;
-		//extern template class SOFA_XICATHPLUGIN_API DataExchange< sofa::defaulttype::Rigid2fTypes >;
-
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<int> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< sofa::type::vector<unsigned int> >;
+extern template class SOFA_MULTITHREADING_PLUGIN_API DataExchange< bool >;
+#endif
 
 	}
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
@@ -92,23 +92,6 @@ namespace sofa
             }
 
 			template<class T>
-			static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-			{
-				std::string dataTypeName = defaulttype::DataTypeName<DataTypes>::name();
-				// check for the right template
-                if ( std::strcmp( dataTypeName.c_str(), arg->getAttribute("template") ) != 0 )
-				{
-					return false;
-					// try to guess from the "from" and "to" data types
-				}
-
-
-				return BaseObject::canCreate(obj, context, arg);
-			}
-
-
-
-			template<class T>
 			static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
 			{	
 				std::string fromPath;

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.inl
@@ -1,7 +1,28 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
 #ifndef _SofaDataExchange_inl__
 #define _SofaDataExchange_inl__
 
-#include "DataExchange.h"
+#include <MultiThreading/DataExchange.h>
 
 
 namespace sofa

--- a/applications/plugins/MultiThreading/src/MultiThreading/MeanComputation.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/MeanComputation.inl
@@ -1,4 +1,25 @@
-#include "MeanComputation.h"
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <MultiThreading/MeanComputation.h>
 
 #include <sofa/component/statecontainer/MechanicalObject.h>
 

--- a/applications/plugins/MultiThreading/test/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/test/CMakeLists.txt
@@ -5,9 +5,11 @@ project(MultiThreading_test)
 set ( HEADER_FILES
 )
 set(SOURCE_FILES
+    DataExchange_test.cpp
+    MeanComputation_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Simulation.Core)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Simulation.Core MultiThreading)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/MultiThreading/test/DataExchange_test.cpp
+++ b/applications/plugins/MultiThreading/test/DataExchange_test.cpp
@@ -1,0 +1,112 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <MultiThreading/DataExchange.h>
+
+namespace sofa
+{
+TEST(DataExchange, getTemplateName)
+{
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<sofa::type::Vec3d>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<Vec3d>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<sofa::type::Vec2d>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<Vec2d>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<double>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<double>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::Vec3d>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "Vec3d");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<double>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "double");
+    }
+
+
+
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<sofa::type::Vec3f>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<Vec3f>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<sofa::type::Vec2f>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<Vec2f>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<float>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<float>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::Vec3f>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "Vec3f");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<float>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "float");
+    }
+
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<int>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<int>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<sofa::type::vector<unsigned int>>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "vector<unsigned_int>");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::core::DataExchange<bool>
+        >("", "");
+        EXPECT_EQ(engine->getTemplateName(), "bool");
+    }
+}
+}

--- a/applications/plugins/MultiThreading/test/DataExchange_test.cpp
+++ b/applications/plugins/MultiThreading/test/DataExchange_test.cpp
@@ -42,7 +42,7 @@ TEST(DataExchange, getTemplateName)
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<sofa::type::vector<double>>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "vector<double>");
+        EXPECT_EQ(engine->getTemplateName(), "vector<d>");
     }
     {
         const auto engine = sofa::core::objectmodel::New<
@@ -54,7 +54,7 @@ TEST(DataExchange, getTemplateName)
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<double>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "double");
+        EXPECT_EQ(engine->getTemplateName(), "d");
     }
 
 
@@ -75,7 +75,7 @@ TEST(DataExchange, getTemplateName)
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<sofa::type::vector<float>>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "vector<float>");
+        EXPECT_EQ(engine->getTemplateName(), "vector<f>");
     }
     {
         const auto engine = sofa::core::objectmodel::New<
@@ -87,20 +87,20 @@ TEST(DataExchange, getTemplateName)
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<float>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "float");
+        EXPECT_EQ(engine->getTemplateName(), "f");
     }
 
     {
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<sofa::type::vector<int>>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "vector<int>");
+        EXPECT_EQ(engine->getTemplateName(), "vector<i>");
     }
     {
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<sofa::type::vector<unsigned int>>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "vector<unsigned_int>");
+        EXPECT_EQ(engine->getTemplateName(), "vector<I>");
     }
     {
         const auto engine = sofa::core::objectmodel::New<

--- a/applications/plugins/MultiThreading/test/MeanComputation_test.cpp
+++ b/applications/plugins/MultiThreading/test/MeanComputation_test.cpp
@@ -19,28 +19,42 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <MultiThreading/MeanComputation.inl>
+#include <gtest/gtest.h>
+#include <MultiThreading/MeanComputation.h>
 
-#include <sofa/core/ObjectFactory.h>
-
-#include <sofa/type/Vec.h>
-#include <sofa/defaulttype/VecTypes.h>
-
-namespace sofa::component::engine
+namespace sofa
 {
-
-int MeanComputationEngineClass = core::RegisterObject("Compute the mean of the input elements")
-        .add< MeanComputation<defaulttype::Vec3Types> >(true) // default template
-        .add< MeanComputation<defaulttype::Vec1Types> >()
-        .add< MeanComputation<defaulttype::Vec2Types> >()
-        .add< MeanComputation<defaulttype::Rigid2Types> >()
-        .add< MeanComputation<defaulttype::Rigid3Types> >()
-        ;
-
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec3Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec1Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Vec2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid2Types >;
-template class SOFA_MULTITHREADING_PLUGIN_API MeanComputation< defaulttype::Rigid3Types >;
-
-} // namespace sofa::component::engine
+TEST(MeanComputation, getTemplateName)
+{
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::component::engine::MeanComputation<sofa::defaulttype::Vec3Types>
+        >();
+        EXPECT_EQ(engine->getTemplateName(), "Vec3d");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::component::engine::MeanComputation<sofa::defaulttype::Vec2Types>
+        >();
+        EXPECT_EQ(engine->getTemplateName(), "Vec2d");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::component::engine::MeanComputation<sofa::defaulttype::Vec1Types>
+        >();
+        EXPECT_EQ(engine->getTemplateName(), "Vec1d");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::component::engine::MeanComputation<sofa::defaulttype::Rigid2Types>
+        >();
+        EXPECT_EQ(engine->getTemplateName(), "Rigid2d");
+    }
+    {
+        const auto engine = sofa::core::objectmodel::New<
+            sofa::component::engine::MeanComputation<sofa::defaulttype::Rigid3Types>
+        >();
+        EXPECT_EQ(engine->getTemplateName(), "Rigid3d");
+    }
+}
+}


### PR DESCRIPTION
https://github.com/sofa-framework/sofa/pull/3242 removes some code related to the `getTemplateName` method. This PR adds some unit tests to make sure that #3242 won't break them.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
