### PR TITLE
[core.topology] Add mechanism to check checkTopologyInputTypes

### DIFF
--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/RemovePrimitivePerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/RemovePrimitivePerformer.inl
@@ -370,10 +370,11 @@ bool RemovePrimitivePerformer<DataTypes>::createElementList()
             for(unsigned int i=0; i<listObject.size(); ++i) // loop on all components to find mapping (only tetra for the moment)
             {
                 sofa::core::topology::TopologicalMapping *topoMap = dynamic_cast<sofa::core::topology::TopologicalMapping *>(listObject[i]);
+                const sofa::type::vector<Index>& topoMapIndices = topoMap->Loc2GlobDataVec.getValue();
                 if (topoMap)
                 {
                     // Mapping found: 1- get surface element ID in volumique topology, 2- get volume element ID behind surface element, 3- switching all variables to volumique case
-                    unsigned int volTmp = (topoMap->getLoc2GlobVec()).getValue()[selectedElem[0]];
+                    Index volTmp = topoMapIndices[selectedElem[0]];
                     topo_curr = topoMap->getFrom();
                     selectedElem[0] = topo_curr->getTetrahedraAroundTriangle(volTmp)[0];
                     surfaceOnVolume = true;

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.cpp
@@ -80,5 +80,35 @@ void TopologicalMapping::dumpLoc2GlobVec()
 }
 
 
+bool TopologicalMapping::checkTopologyInputTypes()
+{
+    if (m_inputType == TopologyElementType::UNKNOWN)
+    {
+        dmsg_error() << "The input TopologyElementType has not be set. Define 'm_inputType' to the correct TopologyElementType in the constructor.";
+        return false;
+    }
+
+    if (m_outputType == TopologyElementType::UNKNOWN)
+    {
+        dmsg_error() << "The output TopologyElementType has not be set. Define 'm_outputType' to the correct TopologyElementType in the constructor.";
+        return false;
+    }
+
+
+    if (fromModel.get()->getTopologyType() != m_inputType)
+    {
+        msg_error() << "The type of the input topology '" << fromModel.getPath() << "' does not correspond to a valid '" << elementTypeToString(m_inputType) << "' topology.";
+        return false;
+    }
+
+    if (toModel.get()->getTopologyType() != m_outputType)
+    {
+        msg_error() << "The type of the output topology '" << toModel.getPath() << "' does not correspond to a valid '" << elementTypeToString(m_outputType) << "' topology.";
+        return false;
+    }
+
+    return true;
+}
+
 } /// namespace sofa::core::topology
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.cpp
@@ -24,6 +24,61 @@
 namespace sofa::core::topology
 {
 
+TopologicalMapping::TopologicalMapping()
+    : fromModel(initLink("input", "Input topology to map"))
+    , toModel(initLink("output", "Output topology to map"))
+{
+
+}
+
+
+void TopologicalMapping::setTopologies(In* from, Out* to)
+{
+    this->fromModel.set(from);
+    this->toModel.set(to);
+}
+
+
+Index TopologicalMapping::getGlobIndex(Index ind)
+{
+    if (ind < (Loc2GlobDataVec.getValue()).size())
+    {
+        return (Loc2GlobDataVec.getValue())[ind];
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+Index TopologicalMapping::getFromIndex(Index ind) 
+{ 
+    SOFA_UNUSED(ind);
+    return 0; 
+}
+
+
+void TopologicalMapping::dumpGlob2LocMap()
+{
+    std::map<Index, Index>::iterator itM;
+    msg_info() << "## Log Glob2LocMap - size: " << Glob2LocMap.size() << " ##";
+    for (itM = Glob2LocMap.begin(); itM != Glob2LocMap.end(); ++itM)
+        msg_info() << (*itM).first << " - " << (*itM).second;
+
+    msg_info() << "#################";
+}
+
+
+void TopologicalMapping::dumpLoc2GlobVec()
+{
+    const sofa::type::vector<Index>& buffer = Loc2GlobDataVec.getValue();
+    msg_info() << "## Log Loc2GlobDataVec - size: " << buffer.size() << " ##";
+    for (Index i = 0; i < buffer.size(); ++i)
+        msg_info() << i << " - " << buffer[i];
+
+    msg_info() << "#################";
+}
+
 
 } /// namespace sofa::core::topology
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.cpp
@@ -84,13 +84,13 @@ bool TopologicalMapping::checkTopologyInputTypes()
 {
     if (m_inputType == TopologyElementType::UNKNOWN)
     {
-        dmsg_error() << "The input TopologyElementType has not be set. Define 'm_inputType' to the correct TopologyElementType in the constructor.";
+        dmsg_error() << "The input TopologyElementType has not been set. Define 'm_inputType' to the correct TopologyElementType in the constructor.";
         return false;
     }
 
     if (m_outputType == TopologyElementType::UNKNOWN)
     {
-        dmsg_error() << "The output TopologyElementType has not be set. Define 'm_outputType' to the correct TopologyElementType in the constructor.";
+        dmsg_error() << "The output TopologyElementType has not been set. Define 'm_outputType' to the correct TopologyElementType in the constructor.";
         return false;
     }
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
@@ -55,6 +55,8 @@ public:
     /// Output Topology
     using Out = BaseMeshTopology;
 
+    using TopologyElementType = sofa::core::topology::TopologyElementType;
+
     using Index = sofa::Index;
 
 protected:
@@ -198,6 +200,9 @@ public:
     }
 
 protected:
+    [[nodiscard]] bool checkTopologyInputTypes();
+
+protected:
     /// Input source BaseTopology
     SingleLink<TopologicalMapping, In, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> fromModel;
 
@@ -216,6 +221,9 @@ protected:
     std::map<Index, Index> Glob2LocMap;   //TODO put it in Data => Data allow map
 
     std::map<Index, sofa::type::vector<Index> > In2OutMap;
+
+    TopologyElementType m_inputType = TopologyElementType::UNKNOWN;
+    TopologyElementType m_outputType = TopologyElementType::UNKNOWN;
 };
 
 } // namespace topology

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
@@ -45,32 +45,26 @@ namespace topology
 * So, at each time step, the geometrical and adjacency information are consistent in both topologies.
 *
 */
-class TopologicalMapping : public virtual objectmodel::BaseObject
+class SOFA_CORE_API TopologicalMapping : public virtual objectmodel::BaseObject
 {
 public:
     SOFA_ABSTRACT_CLASS(TopologicalMapping, objectmodel::BaseObject);
 
     /// Input Topology
-    typedef BaseMeshTopology In;
+    using In = BaseMeshTopology;
     /// Output Topology
-    typedef BaseMeshTopology Out;
+    using Out = BaseMeshTopology;
 
     using Index = sofa::Index;
 
 protected:
-    TopologicalMapping()
-        : fromModel(initLink("input", "Input topology to map"))
-        , toModel(initLink("output", "Output topology to map"))
-    {}
+    TopologicalMapping();
 
     ~TopologicalMapping() override { }
+
 public:
     /// Specify the input and output models.
-    virtual void setTopologies(In* from, Out* to)
-    {
-        this->fromModel.set( from );
-        this->toModel.set( to );
-    };
+    virtual void setTopologies(In* from, Out* to);
 
     /// Set the path to the objects mapped in the scene graph
     void setPathInputObject(const std::string &o) {fromModel.setPath(o);}
@@ -103,42 +97,13 @@ public:
 
     Data <sofa::type::vector<Index> >& getLoc2GlobVec() {return Loc2GlobDataVec;}
 
-    virtual Index getGlobIndex(Index ind)
-    {
-        if(ind< (Loc2GlobDataVec.getValue()).size())
-        {
-            return (Loc2GlobDataVec.getValue())[ind];
-        }
-        else
-        {
-            return 0;
-        }
-    }
+    virtual Index getGlobIndex(Index ind);
 
-    virtual Index getFromIndex(Index /*ind*/)
-    {
-        return 0;
-    }
+    virtual Index getFromIndex(Index ind);
 
-    void dumpGlob2LocMap()
-    {
-        std::map<Index, Index>::iterator itM;
-        msg_info() << "## Log Glob2LocMap - size: " << Glob2LocMap.size() << " ##";
-        for (itM = Glob2LocMap.begin(); itM != Glob2LocMap.end(); ++itM)
-            msg_info() << (*itM).first << " - " << (*itM).second;
+    void dumpGlob2LocMap();
 
-        msg_info() << "#################";
-    }
-
-    void dumpLoc2GlobVec()
-    {
-        const sofa::type::vector<Index>& buffer = Loc2GlobDataVec.getValue();
-        msg_info() << "## Log Loc2GlobDataVec - size: " << buffer.size() << " ##";
-        for (Index i=0; i<buffer.size(); ++i)
-            msg_info() << i << " - " << buffer[i];
-
-        msg_info() << "#################";
-    }
+    void dumpLoc2GlobVec();
 
     /// Method to check the topology mapping maps regarding the upper topology
     virtual bool checkTopologies() {return false;}
@@ -235,10 +200,10 @@ public:
 protected:
     /// Input source BaseTopology
     SingleLink<TopologicalMapping, In, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> fromModel;
-    //In* fromModel;
+
     /// Output target BaseTopology
     SingleLink<TopologicalMapping, Out, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> toModel;
-    //Out* toModel;
+ 
 
     // Two index maps :
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
@@ -95,9 +95,6 @@ public:
 
     /// Accessor to index maps :
     const std::map<Index, Index>& getGlob2LocMap() { return Glob2LocMap;}
-    //const sofa::type::vector<Index>& getLoc2GlobVec(){ return Loc2GlobVec.getValue();}
-
-    Data <sofa::type::vector<Index> >& getLoc2GlobVec() {return Loc2GlobDataVec;}
 
     virtual Index getGlobIndex(Index ind);
 
@@ -202,23 +199,21 @@ public:
 protected:
     [[nodiscard]] bool checkTopologyInputTypes();
 
-protected:
+public:
     /// Input source BaseTopology
-    SingleLink<TopologicalMapping, In, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> fromModel;
+    SingleLink<TopologicalMapping, In, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> fromModel;
 
     /// Output target BaseTopology
-    SingleLink<TopologicalMapping, Out, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> toModel;
- 
-
-    // Two index maps :
+    SingleLink<TopologicalMapping, Out, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> toModel;
 
     // Array which gives for each index (local index) of an element in the OUTPUT topology
     // the corresponding index (global index) of the same element in the INPUT topology :
     Data <sofa::type::vector<Index> > Loc2GlobDataVec;
 
+protected:
     // Map which gives for each index (global index) of an element in the INPUT topology
     // the corresponding index (local index) of the same element in the OUTPUT topology :
-    std::map<Index, Index> Glob2LocMap;   //TODO put it in Data => Data allow map
+    std::map<Index, Index> Glob2LocMap;
 
     std::map<Index, sofa::type::vector<Index> > In2OutMap;
 

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementType.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementType.h
@@ -43,4 +43,21 @@ enum class ElementType : sofa::Size
 
 constexpr sofa::Size NumberOfElementType = static_cast<sofa::Size>(sofa::geometry::ElementType::SIZE);
 
+constexpr const char* elementTypeToString(ElementType type)
+{
+    switch (type)
+    {
+    case ElementType::POINT: { return "Point"; }
+    case ElementType::EDGE: { return "Edge"; }
+    case ElementType::TRIANGLE: { return "Triangle"; }
+    case ElementType::QUAD: { return "Quad"; }
+    case ElementType::TETRAHEDRON: { return "Tetrahedron"; }
+    case ElementType::HEXAHEDRON: { return "Hexahedron"; }
+    case ElementType::PENTAHEDRON: { return "Pentahedron"; }
+    case ElementType::PYRAMID: { return "Pyramid"; }
+    default: 
+        return "Unknown";
+    }
+}
+
 } // namespace sofa::geometry


### PR DESCRIPTION
- Move some code in cpp
- Add TopologyElementType to be set by child class. By default they are set to:
```
TopologyElementType m_inputType = TopologyElementType::UNKNOWN;
TopologyElementType m_outputType = TopologyElementType::UNKNOWN;
```
- Add method checkTopologyInputTypes to check m_inputType  / m_outputType  against input/output topology container type.

- Add elementTypeToString method to be able to display error.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
