### PR TITLE
[FEM.Elastic] Speedup hexa drawing in force field

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
@@ -1209,38 +1209,44 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
+    vparams->drawTool()->setLightingEnabled(false);
+
+    if(_sparseGrid )
+    {
+        vparams->drawTool()->enableBlending();
+    }
+
     if (vparams->displayFlags().getShowWireFrame())
         vparams->drawTool()->setPolygonMode(0,true);
 
+    const Real percentage = f_drawPercentageOffset.getValue();
+    const Real oneMinusPercentage = static_cast<Real>(1) - percentage;
+
     typename VecElement::const_iterator it;
-    sofa::Index i;
+    sofa::Index i {};
     const auto* indexedElements = this->getIndexedElements();
-    for(it = indexedElements->begin(), i = 0 ; it != indexedElements->end() ; ++it, ++i)
+    for (const auto& element : *indexedElements)
     {
-        Index a = (*it)[0];
-        Index b = (*it)[1];
-        Index d = (*it)[3];
-        Index c = (*it)[2];
-        Index e = (*it)[4];
-        Index f = (*it)[5];
-        Index h = (*it)[7];
-        Index g = (*it)[6];
+        const Coord& a = x[element[0]];
+        const Coord& b = x[element[1]];
+        const Coord& c = x[element[2]];
+        const Coord& d = x[element[3]];
+        const Coord& e = x[element[4]];
+        const Coord& f = x[element[5]];
+        const Coord& g = x[element[6]];
+        const Coord& h = x[element[7]];
 
-        Coord center = (x[a]+x[b]+x[c]+x[d]+x[e]+x[g]+x[f]+x[h])*0.125;
-        Real percentage = f_drawPercentageOffset.getValue();
-        Coord pa = x[a]-(x[a]-center)*percentage;
-        Coord pb = x[b]-(x[b]-center)*percentage;
-        Coord pc = x[c]-(x[c]-center)*percentage;
-        Coord pd = x[d]-(x[d]-center)*percentage;
-        Coord pe = x[e]-(x[e]-center)*percentage;
-        Coord pf = x[f]-(x[f]-center)*percentage;
-        Coord pg = x[g]-(x[g]-center)*percentage;
-        Coord ph = x[h]-(x[h]-center)*percentage;
+        const Coord center = (a + b + c + d + e + f + g + h ) * static_cast<Real>(0.125);
+        const Coord centerPercent = center * percentage;
 
-        if(_sparseGrid )
-        {
-            vparams->drawTool()->enableBlending();
-        }
+        Coord pa = a * oneMinusPercentage + centerPercent;
+        Coord pb = b * oneMinusPercentage + centerPercent;
+        Coord pc = c * oneMinusPercentage + centerPercent;
+        Coord pd = d * oneMinusPercentage + centerPercent;
+        Coord pe = e * oneMinusPercentage + centerPercent;
+        Coord pf = f * oneMinusPercentage + centerPercent;
+        Coord pg = g * oneMinusPercentage + centerPercent;
+        Coord ph = h * oneMinusPercentage + centerPercent;
 
         std::vector< type::Vector3 > points[6] =
         {
@@ -1252,21 +1258,18 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
             { pb, pc, pg, pb, pg, pf },
         };
 
-        vparams->drawTool()->setLightingEnabled(false);
-        vparams->drawTool()->drawTriangles(points[0], sofa::type::RGBAColor(0.7f,0.7f,0.1f,(_sparseGrid?_sparseGrid->getStiffnessCoef(i):1.0f)));
-        vparams->drawTool()->drawTriangles(points[1], sofa::type::RGBAColor(0.7f,0.0f,0.0f,(_sparseGrid?_sparseGrid->getStiffnessCoef(i):1.0f)));
-        vparams->drawTool()->drawTriangles(points[2], sofa::type::RGBAColor(0.0f,0.7f,0.0f,(_sparseGrid?_sparseGrid->getStiffnessCoef(i):1.0f)));
-        vparams->drawTool()->drawTriangles(points[3], sofa::type::RGBAColor(0.0f,0.0f,0.7f,(_sparseGrid?_sparseGrid->getStiffnessCoef(i):1.0f)));
-        vparams->drawTool()->drawTriangles(points[4], sofa::type::RGBAColor(0.1f,0.7f,0.7f,(_sparseGrid?_sparseGrid->getStiffnessCoef(i):1.0f)));
-        vparams->drawTool()->drawTriangles(points[5], sofa::type::RGBAColor(0.7f,0.1f,0.7f,(_sparseGrid?_sparseGrid->getStiffnessCoef(i):1.0f)));
+        const float stiffnessCoef = _sparseGrid ? _sparseGrid->getStiffnessCoef(i) : 1.0f;
 
+        vparams->drawTool()->drawTriangles(points[0], sofa::type::RGBAColor(0.7f,0.7f,0.1f,stiffnessCoef));
+        vparams->drawTool()->drawTriangles(points[1], sofa::type::RGBAColor(0.7f,0.0f,0.0f,stiffnessCoef));
+        vparams->drawTool()->drawTriangles(points[2], sofa::type::RGBAColor(0.0f,0.7f,0.0f,stiffnessCoef));
+        vparams->drawTool()->drawTriangles(points[3], sofa::type::RGBAColor(0.0f,0.0f,0.7f,stiffnessCoef));
+        vparams->drawTool()->drawTriangles(points[4], sofa::type::RGBAColor(0.1f,0.7f,0.7f,stiffnessCoef));
+        vparams->drawTool()->drawTriangles(points[5], sofa::type::RGBAColor(0.7f,0.1f,0.7f,stiffnessCoef));
+
+        ++i;
     }
 
-    if (vparams->displayFlags().getShowWireFrame())
-        vparams->drawTool()->setPolygonMode(0,false);
-
-    if(_sparseGrid )
-       vparams->drawTool()->disableBlending();
 }
 
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
@@ -1205,6 +1205,8 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
     if (!this->mstate) return;
     if (!m_topology) return;
 
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
+
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
     if (vparams->displayFlags().getShowWireFrame())

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
@@ -1222,9 +1222,21 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
     const Real percentage = f_drawPercentageOffset.getValue();
     const Real oneMinusPercentage = static_cast<Real>(1) - percentage;
 
-    typename VecElement::const_iterator it;
-    sofa::Index i {};
     const auto* indexedElements = this->getIndexedElements();
+
+    sofa::type::fixed_array<std::vector<sofa::type::Vector3>, 6 > quads; //one list of quads per hexahedron face
+    sofa::type::fixed_array<std::vector<RGBAColor>, 6> colors; //one list of quads per hexahedron face
+
+    for (auto& q : quads)
+    {
+        q.reserve(indexedElements->size() * 4);
+    }
+    for (auto& c : colors)
+    {
+        c.reserve(indexedElements->size() * 4);
+    }
+
+    sofa::Index i {};
     for (const auto& element : *indexedElements)
     {
         const Coord& a = x[element[0]];
@@ -1239,37 +1251,72 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         const Coord center = (a + b + c + d + e + f + g + h ) * static_cast<Real>(0.125);
         const Coord centerPercent = center * percentage;
 
-        Coord pa = a * oneMinusPercentage + centerPercent;
-        Coord pb = b * oneMinusPercentage + centerPercent;
-        Coord pc = c * oneMinusPercentage + centerPercent;
-        Coord pd = d * oneMinusPercentage + centerPercent;
-        Coord pe = e * oneMinusPercentage + centerPercent;
-        Coord pf = f * oneMinusPercentage + centerPercent;
-        Coord pg = g * oneMinusPercentage + centerPercent;
-        Coord ph = h * oneMinusPercentage + centerPercent;
+        const Coord pa = a * oneMinusPercentage + centerPercent;
+        const Coord pb = b * oneMinusPercentage + centerPercent;
+        const Coord pc = c * oneMinusPercentage + centerPercent;
+        const Coord pd = d * oneMinusPercentage + centerPercent;
+        const Coord pe = e * oneMinusPercentage + centerPercent;
+        const Coord pf = f * oneMinusPercentage + centerPercent;
+        const Coord pg = g * oneMinusPercentage + centerPercent;
+        const Coord ph = h * oneMinusPercentage + centerPercent;
 
-        std::vector< type::Vector3 > points[6] =
-        {
-            { pa, pb, pc, pa, pc, pd },
-            { pe, pf, pg, pe, pg, ph },
-            { pc, pd, ph, pc, ph, pg },
-            { pa, pb, pf, pa, pf, pe },
-            { pa, pd, ph, pa, ph, pe },
-            { pb, pc, pg, pb, pg, pf },
-        };
+        quads[0].emplace_back(pa);
+        quads[0].emplace_back(pb);
+        quads[0].emplace_back(pc);
+        quads[0].emplace_back(pd);
+
+        quads[1].emplace_back(pe);
+        quads[1].emplace_back(pf);
+        quads[1].emplace_back(pg);
+        quads[1].emplace_back(ph);
+
+        quads[2].emplace_back(pc);
+        quads[2].emplace_back(pd);
+        quads[2].emplace_back(ph);
+        quads[2].emplace_back(pg);
+
+        quads[3].emplace_back(pa);
+        quads[3].emplace_back(pb);
+        quads[3].emplace_back(pf);
+        quads[3].emplace_back(pe);
+
+        quads[4].emplace_back(pa);
+        quads[4].emplace_back(pd);
+        quads[4].emplace_back(ph);
+        quads[4].emplace_back(pe);
+
+        quads[5].emplace_back(pb);
+        quads[5].emplace_back(pc);
+        quads[5].emplace_back(pg);
+        quads[5].emplace_back(pf);
 
         const float stiffnessCoef = _sparseGrid ? _sparseGrid->getStiffnessCoef(i) : 1.0f;
+        sofa::type::fixed_array<sofa::type::RGBAColor, 6> quadColors {
+            sofa::type::RGBAColor(0.7f,0.7f,0.1f,stiffnessCoef),
+            sofa::type::RGBAColor(0.7f,0.0f,0.0f,stiffnessCoef),
+            sofa::type::RGBAColor(0.0f,0.7f,0.0f,stiffnessCoef),
+            sofa::type::RGBAColor(0.0f,0.0f,0.7f,stiffnessCoef),
+            sofa::type::RGBAColor(0.1f,0.7f,0.7f,stiffnessCoef),
+            sofa::type::RGBAColor(0.7f,0.1f,0.7f,stiffnessCoef)
+        };
 
-        vparams->drawTool()->drawTriangles(points[0], sofa::type::RGBAColor(0.7f,0.7f,0.1f,stiffnessCoef));
-        vparams->drawTool()->drawTriangles(points[1], sofa::type::RGBAColor(0.7f,0.0f,0.0f,stiffnessCoef));
-        vparams->drawTool()->drawTriangles(points[2], sofa::type::RGBAColor(0.0f,0.7f,0.0f,stiffnessCoef));
-        vparams->drawTool()->drawTriangles(points[3], sofa::type::RGBAColor(0.0f,0.0f,0.7f,stiffnessCoef));
-        vparams->drawTool()->drawTriangles(points[4], sofa::type::RGBAColor(0.1f,0.7f,0.7f,stiffnessCoef));
-        vparams->drawTool()->drawTriangles(points[5], sofa::type::RGBAColor(0.7f,0.1f,0.7f,stiffnessCoef));
+        for (unsigned int j = 0; j < 6; ++j)
+        {
+            auto& faceColors = colors[j];
+            const auto& color = quadColors[j];
+            for (unsigned int k = 0; k < 4; ++k)
+            {
+                faceColors.emplace_back(color);
+            }
+        }
 
         ++i;
     }
 
+    for (unsigned int j = 0; j < 6; ++j)
+    {
+        vparams->drawTool()->drawQuads(quads[j], colors[j]);
+    }
 }
 
 


### PR DESCRIPTION
Calls to OpenGL primitives are reduced.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
