### PR TITLE
[Config] Change type of CMake message when adding a module

### DIFF
--- a/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
@@ -136,7 +136,7 @@ macro(sofa_add_generic directory name type)
         endif()
 
         if(${option})
-            message("Adding ${type_lower} ${name}")
+            message(STATUS "Adding ${type_lower} ${name}")
             add_subdirectory(${directory} "${ARG_BINARY_DIR}")
         endif()
 


### PR DESCRIPTION
Previously, the default mode was NOTICE, which print the message in red. The doc says "Important message printed to stderr to attract user's attention.". The consequence was that almost all the CMake log was written in red, and it was difficult to find the true important messages. This commit change the type of message so it is written in black.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
