### PR TITLE
[Topology.container] Fix missing TopologyElementType setting in SparseGridTopology init

### DIFF
--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridTopology.cpp
@@ -182,6 +182,9 @@ void SparseGridTopology::init()
             _nodeCubesAdjacency[ hexahedra[i][j] ].push_back( i );
         }
     }
+
+	m_upperElementType = core::topology::TopologyElementType::HEXAHEDRON;
+
 }
 
 

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridTopology.cpp
@@ -183,7 +183,7 @@ void SparseGridTopology::init()
         }
     }
 
-	m_upperElementType = core::topology::TopologyElementType::HEXAHEDRON;
+    m_upperElementType = core::topology::TopologyElementType::HEXAHEDRON;
 
 }
 


### PR DESCRIPTION
Add the element type to SparseGrid to be able o use it with HexaToTetrahedraTopologicalMApping again. 
The Sparsgrid component only produces Hexa component, so this can be explicitly defined at the end of the init. 





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
