### PR TITLE
[BarycentricMappers] Fix potential division by 0

### DIFF
--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
@@ -341,7 +341,13 @@ BarycentricMapperMeshTopology<In,Out>::createPointInLine ( const typename Out::C
     const typename In::Coord p0 = ( *points ) [elem[0]];
     const typename In::Coord pA = ( *points ) [elem[1]] - p0;
     typename In::Coord pos = Out::getCPos(p) - p0;
-    baryCoords[0] = ( ( pos*pA ) /pA.norm2() );
+
+    const SReal L2 = pA.norm2(); 
+    if (L2 < FLT_EPSILON) // in case of null length edge, avoid division by 0
+        baryCoords[0] = 0.0;
+    else
+        baryCoords[0] = ((pos * pA) / L2);
+
     return this->addPointInLine ( lineIndex, baryCoords );
 }
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
@@ -343,7 +343,7 @@ BarycentricMapperMeshTopology<In,Out>::createPointInLine ( const typename Out::C
     typename In::Coord pos = Out::getCPos(p) - p0;
 
     const SReal L2 = pA.norm2(); 
-    if (L2 < FLT_EPSILON) // in case of null length edge, avoid division by 0
+    if (L2 < std::numeric_limits<float>::epsilon()) // in case of null length edge, avoid division by 0
         baryCoords[0] = 0.0;
     else
         baryCoords[0] = ((pos * pA) / L2);

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperMeshTopology.inl
@@ -343,7 +343,7 @@ BarycentricMapperMeshTopology<In,Out>::createPointInLine ( const typename Out::C
     typename In::Coord pos = Out::getCPos(p) - p0;
 
     const SReal L2 = pA.norm2(); 
-    if (L2 < std::numeric_limits<float>::epsilon()) // in case of null length edge, avoid division by 0
+    if (L2 < std::numeric_limits<SReal>::epsilon()) // in case of null length edge, avoid division by 0
         baryCoords[0] = 0.0;
     else
         baryCoords[0] = ((pos * pA) / L2);

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.cpp
@@ -127,25 +127,26 @@ void RegularGridTopology::setPos(BoundingBox b)
 void RegularGridTopology::setPos(SReal xmin, SReal xmax, SReal ymin, SReal ymax, SReal zmin, SReal zmax)
 {
     SReal p0x=xmin, p0y=ymin, p0z=zmin;
+    const Vec3i _n = d_n.getValue() - Vec3i(1,1,1);
 
-    if (d_n.getValue()[0]>1)
-        setDx(Vector3((xmax-xmin)/(d_n.getValue()[0]-1), 0_sreal, 0_sreal));
+    if (_n[0] > 0.0)
+        setDx(Vector3((xmax - xmin) / _n[0], 0_sreal, 0_sreal));
     else
     {
         setDx(Vector3(xmax-xmin, 0_sreal, 0_sreal));
         p0x = (xmax+xmin)/2;
     }
 
-    if (d_n.getValue()[1]>1)
-        setDy(Vector3(0_sreal,(ymax-ymin)/(d_n.getValue()[1]-1), 0_sreal));
+    if (_n[1] > 0)
+        setDy(Vector3(0_sreal, (ymax - ymin) / _n[1], 0_sreal));
     else
     {
         setDy(Vector3(0_sreal, ymax-ymin, 0_sreal));
         p0y = (ymax+ymin)/2;
     }
 
-    if (d_n.getValue()[2]>1)
-        setDz(Vector3(0_sreal, 0_sreal,(zmax-zmin)/(d_n.getValue()[2]-1)));
+    if (_n[2] > 0)
+        setDz(Vector3(0_sreal, 0_sreal, (zmax - zmin) / _n[2]));
     else
     {
         setDz(Vector3(0_sreal, 0_sreal, zmax-zmin));

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.cpp
@@ -129,7 +129,7 @@ void RegularGridTopology::setPos(SReal xmin, SReal xmax, SReal ymin, SReal ymax,
     SReal p0x=xmin, p0y=ymin, p0z=zmin;
     const Vec3i _n = d_n.getValue() - Vec3i(1,1,1);
 
-    if (_n[0] > 0.0)
+    if (_n[0] > 0)
         setDx(Vector3((xmax - xmin) / _n[0], 0_sreal, 0_sreal));
     else
     {


### PR DESCRIPTION
To avoid NaN propagation when a wrong constraint is created using barycentricMapper and CreatePointLine.

Also add a small changes in regularGrid done during debug division by 0.

fix https://github.com/sofa-framework/BeamAdapter/issues/55  (does it works across repo?)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
