### PR TITLE
[Simulation] Separate factory code from TaskScheduler

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -43,6 +43,7 @@
 #include <sofa/simulation/TaskScheduler.h>
 #include <sofa/component/animationloop/FreeMotionTask.h>
 #include <sofa/simulation/CollisionVisitor.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVInitVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVInitVisitor;
@@ -138,7 +139,7 @@ void FreeMotionAnimationLoop::init()
         defaultSolver.reset();
     }
 
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (d_parallelCollisionDetectionAndFreeMotion.getValue() || d_parallelODESolving.getValue())
     {
@@ -334,7 +335,7 @@ void FreeMotionAnimationLoop::FreeMotionAndCollisionDetection(const sofa::core::
     {
         ScopedAdvancedTimer timer("FreeMotion+CollisionDetection");
 
-        auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+        auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
         assert(taskScheduler != nullptr);
 
         preCollisionComputation(params);

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -43,7 +43,7 @@
 #include <sofa/simulation/TaskScheduler.h>
 #include <sofa/component/animationloop/FreeMotionTask.h>
 #include <sofa/simulation/CollisionVisitor.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVInitVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVInitVisitor;
@@ -139,7 +139,7 @@ void FreeMotionAnimationLoop::init()
         defaultSolver.reset();
     }
 
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (d_parallelCollisionDetectionAndFreeMotion.getValue() || d_parallelODESolving.getValue())
     {
@@ -335,7 +335,7 @@ void FreeMotionAnimationLoop::FreeMotionAndCollisionDetection(const sofa::core::
     {
         ScopedAdvancedTimer timer("FreeMotion+CollisionDetection");
 
-        auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+        auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
         assert(taskScheduler != nullptr);
 
         preCollisionComputation(params);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -31,6 +31,7 @@
 #include <sofa/core/behavior/MultiVec.h>
 #include <sofa/simulation/DefaultTaskScheduler.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
@@ -126,7 +127,7 @@ GenericConstraintSolver::GenericConstraintSolver()
 GenericConstraintSolver::~GenericConstraintSolver()
 {
     if(d_multithreading.getValue())
-        simulation::TaskScheduler::getInstance()->stop();
+        simulation::TaskSchedulerFactory::create()->stop();
 }
 
 void GenericConstraintSolver::init()
@@ -160,7 +161,7 @@ void GenericConstraintSolver::init()
 
     if(d_multithreading.getValue())
     {
-        simulation::TaskScheduler::getInstance()->init();
+        simulation::TaskSchedulerFactory::create()->init();
     }
 
     if(d_newtonIterations.isSet())
@@ -336,7 +337,7 @@ void GenericConstraintSolver::buildSystem_matrixFree(unsigned int numConstraints
 
 void GenericConstraintSolver::parallelBuildSystem_matrixAssembly(const core::ConstraintParams* cParams)
 {
-    simulation::TaskScheduler* taskScheduler = simulation::TaskScheduler::getInstance();
+    simulation::TaskScheduler* taskScheduler = simulation::TaskSchedulerFactory::create();
     simulation::CpuTask::Status status;
 
     type::vector<GenericConstraintSolver::ComputeComplianceTask> tasks;

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -31,7 +31,7 @@
 #include <sofa/core/behavior/MultiVec.h>
 #include <sofa/simulation/DefaultTaskScheduler.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
@@ -127,7 +127,7 @@ GenericConstraintSolver::GenericConstraintSolver()
 GenericConstraintSolver::~GenericConstraintSolver()
 {
     if(d_multithreading.getValue())
-        simulation::TaskSchedulerFactory::create()->stop();
+        simulation::MainTaskSchedulerFactory::createInRegistry()->stop();
 }
 
 void GenericConstraintSolver::init()
@@ -161,7 +161,7 @@ void GenericConstraintSolver::init()
 
     if(d_multithreading.getValue())
     {
-        simulation::TaskSchedulerFactory::create()->init();
+        simulation::MainTaskSchedulerFactory::createInRegistry()->init();
     }
 
     if(d_newtonIterations.isSet())
@@ -337,7 +337,7 @@ void GenericConstraintSolver::buildSystem_matrixFree(unsigned int numConstraints
 
 void GenericConstraintSolver::parallelBuildSystem_matrixAssembly(const core::ConstraintParams* cParams)
 {
-    simulation::TaskScheduler* taskScheduler = simulation::TaskSchedulerFactory::create();
+    simulation::TaskScheduler* taskScheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
     simulation::CpuTask::Status status;
 
     type::vector<GenericConstraintSolver::ComputeComplianceTask> tasks;

--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
@@ -32,7 +32,7 @@
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/behavior/BaseMass.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
@@ -169,7 +169,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::init()
     m_nbColsJ1 = ms1->getSize()*DerivSize1;
     m_nbColsJ2 = ms2->getSize()*DerivSize2;
 
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (d_parallelTasks.getValue())
     {
@@ -441,7 +441,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::addKToMatrix(const Mechanic
     MultiMatrixAccessor::InteractionMatrixRef mat12 = matrix->getMatrix(mstate1, mstate2);
     MultiMatrixAccessor::InteractionMatrixRef mat21 = matrix->getMatrix(mstate2, mstate1);
 
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
 
     ///////////////////////////     STEP 1      ////////////////////////////////////

--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
@@ -32,6 +32,7 @@
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/behavior/BaseMass.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
@@ -168,7 +169,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::init()
     m_nbColsJ1 = ms1->getSize()*DerivSize1;
     m_nbColsJ2 = ms2->getSize()*DerivSize2;
 
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (d_parallelTasks.getValue())
     {
@@ -440,7 +441,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::addKToMatrix(const Mechanic
     MultiMatrixAccessor::InteractionMatrixRef mat12 = matrix->getMatrix(mstate1, mstate2);
     MultiMatrixAccessor::InteractionMatrixRef mat21 = matrix->getMatrix(mstate2, mstate1);
 
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
 
     ///////////////////////////     STEP 1      ////////////////////////////////////

--- a/Sofa/framework/Helper/src/sofa/helper/StringUtils.h
+++ b/Sofa/framework/Helper/src/sofa/helper/StringUtils.h
@@ -41,12 +41,13 @@ std::vector<std::string> SOFA_HELPER_API split(const std::string& s, char delimi
 ///
 /// Taken from https://github.com/ekg/split/blob/master/join.h (I don't know what is the licence
 /// but thank for the author.
-template<class S, class T>
-std::string join(std::vector<T>& elems, S& delim) {
+template<class S, class Container>
+std::string join(const Container& elems, const S& delim)
+{
     std::stringstream ss;
     if(elems.empty())
         return "";
-    typename std::vector<T>::iterator e = elems.begin();
+    auto e = elems.begin();
     ss << *e++;
     for (; e != elems.end(); ++e) {
         ss << delim << *e;

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -67,10 +67,13 @@ set(HEADER_FILES
     ${SRC_ROOT}/BaseSimulationExporter.h
     ${SRC_ROOT}/TaskScheduler.h
     ${SRC_ROOT}/TaskSchedulerFactory.h
+    ${SRC_ROOT}/TaskSchedulerRegistry.h
     ${SRC_ROOT}/DefaultTaskScheduler.h
     ${SRC_ROOT}/Task.h
     ${SRC_ROOT}/InitTasks.h
     ${SRC_ROOT}/Locks.h
+    ${SRC_ROOT}/MainTaskSchedulerFactory.h
+    ${SRC_ROOT}/MainTaskSchedulerRegistry.h
     ${SRC_ROOT}/WorkerThread.h
     ${SRC_ROOT}/events/BuildConstraintSystemEndEvent.h
     ${SRC_ROOT}/events/SimulationInitDoneEvent.h
@@ -157,6 +160,8 @@ set(SOURCE_FILES
     ${SRC_ROOT}/InitVisitor.cpp
     ${SRC_ROOT}/IntegrateBeginEvent.cpp
     ${SRC_ROOT}/IntegrateEndEvent.cpp
+    ${SRC_ROOT}/MainTaskSchedulerRegistry.cpp
+    ${SRC_ROOT}/MainTaskSchedulerFactory.cpp
     ${SRC_ROOT}/MechanicalOperations.cpp
     ${SRC_ROOT}/MechanicalVPrintVisitor.cpp
     ${SRC_ROOT}/MechanicalVisitor.cpp
@@ -193,6 +198,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/BaseSimulationExporter.cpp
     ${SRC_ROOT}/TaskScheduler.cpp
     ${SRC_ROOT}/TaskSchedulerFactory.cpp
+    ${SRC_ROOT}/TaskSchedulerRegistry.cpp
     ${SRC_ROOT}/DefaultTaskScheduler.cpp
     ${SRC_ROOT}/Task.cpp
     ${SRC_ROOT}/InitTasks.cpp

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -66,6 +66,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/init.h
     ${SRC_ROOT}/BaseSimulationExporter.h
     ${SRC_ROOT}/TaskScheduler.h
+    ${SRC_ROOT}/TaskSchedulerFactory.h
     ${SRC_ROOT}/DefaultTaskScheduler.h
     ${SRC_ROOT}/Task.h
     ${SRC_ROOT}/InitTasks.h
@@ -191,6 +192,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/fwd.cpp
     ${SRC_ROOT}/BaseSimulationExporter.cpp
     ${SRC_ROOT}/TaskScheduler.cpp
+    ${SRC_ROOT}/TaskSchedulerFactory.cpp
     ${SRC_ROOT}/DefaultTaskScheduler.cpp
     ${SRC_ROOT}/Task.cpp
     ${SRC_ROOT}/InitTasks.cpp

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultTaskScheduler.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultTaskScheduler.cpp
@@ -23,12 +23,12 @@
 
 #include <sofa/helper/system/thread/thread_specific_ptr.h>
 #include <sofa/simulation/WorkerThread.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 namespace sofa::simulation
 {
 
-const bool DefaultTaskSchedulerRegistered = TaskSchedulerFactory::registerScheduler(
+const bool DefaultTaskSchedulerRegistered = MainTaskSchedulerFactory::registerScheduler(
     DefaultTaskScheduler::name(),
     &DefaultTaskScheduler::create);
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultTaskScheduler.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultTaskScheduler.cpp
@@ -23,11 +23,15 @@
 
 #include <sofa/helper/system/thread/thread_specific_ptr.h>
 #include <sofa/simulation/WorkerThread.h>
-
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::simulation
-{       
-        
+{
+
+const bool DefaultTaskSchedulerRegistered = TaskSchedulerFactory::registerScheduler(
+    DefaultTaskScheduler::name(),
+    &DefaultTaskScheduler::create);
+
 class StdTaskAllocator : public Task::Allocator
 {
 public:

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/InitTasks.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/InitTasks.cpp
@@ -29,6 +29,7 @@
 #include <sofa/simulation/TaskScheduler.h>
 
 #include <thread>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::simulation
 {
@@ -69,7 +70,7 @@ Task::MemoryAlloc InitPerThreadDataTask::run()
 // temp remove this function to use the global one
 void initThreadLocalData()
 {
-    TaskScheduler* scheduler = TaskScheduler::getInstance();
+    TaskScheduler* scheduler = TaskSchedulerFactory::create();
     std::atomic<int> atomicCounter = scheduler->getThreadCount();
             
     std::mutex  InitThreadSpecificMutex;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/InitTasks.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/InitTasks.cpp
@@ -29,7 +29,7 @@
 #include <sofa/simulation/TaskScheduler.h>
 
 #include <thread>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 namespace sofa::simulation
 {
@@ -70,7 +70,7 @@ Task::MemoryAlloc InitPerThreadDataTask::run()
 // temp remove this function to use the global one
 void initThreadLocalData()
 {
-    TaskScheduler* scheduler = TaskSchedulerFactory::create();
+    TaskScheduler* scheduler = MainTaskSchedulerFactory::createInRegistry();
     std::atomic<int> atomicCounter = scheduler->getThreadCount();
             
     std::mutex  InitThreadSpecificMutex;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SolveVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SolveVisitor.cpp
@@ -25,7 +25,7 @@
 #include <sofa/core/behavior/OdeSolver.h>
 #include <sofa/simulation/TaskScheduler.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 namespace sofa::simulation
 {
@@ -63,7 +63,7 @@ void SolveVisitor::processNodeBottomUp(simulation::Node*)
 
     if (!m_tasks.empty())
     {
-        auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+        auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
         assert(taskScheduler != nullptr);
         sofa::helper::ScopedAdvancedTimer parallelSolveTimer("waitParallelTasks");
         taskScheduler->workUntilDone(&m_status);
@@ -122,7 +122,7 @@ void SolveVisitor::sequentialSolve(simulation::Node* node)
 
 void SolveVisitor::parallelSolve(simulation::Node* node)
 {
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
 
     for (auto* solver : node->solver)
@@ -134,7 +134,7 @@ void SolveVisitor::parallelSolve(simulation::Node* node)
 
 void SolveVisitor::initializeTaskScheduler()
 {
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SolveVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SolveVisitor.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/behavior/OdeSolver.h>
 #include <sofa/simulation/TaskScheduler.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::simulation
 {
@@ -62,7 +63,7 @@ void SolveVisitor::processNodeBottomUp(simulation::Node*)
 
     if (!m_tasks.empty())
     {
-        auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+        auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
         assert(taskScheduler != nullptr);
         sofa::helper::ScopedAdvancedTimer parallelSolveTimer("waitParallelTasks");
         taskScheduler->workUntilDone(&m_status);
@@ -121,7 +122,7 @@ void SolveVisitor::sequentialSolve(simulation::Node* node)
 
 void SolveVisitor::parallelSolve(simulation::Node* node)
 {
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
 
     for (auto* solver : node->solver)
@@ -133,7 +134,7 @@ void SolveVisitor::parallelSolve(simulation::Node* node)
 
 void SolveVisitor::initializeTaskScheduler()
 {
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskScheduler.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskScheduler.cpp
@@ -21,29 +21,30 @@
 ******************************************************************************/
 #include <sofa/simulation/TaskScheduler.h>
 
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerRegistry.h>
 
 namespace sofa::simulation
 {
 
 TaskScheduler* TaskScheduler::create(const char* name)
 {
-    return TaskSchedulerFactory::create(name);
+    return MainTaskSchedulerFactory::createInRegistry(name);
 }
 
 bool TaskScheduler::registerScheduler(const char* name, TaskSchedulerCreatorFunction creatorFunc)
 {
-    return TaskSchedulerFactory::registerScheduler(name, creatorFunc);
+    return MainTaskSchedulerFactory::registerScheduler(name, creatorFunc);
 }
-        
+
 TaskScheduler* TaskScheduler::getInstance()
 {
-    return TaskSchedulerFactory::create();
+    return MainTaskSchedulerFactory::createInRegistry();
 }
 
 std::string TaskScheduler::getCurrentName()
 {
-    if (const auto& lastCreated = TaskSchedulerFactory::getLastCreated())
+    if (const auto& lastCreated = MainTaskSchedulerRegistry::getLastInserted())
     {
         return lastCreated.value().first;
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskScheduler.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskScheduler.cpp
@@ -21,68 +21,34 @@
 ******************************************************************************/
 #include <sofa/simulation/TaskScheduler.h>
 
-#include <sofa/simulation/DefaultTaskScheduler.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::simulation
 {
 
-// the order of initialization of these static vars is important
-// the TaskScheduler::_schedulers must be initialized before any call to TaskScheduler::registerScheduler
-std::map<std::string, TaskScheduler::TaskSchedulerCreatorFunction> TaskScheduler::_schedulers;
-std::string TaskScheduler::_currentSchedulerName;
-TaskScheduler* TaskScheduler::_currentScheduler = nullptr;
-        
-// register default task scheduler
-const bool DefaultTaskScheduler::isRegistered = TaskScheduler::registerScheduler(DefaultTaskScheduler::name(), &DefaultTaskScheduler::create);
-        
-        
 TaskScheduler* TaskScheduler::create(const char* name)
 {
-    // is already the current scheduler
-    std::string nameStr(name);
-    if (!nameStr.empty() && _currentSchedulerName == name)
-        return _currentScheduler;
-            
-    auto iter = _schedulers.find(name);
-    if (iter == _schedulers.end())
-    {
-        // error scheduler not registered
-        // create the default task scheduler
-        iter = _schedulers.end();
-        --iter;
-    }
-            
-    if (_currentScheduler != nullptr)
-    {
-        delete _currentScheduler;
-    }
-            
-    TaskSchedulerCreatorFunction& creatorFunc = iter->second;
-    _currentScheduler = creatorFunc();
-            
-    _currentSchedulerName = iter->first;
-            
-    Task::setAllocator(_currentScheduler->getTaskAllocator());
-            
-    return _currentScheduler;
+    return TaskSchedulerFactory::create(name);
 }
-        
-        
+
 bool TaskScheduler::registerScheduler(const char* name, TaskSchedulerCreatorFunction creatorFunc)
 {
-    _schedulers[name] = creatorFunc;
-    return true;
+    return TaskSchedulerFactory::registerScheduler(name, creatorFunc);
 }
         
 TaskScheduler* TaskScheduler::getInstance()
 {
-    if (_currentScheduler == nullptr)
+    return TaskSchedulerFactory::create();
+}
+
+std::string TaskScheduler::getCurrentName()
+{
+    if (const auto& lastCreated = TaskSchedulerFactory::getLastCreated())
     {
-        TaskScheduler::create();
-        _currentScheduler->init();
+        return lastCreated.value().first;
     }
-            
-    return _currentScheduler;
+
+    return {};
 }
 
 } // namespace sofa::simulation

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskScheduler.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskScheduler.h
@@ -43,38 +43,38 @@ public:
     virtual ~TaskScheduler() = default;
 
     /**
-        * Check if a TaskScheduler already exists with this name.
-        * If not, it creates and registers a new TaskScheduler of type DefaultTaskScheduler with
-        * name as a key
-        *
-        * @param name key to find or create a TaskScheduler
-        * @return A TaskScheduler
-        */
+     * Check if a TaskScheduler already exists with this name.
+     * If not, it creates and registers a new TaskScheduler of type DefaultTaskScheduler with
+     * name as a key
+     *
+     * @param name key to find or create a TaskScheduler
+     * @return A TaskScheduler
+     */
     static TaskScheduler* create(const char* name = "");
             
     typedef std::function<TaskScheduler* ()> TaskSchedulerCreatorFunction;
 
     /**
-        * Register a new scheduler in the factory
-        *
-        * @param name key in the factory
-        * @param creatorFunc function creating a new TaskScheduler or a derived class
-        * @return
-        */
+     * Register a new scheduler in the factory
+     *
+     * @param name key in the factory
+     * @param creatorFunc function creating a new TaskScheduler or a derived class
+     * @return
+     */
     static bool registerScheduler(const char* name, TaskSchedulerCreatorFunction creatorFunc);
 
     /**
-        * Get the current TaskScheduler instance.
-        *
-        * If not instance has been created yet, a new one with empty name is created.
-        * @return The current TaskScheduler instance
-        */
+     * Get the current TaskScheduler instance.
+     *
+     * If not instance has been created yet, a new one with empty name is created.
+     * @return The current TaskScheduler instance
+     */
     static TaskScheduler* getInstance();
 
     /**
-        * Get the name of the current TaskScheduler instance
-        * @return The name of the current TaskScheduler instance
-        */
+     * Get the name of the current TaskScheduler instance
+     * @return The name of the current TaskScheduler instance
+     */
     static const std::string& getCurrentName()  { return _currentSchedulerName; }
             
     // interface

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
@@ -51,14 +51,13 @@ TaskScheduler* TaskSchedulerFactory::create(const std::string& name)
         const auto creationIt = s_schedulerCreationFunctions.find(name);
         if (creationIt != s_schedulerCreationFunctions.end())
         {
-            const auto insertion = s_schedulers.insert({name,
-                std::unique_ptr<TaskScheduler>(creationIt->second())});
-            if (!insertion.second)
-            {
-                msg_error("TaskSchedulerFactory") << "Cannot create task scheduler '" << name
+            const auto [fst, snd] = s_schedulers.insert(
+                {name, std::unique_ptr<TaskScheduler>(creationIt->second())});
+
+            msg_error_when(!snd, "TaskSchedulerFactory") << "Cannot create task scheduler '" << name
                     << "' from the factory: a task scheduler with this name already exists";
-            }
-            scheduler = insertion.first->second.get();
+
+            scheduler = fst->second.get();
         }
         else
         {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
@@ -89,4 +89,9 @@ const std::optional<std::pair<std::string, TaskScheduler*> >& TaskSchedulerFacto
     return s_lastCreated;
 }
 
+void TaskSchedulerFactory::clear()
+{
+    s_schedulers.clear();
+}
+
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
@@ -1,0 +1,93 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/DefaultTaskScheduler.h>
+
+namespace sofa::simulation
+{
+
+std::map<std::string, std::function<TaskScheduler*()>> TaskSchedulerFactory::s_schedulerCreationFunctions;
+std::map<std::string, std::unique_ptr<TaskScheduler> > TaskSchedulerFactory::s_schedulers;
+
+bool TaskSchedulerFactory::registerScheduler(const std::string& name,
+    std::function<TaskScheduler*()> creatorFunc)
+{
+    const bool isInserted = s_schedulerCreationFunctions.insert({name, creatorFunc}).second;
+    msg_error_when(!isInserted, "TaskSchedulerFactory") << "Cannot register task scheduler '" << name
+            << "' into the factory: a task scheduler with this name already exists";
+    return isInserted;
+}
+
+TaskScheduler* TaskSchedulerFactory::create(const std::string& name)
+{
+    TaskScheduler* scheduler { nullptr };
+    if (const auto it = s_schedulers.find(name); it != s_schedulers.end())
+    {
+        scheduler = it->second.get();
+    }
+    else
+    {
+        const auto creationIt = s_schedulerCreationFunctions.find(name);
+        if (creationIt != s_schedulerCreationFunctions.end())
+        {
+            const auto insertion = s_schedulers.insert({name,
+                std::unique_ptr<TaskScheduler>(creationIt->second())});
+            if (!insertion.second)
+            {
+                msg_error("TaskSchedulerFactory") << "Cannot create task scheduler '" << name
+                    << "' from the factory: a task scheduler with this name already exists";
+            }
+            scheduler = insertion.first->second.get();
+        }
+        else
+        {
+            msg_error("TaskSchedulerFactory") << "Cannot create task scheduler '" << name
+                << "': it has not been registered into the factory";
+        }
+    }
+
+    if (scheduler)
+    {
+        Task::setAllocator(scheduler->getTaskAllocator());
+        s_lastCreated = std::make_pair(name, scheduler);
+    }
+    else
+    {
+        s_lastCreated.reset();
+    }
+
+    return scheduler;
+}
+
+TaskScheduler* TaskSchedulerFactory::create()
+{
+    return TaskSchedulerFactory::create(DefaultTaskScheduler::name());
+}
+
+const std::optional<std::pair<std::string, TaskScheduler*> >& TaskSchedulerFactory::getLastCreated()
+{
+    return s_lastCreated;
+}
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
@@ -89,6 +89,16 @@ const std::optional<std::pair<std::string, TaskScheduler*> >& TaskSchedulerFacto
     return s_lastCreated;
 }
 
+std::set<std::string> TaskSchedulerFactory::getAvailableSchedulers()
+{
+    std::set<std::string> schedulers;
+    for (const auto& [name, _] : s_schedulerCreationFunctions)
+    {
+        schedulers.insert(name);
+    }
+    return schedulers;
+}
+
 void TaskSchedulerFactory::clear()
 {
     s_schedulers.clear();

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <set>
 #include <map>
+#include <string>
 
 namespace sofa::simulation
 {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
@@ -52,6 +52,11 @@ public:
 
     static const std::optional<std::pair<std::string, TaskScheduler*> >& getLastCreated();
 
+    /**
+     * Clear the factory. Everything that was registered is lost.
+     */
+    static void clear();
+
 private:
     // factory map: registered schedulers: name, creation function
     static std::map<std::string, std::function<TaskScheduler*()> > s_schedulerCreationFunctions;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
@@ -23,17 +23,18 @@
 
 #include <sofa/simulation/config.h>
 #include <functional>
-#include <map>
-#include <optional>
-#include <memory>
-#include <string>
 #include <set>
+#include <map>
 
 namespace sofa::simulation
 {
 
 class TaskScheduler;
 
+/**
+ * Simple factory structure used to instantiate a @TaskScheduler based on a name. The name and a
+ * creation function must be registered before trying to instantiate.
+ */
 class SOFA_SIMULATION_CORE_API TaskSchedulerFactory
 {
 public:
@@ -45,29 +46,19 @@ public:
      * @param creatorFunc function creating a new TaskScheduler or a derived class
      * @return false if scheduler could not be registered
      */
-    static bool registerScheduler(const std::string& name, std::function<TaskScheduler* ()> creatorFunc);
+    bool registerScheduler(const std::string& name,
+                           const std::function<TaskScheduler* ()>& creatorFunc);
 
-
-    static TaskScheduler* create(const std::string& name);
-    static TaskScheduler* create();
-
-    static const std::optional<std::pair<std::string, TaskScheduler*> >& getLastCreated();
-
-    static std::set<std::string> getAvailableSchedulers();
+    TaskScheduler* instantiate(const std::string& name);
 
     /**
-     * Clear the factory. Everything that was registered is lost.
+     * @return a list of registered schedulers
      */
-    static void clear();
+    std::set<std::string> getAvailableSchedulers();
 
 private:
-    // factory map: registered schedulers: name, creation function
-    static std::map<std::string, std::function<TaskScheduler*()> > s_schedulerCreationFunctions;
-
-    static std::map<std::string, std::unique_ptr<TaskScheduler> > s_schedulers;
-
-    inline static std::optional<std::pair<std::string, TaskScheduler*> > s_lastCreated {};
+    /// factory map: registered schedulers: name, creation function
+    std::map<std::string, std::function<TaskScheduler*()> > m_schedulerCreationFunctions;
 };
-
 
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
@@ -27,6 +27,7 @@
 #include <optional>
 #include <memory>
 #include <string>
+#include <set>
 
 namespace sofa::simulation
 {
@@ -51,6 +52,8 @@ public:
     static TaskScheduler* create();
 
     static const std::optional<std::pair<std::string, TaskScheduler*> >& getLastCreated();
+
+    static std::set<std::string> getAvailableSchedulers();
 
     /**
      * Clear the factory. Everything that was registered is lost.

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <map>
 #include <optional>
+#include <memory>
 
 namespace sofa::simulation
 {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <optional>
 #include <memory>
+#include <string>
 
 namespace sofa::simulation
 {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/config.h.in
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/config.h.in
@@ -39,3 +39,12 @@
     SOFA_ATTRIBUTE_DEPRECATED( \
     "v22.12", "v23.06", "use MechanicalBuildConstraintMatrix followed by MechanicalAccumulateMatrixDeriv")
 #endif // SOFA_BUILD_SOFA_SIMULATION_CORE
+
+
+#ifdef SOFA_BUILD_SOFA_SIMULATION_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED_STATIC_TASKSCHEDULER()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED_STATIC_TASKSCHEDULER() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+    "v22.12", "v23.06", "Use TaskSchedulerFactory instead")
+#endif // SOFA_BUILD_SOFA_SIMULATION_CORE

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/init.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/init.cpp
@@ -24,6 +24,8 @@
 #include <sofa/core/init.h>
 #include <sofa/helper/init.h>
 
+#include <sofa/simulation/TaskSchedulerFactory.h>
+
 namespace sofa
 {
 
@@ -54,6 +56,7 @@ SOFA_SIMULATION_CORE_API void cleanup()
 {
     if (!s_cleanedUp)
     {
+        sofa::simulation::TaskSchedulerFactory::clear();
         sofa::core::cleanup();
         s_cleanedUp = true;
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/init.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/init.cpp
@@ -24,7 +24,7 @@
 #include <sofa/core/init.h>
 #include <sofa/helper/init.h>
 
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerRegistry.h>
 
 namespace sofa
 {
@@ -56,7 +56,7 @@ SOFA_SIMULATION_CORE_API void cleanup()
 {
     if (!s_cleanedUp)
     {
-        sofa::simulation::TaskSchedulerFactory::clear();
+        sofa::simulation::MainTaskSchedulerRegistry::clear();
         sofa::core::cleanup();
         s_cleanedUp = true;
     }

--- a/Sofa/framework/Simulation/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCE_FILES
     TaskSchedulerTests.cpp
     TaskSchedulerTestTasks.h
     TaskSchedulerTestTasks.cpp
+    TaskSchedulerFactory_test.cpp
     )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/Sofa/framework/Simulation/Core/test/TaskSchedulerFactory_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/TaskSchedulerFactory_test.cpp
@@ -20,41 +20,52 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <gtest/gtest.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 #include <sofa/simulation/DefaultTaskScheduler.h>
 
 namespace sofa
 {
 
-TEST(TaskSchedulerFactory, registerAlreadyInFactory)
+TEST(TaskSchedulerFactory, instantiateNotInFactory)
 {
-    const bool isRegistered = simulation::TaskSchedulerFactory::registerScheduler(
+    simulation::TaskSchedulerFactory factory;
+    const simulation::TaskScheduler* scheduler = factory.instantiate("notInFactory");
+    EXPECT_EQ(scheduler, nullptr);
+}
+
+
+
+TEST(MainTaskSchedulerFactory, createEmpty)
+{
+    const simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    EXPECT_NE(dynamic_cast<const simulation::DefaultTaskScheduler*>(scheduler), nullptr);
+}
+
+TEST(MainTaskSchedulerFactory, createDefault)
+{
+    const simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry(simulation::DefaultTaskScheduler::name());
+    EXPECT_NE(dynamic_cast<const simulation::DefaultTaskScheduler*>(scheduler), nullptr);
+}
+
+
+TEST(MainTaskSchedulerFactory, createNotInFactory)
+{
+    const simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry("notInFactory");
+    EXPECT_EQ(scheduler, nullptr);
+}
+
+TEST(MainTaskSchedulerFactory, registerAlreadyInFactory)
+{
+    simulation::TaskSchedulerFactory factory;
+    const bool isRegistered = simulation::MainTaskSchedulerFactory::registerScheduler(
         simulation::DefaultTaskScheduler::name(),
         &simulation::DefaultTaskScheduler::create);
     EXPECT_FALSE(isRegistered);
 }
 
-TEST(TaskSchedulerFactory, createEmpty)
+TEST(MainTaskSchedulerFactory, registerNew)
 {
-    const simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
-    EXPECT_NE(dynamic_cast<const simulation::DefaultTaskScheduler*>(scheduler), nullptr);
-}
-
-TEST(TaskSchedulerFactory, createDefault)
-{
-    const simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create(simulation::DefaultTaskScheduler::name());
-    EXPECT_NE(dynamic_cast<const simulation::DefaultTaskScheduler*>(scheduler), nullptr);
-}
-
-TEST(TaskSchedulerFactory, createNotInFactory)
-{
-    const simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create("notInFactory");
-    EXPECT_EQ(scheduler, nullptr);
-}
-
-TEST(TaskSchedulerFactory, registerNew)
-{
-    const bool isRegistered = simulation::TaskSchedulerFactory::registerScheduler(
+    const bool isRegistered = simulation::MainTaskSchedulerFactory::registerScheduler(
         "notTheSameKey", &simulation::DefaultTaskScheduler::create);
     EXPECT_TRUE(isRegistered);
 }

--- a/Sofa/framework/Simulation/Core/test/TaskSchedulerFactory_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/TaskSchedulerFactory_test.cpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/DefaultTaskScheduler.h>
+
+namespace sofa
+{
+
+TEST(TaskSchedulerFactory, registerAlreadyInFactory)
+{
+    const bool isRegistered = simulation::TaskSchedulerFactory::registerScheduler(
+        simulation::DefaultTaskScheduler::name(),
+        &simulation::DefaultTaskScheduler::create);
+    EXPECT_FALSE(isRegistered);
+}
+
+TEST(TaskSchedulerFactory, createEmpty)
+{
+    const simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
+    EXPECT_NE(dynamic_cast<const simulation::DefaultTaskScheduler*>(scheduler), nullptr);
+}
+
+TEST(TaskSchedulerFactory, createDefault)
+{
+    const simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create(simulation::DefaultTaskScheduler::name());
+    EXPECT_NE(dynamic_cast<const simulation::DefaultTaskScheduler*>(scheduler), nullptr);
+}
+
+TEST(TaskSchedulerFactory, createNotInFactory)
+{
+    const simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create("notInFactory");
+    EXPECT_EQ(scheduler, nullptr);
+}
+
+TEST(TaskSchedulerFactory, registerNew)
+{
+    const bool isRegistered = simulation::TaskSchedulerFactory::registerScheduler(
+        "notTheSameKey", &simulation::DefaultTaskScheduler::create);
+    EXPECT_TRUE(isRegistered);
+}
+
+}

--- a/Sofa/framework/Simulation/Core/test/TaskSchedulerTestTasks.cpp
+++ b/Sofa/framework/Simulation/Core/test/TaskSchedulerTestTasks.cpp
@@ -1,6 +1,7 @@
 #include "TaskSchedulerTestTasks.h"
 
 #include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 using sofa::simulation::Task;
 
@@ -20,7 +21,7 @@ namespace sofa
         
         int64_t x, y;
         
-        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::getInstance();
+        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
         
         FibonacciTask task0(_N - 1, &x, &status);
         FibonacciTask task1(_N - 2, &y, &status);
@@ -52,7 +53,7 @@ namespace sofa
         
         int64_t x, y;
         
-        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::getInstance();
+        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
         
         IntSumTask task0(_first, mid, &x, &status);
         IntSumTask task1(mid+1, _last, &y, &status);

--- a/Sofa/framework/Simulation/Core/test/TaskSchedulerTestTasks.cpp
+++ b/Sofa/framework/Simulation/Core/test/TaskSchedulerTestTasks.cpp
@@ -1,7 +1,7 @@
 #include "TaskSchedulerTestTasks.h"
 
 #include <sofa/simulation/TaskScheduler.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 using sofa::simulation::Task;
 
@@ -21,7 +21,7 @@ namespace sofa
         
         int64_t x, y;
         
-        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
+        simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
         
         FibonacciTask task0(_N - 1, &x, &status);
         FibonacciTask task1(_N - 2, &y, &status);
@@ -53,7 +53,7 @@ namespace sofa
         
         int64_t x, y;
         
-        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
+        simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
         
         IntSumTask task0(_first, mid, &x, &status);
         IntSumTask task1(mid+1, _last, &y, &status);

--- a/Sofa/framework/Simulation/Core/test/TaskSchedulerTests.cpp
+++ b/Sofa/framework/Simulation/Core/test/TaskSchedulerTests.cpp
@@ -1,6 +1,6 @@
 #include "TaskSchedulerTestTasks.h"
 
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 #include <sofa/simulation/CpuTask.h>
 #include <sofa/simulation/DefaultTaskScheduler.h>
 #include <sofa/testing/BaseTest.h>
@@ -10,7 +10,7 @@ namespace sofa
     // compute the Fibonacci number for input N
     static int64_t Fibonacci(int64_t N, int nbThread = 0)
     {
-        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create(simulation::DefaultTaskScheduler::name());
+        simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry(simulation::DefaultTaskScheduler::name());
         scheduler->init(nbThread);
         
         simulation::CpuTask::Status status;
@@ -28,7 +28,7 @@ namespace sofa
     // compute the sum of integers from 1 to N
     static int64_t IntSum1ToN(const int64_t N, int nbThread = 0)
     {
-        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create(simulation::DefaultTaskScheduler::name());
+        simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry(simulation::DefaultTaskScheduler::name());
         scheduler->init(nbThread);
         
         simulation::CpuTask::Status status;

--- a/Sofa/framework/Simulation/Core/test/TaskSchedulerTests.cpp
+++ b/Sofa/framework/Simulation/Core/test/TaskSchedulerTests.cpp
@@ -1,6 +1,6 @@
 #include "TaskSchedulerTestTasks.h"
 
-#include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 #include <sofa/simulation/CpuTask.h>
 #include <sofa/simulation/DefaultTaskScheduler.h>
 #include <sofa/testing/BaseTest.h>
@@ -10,7 +10,7 @@ namespace sofa
     // compute the Fibonacci number for input N
     static int64_t Fibonacci(int64_t N, int nbThread = 0)
     {
-        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::create(simulation::DefaultTaskScheduler::name());
+        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create(simulation::DefaultTaskScheduler::name());
         scheduler->init(nbThread);
         
         simulation::CpuTask::Status status;
@@ -28,7 +28,7 @@ namespace sofa
     // compute the sum of integers from 1 to N
     static int64_t IntSum1ToN(const int64_t N, int nbThread = 0)
     {
-        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::create(simulation::DefaultTaskScheduler::name());
+        simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create(simulation::DefaultTaskScheduler::name());
         scheduler->init(nbThread);
         
         simulation::CpuTask::Status status;

--- a/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
@@ -62,6 +62,7 @@
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 #include <cstdlib>
 #include <cmath>
@@ -95,11 +96,12 @@ void AnimationLoopParallelScheduler::init()
         mNbThread = threadNumber.getValue();
     }
 
-    _taskScheduler = TaskScheduler::getInstance();
+    _taskScheduler = TaskSchedulerFactory::create();
 
-    if (TaskScheduler::getCurrentName() != schedulerName.getValue())
+    if (!TaskSchedulerFactory::getLastCreated().has_value()
+            || TaskSchedulerFactory::getLastCreated().value().first != schedulerName.getValue())
     {
-        _taskScheduler = TaskScheduler::create(schedulerName.getValue().c_str());
+        _taskScheduler = TaskSchedulerFactory::create(schedulerName.getValue().c_str());
     }
     _taskScheduler->init( mNbThread );
 }

--- a/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
@@ -62,7 +62,7 @@
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 #include <cstdlib>
 #include <cmath>
@@ -98,20 +98,20 @@ void AnimationLoopParallelScheduler::init()
 
     if (schedulerName.isSet())
     {
-        _taskScheduler = TaskSchedulerFactory::create(schedulerName.getValue() );
+        _taskScheduler = MainTaskSchedulerFactory::createInRegistry(schedulerName.getValue() );
         if (!_taskScheduler)
         {
             msg_error() << "'" << schedulerName.getValue()
                 << "' is not a valid name for a task scheduler. Falling back to the default "
                 "task scheduler. The list of available schedulers is: ["
-                << sofa::helper::join(TaskSchedulerFactory::getAvailableSchedulers(), ',')
+                << sofa::helper::join(MainTaskSchedulerFactory::getAvailableSchedulers(), ',')
                 << "]";
         }
     }
 
     if (!_taskScheduler)
     {
-        _taskScheduler = TaskSchedulerFactory::create();
+        _taskScheduler = MainTaskSchedulerFactory::createInRegistry();
     }
 
     if (_taskScheduler)

--- a/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
@@ -96,14 +96,32 @@ void AnimationLoopParallelScheduler::init()
         mNbThread = threadNumber.getValue();
     }
 
-    _taskScheduler = TaskSchedulerFactory::create();
-
-    if (!TaskSchedulerFactory::getLastCreated().has_value()
-            || TaskSchedulerFactory::getLastCreated().value().first != schedulerName.getValue())
+    if (schedulerName.isSet())
     {
-        _taskScheduler = TaskSchedulerFactory::create(schedulerName.getValue().c_str());
+        _taskScheduler = TaskSchedulerFactory::create(schedulerName.getValue() );
+        if (!_taskScheduler)
+        {
+            msg_error() << "'" << schedulerName.getValue()
+                << "' is not a valid name for a task scheduler. Falling back to the default "
+                "task scheduler. The list of available schedulers is: ["
+                << sofa::helper::join(TaskSchedulerFactory::getAvailableSchedulers(), ',')
+                << "]";
+        }
     }
-    _taskScheduler->init( mNbThread );
+
+    if (!_taskScheduler)
+    {
+        _taskScheduler = TaskSchedulerFactory::create();
+    }
+
+    if (_taskScheduler)
+    {
+        _taskScheduler->init( mNbThread );
+    }
+    else
+    {
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+    }
 }
 
 void AnimationLoopParallelScheduler::bwdInit()

--- a/applications/plugins/MultiThreading/src/MultiThreading/BeamLinearMapping_mt.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/BeamLinearMapping_mt.inl
@@ -26,7 +26,7 @@
 #include <MultiThreading/BeamLinearMapping_tasks.inl>
 
 #include <sofa/simulation/TaskScheduler.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 namespace sofa::component::mapping
 {
@@ -48,7 +48,7 @@ namespace sofa::component::mapping
     template <class TIn, class TOut>
     void BeamLinearMapping_mt< TIn, TOut>::init()
     {
-        simulation::TaskSchedulerFactory::create()->init();
+        simulation::MainTaskSchedulerFactory::createInRegistry()->init();
         
         linear::BeamLinearMapping< TIn, TOut>::init();
     }
@@ -84,7 +84,7 @@ namespace sofa::component::mapping
             
             // create tasks
             simulation::CpuTask::Status status;
-            simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
+            simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
             
             const int taskSize = 2*mGrainSize.getValue();
             
@@ -178,7 +178,7 @@ namespace sofa::component::mapping
             out.resize(this->points.size());
             
             simulation::CpuTask::Status status;
-            simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
+            simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
             
             const int taskSize = 2*mGrainSize.getValue();
             
@@ -265,7 +265,7 @@ namespace sofa::component::mapping
             
             
             simulation::CpuTask::Status status;
-            simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
+            simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
             
             const int taskSize = 2*mGrainSize.getValue();
             

--- a/applications/plugins/MultiThreading/src/MultiThreading/BeamLinearMapping_mt.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/BeamLinearMapping_mt.inl
@@ -26,6 +26,7 @@
 #include <MultiThreading/BeamLinearMapping_tasks.inl>
 
 #include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::component::mapping
 {
@@ -47,7 +48,7 @@ namespace sofa::component::mapping
     template <class TIn, class TOut>
     void BeamLinearMapping_mt< TIn, TOut>::init()
     {
-        simulation::TaskScheduler::getInstance()->init();
+        simulation::TaskSchedulerFactory::create()->init();
         
         linear::BeamLinearMapping< TIn, TOut>::init();
     }
@@ -83,7 +84,7 @@ namespace sofa::component::mapping
             
             // create tasks
             simulation::CpuTask::Status status;
-            simulation::TaskScheduler* scheduler = simulation::TaskScheduler::getInstance();
+            simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
             
             const int taskSize = 2*mGrainSize.getValue();
             
@@ -177,7 +178,7 @@ namespace sofa::component::mapping
             out.resize(this->points.size());
             
             simulation::CpuTask::Status status;
-            simulation::TaskScheduler* scheduler = simulation::TaskScheduler::getInstance();
+            simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
             
             const int taskSize = 2*mGrainSize.getValue();
             
@@ -264,7 +265,7 @@ namespace sofa::component::mapping
             
             
             simulation::CpuTask::Status status;
-            simulation::TaskScheduler* scheduler = simulation::TaskScheduler::getInstance();
+            simulation::TaskScheduler* scheduler = simulation::TaskSchedulerFactory::create();
             
             const int taskSize = 2*mGrainSize.getValue();
             

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
@@ -27,6 +27,7 @@
 #include <sofa/core/CollisionModel.h>
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::component::collision
 {
@@ -46,7 +47,7 @@ void ParallelBVHNarrowPhase::init()
 
     // initialize the thread pool
 
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {
@@ -68,7 +69,7 @@ void ParallelBVHNarrowPhase::addCollisionPairs(const sofa::type::vector< std::pa
         return;
     }
 
-    auto *taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
 
     if (taskScheduler->getThreadCount() == 0)

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
@@ -27,7 +27,7 @@
 #include <sofa/core/CollisionModel.h>
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 namespace sofa::component::collision
 {
@@ -47,7 +47,7 @@ void ParallelBVHNarrowPhase::init()
 
     // initialize the thread pool
 
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {
@@ -62,14 +62,14 @@ void ParallelBVHNarrowPhase::init()
 
 void ParallelBVHNarrowPhase::addCollisionPairs(const sofa::type::vector< std::pair<core::CollisionModel*, core::CollisionModel*> >& v)
 {
-    ScopedAdvancedTimer createTasksTimer("addCollisionPairs");
+    ScopedAdvancedTimer addCollisionPairsTimer("addCollisionPairs");
 
     if (v.empty())
     {
         return;
     }
 
-    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto *taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
 
     if (taskScheduler->getThreadCount() == 0)

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
@@ -25,6 +25,7 @@
 #include <sofa/simulation/TaskScheduler.h>
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::component::collision
 {
@@ -45,7 +46,7 @@ void ParallelBruteForceBroadPhase::init()
 
     // initialize the thread pool
 
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {
@@ -97,7 +98,7 @@ void ParallelBruteForceBroadPhase::addCollisionModels(const sofa::type::vector<c
         return;
     }
 
-    auto *taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
 
     if (taskScheduler->getThreadCount() == 0)

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
@@ -25,7 +25,7 @@
 #include <sofa/simulation/TaskScheduler.h>
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 namespace sofa::component::collision
 {
@@ -46,7 +46,7 @@ void ParallelBruteForceBroadPhase::init()
 
     // initialize the thread pool
 
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {
@@ -98,7 +98,7 @@ void ParallelBruteForceBroadPhase::addCollisionModels(const sofa::type::vector<c
         return;
     }
 
-    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto *taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
 
     if (taskScheduler->getThreadCount() == 0)

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
@@ -23,7 +23,7 @@
 
 #include <MultiThreading/ParallelHexahedronFEMForceField.h>
 #include <sofa/simulation/TaskScheduler.h>
-#include <sofa/simulation/TaskSchedulerFactory.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
 
 namespace sofa::component::forcefield
 {
@@ -38,7 +38,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::init()
 template<class DataTypes>
 void ParallelHexahedronFEMForceField<DataTypes>::initTaskScheduler()
 {
-    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {
@@ -76,7 +76,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addForce(const core::Mechanical
         this->needUpdateTopology = false;
     }
 
-    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto *taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() == 0)
     {
@@ -220,7 +220,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addDForce (const core::Mechanic
     if (_df.size() != _dx.size())
         _df.resize(_dx.size());
 
-    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
+    auto *taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() == 0)
     {

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
@@ -23,6 +23,7 @@
 
 #include <MultiThreading/ParallelHexahedronFEMForceField.h>
 #include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/TaskSchedulerFactory.h>
 
 namespace sofa::component::forcefield
 {
@@ -37,7 +38,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::init()
 template<class DataTypes>
 void ParallelHexahedronFEMForceField<DataTypes>::initTaskScheduler()
 {
-    auto* taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto* taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() < 1)
     {
@@ -75,7 +76,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addForce(const core::Mechanical
         this->needUpdateTopology = false;
     }
 
-    auto *taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() == 0)
     {
@@ -219,7 +220,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addDForce (const core::Mechanic
     if (_df.size() != _dx.size())
         _df.resize(_dx.size());
 
-    auto *taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    auto *taskScheduler = sofa::simulation::TaskSchedulerFactory::create();
     assert(taskScheduler != nullptr);
     if (taskScheduler->getThreadCount() == 0)
     {


### PR DESCRIPTION
TaskScheduler was doing several things:
- A base class for task schedulers
- A factory to register and create task schedulers

The factory code is extracted from the TaskScheduler class and moved into its dedicated class and file.

I refactored a bit how the factory works:
Before, it was like there could be only one TaskScheduler at a time. Everytime a new TaskScheduler was created, the previous one is destroyed. It prevents the use of multiple TaskScheduler with different type (derived class). Instead, the task schedulers are now stored in a map. 
The only issue is related to the task allocator. The task allocator is used every time a task is created. The task allocator is supposed to depend on the TaskScheduler where the task will be added. But in practice, a Task is created independently from the TaskScheduler. So I kept the old system that calls a static function setting the allocator when the task scheduler is created.

Some unit tests are introduced

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
