### PR TITLE
[Constraint.lagrangian] Update BilateralInteractionConstraint namespace

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.cpp
@@ -29,10 +29,6 @@
 namespace sofa::component::constraint::lagrangian::model
 {
 
-namespace bilateralinteractionconstraint
-{
-
-
 class RigidImpl {};
 
 
@@ -330,7 +326,5 @@ int BilateralInteractionConstraintClass = core::RegisterObject("BilateralInterac
 
 template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API BilateralInteractionConstraint<Vec3Types>;
 template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API BilateralInteractionConstraint<Rigid3Types>;
-
-}
 
 } //namespace sofa::component::constraint::lagrangian::model

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.h
@@ -34,7 +34,7 @@
 
 #include <sofa/component/constraint/lagrangian/model/BilateralConstraintResolution.h>
 
-namespace sofa::component::constraint::lagrangian::model::bilateralinteractionconstraint
+namespace sofa::component::constraint::lagrangian::model
 {
 
 /// These 'using' are in a per-file namespace so they will not leak
@@ -184,13 +184,4 @@ extern template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API BilateralIn
 extern template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API BilateralInteractionConstraint< Rigid3Types >;
 #endif
 
-} // namespace sofa::component::constraint::lagrangian::model::bilateralinteractionconstraint
-
-namespace sofa::component::constraint::lagrangian::model
-{
-/// Import the following into the constraintset namespace to preserve
-/// compatibility with the existing sofa source code.
-using bilateralinteractionconstraint::BilateralInteractionConstraint;
-using bilateralinteractionconstraint::BilateralInteractionConstraintSpecialization;
-
-} //namespace sofa::component::constraint::lagrangian::model
+} // namespace sofa::component::constraint::lagrangian::model

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -32,7 +32,7 @@
 #include <sofa/core/ConstraintParams.h>
 #include <algorithm> // for std::min
 
-namespace sofa::component::constraint::lagrangian::model::bilateralinteractionconstraint
+namespace sofa::component::constraint::lagrangian::model
 {
 
 using sofa::core::objectmodel::KeypressedEvent ;
@@ -363,4 +363,4 @@ void BilateralInteractionConstraint<DataTypes>::handleEvent(Event *event)
 }
 
 
-} //namespace sofa::component::constraint::lagrangian::model::bilateralinteractionconstraint
+} //namespace sofa::component::constraint::lagrangian::model


### PR DESCRIPTION
bilateralinteractionconstraint was in it's own namespace: `sofa::component::constraint::lagrangian::model::bilateralinteractionconstraint`
with some using to declare it in `sofa::component::constraint::lagrangian::model`

I don't know if it was done on purpose?


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
