### PR TITLE
[GL.Rendering3D] OglModel: Minor cleanups

### DIFF
--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -37,13 +37,9 @@ namespace sofa::gl::component::rendering3d
 using sofa::type::RGBAColor;
 using sofa::type::Material;
 using namespace sofa::type;
-using namespace sofa::defaulttype;
 
 int OglModelClass = core::RegisterObject("Generic visual model for OpenGL display")
     .add< OglModel >();
-
-template<class T>
-const T* getData(const sofa::type::vector<T>& v) { return &v[0]; }
 
 
 OglModel::OglModel()
@@ -901,7 +897,7 @@ void OglModel::updateVertexBuffer()
         glBufferSubData(GL_ARRAY_BUFFER,
                         positionsBufferSize + normalsBufferSize,
                         textureCoordsBufferSize,
-                        getData(vtexcoords));
+                        vtexcoords.data());
 
         if (hasTangents)
         {

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
@@ -32,8 +32,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/component/visual/VisualModelImpl.h>
 
-#define   NB_MAX_TEXTURES 16
-
 namespace sofa::gl::component::rendering3d
 {
 
@@ -148,7 +146,5 @@ public:
     void updateTrianglesIndicesBuffer();
     void updateQuadsIndicesBuffer();
 };
-
-typedef sofa::type::Vec<3,GLfloat> GLVec3f;
 
 } // namespace sofa::gl::component::rendering3d


### PR DESCRIPTION
- remove useless preprocessor definition
- remove useless typedef
- remove useless utility template function getData() and its unique usage, as the .data() function from type::vector does the same



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
