### PR TITLE
[Examples] Fix & Clean ProjectToPlaneConstraint and RegularGridTopology_dimension scenes

### DIFF
--- a/examples/Components/constraint/ProjectToPlaneConstraint.scn
+++ b/examples/Components/constraint/ProjectToPlaneConstraint.scn
@@ -12,22 +12,35 @@
     <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <VisualStyle displayFlags="hideVisualModels showBehavior" />
+    
+    <DefaultAnimationLoop />
+    
+    <RegularGridTopology name="grid" nx="3" ny="3" nz="3" xmin="0" xmax="1" ymin="0" ymax="1" zmin="0" zmax="1" />
+    
     <Node 	name="Square"  >
-        <EulerImplicitSolver name="Euler Implicit"  printLog="0"  rayleighStiffness="0.5"  rayleighMass="0.5"  vdamping="0" />
-        <CGLinearSolver template="GraphScattered" name="CG Solver"  printLog="0"  iterations="40"  tolerance="1e-06"  threshold="1e-10"  verbose="0" />
-        <RegularGridTopology name="grid" nx="3" ny="3" nz="3" xmin="0" xmax="1" ymin="0" ymax="1" zmin="0" zmax="1" />
-        <MechanicalObject template="Vec3d" name="mObject1"   showIndices="false" showIndicesScale="0.001" />
+        <EulerImplicitSolver name="Euler Implicit" rayleighStiffness="0.5"  rayleighMass="0.5"  />
+        <CGLinearSolver template="GraphScattered" name="CG Solver" iterations="40" tolerance="1e-06" threshold="1e-10" />
+        
+        <MechanicalObject template="Vec3d" name="mObject1"  position="@../grid.position" />
+        
+        <TetrahedronSetTopologyContainer name="Container" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+        
+        <Hexa2TetraTopologicalMapping name="Mapping"  input="@../grid"  output="@Container" />
+        
+        <TetrahedronFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="500" />
         <UniformMass totalMass="1" />
-        <BoxConstraint box="-0.05 -0.05 -0.05    0.05 0.05 0.05" drawBoxes="1"  />
+        <BoxConstraint box="-0.05 -0.05 -0.05    0.05 0.05 0.05" drawBoxes="0"  />
         <BoxROI box="-0.05 -0.05 -0.05    0.05 1.05 1.05" drawBoxes="1" name="ProjectToPlane"/>
         <ProjectToPlaneConstraint normal="1 0 0" indices="@[-1].indices" drawSize="0.03" />
         <Node 	name="Boundary Edges"  >
             <TriangleSetTopologyContainer name="Container" />
             <TriangleSetTopologyModifier name="Modifier" />
             <TriangleSetGeometryAlgorithms template="Vec3d" name="GeomAlgo"  drawTriangles="1" />
-            <Tetra2TriangleTopologicalMapping name="Mapping"  input="@../grid"  output="@Container" />
-            <BoxROI box="0.95 -0.05 -0.05    1.05 1.05 1.05" drawBoxes="1" position="@../mObject1.rest_position" drawTriangles="1" triangles="@Container.edges" name="pressureBox" />
-            <TrianglePressureForceField template="Vec3d" showForces="1"/>
+            <Tetra2TriangleTopologicalMapping name="Mapping"  input="@../Container"  output="@Container" />
+            <BoxROI box="0.95 -0.05 -0.05    1.05 1.05 1.05" drawBoxes="1" position="@../mObject1.rest_position" drawTriangles="0" triangles="@Container.triangles" name="pressureBox" />
+            <TrianglePressureForceField template="Vec3d" showForces="1" pressure="10 10 0" triangleList="@pressureBox.triangleIndices"/>
         </Node>
     </Node>
 </Node>

--- a/examples/Components/topology/RegularGridTopology_dimension.scn
+++ b/examples/Components/topology/RegularGridTopology_dimension.scn
@@ -1,25 +1,29 @@
 <?xml version="1.0"?>
 <Node name="root" gravity="0 -9.81 0" dt="0.01">
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase DefaultPipeline] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->
-    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
-    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
-    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
-    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
-    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
-    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [HexahedronFEMForceField TriangularFEMForceField] -->
-    <RequiredPlugin name="Sofa.Component.SolidMechanics.Spring"/> <!-- Needed to use components [RegularGridSpringForceField] -->
-    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [QuadSetGeometryAlgorithms QuadSetTopologyContainer QuadSetTopologyModifier] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2QuadTopologicalMapping] -->
-    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
-    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+    <Node name="RequiredPlugins" >
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase DefaultPipeline] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [HexahedronFEMForceField TriangularFEMForceField] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.Spring"/> <!-- Needed to use components [RegularGridSpringForceField] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [QuadSetGeometryAlgorithms QuadSetTopologyContainer QuadSetTopologyModifier] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2QuadTopologicalMapping] -->
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+    </Node>
     <VisualStyle displayFlags="showBehaviorModels showVisual" />
+    
     <DefaultPipeline name="default21" verbose="0" />
+    <DefaultAnimationLoop/>
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <DefaultContactManager name="default22" response="PenalityContactForceField" />
@@ -28,12 +32,13 @@
     <EulerImplicitSolver name="cg_odesolver" printLog="0"  rayleighStiffness="0.1" rayleighMass="0.1" />
     <CGLinearSolver template="GraphScattered" name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
 
+
     <Node name="Cube" gravity="0 -9.81 0">
-        <RegularGridTopology name="grid" n="6 6 6" min="-10 -10 -10" max="10 10 10" p0="-30 -10 -10" computeHexaList="0"/>
+        <RegularGridTopology name="grid" n="6 6 6" min="-10 -10 -10" max="10 10 10" p0="-30 -10 -10" computeHexaList="1"/>
         <MechanicalObject template="Vec3d" name="Hexa" />
-        <UniformMass template="Vec3d,double" name="default25" vertexMass="10" />
+        <UniformMass vertexMass="10" />
         <HexahedronFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="500" />
-        <BoxROI template="Vec3d" name="box_roi" box="-31 9 -11 -9 11 11" indices="0" drawSize="0" />
+        <BoxROI template="Vec3d" name="box_roi" box="-31 9 -11 -9 11 11" drawSize="0" />
         <FixedConstraint template="Vec3d" name="default27" indices="@box_roi.indices" drawSize="0" />
 
         <Node name="Q">
@@ -53,10 +58,10 @@
     <Node name="Square" gravity="0 -9.81 0">
         <RegularGridTopology name="grid" n="6 1 6" min="-10 -10 -10" max="10 10 10" p0="-6 10 -10" computeHexaList="0"/>
         <MechanicalObject template="Vec3d" name="Tri" />
-        <UniformMass template="Vec3d,double" name="default25" vertexMass="10" />
+        <UniformMass vertexMass="10" />
         <TriangularFEMForceField name="FEM" youngModulus="600" poissonRatio="0.3" method="large" />
-<!--        <TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" /> -->
-        <BoxROI template="Vec3d" name="box_roi" box="-7 9 -11 17 11 -9" indices="0" drawBoxes="0" />
+        <TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" />
+        <BoxROI template="Vec3d" name="box_roi" box="-7 9 -11 17 11 -9" drawBoxes="0" />
         <FixedConstraint template="Vec3d" name="default27" indices="@box_roi.indices" drawSize="0" />
 
         <TriangleCollisionModel />
@@ -70,10 +75,10 @@
     <Node name="Line" gravity="0 -9.81 0">
         <RegularGridTopology name="grid" n="1 1 6" min="-10 -10 -10" max="10 10 10" p0="18 10 -10" computeHexaList="0"/>
         <MechanicalObject template="Vec3d" name="Edge" />
-        <UniformMass template="Vec3d,double" name="default25" vertexMass="10" />
+        <UniformMass vertexMass="10" />
 
         <RegularGridSpringForceField name="Springs" stiffness="300" damping="2" />
-        <BoxROI template="Vec3d" name="box_roi" box="17 9 -11 20 11 -9" indices="0" drawBoxes="0" />
+        <BoxROI template="Vec3d" name="box_roi" box="17 9 -11 20 11 -9" drawBoxes="0" />
         <FixedConstraint template="Vec3d" name="default27" indices="@box_roi.indices" drawSize="0" />
 
         <Node name="Visu">


### PR DESCRIPTION
- Result for `RegularGridTopology_dimension.scn` -> showing how to create, 3D (Hexa), 2D (Quad) or 1D (Line) grid. 

![RegularGridTopology_dimension_00000001](https://user-images.githubusercontent.com/21199245/199712906-8bcfbfa0-e4d5-4109-90c8-d8c891c8b13c.png)

- Result for `ProjectToPlaneConstraint.scn`  -> not 100% sure about the expected behavior, but at least there is no error/warning and it is moving ! (constrained by the Plane on the left)

![ProjectToPlaneConstraint_00000001](https://user-images.githubusercontent.com/21199245/199713180-eed459e5-bd23-4e0e-8f08-2f43c2ba7c8c.png)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
