### PR TITLE
[SofaPhysicsAPI] Add several methods using output parameters

### DIFF
--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -50,7 +50,7 @@ public:
     virtual ~SofaPhysicsAPI();
 
     /// Load an XML file containing the main scene description
-    bool load(const char* filename);
+    int load(const char* filename);
     int unload();
 
     virtual const char* APIName();

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -118,6 +118,7 @@ public:
     double getCurrentFPS() const;
 
     double* getGravity() const;
+    int getGravity(double* values) const;
     void setGravity(double* gravity);
 
     /// Return the number of currently active data monitors

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -49,9 +49,9 @@ public:
     SofaPhysicsAPI(bool useGUI = false, int GUIFramerate = 0);
     virtual ~SofaPhysicsAPI();
 
-    /// Load an XML file containing the main scene description
+    /// Load an XML file containing the main scene description. Will return API_SUCCESS or API_SCENE_FAILED if loading failed
     int load(const char* filename);
-    /// Call unload of the current scene graph.
+    /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
 
     /// Get the current api Name behind this interface.

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -35,7 +35,7 @@ typedef void* ID;           ///< Type used for IDs
 // Exit code
 #define API_SUCCESS EXIT_SUCCESS
 #define API_NULL -1
-
+#define API_SCENE_FAILED -10
 
 /// Internal implementation sub-class
 class SofaPhysicsSimulation;
@@ -50,6 +50,7 @@ public:
 
     /// Load an XML file containing the main scene description
     bool load(const char* filename);
+    int unload();
 
     virtual const char* APIName();
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -32,11 +32,11 @@ typedef unsigned int Index; ///< Type used for topology indices
 typedef float Real;         ///< Type used for coordinates
 typedef void* ID;           ///< Type used for IDs
 
-// Exit code
-#define API_SUCCESS EXIT_SUCCESS
-#define API_NULL -1
-#define API_SCENE_NULL -11
-#define API_SCENE_FAILED -10
+/// List of error code to be used to translate methods return values without logging system
+#define API_SUCCESS EXIT_SUCCESS ///< success value
+#define API_NULL -1              ///< SofaPhysicsAPI created is null
+#define API_SCENE_NULL -10       ///< Scene creation failed. I.e Root node is null
+#define API_SCENE_FAILED -11     ///< Scene loading failed. I.e root node is null but scene is still empty
 
 /// Internal implementation sub-class
 class SofaPhysicsSimulation;
@@ -51,10 +51,13 @@ public:
 
     /// Load an XML file containing the main scene description
     int load(const char* filename);
+    /// Call unload of the current scene graph.
     int unload();
 
+    /// Get the current api Name behind this interface.
     virtual const char* APIName();
 
+    /// Create an empty scene with only a SOFA root Node.
     virtual void createScene();
 
     /// Start the simulation
@@ -125,7 +128,9 @@ public:
     double getCurrentFPS() const;
 
     double* getGravity() const;
+    /// Get the current scene gravity using the ouptut @param values which is a double[3]. Return error code.
     int getGravity(double* values) const;
+    /// Set the current scene gravity using the input @param gravity which is a double[3]
     void setGravity(double* gravity);
 
     /// Return the number of currently active data monitors
@@ -158,11 +163,11 @@ public:
 
     unsigned int getNbVertices(); ///< number of vertices
     const Real* getVPositions();  ///< vertices positions (Vec3)
-    int getVPositions(Real* values);
+    int getVPositions(Real* values); ///< get the positions/vertices of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]
     const Real* getVNormals();    ///< vertices normals   (Vec3)
-    int getVNormals(Real* values);
+    int getVNormals(Real* values); ///< get the normals per vertex of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]
     const Real* getVTexCoords();  ///< vertices UVs       (Vec2)
-    int getVTexCoords(Real* values);
+    int getVTexCoords(Real* values); ///< get the texture coordinates (UV) per vertex of this mesh inside ouput @param values, of type Real[ 2*nbVertices ]
     int getTexCoordRevision();    ///< changes each time texture coord data are updated
     int getVerticesRevision();    ///< changes each time vertices data are updated
 
@@ -179,12 +184,12 @@ public:
 
     unsigned int getNbTriangles(); ///< number of triangles
     const Index* getTriangles();   ///< triangles topology (3 indices / triangle)
-    int getTriangles(int* values);
+    int getTriangles(int* values); ///< get the triangle topology inside ouput @param values, of type int[ 3*nbTriangles ]
     int getTrianglesRevision();    ///< changes each time triangles data is updated
 
     unsigned int getNbQuads(); ///< number of quads
     const Index* getQuads();   ///< quads topology (4 indices / quad)
-    int getQuads(int* values);
+    int getQuads(int* values); ///< get the quad topology inside ouput @param values, of type int[ 4*nbQuads ]
     int getQuadsRevision();    ///< changes each time quads data is updated
 
     /// Internal implementation sub-class

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -35,6 +35,7 @@ typedef void* ID;           ///< Type used for IDs
 // Exit code
 #define API_SUCCESS EXIT_SUCCESS
 #define API_NULL -1
+#define API_SCENE_NULL -11
 #define API_SCENE_FAILED -10
 
 /// Internal implementation sub-class

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -32,6 +32,11 @@ typedef unsigned int Index; ///< Type used for topology indices
 typedef float Real;         ///< Type used for coordinates
 typedef void* ID;           ///< Type used for IDs
 
+// Exit code
+#define API_SUCCESS EXIT_SUCCESS
+#define API_NULL -1
+
+
 /// Internal implementation sub-class
 class SofaPhysicsSimulation;
 
@@ -151,8 +156,11 @@ public:
 
     unsigned int getNbVertices(); ///< number of vertices
     const Real* getVPositions();  ///< vertices positions (Vec3)
+    int getVPositions(Real* values);
     const Real* getVNormals();    ///< vertices normals   (Vec3)
+    int getVNormals(Real* values);
     const Real* getVTexCoords();  ///< vertices UVs       (Vec2)
+    int getVTexCoords(Real* values);
     int getTexCoordRevision();    ///< changes each time texture coord data are updated
     int getVerticesRevision();    ///< changes each time vertices data are updated
 
@@ -169,10 +177,12 @@ public:
 
     unsigned int getNbTriangles(); ///< number of triangles
     const Index* getTriangles();   ///< triangles topology (3 indices / triangle)
+    int getTriangles(int* values);
     int getTrianglesRevision();    ///< changes each time triangles data is updated
 
     unsigned int getNbQuads(); ///< number of quads
     const Index* getQuads();   ///< quads topology (4 indices / quad)
+    int getQuads(int* values);
     int getQuadsRevision();    ///< changes each time quads data is updated
 
     /// Internal implementation sub-class

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
@@ -245,7 +245,11 @@ const Real* SofaPhysicsOutputMesh::Impl::getVPositions()  ///< vertices position
 
 int SofaPhysicsOutputMesh::Impl::getVPositions(Real* values)
 {
-    const sofa::type::vector<Coord>& coords = (sObj->m_positions).getValue();
+    Data<sofa::type::vector<Coord> >* data =
+        (!sObj->m_vertPosIdx.getValue().empty()) ?
+        &(sObj->m_vertices2) : &(sObj->m_positions);
+
+    const sofa::type::vector<Coord>& coords = data->getValue();
     for (unsigned int i = 0; i < coords.size(); ++i)
     {
         values[i * 3] = coords[i].x();

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
@@ -51,18 +51,37 @@ unsigned int SofaPhysicsOutputMesh::getNbVertices() ///< number of vertices
 {
     return impl->getNbVertices();
 }
+
 const Real* SofaPhysicsOutputMesh::getVPositions()  ///< vertices positions (Vec3)
 {
     return impl->getVPositions();
 }
+
+int SofaPhysicsOutputMesh::getVPositions(Real* values)
+{
+    return impl->getVPositions(values);
+}
+
 const Real* SofaPhysicsOutputMesh::getVNormals()    ///< vertices normals   (Vec3)
 {
     return impl->getVNormals();
 }
+
+int SofaPhysicsOutputMesh::getVNormals(Real* values)
+{
+    return impl->getVNormals(values);
+}
+
 const Real* SofaPhysicsOutputMesh::getVTexCoords()  ///< vertices UVs       (Vec2)
 {
     return impl->getVTexCoords();
 }
+
+int SofaPhysicsOutputMesh::getVTexCoords(Real* values)
+{
+    return impl->getVTexCoords(values);
+}
+
 int SofaPhysicsOutputMesh::getTexCoordRevision()    ///< changes each time tex coord data are updated
 {
     return impl->getTexCoordRevision();
@@ -121,6 +140,12 @@ const Index* SofaPhysicsOutputMesh::getTriangles()   ///< triangles topology (3 
 {
     return impl->getTriangles();
 }
+
+int SofaPhysicsOutputMesh::getTriangles(int* values)
+{
+    return impl->getTriangles(values);
+}
+
 int SofaPhysicsOutputMesh::getTrianglesRevision()    ///< changes each time triangles data is updated
 {
     return impl->getTrianglesRevision();
@@ -134,6 +159,12 @@ const Index* SofaPhysicsOutputMesh::getQuads()   ///< quads topology (4 indices 
 {
     return impl->getQuads();
 }
+
+int SofaPhysicsOutputMesh::getQuads(int* values)
+{
+    return impl->getQuads(values);
+}
+
 int SofaPhysicsOutputMesh::getQuadsRevision()    ///< changes each time quads data is updated
 {
     return impl->getQuadsRevision();
@@ -211,16 +242,52 @@ const Real* SofaPhysicsOutputMesh::Impl::getVPositions()  ///< vertices position
         &(sObj->m_vertices2) : &(sObj->m_positions);
     return (const Real*) data->getValue().data();
 }
+
+int SofaPhysicsOutputMesh::Impl::getVPositions(Real* values)
+{
+    const sofa::type::vector<Coord>& coords = (sObj->m_positions).getValue();
+    for (unsigned int i = 0; i < coords.size(); ++i)
+    {
+        values[i * 3] = coords[i].x();
+        values[i * 3 + 1] = coords[i].y();
+        values[i * 3 + 2] = coords[i].z();
+    }
+    return API_SUCCESS;
+}
+
 const Real* SofaPhysicsOutputMesh::Impl::getVNormals()    ///< vertices normals   (Vec3)
 {
     Data<sofa::type::vector<Deriv> > * data = &(sObj->m_vnormals);
     return (const Real*) data->getValue().data();
 }
 
+int SofaPhysicsOutputMesh::Impl::getVNormals(Real* values)
+{
+    const sofa::type::vector<Coord>& normals = (sObj->m_vnormals).getValue();
+    for (unsigned int i = 0; i < normals.size(); ++i)
+    {
+        values[i * 3] = normals[i].x();
+        values[i * 3 + 1] = normals[i].y();
+        values[i * 3 + 2] = normals[i].z();
+    }
+    return API_SUCCESS;
+}
+
 const Real* SofaPhysicsOutputMesh::Impl::getVTexCoords()  ///< vertices UVs       (Vec2)
 {
     Data<sofa::type::vector<TexCoord> > * data = &(sObj->m_vtexcoords);
     return (const Real*) data->getValue().data();
+}
+
+int SofaPhysicsOutputMesh::Impl::getVTexCoords(Real* values)
+{
+    const sofa::type::vector<TexCoord>& texCoords = (sObj->m_vtexcoords).getValue();
+    for (unsigned int i = 0; i < texCoords.size(); ++i)
+    {
+        values[i * 2] = texCoords[i].x();
+        values[i * 2 + 1] = texCoords[i].y();
+    }
+    return API_SUCCESS;
 }
 
 int SofaPhysicsOutputMesh::Impl::getTexCoordRevision()    ///< changes each time tex coord data are updated
@@ -313,11 +380,25 @@ unsigned int SofaPhysicsOutputMesh::Impl::getNbTriangles() ///< number of triang
     Data<sofa::type::vector<Triangle> > * data = &(sObj->m_triangles);
     return (unsigned int) data->getValue().size();
 }
+
 const Index* SofaPhysicsOutputMesh::Impl::getTriangles()   ///< triangles topology (3 indices / triangle)
 {
     Data<sofa::type::vector<Triangle> > * data = &(sObj->m_triangles);
     return (const Index*) data->getValue().data();
 }
+
+int SofaPhysicsOutputMesh::Impl::getTriangles(int* values)
+{
+    const sofa::type::vector<Triangle>& dTriangles = (sObj->m_triangles).getValue();
+    for (unsigned int i = 0; i < dTriangles.size(); ++i)
+    {
+        values[i * 3] = dTriangles[i][0];
+        values[i * 3 + 1] = dTriangles[i][1];
+        values[i * 3 + 2] = dTriangles[i][2];
+    }
+    return API_SUCCESS;
+}
+
 int SofaPhysicsOutputMesh::Impl::getTrianglesRevision()    ///< changes each time triangles data is updated
 {
     Data<sofa::type::vector<Triangle> > * data = &(sObj->m_triangles);
@@ -325,16 +406,32 @@ int SofaPhysicsOutputMesh::Impl::getTrianglesRevision()    ///< changes each tim
     return data->getCounter();
 }
 
+
 unsigned int SofaPhysicsOutputMesh::Impl::getNbQuads() ///< number of quads
 {
     Data<sofa::type::vector<Quad> > * data = &(sObj->m_quads);
     return (unsigned int) data->getValue().size();
 }
+
 const Index* SofaPhysicsOutputMesh::Impl::getQuads()   ///< quads topology (4 indices / quad)
 {
     Data<sofa::type::vector<Quad> > * data = &(sObj->m_quads);
     return (const Index*) data->getValue().data();
 }
+
+int SofaPhysicsOutputMesh::Impl::getQuads(int* values)
+{
+    const sofa::type::vector<Quad>& dQuads = (sObj->m_quads).getValue();
+    for (unsigned int i = 0; i < dQuads.size(); ++i)
+    {
+        values[i * 4] = dQuads[i][0];
+        values[i * 4 + 1] = dQuads[i][1];
+        values[i * 4 + 2] = dQuads[i][2];
+        values[i * 4 + 3] = dQuads[i][3];
+    }
+    return API_SUCCESS;
+}
+
 int SofaPhysicsOutputMesh::Impl::getQuadsRevision()    ///< changes each time quads data is updated
 {
     Data<sofa::type::vector<Quad> > * data = &(sObj->m_quads);

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh_impl.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh_impl.h
@@ -40,8 +40,11 @@ public:
 
     unsigned int getNbVertices(); ///< number of vertices
     const Real* getVPositions();  ///< vertices positions (Vec3)
+    int getVPositions(Real* values);
     const Real* getVNormals();    ///< vertices normals   (Vec3)
+    int getVNormals(Real* values);
     const Real* getVTexCoords();  ///< vertices UVs       (Vec2)
+    int getVTexCoords(Real* values);
     int getTexCoordRevision();    ///< changes each time texture coord data are updated
     int getVerticesRevision();    ///< changes each time vertices data are updated
     
@@ -58,10 +61,12 @@ public:
 
     unsigned int getNbTriangles(); ///< number of triangles
     const Index* getTriangles();   ///< triangles topology (3 indices / triangle)
+    int getTriangles(int* values);
     int getTrianglesRevision();    ///< changes each time triangles data is updated
 
     unsigned int getNbQuads(); ///< number of quads
     const Index* getQuads();   ///< quads topology (4 indices / quad)
+    int getQuads(int* values);
     int getQuadsRevision();    ///< changes each time quads data is updated
 
     typedef sofa::core::visual::VisualModel SofaVisualOutputMesh;

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh_impl.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh_impl.h
@@ -40,11 +40,11 @@ public:
 
     unsigned int getNbVertices(); ///< number of vertices
     const Real* getVPositions();  ///< vertices positions (Vec3)
-    int getVPositions(Real* values);
+    int getVPositions(Real* values); ///< get the positions/vertices of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]
     const Real* getVNormals();    ///< vertices normals   (Vec3)
-    int getVNormals(Real* values);
+    int getVNormals(Real* values); ///< get the normals per vertex of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]
     const Real* getVTexCoords();  ///< vertices UVs       (Vec2)
-    int getVTexCoords(Real* values);
+    int getVTexCoords(Real* values); ///< get the texture coordinates (UV) per vertex of this mesh inside ouput @param values, of type Real[ 2*nbVertices ]
     int getTexCoordRevision();    ///< changes each time texture coord data are updated
     int getVerticesRevision();    ///< changes each time vertices data are updated
     
@@ -61,12 +61,12 @@ public:
 
     unsigned int getNbTriangles(); ///< number of triangles
     const Index* getTriangles();   ///< triangles topology (3 indices / triangle)
-    int getTriangles(int* values);
+    int getTriangles(int* values); ///< get the triangle topology inside ouput @param values, of type int[ 3*nbTriangles ]
     int getTrianglesRevision();    ///< changes each time triangles data is updated
 
     unsigned int getNbQuads(); ///< number of quads
     const Index* getQuads();   ///< quads topology (4 indices / quad)
-    int getQuads(int* values);
+    int getQuads(int* values); ///< get the quad topology inside ouput @param values, of type int[ 4*nbQuads ]
     int getQuadsRevision();    ///< changes each time quads data is updated
 
     typedef sofa::core::visual::VisualModel SofaVisualOutputMesh;

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -71,7 +71,7 @@ const char *SofaPhysicsAPI::APIName()
     return impl->APIName();
 }
 
-bool SofaPhysicsAPI::load(const char* filename)
+int SofaPhysicsAPI::load(const char* filename)
 {
     return impl->load(filename);
 }
@@ -306,7 +306,7 @@ const char *SofaPhysicsSimulation::APIName()
     return "SofaPhysicsSimulation API";
 }
 
-bool SofaPhysicsSimulation::load(const char* cfilename)
+int SofaPhysicsSimulation::load(const char* cfilename)
 {
     std::string filename = cfilename;
     std::cout << "FROM APP: SofaPhysicsSimulation::load(" << filename << ")" << std::endl;
@@ -329,7 +329,7 @@ bool SofaPhysicsSimulation::load(const char* cfilename)
     else
     {
         m_RootNode = m_Simulation->createNewGraph("");
-        success = false;
+        return API_SCENE_FAILED;
     }
     initTexturesDone = false;
     lastW = 0;
@@ -338,7 +338,7 @@ bool SofaPhysicsSimulation::load(const char* cfilename)
 
 //    if (isAnimated() != wasAnimated)
 //        animatedChanged();
-    return success;
+    return API_SUCCESS;
 }
 
 int SofaPhysicsSimulation::unload()
@@ -594,7 +594,7 @@ void SofaPhysicsSimulation::updateCurrentFPS()
     ++frameCounter;
 }
 
-void SofaPhysicsSimulation::updateOutputMeshes()
+int SofaPhysicsSimulation::updateOutputMeshes()
 {
     sofa::simulation::Node* groot = getScene();
     if (!groot)
@@ -602,10 +602,10 @@ void SofaPhysicsSimulation::updateOutputMeshes()
         sofaOutputMeshes.clear();
         outputMeshes.clear();
 
-        return;
+        return API_SCENE_NULL;
     }
     sofaOutputMeshes.clear();    
-    groot->get<SofaOutputMesh>(&sofaOutputMeshes, sofa::core::objectmodel::BaseContext::SearchDown);
+    groot->get<SofaOutputMesh>(&sofaOutputMeshes, sofa::core::objectmodel::BaseContext::SearchRoot);
 
     outputMeshes.resize(sofaOutputMeshes.size());
 
@@ -620,6 +620,8 @@ void SofaPhysicsSimulation::updateOutputMeshes()
         }
         outputMeshes[i] = oMesh;
     }
+
+    return sofaOutputMeshes.size();
 }
 
 unsigned int SofaPhysicsSimulation::getNbOutputMeshes() const

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -309,11 +309,9 @@ const char *SofaPhysicsSimulation::APIName()
 int SofaPhysicsSimulation::load(const char* cfilename)
 {
     std::string filename = cfilename;
-    std::cout << "FROM APP: SofaPhysicsSimulation::load(" << filename << ")" << std::endl;
     sofa::helper::BackTrace::autodump();
 
     //bool wasAnimated = isAnimated();
-    bool success = true;
     sofa::helper::system::DataRepository.findFile(filename);
     m_RootNode = m_Simulation->load(filename.c_str());
     if (m_RootNode.get())

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -350,7 +350,7 @@ int SofaPhysicsSimulation::unload()
     else
     {
         msg_error("SofaPhysicsSimulation") << "Error: can't get scene root node.";
-        return API_SCENE_FAILED;
+        return API_SCENE_NULL;
     }
 
     return API_SUCCESS;
@@ -469,11 +469,11 @@ int SofaPhysicsSimulation::getGravity(double* values) const
         values[0] = g.x();
         values[1] = g.y();
         values[2] = g.z();
-        return 1.0;
+        return API_SUCCESS;
     }
     else
     {
-        return -1;
+        return API_SCENE_NULL;
     }
 }
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -177,6 +177,11 @@ double* SofaPhysicsAPI::getGravity() const
     return impl->getGravity();
 }
 
+int SofaPhysicsAPI::getGravity(double* values) const
+{
+    return impl->getGravity(values);
+}
+
 void SofaPhysicsAPI::setGravity(double* gravity)
 {
     impl->setGravity(gravity);
@@ -434,6 +439,22 @@ double *SofaPhysicsSimulation::getGravity() const
     }
 
     return gravityVec;
+}
+
+int SofaPhysicsSimulation::getGravity(double* values) const
+{
+    if (getScene())
+    {
+        const auto& g = getScene()->getContext()->getGravity();
+        values[0] = g.x();
+        values[1] = g.y();
+        values[2] = g.z();
+        return 1.0;
+    }
+    else
+    {
+        return -1;
+    }
 }
 
 void SofaPhysicsSimulation::setGravity(double* gravity)

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -76,6 +76,11 @@ bool SofaPhysicsAPI::load(const char* filename)
     return impl->load(filename);
 }
 
+int SofaPhysicsAPI::unload()
+{
+    return impl->unload();
+}
+
 void SofaPhysicsAPI::createScene()
 {
     std::cout << "SofaPhysicsAPI::createScene" <<std::endl;
@@ -334,6 +339,21 @@ bool SofaPhysicsSimulation::load(const char* cfilename)
 //    if (isAnimated() != wasAnimated)
 //        animatedChanged();
     return success;
+}
+
+int SofaPhysicsSimulation::unload()
+{
+    if (m_RootNode.get())
+    {
+        m_Simulation->unload(m_RootNode);
+    }
+    else
+    {
+        msg_error("SofaPhysicsSimulation") << "Error: can't get scene root node.";
+        return API_SCENE_FAILED;
+    }
+
+    return API_SUCCESS;
 }
 
 void SofaPhysicsSimulation::createScene()

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -48,6 +48,7 @@ public:
     const char* APIName();
 
     bool load(const char* filename);
+    int unload();
     void createScene();
 
     void start();

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -77,6 +77,8 @@ public:
     double getTime() const;
     double getCurrentFPS() const;
     double* getGravity() const;
+    int getGravity(double* values) const;
+
     void setGravity(double* gravity);
 
     unsigned int getNbDataMonitors();

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -47,7 +47,10 @@ public:
 
     const char* APIName();
 
+    /// Load an XML file containing the main scene description. Will return API_SUCCESS or API_SCENE_FAILED if loading failed
     int load(const char* filename);
+
+    /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
     void createScene();
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -47,7 +47,7 @@ public:
 
     const char* APIName();
 
-    bool load(const char* filename);
+    int load(const char* filename);
     int unload();
     void createScene();
 
@@ -135,7 +135,7 @@ protected:
     double currentFPS;
 
     void update();
-    void updateOutputMeshes();
+    int updateOutputMeshes();
     void updateCurrentFPS();
     void beginStep();
     void endStep();


### PR DESCRIPTION
Include PR #3519 

Add several methods similar to existing one but using output parameters. 
Done to access:
- gravity
- vertices / normals / texcoords
- edge / triangles / quads
Also add method to unload a scene.

All methods return an int corresponding to a exit code.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
