### PR TITLE
[Helper] Portable thread local storage duration

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.h
@@ -216,12 +216,8 @@ public:
             /// return the instance of the factory. Creates it if doesn't exist yet.
             static IdFactory& getInstance()
             {
-                SOFA_THREAD_SPECIFIC_PTR(IdFactory, instance);
-                if (instance == nullptr)
-                {
-                    instance = new IdFactory;
-                }
-                return *instance;
+                static thread_local IdFactory factory;
+                return factory;
             }
         };
 


### PR DESCRIPTION
Since C++11, it is possible to declare a variable with one copy per thread with the keyword `thread_local`.

The consequence is that the code in `thread_specific_ptr.h` could be deprecated as it is not used anywhere else (not in this PR).

Bonus: remove a memory leak.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
