### PR TITLE
[SofaDistanceGrid] Set invalid state if cannot load mesh

### DIFF
--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -67,6 +67,12 @@ void DistanceGridForceField<DataTypes>::init()
                                     nx.getValue(),ny.getValue(),nz.getValue(),
                                     box.getValue()[0],box.getValue()[1]);
 
+    if (grid == nullptr)
+    {
+        sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+
     if (this->stiffnessArea.getValue() != 0 && this->mstate)
     {
         core::topology::BaseMeshTopology* topology = this->getContext()->getMeshTopology();
@@ -125,6 +131,7 @@ void DistanceGridForceField<DataTypes>::init()
         }
     }
 
+    sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 template<class DataTypes>

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -70,6 +70,7 @@ void DistanceGridForceField<DataTypes>::init()
     if (grid == nullptr)
     {
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        msg_error() << "Failed to initialize: Invalid distance grid";
         return;
     }
 


### PR DESCRIPTION
Fix a crash at init of example `DistanceGridForceField-liver.scn`, when FlowVR library is not compiled.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
