### PR TITLE
[plugins] SofaCUDA does not require Sofa.GL

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -64,8 +64,9 @@ endif()
 sofa_find_package(Sofa.GL QUIET)
 if(Sofa.GL_FOUND)
     sofa_add_subdirectory(plugin VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't work without OPENGL
-    sofa_add_subdirectory(plugin SofaCUDA SofaCUDA)           # SofaCUDA plugin can't work without OPENGL
     sofa_add_subdirectory(plugin SofaSimpleGUI SofaSimpleGUI) # SofaSimpleGUI plugin can't work without OPENGL
 else()
-    message("Sofa.GL not found; disabling SofaCUDA, SofaSimpleGUI and VolumetricRendering plugins")
+    message("Sofa.GL not found; disabling SofaSimpleGUI and VolumetricRendering plugins")
 endif()
+
+sofa_add_subdirectory(plugin SofaCUDA SofaCUDA)

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -63,8 +63,8 @@ endif()
 
 sofa_find_package(Sofa.GL QUIET)
 if(Sofa.GL_FOUND)
-    sofa_add_subdirectory(plugin VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't work without OPENGL
     sofa_add_subdirectory(plugin SofaSimpleGUI SofaSimpleGUI) # SofaSimpleGUI plugin can't work without OPENGL
+    sofa_add_subdirectory(plugin VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't work without OPENGL
 else()
     message("Sofa.GL not found; disabling SofaSimpleGUI and VolumetricRendering plugins")
 endif()

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -63,9 +63,9 @@ endif()
 
 sofa_find_package(Sofa.GL QUIET)
 if(Sofa.GL_FOUND)
+    sofa_add_subdirectory(plugin VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't work without OPENGL
     sofa_add_subdirectory(plugin SofaCUDA SofaCUDA)           # SofaCUDA plugin can't work without OPENGL
     sofa_add_subdirectory(plugin SofaSimpleGUI SofaSimpleGUI) # SofaSimpleGUI plugin can't work without OPENGL
-    sofa_add_subdirectory(plugin VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't work without OPENGL
 else()
     message("Sofa.GL not found; disabling SofaCUDA, SofaSimpleGUI and VolumetricRendering plugins")
 endif()


### PR DESCRIPTION
SofaCUDA declaration is moved out of the condition on Sofa.GL.
It is moved after VolumetricRendering, because SofaCUDA has a dependency to VolumetricRendering. Therefore, VolumetricRendering must be declared first.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
