### PR TITLE
Revert "[Sofa.Core] Linear time getRoot() method in BaseNode and Node"

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
@@ -35,23 +35,18 @@ namespace core
 namespace objectmodel
 {
 
-BaseNode::BaseNode() : m_root(this)
-{
-}
+BaseNode::BaseNode()
+{}
 
 BaseNode::~BaseNode()
 {}
 
 BaseNode* BaseNode::getRoot() const
 {
-    return m_root;
+    BaseNode* firstParent = getFirstParent();
+    if (!firstParent) return const_cast<BaseNode*>(this);
+    else return firstParent->getRoot();
 }
-
-void BaseNode::setRoot(BaseNode* newroot)
-{
-    m_root = newroot;
-}
-
 
 core::behavior::BaseAnimationLoop* BaseNode::getAnimationLoop() const
 {

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.h
@@ -54,8 +54,6 @@ protected:
     BaseNode() ;
     ~BaseNode() override;
 
-    BaseNode* m_root {nullptr} ;
-
 private:
     BaseNode(const BaseNode& n) ;
     BaseNode& operator=(const BaseNode& n) ;
@@ -79,8 +77,7 @@ public:
     virtual BaseNode* getFirstParent() const = 0;
 
     /// returns the root by following up the first parent for multinodes
-    BaseNode* getRoot() const;
-    void setRoot(BaseNode*) ;
+    virtual BaseNode* getRoot() const;
 
     /// Add a child node
     virtual void addChild(BaseNode::SPtr node) = 0;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -481,11 +481,6 @@ public:
         return getRoot()->getContext();
     }
 
-    Node* getRoot() const
-    {
-        return static_cast<Node*>(BaseNode::getRoot());
-    }
-
     Node* setDebug(bool);
     bool getDebug() const;
     void printComponents();


### PR DESCRIPTION
Reverts sofa-framework/sofa#3059 

This PR causes issues with Node that have multiple parents().
This was not detected in the CI because scene with multiple parents are not possible with xml scene.  


Thanks to @EulalieCoevoet for pointing the problem.