### PR TITLE
[VectorTypeInfo] Change default handling of data buffer

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Text.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Text.h
@@ -32,8 +32,8 @@ struct DataTypeInfo<std::string> : public TextTypeInfo<std::string>
     static const std::string name() { return "string"; }
     static const std::string GetTypeName(){ return "string"; }
 
-    static const void* getValuePtr(const std::string& data) { return &data[0]; }
-    static void* getValuePtr(std::string& data) { return &data[0]; }
+    static const void* getValuePtr(const std::string& data) { return data.data(); }
+    static void* getValuePtr(std::string& data) { return data.data(); }
 };
 
 } /// namespace sofa::defaulttype

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
@@ -193,12 +193,12 @@ struct VectorTypeInfo
 
     static const void* getValuePtr(const DataType& data)
     {
-        return &data[0];
+        return data.data();
     }
 
     static void* getValuePtr(DataType& data)
     {
-        return &data[0];
+        return data.data();
     }
 };
 


### PR DESCRIPTION
In the `getValuePtr` methods, a buffer on vector data is obtained by actually returning a reference to the vector first element. However the case where the method is called on an empty (but valid) vector is not handled. This may lead to an execution error, for instance when using SofaPython3 to assign values to a component's Data dynamically. This specific scenario is the object of a second PR in SofaPython3 [(link to the PR)](https://github.com/sofa-framework/SofaPython3/pull/318).

To change this, we propose to use the `std::vector.data()` method, which handles the case when the vector is actually empty (however returning a pointer that may or may not be null).

All unit tests work on my setup with this modification. However I don't fully understand the consequences of a change at this depth in SOFA's core, so additional opinions would be useful.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
