### PR TITLE
[LinearSolver.Direct] Segfault in SparseLDLSolver due to empty system matrix

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -86,6 +86,7 @@ bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::factorize(
 
     if (n == 0)
     {
+        msg_warning() << "Invalid Linear System to solve. Please insure that there is enough constraints (not rank deficient)." ;
         return true;
     }
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -84,6 +84,11 @@ bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::factorize(
 
     int n = M.colSize();
 
+    if (n == 0)
+    {
+        return true;
+    }
+
     int * M_colptr = (int *)Mfiltered.getRowBegin().data();
     int * M_rowind = (int *)Mfiltered.getColsIndex().data();
     Real * M_values = (Real *)Mfiltered.getColsValue().data();


### PR DESCRIPTION
Hi all,
As discussed with @alxbilger in https://github.com/sofa-framework/sofa/issues/3499

Add a check that catches an empty system to solve. This might happen due to topological changes.

Thanks again for the help, @alxbilger ! :)

Cheers,
Paul
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
