### PR TITLE
[Lagrangian.Solver] Merge duplicated code into small but expressive functions

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -115,6 +115,19 @@ private:
     unsigned int _numConstraints;
     SReal _mu;
 
+    /// Call the method resetConstraint on all the mechanical states and BaseConstraintSet
+    void resetConstraints(core::ConstraintParams cparams);
+    /// Call the method buildConstraintMatrix on all the BaseConstraintSet
+    void buildConstraintMatrix(core::ConstraintParams cparams);
+    /// Call the method applyJT on all the mappings
+    void accumulateMatrixDeriv(core::ConstraintParams cparams);
+    /// Multigrid hierarchy is resized and cleared
+    void buildHierarchy();
+    /// Call the method getConstraintInfo on all the BaseConstraintSet
+    void getConstraintInfo(core::ConstraintParams cparams);
+    /// Call the method addComplianceInConstraintSpace on all the BaseConstraintCorrection
+    void addComplianceInConstraintSpace(core::ConstraintParams cparams);
+
     /// for built lcp ///
     void build_LCP();
     LCPConstraintProblem lcp1, lcp2, lcp3; // Triple buffer for LCP.


### PR DESCRIPTION
The solver offers two methods to solve the constraint system: `build_LCP` and `build_problem_info`. They were very similar and long functions with a lot of duplicated code. The duplicated code has been moved into small functions.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
