### PR TITLE
[CMake] Speed-up Configuration (again)

### DIFF
--- a/Sofa/GUI/Common/CMakeLists.txt
+++ b/Sofa/GUI/Common/CMakeLists.txt
@@ -74,7 +74,7 @@ set (COMPAT_HEADER_FILES
     ${COMPATSOFAGUICOMMON_ROOT}/sofa/gui/ViewerFactory.h
 )
 
-find_package(Sofa.Simulation.Common REQUIRED)
+sofa_find_package(Sofa.Simulation.Common REQUIRED)
 sofa_find_package(Sofa.Component.Setting REQUIRED)
 sofa_find_package(Sofa.Component.Collision.Response.Contact REQUIRED)
 sofa_find_package(Sofa.GUI.Component REQUIRED)

--- a/Sofa/GUI/Component/CMakeLists.txt
+++ b/Sofa/GUI/Component/CMakeLists.txt
@@ -52,7 +52,7 @@ set(SOURCE_FILES
 
 )
 
-find_package(Sofa.Simulation.Core REQUIRED)
+sofa_find_package(Sofa.Simulation.Core REQUIRED)
 sofa_find_package(Sofa.Component.Setting REQUIRED)
 sofa_find_package(Sofa.Component.Visual REQUIRED)
 sofa_find_package(Sofa.Component.SolidMechanics.Spring REQUIRED)

--- a/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
@@ -378,11 +378,13 @@ macro(sofa_find_package name)
         list(REMOVE_ITEM find_package_args "BOTH_SCOPES")
     endif()
 
-    find_package(${name} ${find_package_args})
-
-    if(TARGET ${name} AND NOT ${name}_FOUND)
+    if(NOT TARGET ${name})
+        find_package(${name} ${find_package_args})
+    else()
         # Dirty ? set the variable _FOUND if the target is present
-        set(${name}_FOUND TRUE)
+        if(NOT ${name}_FOUND)
+            set(${name}_FOUND TRUE)
+        endif()
     endif()
 
     string(TOUPPER ${name} name_upper)

--- a/Sofa/framework/Simulation/Common/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Common/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SOURCE_FILES
     ${SOFA_SIMULATION_COMMON_SRC}/xml/XML.cpp
 )
 
-find_package(Sofa.Core REQUIRED)
+sofa_find_package(Sofa.Core REQUIRED)
 sofa_find_package(Sofa.Simulation.Core REQUIRED)
 sofa_find_package(TinyXML REQUIRED)
 

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -254,7 +254,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/mechanicalvisitor/MechanicalVSizeVisitor.cpp
 )
 
-find_package(Sofa.Core REQUIRED)
+sofa_find_package(Sofa.Core REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 

--- a/Sofa/framework/Testing/CMakeLists.txt
+++ b/Sofa/framework/Testing/CMakeLists.txt
@@ -39,7 +39,7 @@ set (COMPAT_HEADER_FILES
     ${COMPATSRC_ROOT}/SofaSimulationGraph/testing/BaseSimulationTest.h
 )
 
-find_package(Sofa.Helper REQUIRED)
+sofa_find_package(Sofa.Helper REQUIRED)
 sofa_find_package(Sofa.DefaultType REQUIRED)
 sofa_find_package(Sofa.Core REQUIRED)
 sofa_find_package(Sofa.Simulation.Graph REQUIRED)

--- a/applications/collections/deprecated/CMakeLists.txt
+++ b/applications/collections/deprecated/CMakeLists.txt
@@ -45,7 +45,7 @@ sofa_add_subdirectory(collection modules/SofaDenseSolver SofaDenseSolver ON WHEN
 
 sofa_add_subdirectory(collection modules/SofaNonUniformFem SofaNonUniformFem ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 
-find_package(Sofa.GL QUIET)
+sofa_find_package(Sofa.GL QUIET)
 sofa_add_subdirectory(collection modules/SofaOpenglVisual SofaOpenglVisual ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS AND Sofa.GL_FOUND" VALUE_IF_HIDDEN OFF)
 
 ## Misc

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-find_package(Sofa.Framework)
+find_package(Sofa.Config REQUIRED)
 
 if(SOFA_BUILD_TESTS OR SOFA_BUILD_RELEASE_PACKAGE)
     # (Deprecated) Library used to write high level tests involving many components.
@@ -61,7 +61,7 @@ if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_SYSTEM_NAME} MATCHES "
     sofa_add_subdirectory(plugin SofaPardisoSolver SofaPardisoSolver) # SofaPardisoSolver is only available under linux with gcc
 endif()
 
-find_package(Sofa.GL QUIET)
+sofa_find_package(Sofa.GL QUIET)
 if(Sofa.GL_FOUND)
     sofa_add_subdirectory(plugin SofaCUDA SofaCUDA)           # SofaCUDA plugin can't work without OPENGL
     sofa_add_subdirectory(plugin SofaSimpleGUI SofaSimpleGUI) # SofaSimpleGUI plugin can't work without OPENGL

--- a/applications/projects/SceneChecking/CMakeLists.txt
+++ b/applications/projects/SceneChecking/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(SceneChecking LANGUAGES CXX)
 
-find_package(Sofa.Simulation.Core REQUIRED)
+find_package(Sofa.Config REQUIRED)
+sofa_find_package(Sofa.Simulation.Core REQUIRED)
 sofa_find_package(Sofa.Component.SceneUtility REQUIRED)
 sofa_find_package(Sofa.Component.Collision.Response.Contact REQUIRED)
 


### PR DESCRIPTION
Since SofaNG, cmake was again slow to configure (especially on Windows)
After investigation, the previous sofa_find_package() was nulliified in #3120 , and I dont really see why. And the associated commit message is not informative https://github.com/sofa-framework/sofa/pull/3120/commits/8a3ae2dacc1bdff9be83aee15744a37e21eb0054

Bringing it back bring the config time from ~18s to 4.5s on Windows/MSVC generator on a minimal preset (all framework + comonents+ GL + GUI)
(Manjaro/ninja generator go from 4 to 2.5s)
So it is quite nice all in all 🥸

Trace: (orange part is time for `find_package()`)
Before: ![cmake1](https://user-images.githubusercontent.com/11028016/195506545-32c3d4db-b6b2-4500-a3fb-dce59da50c53.png)
After: ![cmake2](https://user-images.githubusercontent.com/11028016/195506607-e6ede1f9-c5fd-497d-bd4f-dd4832da918a.png)

Install procedure should not be impacted, as the cmake.in files are not touched.


\+ this PR fixes some missing sofa_find_package() here and there.

Lets see if the CI confirms if https://github.com/sofa-framework/sofa/pull/3120/commits/8a3ae2dacc1bdff9be83aee15744a37e21eb0054 was only a mistake
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
