### PR TITLE
[test] Fix mutiple component init calls in several tests

### DIFF
--- a/Sofa/Component/MechanicalLoad/tests/QuadPressureForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/QuadPressureForceField_test.cpp
@@ -90,6 +90,8 @@ struct QuadPressureForceField_test : public ForceField_test<_QuadPressureForceFi
     // Test that the force value is constant
     void test_constantForce()
     {
+        sofa::simulation::getSimulation()->init(Inherited::node.get());
+
         // Do a few animation steps
         for(int k=0;k<10;k++)
         {
@@ -97,7 +99,7 @@ struct QuadPressureForceField_test : public ForceField_test<_QuadPressureForceFi
         }
 
         // run the forcefield_test
-        Inherited::run_test( x, v, f );
+        Inherited::run_test( x, v, f, false );
     }
 
 };

--- a/Sofa/Component/MechanicalLoad/tests/QuadPressureForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/QuadPressureForceField_test.cpp
@@ -90,8 +90,6 @@ struct QuadPressureForceField_test : public ForceField_test<_QuadPressureForceFi
     // Test that the force value is constant
     void test_constantForce()
     {
-        sofa::simulation::getSimulation()->init(Inherited::node.get());
-
         // Do a few animation steps
         for(int k=0;k<10;k++)
         {

--- a/Sofa/Component/MechanicalLoad/tests/TrianglePressureForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/TrianglePressureForceField_test.cpp
@@ -88,6 +88,8 @@ struct TrianglePressureForceField_test : public ForceField_test<_TrianglePressur
     // Test that the force value is constant
     void test_constantForce()
     {
+        sofa::simulation::getSimulation()->init(Inherited::node.get());
+
         // Do a few animation steps
         for(int k=0;k<10;k++)
         {
@@ -95,7 +97,7 @@ struct TrianglePressureForceField_test : public ForceField_test<_TrianglePressur
         }
 
         // run the forcefield_test
-        Inherited::run_test( x, v, f );
+        Inherited::run_test( x, v, f, false );
     }
 
 };

--- a/Sofa/Component/MechanicalLoad/tests/TrianglePressureForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/TrianglePressureForceField_test.cpp
@@ -88,8 +88,6 @@ struct TrianglePressureForceField_test : public ForceField_test<_TrianglePressur
     // Test that the force value is constant
     void test_constantForce()
     {
-        sofa::simulation::getSimulation()->init(Inherited::node.get());
-
         // Do a few animation steps
         for(int k=0;k<10;k++)
         {

--- a/Sofa/Component/MechanicalLoad/tests/scenes/QuadPressureForceField.scn
+++ b/Sofa/Component/MechanicalLoad/tests/scenes/QuadPressureForceField.scn
@@ -1,16 +1,17 @@
 <?xml version="1.0"?>
 
 <Node 	name="Root" gravity="0 0 0" time="0" animate="0"  dt="0.5" showAxis="true">
-	<RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
-	<RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
-	<RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [QuadSetGeometryAlgorithms QuadSetTopologyContainer QuadSetTopologyModifier] -->
-	
-	<MechanicalObject name="DOFs" showObject="1"  showObjectScale="5"  showIndices="1"  showIndicesScale="0.0003" position="0 0 0 1 0 0 0 1 0 1 1 0" />
-	<MeshTopology name="quad" quads="0 1 3 2"  drawQuads="1" position="@DOFs.position"/>
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [QuadSetGeometryAlgorithms QuadSetTopologyContainer QuadSetTopologyModifier] -->
+    <DefaultAnimationLoop />
 
-	<QuadSetTopologyContainer name="QuadContainer" quads="@quad.quads"/>
-	<QuadSetTopologyModifier />
-	<QuadSetGeometryAlgorithms template="Vec3d" />
-	<!--<QuadPressureForceField normal="0 0 1" dmin="-0.01" dmax="0.01" showForces="1" pressure="0 0 0.2"/>-->
+    <MechanicalObject name="DOFs" showObject="1"  showObjectScale="5"  showIndices="1"  showIndicesScale="0.0003" position="0 0 0 1 0 0 0 1 0 1 1 0" />
+    <MeshTopology name="quad" quads="0 1 3 2"  drawQuads="1" position="@DOFs.position"/>
+
+    <QuadSetTopologyContainer name="QuadContainer" quads="@quad.quads"/>
+    <QuadSetTopologyModifier />
+    <QuadSetGeometryAlgorithms template="Vec3d" />
+    <!--<QuadPressureForceField normal="0 0 1" dmin="-0.01" dmax="0.01" showForces="1" pressure="0 0 0.2"/>-->
 
 </Node>

--- a/Sofa/Component/MechanicalLoad/tests/scenes/TrianglePressureForceField.scn
+++ b/Sofa/Component/MechanicalLoad/tests/scenes/TrianglePressureForceField.scn
@@ -1,16 +1,18 @@
 <?xml version="1.0"?>
 
 <Node 	name="Root" gravity="0 0 0" time="0" animate="0"  dt="0.5" showAxis="true">
-	<RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
-	<RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
-	<RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetGeometryAlgorithms TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
-	
-	<MechanicalObject name="DOFs" showObject="1"  showObjectScale="5"  showIndices="1"  showIndicesScale="0.0003" position="0 0 0 1 0 0 0 1 0" />
-	<MeshTopology name="triangle" triangles="0 1 2"  drawTriangles="1" position="@DOFs.position"/>
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetGeometryAlgorithms TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
 
-	<TriangleSetTopologyContainer name="TriangleContainer" triangles="@triangle.triangles"/>
-	<TriangleSetTopologyModifier />
-	<TriangleSetGeometryAlgorithms template="Vec3d" />
-	<!--<TrianglePressureForceField normal="0 0 1" dmin="-0.01" dmax="0.01" showForces="1" pressure="0 0 0.6"/>-->
+    <DefaultAnimationLoop />
+
+    <MechanicalObject name="DOFs" showObject="1"  showObjectScale="5"  showIndices="1"  showIndicesScale="0.0003" position="0 0 0 1 0 0 0 1 0" />
+    <MeshTopology name="triangle" triangles="0 1 2"  drawTriangles="1" position="@DOFs.position"/>
+
+    <TriangleSetTopologyContainer name="TriangleContainer" triangles="@triangle.triangles"/>
+    <TriangleSetTopologyModifier />
+    <TriangleSetGeometryAlgorithms template="Vec3d" />
+    <!--<TrianglePressureForceField normal="0 0 1" dmin="-0.01" dmax="0.01" showForces="1" pressure="0 0 0.6"/>-->
 
 </Node>

--- a/Sofa/Component/SolidMechanics/Testing/src/sofa/component/solidmechanics/testing/ForceFieldTestCreation.h
+++ b/Sofa/Component/SolidMechanics/Testing/src/sofa/component/solidmechanics/testing/ForceFieldTestCreation.h
@@ -157,7 +157,7 @@ struct ForceField_test : public BaseSimulationTest, NumericTest<typename _ForceF
      * The change of potential energy is compared to the dot product between displacement and force.
      * The  change of force is compared to the change computed by function addDForce, and to the product of the position change with the stiffness matrix.
      */
-    void run_test( const VecCoord& x, const VecDeriv& v, const VecDeriv& ef )
+    void run_test( const VecCoord& x, const VecDeriv& v, const VecDeriv& ef, bool initScene = true )
     {
         if( !(flags & TEST_POTENTIAL_ENERGY) ) msg_warning("ForceFieldTest") << "Potential energy is not tested";
 
@@ -176,7 +176,10 @@ struct ForceField_test : public BaseSimulationTest, NumericTest<typename _ForceF
         sofa::testing::copyToData( vdof, v );
 
         // init scene and compute force
-        sofa::simulation::getSimulation()->init(this->node.get());
+        if (initScene)
+        {
+            sofa::simulation::getSimulation()->init(this->node.get());
+        }
         core::MechanicalParams mparams;
         mparams.setKFactor(1.0);
         MechanicalResetForceVisitor resetForce(&mparams, core::VecDerivId::force());

--- a/Sofa/Component/SolidMechanics/simutests/AffinePatch_test.cpp
+++ b/Sofa/Component/SolidMechanics/simutests/AffinePatch_test.cpp
@@ -85,7 +85,7 @@ struct AffinePatch_sofa_test : public sofa::testing::BaseSimulationTest, sofa::t
         // Init simulation
         sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
 
-         root = simulation::getSimulation()->createNewGraph("root");
+        root = simulation::getSimulation()->createNewGraph("root");
 
     }
 

--- a/Sofa/Component/SolidMechanics/simutests/LinearElasticity_test.cpp
+++ b/Sofa/Component/SolidMechanics/simutests/LinearElasticity_test.cpp
@@ -227,8 +227,10 @@ struct LinearElasticity_test : public sofa::testing::BaseSimulationTest, sofa::t
         ff->setMethod(0); // small method
         return (ForceFieldSPtr )ff;
     }
-    bool testLinearElasticityInTraction(LinearElasticityFF createForceField)
-    {
+    bool testLinearElasticityInTraction(LinearElasticityFF createForceField){
+
+        sofa::simulation::getSimulation()->init(tractionStruct.root.get());
+
         size_t i,j,k;
         for (k=0;k<sizeYoungModulusArray;++k) {
             Real youngModulus=youngModulusArray[k];
@@ -241,12 +243,10 @@ struct LinearElasticity_test : public sofa::testing::BaseSimulationTest, sofa::t
                 for (i=0;i<sizePressureArray;++i) {
                     // set the pressure on the top part
                     Real pressure= pressureArray[i];
-                    tractionStruct.forceField.get()->pressure=Coord(0,0,pressure);
 
-                    // reset simulation and init the triangle pressure forcefield
+                    tractionStruct.forceField.get()->setPressure(Coord(0, 0, pressure));
                     sofa::simulation::getSimulation()->reset(tractionStruct.root.get());
-                    // sofa::simulation::getSimulation()->init(tractionStruct.root.get());
-                    tractionStruct.forceField.get()->init();
+                    
                     // record the initial point of a given vertex
                     Coord p0=tractionStruct.dofs.get()->read(sofa::core::ConstVecCoordId::position())->getValue()[vIndex];
 

--- a/Sofa/Component/SolidMechanics/simutests/LinearElasticity_test.cpp
+++ b/Sofa/Component/SolidMechanics/simutests/LinearElasticity_test.cpp
@@ -225,10 +225,8 @@ struct LinearElasticity_test : public sofa::testing::BaseSimulationTest, sofa::t
         ff->setMethod(0); // small method
         return (ForceFieldSPtr )ff;
     }
-    bool testLinearElasticityInTraction(LinearElasticityFF createForceField){
-
-        sofa::simulation::getSimulation()->init(tractionStruct.root.get());
-
+    bool testLinearElasticityInTraction(LinearElasticityFF createForceField)
+    {
         size_t i,j,k;
         for (k=0;k<sizeYoungModulusArray;++k) {
             Real youngModulus=youngModulusArray[k];

--- a/Sofa/Component/SolidMechanics/simutests/LinearElasticity_test.cpp
+++ b/Sofa/Component/SolidMechanics/simutests/LinearElasticity_test.cpp
@@ -42,6 +42,7 @@
 #include <sofa/component/constraint/projective/FixedConstraint.h>
 #include <sofa/component/constraint/projective/FixedPlaneConstraint.h>
 #include <sofa/component/constraint/projective/ProjectToLineConstraint.h>
+#include <sofa/simulation/DefaultAnimationLoop.h>
 
 namespace sofa {
 
@@ -91,6 +92,7 @@ CylinderTractionStruct<DataTypes>  createCylinderTractionScene(
     root->setAnimate(false);
     root->setDt(0.05);
 
+    sofa::modeling::addNew<sofa::simulation::DefaultAnimationLoop>(root, "animationLoop");
 
     // GenerateCylinder object
     typename sofa::component::engine::generate::GenerateCylinder<DataTypes>::SPtr eng= sofa::modeling::addNew<sofa::component::engine::generate::GenerateCylinder<DataTypes> >(root,"cylinder");

--- a/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/RegularGridNodeCreation.h
+++ b/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/RegularGridNodeCreation.h
@@ -28,7 +28,7 @@
 #include <sofa/component/odesolver/backward/EulerImplicitSolver.h>
 #include <sofa/component/engine/select/PairBoxRoi.h>
 #include <sofa/component/engine/select/BoxROI.h>
-
+#include <sofa/simulation/DefaultAnimationLoop.h>
 
 namespace sofa
 {
@@ -73,6 +73,8 @@ PatchTestStruct<DataTypes> createRegularGridScene(
     root->setGravity({ 0,0,0 });
     root->setAnimate(false);
     root->setDt(0.05);
+
+    sofa::modeling::addNew<sofa::simulation::DefaultAnimationLoop>(root, "animationLoop");
 
     // Node square
     simulation::Node::SPtr SquareNode = root->createChild("Square");


### PR DESCRIPTION
- Remove unwanted second call to graph init in Triangle and Quad PressureFF
- Remove multiple call to Component init in LinearElasticity_test instead of using SetPressure method
- Remove some missing animationLoop warnings 

Those wrong behaviors are failing in PR #3369 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
