### PR TITLE
[Core] Support getObjects on set containers

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
@@ -283,6 +283,7 @@ public:
         ptr = this->get<T>(path);
     }
 
+    /// Helper functor allowing to insert an object into a container
     template<class T, class Container>
     class GetObjectsCallBackT;
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
@@ -147,7 +147,7 @@ public:
     class GetObjectsCallBack
     {
     public:
-      virtual ~GetObjectsCallBack() {}
+        virtual ~GetObjectsCallBack() = default;
         virtual void operator()(void* ptr) = 0;
     };
 
@@ -284,17 +284,7 @@ public:
     }
 
     template<class T, class Container>
-    class GetObjectsCallBackT : public GetObjectsCallBack
-    {
-    public:
-        Container* dest;
-        GetObjectsCallBackT(Container* d) : dest(d) {}
-        virtual ~GetObjectsCallBackT() override {}
-        void operator()(void* ptr) override
-	{
-	    dest->push_back(reinterpret_cast<T*>(ptr));
-	}
-    };
+    class GetObjectsCallBackT;
 
     /// Generic list of objects access template wrapper, possibly searching up or down from the current context
     template<class T, class Container>
@@ -412,6 +402,25 @@ public:
 
 protected:
     ComponentNameHelper m_nameHelper;
+};
+
+template<class T, class Container>
+class BaseContext::GetObjectsCallBackT : public BaseContext::GetObjectsCallBack
+{
+public:
+    Container* dest;
+    GetObjectsCallBackT(Container* d) : dest(d) {}
+    void operator()(void* ptr) override
+    {
+        if constexpr (sofa::type::trait::is_vector<Container>::value)
+        {
+            dest->push_back(reinterpret_cast<T*>(ptr));
+        }
+        else //for sets
+        {
+            dest->insert(reinterpret_cast<T*>(ptr));
+        }
+    }
 };
 
 } // namespace sofa::core::objectmodel

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -166,7 +166,7 @@ public:
 
     /// Initialize the components
     void init(const sofa::core::ExecParams* params);
-    bool isInitialized() {return initialized;}
+    bool isInitialized() const {return initialized;}
     /// Apply modifications to the components
     void reinit(const sofa::core::ExecParams* params);
     /// Draw the objects (using visual visitors)

--- a/Sofa/framework/Simulation/Graph/test/Node_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Node_test.cpp
@@ -26,6 +26,7 @@ using sofa::testing::BaseSimulationTest ;
 using namespace sofa::simpleapi ;
 
 #include "Node_test.h"
+#include <unordered_set>
 
 namespace sofa
 {
@@ -122,6 +123,59 @@ TEST(Node_test, addObjectPreventingSharedContext)
 
 }
 
+TEST(Node_test, getObjectsStdVector)
+{
+    sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
+    Dummy::SPtr A = core::objectmodel::New<Dummy>("A");
+    Dummy::SPtr B = core::objectmodel::New<Dummy>("B");
+
+    root->addObject(A);
+    root->addObject(B);
+
+    std::vector<Dummy*> objects;
+    root->BaseContext::getObjects(objects, core::objectmodel::BaseContext::SearchDirection::SearchDown);
+
+    EXPECT_EQ(objects.size(), 2);
+
+    EXPECT_NE(std::find(objects.begin(), objects.end(), A.get()), objects.end());
+    EXPECT_NE(std::find(objects.begin(), objects.end(), B.get()), objects.end());
+}
+
+TEST(Node_test, getObjectsStdSet)
+{
+    sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
+    Dummy::SPtr A = core::objectmodel::New<Dummy>("A");
+    Dummy::SPtr B = core::objectmodel::New<Dummy>("B");
+
+    root->addObject(A);
+    root->addObject(B);
+
+    std::set<Dummy*> objects;
+    root->BaseContext::getObjects(objects, core::objectmodel::BaseContext::SearchDirection::SearchDown);
+
+    EXPECT_EQ(objects.size(), 2);
+
+    EXPECT_NE(objects.find(A.get()), objects.end());
+    EXPECT_NE(objects.find(B.get()), objects.end());
+}
+
+TEST(Node_test, getObjectsStdUnorderedSet)
+{
+    sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
+    Dummy::SPtr A = core::objectmodel::New<Dummy>("A");
+    Dummy::SPtr B = core::objectmodel::New<Dummy>("B");
+
+    root->addObject(A);
+    root->addObject(B);
+
+    std::unordered_set<Dummy*> objects;
+    root->BaseContext::getObjects(objects, core::objectmodel::BaseContext::SearchDirection::SearchDown);
+
+    EXPECT_EQ(objects.size(), 2);
+
+    EXPECT_NE(objects.find(A.get()), objects.end());
+    EXPECT_NE(objects.find(B.get()), objects.end());
+}
 
 }// namespace sofa
 


### PR DESCRIPTION
This is to support `root->getObjects( objects, ...)`, when `objects` is a `std::set` or a `std::unordered_set`. Otherwise, only containers with a `push_back` method could be supported.
I also moved the class definition out of the `BaseContext` class to ease the reading.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
