### PR TITLE
[image, FEM, LinearSolver] fix Eigen3 assertion with SVD

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
@@ -620,7 +620,9 @@ void TriangularFEMForceField<DataTypes>::computeStiffness(Stiffness& K, const St
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computePrincipalStrain(Index elementIndex, TriangleInformation& triangleInfo)
 {
-    Eigen::Matrix<Real, 2, 2> e;
+    Eigen::Matrix<Real, -1, -1> e;
+    e.resize(2, 2);
+
     e(0,0) = triangleInfo.strain[0];
     e(0,1) = triangleInfo.strain[2];
     e(1,0) = triangleInfo.strain[2];
@@ -647,7 +649,9 @@ void TriangularFEMForceField<DataTypes>::computePrincipalStrain(Index elementInd
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computePrincipalStress(Index elementIndex, TriangleInformation& triangleInfo)
 {
-    Eigen::Matrix<Real, 2, 2> e;
+    Eigen::Matrix<Real, -1, -1> e;
+    e.resize(2, 2);
+
     //voigt notation to symmetric matrix
     e(0,0) = triangleInfo.stress[0];
     e(0,1) = triangleInfo.stress[2];

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/PlasticMaterial.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/PlasticMaterial.cpp
@@ -85,7 +85,9 @@ void PlasticMaterial::computeDStress(Vector3& dStress, Vector3& dStrain)
 
 SReal PlasticMaterial::computeVonMisesStrain(Vector3 &strain)
 {
-	Eigen::Matrix<SReal, 2, 2> e;
+	Eigen::Matrix<SReal, -1, -1> e;
+	e.resize(2, 2);
+
 	e(0,0) = strain[0];
 	e(0,1) = strain[2];
 	e(1,0) = strain[2];

--- a/applications/plugins/image/MeshToImageEngine.h
+++ b/applications/plugins/image/MeshToImageEngine.h
@@ -325,6 +325,13 @@ protected:
             Eigen::Matrix<Real, -1, -1> e;
             e.resize(3, 3);
             e.setZero();
+            for (size_t j = 0; j < 3; j++) 
+            { 
+                for (size_t k = j; k < 3; k++)  
+                    e(j , k) = M[j][k]; 
+                for (size_t k = 0; k < j; k++)  
+                    e(k , j) = e(j, k ); 
+            }
 
             //compute eigenvalues and eigenvectors
             Eigen::JacobiSVD svd(e, Eigen::ComputeThinU | Eigen::ComputeThinV);

--- a/applications/plugins/image/MeshToImageEngine.h
+++ b/applications/plugins/image/MeshToImageEngine.h
@@ -322,7 +322,9 @@ protected:
             M/=(Real)nbpTotal;
 
             // get eigen vectors of the covariance matrix
-            Eigen::Matrix<Real, 3, 3> e = Eigen::Matrix<Real, 3, 3>::Zero();
+            Eigen::Matrix<Real, -1, -1> e;
+            e.resize(3, 3);
+            e.setZero();
 
             //compute eigenvalues and eigenvectors
             Eigen::JacobiSVD svd(e, Eigen::ComputeThinU | Eigen::ComputeThinV);


### PR DESCRIPTION
While investigating the error in  image/examples/distanceFieldFilter.scn (raised in #3329 for example),
Eigen3 was throwing an assertion in Debug (and surely throwing unexpected errors in Release)

https://ci.inria.fr/sofa-ci-dev/job/sofa-framework/job/master/CI_CONFIG=ubuntu_clang,CI_PLUGINS=options,CI_TYPE=debug/3967/testReport/SceneTests/applications_plugins_image_examples/MeshToImageMultipleRoi_scn/
for an example of the dump on the CI

The problem was that if one wants to compute matrices ThinU & ThinV for Eigen::SVD, the given matrices need to be set with a dynamic size.
-> https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/src/SVD/JacobiSVD.h#L640

So the solution are either:
 - compute full V and full U and keep fixed size matrices
 - or set the matrices dynamic and resize to 3x3

It appeared that this combination EigenSVD, ThinU/V and fixed-size matrices was used in PlasticMaterial (FEM.HyperElastic), TriangularFEMForceField (FEM.Elastic) and SVDLinearSolver (LinearSolver.Direct)

\+ the use of SVD in MeshToImage was a little weird (doing it on matrix filled of Zeros). It appears that the code fillling the matrix did disappear while the code was converted from NewMat to Eigen3, so I restored it.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
