### PR TITLE
[DefaultType] Remove template aliases

### DIFF
--- a/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
@@ -148,6 +148,7 @@ public:
     DefaultTemplate3<DataOne, DataTwo, NotAType> m_ptr9;
     OuterClass<DataOne> m_ptr10;
     OuterClass<DataOne>::InnerClass<DataTwo> m_ptr11;
+    DefaultTemplate1<float> m_ptr12;
 
     sofa::core::objectmodel::Base* m_baseptr1 {&m_ptr1};
     sofa::core::objectmodel::Base* m_baseptr2 {&m_ptr2};
@@ -261,4 +262,11 @@ TEST_F(BaseClass_test, checkNestedClass)
 
     EXPECT_EQ(m_ptr11.getClassName(),"InnerClass") ;
     EXPECT_EQ(m_ptr11.getTemplateName(),"Two") ;
+}
+
+TEST_F(BaseClass_test, floatingPointType)
+{
+    EXPECT_EQ(sofa::defaulttype::DataTypeName<float>::name(), "f");
+    EXPECT_EQ(sofa::helper::NameDecoder::getTemplateName<DefaultTemplate1<float> >(), "float");
+    EXPECT_EQ(m_ptr12.getTemplateName(), "float");
 }

--- a/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
@@ -148,7 +148,6 @@ public:
     DefaultTemplate3<DataOne, DataTwo, NotAType> m_ptr9;
     OuterClass<DataOne> m_ptr10;
     OuterClass<DataOne>::InnerClass<DataTwo> m_ptr11;
-    DefaultTemplate1<float> m_ptr12;
 
     sofa::core::objectmodel::Base* m_baseptr1 {&m_ptr1};
     sofa::core::objectmodel::Base* m_baseptr2 {&m_ptr2};
@@ -264,9 +263,16 @@ TEST_F(BaseClass_test, checkNestedClass)
     EXPECT_EQ(m_ptr11.getTemplateName(),"Two") ;
 }
 
-TEST_F(BaseClass_test, floatingPointType)
+TEST(BaseClass, floatingPointType)
 {
-    EXPECT_EQ(sofa::defaulttype::DataTypeName<float>::name(), "f");
-    EXPECT_EQ(sofa::helper::NameDecoder::getTemplateName<DefaultTemplate1<float> >(), "float");
-    EXPECT_EQ(m_ptr12.getTemplateName(), "float");
+    {
+        EXPECT_EQ(sofa::defaulttype::DataTypeName<float>::name(), "f");
+        const auto object = sofa::core::objectmodel::New<DefaultTemplate1<float> >();
+        EXPECT_EQ(object->getTemplateName(), "float");
+    }
+    {
+        EXPECT_EQ(sofa::defaulttype::DataTypeName<double>::name(), "d");
+        const auto object = sofa::core::objectmodel::New<DefaultTemplate1<double> >();
+        EXPECT_EQ(object->getTemplateName(), "double");
+    }
 }

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
@@ -131,8 +131,6 @@ static RegisterTemplateAlias Rigid2dAlias("Rigid2d", sofa::defaulttype::Rigid2Ty
 static RegisterTemplateAlias Rigid3dAlias("Rigid3d", sofa::defaulttype::Rigid3Types::Name(), isSRealFloat());
 
 // Compatibility aliases used previously in DataExchange (see PR#3380)
-static RegisterTemplateAlias floatAlias("float", sofa::defaulttype::DataTypeName<float>::name(), true);
-static RegisterTemplateAlias doubleAlias("double", sofa::defaulttype::DataTypeName<double>::name(), true);
 static RegisterTemplateAlias vector_intAlias("vector<int>", sofa::defaulttype::DataTypeName<sofa::type::vector<int> >::name(), true);
 static RegisterTemplateAlias vector_uintAlias("vector<unsigned_int>", sofa::defaulttype::DataTypeName<sofa::type::vector<unsigned int> >::name(), true);
 static RegisterTemplateAlias vector_floatAlias("vector<float>", sofa::defaulttype::DataTypeName<sofa::type::vector<float> >::name(), true);

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
@@ -81,10 +81,17 @@ namespace sofa
 
 			void handleEvent( core::objectmodel::Event* event ) override;
 
-			static std::string GetCustomTemplateName()
-			{
-				return sofa::defaulttype::DataTypeName<DataTypes>::name();
-			}
+            static const std::string GetCustomTemplateName()
+            {
+                if constexpr (std::is_scalar_v<DataTypes>)
+                {
+                    return GetDefaultTemplateName();
+                }
+                else
+                {
+                    return sofa::defaulttype::DataTypeName<DataTypes>::name();
+                }
+            }
 
 			template<class T>
 			static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)

--- a/applications/plugins/MultiThreading/test/DataExchange_test.cpp
+++ b/applications/plugins/MultiThreading/test/DataExchange_test.cpp
@@ -54,7 +54,7 @@ TEST(DataExchange, getTemplateName)
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<double>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "d");
+        EXPECT_EQ(engine->getTemplateName(), "double");
     }
 
 
@@ -87,7 +87,7 @@ TEST(DataExchange, getTemplateName)
         const auto engine = sofa::core::objectmodel::New<
             sofa::core::DataExchange<float>
         >("", "");
-        EXPECT_EQ(engine->getTemplateName(), "f");
+        EXPECT_EQ(engine->getTemplateName(), "float");
     }
 
     {


### PR DESCRIPTION
Template aliases are clarified. They were introduced for `double` and `float` because of `DataExchange`. But it is a mistake since the default behavior is not in `DataExchange`. Therefore, I restored the template name to be `double` and `float` instead of `d` and `f` only for scalars. This is to mimic the default behavior. Template aliases are removed.

Fixes https://github.com/sofa-framework/sofa/issues/3450

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
