### PR TITLE
[Sofa.Core] TagSet: move method definitions in cpp

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/TagSet.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/TagSet.cpp
@@ -24,6 +24,16 @@
 namespace sofa::core::objectmodel
 {
 
+TagSet::TagSet(const Tag& t)
+{
+    this->insert(t);
+}
+
+bool TagSet::includes(const Tag& t) const
+{
+    return this->count(t) > 0;
+}
+
 bool TagSet::includes(const TagSet& t) const
 {
     if (t.empty())

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/TagSet.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/TagSet.h
@@ -32,11 +32,11 @@ namespace sofa::core::objectmodel
 class SOFA_CORE_API TagSet : public std::set<Tag>
 {
 public:
-    TagSet() {}
+    TagSet() = default;
     /// Automatic conversion between a tag and a tagset composed of this tag
-    TagSet(const Tag& t) { this->insert(t); }
+    TagSet(const Tag& t);
     /// Returns true if this TagSet contains specified tag
-    bool includes(const Tag& t) const { return this->count(t) > 0; }
+    bool includes(const Tag& t) const;
     /// Returns true if this TagSet contains all specified tags
     bool includes(const TagSet& t) const;
 };


### PR DESCRIPTION
While doing #3401 , I noticed that
```
 11512 ms: std::set<sofa::core::objectmodel::Tag>::insert (688 times, avg 16 ms)
```
insert() from Tagset does not really require to be inlined, so I moved the two inline def into the associated cpp
Then:
```
3256 ms: std::set<sofa::core::objectmodel::Tag>::insert (209 times, avg 15 ms)
```
not extraordinary but _ca ne mange pas de pain_

Note that TagSet directly inherits from `std::set<Tag>` which is really not recommended...


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
