### PR TITLE
[Sofa.Core] VecId: move definition of VecTypeLabels in its own Translation Unit

### DIFF
--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -197,6 +197,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/PathResolver.cpp
     ${SRC_ROOT}/SofaLibrary.cpp
     ${SRC_ROOT}/State.cpp
+    ${SRC_ROOT}/VecId.cpp
     ${SRC_ROOT}/behavior/BaseAnimationLoop.cpp
     ${SRC_ROOT}/behavior/BaseConstraint.cpp
     ${SRC_ROOT}/behavior/BaseConstraintCorrection.cpp

--- a/Sofa/framework/Core/src/sofa/core/VecId.cpp
+++ b/Sofa/framework/Core/src/sofa/core/VecId.cpp
@@ -1,0 +1,35 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/VecId.h>
+
+
+namespace sofa::core
+{
+
+const std::unordered_map<VecType, std::string> VecTypeLabels {
+    {V_ALL, "(V_ALL)"},
+    {V_COORD, "(V_COORD)"},
+    {V_DERIV, "(V_DERIV)"},
+    {V_MATDERIV, "(V_MATDERIV)"}
+};
+
+} // namespace sofa::core

--- a/Sofa/framework/Core/src/sofa/core/VecId.cpp
+++ b/Sofa/framework/Core/src/sofa/core/VecId.cpp
@@ -21,11 +21,10 @@
 ******************************************************************************/
 #include <sofa/core/VecId.h>
 
-
 namespace sofa::core
 {
 
-const std::unordered_map<VecType, std::string> VecTypeLabels {
+SOFA_CORE_API const std::unordered_map<VecType, std::string> VecTypeLabels {
     {V_ALL, "(V_ALL)"},
     {V_COORD, "(V_COORD)"},
     {V_DERIV, "(V_DERIV)"},

--- a/Sofa/framework/Core/src/sofa/core/VecId.h
+++ b/Sofa/framework/Core/src/sofa/core/VecId.h
@@ -22,7 +22,8 @@
 #ifndef SOFA_CORE_VECID_H
 #define SOFA_CORE_VECID_H
 
-#include <sofa/config.h>
+#include <sofa/core/config.h>
+
 #include <string>
 #include <sstream>
 #include <cassert>
@@ -40,7 +41,7 @@ enum VecType
     V_MATDERIV,
 };
 
-extern const std::unordered_map<VecType, std::string> VecTypeLabels;
+SOFA_CORE_API extern const std::unordered_map<VecType, std::string> VecTypeLabels;
 
 /// Types of vectors that can be stored in State
 enum VecAccess

--- a/Sofa/framework/Core/src/sofa/core/VecId.h
+++ b/Sofa/framework/Core/src/sofa/core/VecId.h
@@ -40,12 +40,7 @@ enum VecType
     V_MATDERIV,
 };
 
-static const std::unordered_map<VecType, std::string> VecTypeLabels {
-    {V_ALL, "(V_ALL)"},
-    {V_COORD, "(V_COORD)"},
-    {V_DERIV, "(V_DERIV)"},
-    {V_MATDERIV, "(V_MATDERIV)"}
-};
+extern const std::unordered_map<VecType, std::string> VecTypeLabels;
 
 /// Types of vectors that can be stored in State
 enum VecAccess


### PR DESCRIPTION
.. instead of being inlined.

trace from clang `-ftime-trace` and [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer)
quite big, so just a few relevant lines:

before
```
 16237 ms: std::_Hashtable<sofa::core::VecType, std::pair<const sofa::core::VecType, std::basic_string<char>>, std::allocator<std... (1581 times, avg 10 ms)
 13454 ms: std::unordered_map<sofa::core::VecType, std::basic_string<char>>::unordered_map (527 times, avg 25 ms)
 13237 ms: std::_Hashtable<sofa::core::VecType, std::pair<const sofa::core::VecType, std::basic_string<char>>, std::allocator<std... (527 times, avg 25 ms)
  9245 ms: std::__detail::_Insert_base<sofa::core::VecType, std::pair<const sofa::core::VecType, std::basic_string<char>>, std::a... (527 times, avg 17 ms)
  9002 ms: std::_Hashtable<sofa::core::VecType, std::pair<const sofa::core::VecType, std::basic_string<char>>, std::allocator<std... (527 times, avg 17 ms)
  8232 ms: std::_Hashtable<sofa::core::VecType, std::pair<const sofa::core::VecType, std::basic_string<char>>, std::allocator<std... (527 times, avg 15 ms)
...

after
...
  6836 ms: std::_Hashtable<int, std::pair<const int, int>, std::allocator<std::pair<const int, int>>, std::__detail::_Select1st, ... (844 times, avg 8 ms)
  5064 ms: std::_Hashtable<std::basic_string<char>, std::pair<const std::basic_string<char>, unsigned int>, std::allocator<std::p... (679 times, avg 7 ms)
  4954 ms: std::unordered_map<sofa::core::VecType, std::basic_string<char>> (527 times, avg 9 ms)
4075 ms: std::_Hashtable<sofa::core::VecType, std::pair<const sofa::core::VecType, std::basic_string<char>>, std::allocator<std... (527 times, avg 7 ms)

(limited output so the others are lower)
```

In practical, on the same config/setup, compilation time was shorter of  about ~15sec (not that much but still)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
