### PR TITLE
[Type] Conversion to scalar for Mat1x1

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -306,6 +306,12 @@ public:
     template<sofa::Size NbLine = L, typename = std::enable_if_t<NbLine >= 4> >
     constexpr const Line& w() const noexcept { return this->elems[3]; }
 
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == 1 && NbColumn == 1>>
+    constexpr real toReal() const { return this->elems[0][0]; }
+
+    template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == 1 && NbColumn == 1>>
+    constexpr operator real() const { return toReal(); }
+
     /// Set matrix to identity.
     template<sofa::Size NbLine = L, sofa::Size NbColumn = C, typename = std::enable_if_t<NbLine == NbColumn> >
     constexpr void identity() noexcept

--- a/Sofa/framework/Type/test/MatTypes_test.cpp
+++ b/Sofa/framework/Type/test/MatTypes_test.cpp
@@ -313,3 +313,14 @@ TEST(MatTypesTest, identity)
         }
     }
 }
+
+TEST(MatTypesTest, conversionToReal)
+{
+    const sofa::type::Mat<1, 1, SReal>& id = sofa::type::Mat<1, 1, SReal>::Identity();
+
+    const SReal r = id;
+    EXPECT_EQ(r, 1_sreal);
+
+    const SReal p = id.toReal();
+    EXPECT_EQ(p, 1_sreal);
+}


### PR DESCRIPTION
Explicit and implicit conversion to scalar are introduced for matrices 1x1. Unit tests are added.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
