### PR TITLE
[SofaPhysicsAPI] Add C bindings to access C++ api

### DIFF
--- a/applications/projects/SofaPhysicsAPI/CMakeLists.txt
+++ b/applications/projects/SofaPhysicsAPI/CMakeLists.txt
@@ -7,12 +7,14 @@ set(HEADER_FILES
     ${SOFAPHYSICSAPI_SRC_DIR}/SofaPhysicsAPI.h
     ${SOFAPHYSICSAPI_SRC_DIR}/SofaPhysicsOutputMesh_impl.h
     ${SOFAPHYSICSAPI_SRC_DIR}/SofaPhysicsSimulation.h
+    ${SOFAPHYSICSAPI_SRC_DIR}/SofaPhysicsBindings.h
     ${SOFAPHYSICSAPI_SRC_DIR}/fakegui.h
 )
 
 set(SOURCE_FILES
     ${SOFAPHYSICSAPI_SRC_DIR}/SofaPhysicsOutputMesh.cpp
     ${SOFAPHYSICSAPI_SRC_DIR}/SofaPhysicsSimulation.cpp
+    ${SOFAPHYSICSAPI_SRC_DIR}/SofaPhysicsBindings.cpp
     ${SOFAPHYSICSAPI_SRC_DIR}/fakegui.cpp
 )
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -164,11 +164,11 @@ public:
 
     unsigned int getNbVertices(); ///< number of vertices
     const Real* getVPositions();  ///< vertices positions (Vec3)
-    int getVPositions(Real* values); ///< get the positions/vertices of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]
+    int getVPositions(Real* values); ///< get the positions/vertices of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]. Return error code.
     const Real* getVNormals();    ///< vertices normals   (Vec3)
-    int getVNormals(Real* values); ///< get the normals per vertex of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]
+    int getVNormals(Real* values); ///< get the normals per vertex of this mesh inside ouput @param values, of type Real[ 3*nbVertices ]. Return error code.
     const Real* getVTexCoords();  ///< vertices UVs       (Vec2)
-    int getVTexCoords(Real* values); ///< get the texture coordinates (UV) per vertex of this mesh inside ouput @param values, of type Real[ 2*nbVertices ]
+    int getVTexCoords(Real* values); ///< get the texture coordinates (UV) per vertex of this mesh inside ouput @param values, of type Real[ 2*nbVertices ]. Return error code.
     int getTexCoordRevision();    ///< changes each time texture coord data are updated
     int getVerticesRevision();    ///< changes each time vertices data are updated
 
@@ -185,12 +185,12 @@ public:
 
     unsigned int getNbTriangles(); ///< number of triangles
     const Index* getTriangles();   ///< triangles topology (3 indices / triangle)
-    int getTriangles(int* values); ///< get the triangle topology inside ouput @param values, of type int[ 3*nbTriangles ]
+    int getTriangles(int* values); ///< get the triangle topology inside ouput @param values, of type int[ 3*nbTriangles ]. Return error code.
     int getTrianglesRevision();    ///< changes each time triangles data is updated
 
     unsigned int getNbQuads(); ///< number of quads
     const Index* getQuads();   ///< quads topology (4 indices / quad)
-    int getQuads(int* values); ///< get the quad topology inside ouput @param values, of type int[ 4*nbQuads ]
+    int getQuads(int* values); ///< get the quad topology inside ouput @param values, of type int[ 4*nbQuads ]. Return error code.
     int getQuadsRevision();    ///< changes each time quads data is updated
 
     /// Internal implementation sub-class

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -35,6 +35,7 @@ typedef void* ID;           ///< Type used for IDs
 /// List of error code to be used to translate methods return values without logging system
 #define API_SUCCESS EXIT_SUCCESS ///< success value
 #define API_NULL -1              ///< SofaPhysicsAPI created is null
+#define API_MESH_NULL -2         ///< If SofaPhysicsOutputMesh requested/accessed is null
 #define API_SCENE_NULL -10       ///< Scene creation failed. I.e Root node is null
 #define API_SCENE_FAILED -11     ///< Scene loading failed. I.e root node is null but scene is still empty
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -79,7 +79,11 @@ int sofaPhysicsAPI_loadScene(void* ptr, const char* filename)
 {
     SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
     if (api) {
-        return api->load(filename);
+        bool loaded = api->load(filename);
+        if (loaded)
+            return API_SUCCESS;
+        else
+            return API_SCENE_FAILED;
     }
     else
         return API_NULL;

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -87,12 +87,12 @@ int sofaPhysicsAPI_loadScene(void* api_ptr, const char* filename)
 
 int sofaPhysicsAPI_unloadScene(void* api_ptr)
 {
-    //SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
-    //if (api) {
-    //    return api->unloa
-    //}
-    //else
-    return API_NULL;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
+    if (api) {
+        return api->unload();
+    }
+    else
+        return API_NULL;
 }
 
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -34,21 +34,21 @@ void* sofaPhysicsAPI_create()
     return new SofaPhysicsAPI();
 }
 
-int sofaPhysicsAPI_delete(void* ptr)
+int sofaPhysicsAPI_delete(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
         delete api;
     else
         return API_NULL;
-    ptr = NULL;
+    api_ptr = NULL;
 
     return API_SUCCESS;
 }
 
-const char* sofaPhysicsAPI_APIName(void* ptr)
+const char* sofaPhysicsAPI_APIName(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         std::string apiName = api->APIName();
@@ -64,9 +64,9 @@ const char* sofaPhysicsAPI_APIName(void* ptr)
 
 
 // API for scene creation/loading
-int sofaPhysicsAPI_createScene(void* ptr)
+int sofaPhysicsAPI_createScene(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         api->createScene();
         return API_SUCCESS;
@@ -75,9 +75,9 @@ int sofaPhysicsAPI_createScene(void* ptr)
         return API_NULL;
 }
 
-int sofaPhysicsAPI_loadScene(void* ptr, const char* filename)
+int sofaPhysicsAPI_loadScene(void* api_ptr, const char* filename)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->load(filename);
     }
@@ -85,9 +85,9 @@ int sofaPhysicsAPI_loadScene(void* ptr, const char* filename)
         return API_NULL;
 }
 
-int sofaPhysicsAPI_unloadScene(void* ptr)
+int sofaPhysicsAPI_unloadScene(void* api_ptr)
 {
-    //SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    //SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     //if (api) {
     //    return api->unloa
     //}
@@ -97,35 +97,35 @@ int sofaPhysicsAPI_unloadScene(void* ptr)
 
 
 // API for animation loop
-void sofaPhysicsAPI_start(void* ptr)
+void sofaPhysicsAPI_start(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->start();
     }
 }
 
-void sofaPhysicsAPI_stop(void* ptr)
+void sofaPhysicsAPI_stop(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->stop();
     }
 }
 
 
-void sofaPhysicsAPI_step(void* ptr)
+void sofaPhysicsAPI_step(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->step();
     }
 }
 
 
-void sofaPhysicsAPI_reset(void* ptr)
+void sofaPhysicsAPI_reset(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->reset();
     }
@@ -133,9 +133,9 @@ void sofaPhysicsAPI_reset(void* ptr)
 
 
 
-float sofaPhysicsAPI_time(void* ptr)
+float sofaPhysicsAPI_time(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->getTime();
     }
@@ -144,9 +144,9 @@ float sofaPhysicsAPI_time(void* ptr)
 }
 
 
-float sofaPhysicsAPI_timeStep(void* ptr)
+float sofaPhysicsAPI_timeStep(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->getTime();
     }
@@ -155,9 +155,9 @@ float sofaPhysicsAPI_timeStep(void* ptr)
 }
 
 
-void sofaPhysicsAPI_setTimeStep(void* ptr, double value)
+void sofaPhysicsAPI_setTimeStep(void* api_ptr, double value)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->setTimeStep(value);
     }
@@ -165,9 +165,9 @@ void sofaPhysicsAPI_setTimeStep(void* ptr, double value)
 
 
 
-int sofaPhysicsAPI_getGravity(void* ptr, double* values)
+int sofaPhysicsAPI_getGravity(void* api_ptr, double* values)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->getGravity(values);
     }
@@ -176,9 +176,9 @@ int sofaPhysicsAPI_getGravity(void* ptr, double* values)
 }
 
 
-int sofaPhysicsAPI_setGravity(void* ptr, double* values)
+int sofaPhysicsAPI_setGravity(void* api_ptr, double* values)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         api->setGravity(values);
         return API_SUCCESS;
@@ -194,9 +194,9 @@ int sofaPhysicsAPI_setGravity(void* ptr, double* values)
 //////////////    VisualModel Bindings    ////////////////
 //////////////////////////////////////////////////////////
 
-int sofaPhysicsAPI_getNbrVisualModel(void* ptr)
+int sofaPhysicsAPI_getNbrVisualModel(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
         return api->getNbOutputMeshes();
     }
@@ -205,9 +205,9 @@ int sofaPhysicsAPI_getNbrVisualModel(void* ptr)
 }
 
 
-const char* sofaVisualModel_getName(void* ptr, int VModelID)
+const char* sofaVisualModel_getName(void* api_ptr, int VModelID)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(VModelID);
@@ -225,9 +225,9 @@ const char* sofaVisualModel_getName(void* ptr, int VModelID)
 
 
 
-int sofaVisualModel_getNbVertices(void* ptr, const char* name)
+int sofaVisualModel_getNbVertices(void* api_ptr, const char* name)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -241,9 +241,9 @@ int sofaVisualModel_getNbVertices(void* ptr, const char* name)
 }
 
 
-int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer)
+int sofaVisualModel_getVertices(void* api_ptr, const char* name, float* buffer)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -257,9 +257,9 @@ int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer)
 }
 
 
-int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer)
+int sofaVisualModel_getNormals(void* api_ptr, const char* name, float* buffer)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -273,9 +273,9 @@ int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer)
 }
 
 
-int sofaVisualModel_getTexCoords(void* ptr, const char* name, float* buffer)
+int sofaVisualModel_getTexCoords(void* api_ptr, const char* name, float* buffer)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -290,9 +290,9 @@ int sofaVisualModel_getTexCoords(void* ptr, const char* name, float* buffer)
 
 
 
-int sofaVisualModel_getNbEdges(void* ptr, const char* name)
+int sofaVisualModel_getNbEdges(void* api_ptr, const char* name)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -306,7 +306,7 @@ int sofaVisualModel_getNbEdges(void* ptr, const char* name)
 }
 
 
-int sofaVisualModel_getEdges(void* ptr, const char* name, int* buffer)
+int sofaVisualModel_getEdges(void* api_ptr, const char* name, int* buffer)
 {
     //TODO
 
@@ -315,9 +315,9 @@ int sofaVisualModel_getEdges(void* ptr, const char* name, int* buffer)
 
 
 
-int sofaVisualModel_getNbTriangles(void* ptr, const char* name)
+int sofaVisualModel_getNbTriangles(void* api_ptr, const char* name)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -331,9 +331,9 @@ int sofaVisualModel_getNbTriangles(void* ptr, const char* name)
 }
 
 
-int sofaVisualModel_getTriangles(void* ptr, const char* name, int* buffer)
+int sofaVisualModel_getTriangles(void* api_ptr, const char* name, int* buffer)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -348,9 +348,9 @@ int sofaVisualModel_getTriangles(void* ptr, const char* name, int* buffer)
 
 
 
-int sofaVisualModel_getNbQuads(void* ptr, const char* name)
+int sofaVisualModel_getNbQuads(void* api_ptr, const char* name)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
@@ -364,9 +364,9 @@ int sofaVisualModel_getNbQuads(void* ptr, const char* name)
 }
 
 
-int sofaVisualModel_getQuads(void* ptr, const char* name, int* buffer)
+int sofaVisualModel_getQuads(void* api_ptr, const char* name, int* buffer)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -1,0 +1,335 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include "SofaPhysicsBindings.h"
+#include "SofaPhysicsAPI.h"
+
+// Exit code
+#define API_SUCCESS EXIT_SUCCESS
+
+#define API_NULL -1
+
+
+/// Test API
+int test_getAPI_ID()
+{
+    return 2022;
+}
+
+// API creation/destruction methods
+void* sofaPhysicsAPI_create()
+{
+    return new SofaPhysicsAPI();
+}
+
+int sofaPhysicsAPI_delete(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+        delete api;
+    else
+        return API_NULL;
+    ptr = NULL;
+
+    return API_SUCCESS;
+}
+
+const char* sofaPhysicsAPI_APIName(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        std::string apiName = api->APIName();
+        char* cstr = new char[apiName.length() + 1];
+#if defined(_MSC_VER)
+        std::strcpy(cstr, apiName.c_str());
+#endif
+        return cstr;
+    }
+    else
+        return "none";
+}
+
+
+// API for scene creation/loading
+int sofaPhysicsAPI_createScene(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        api->createScene();
+        return API_SUCCESS;
+    }
+    else
+        return API_NULL;
+}
+
+int sofaPhysicsAPI_loadScene(void* ptr, const char* filename)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->load(filename);
+    }
+    else
+        return API_NULL;
+}
+
+int sofaPhysicsAPI_unloadScene(void* ptr)
+{
+    //SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    //if (api) {
+    //    return api->unloa
+    //}
+    //else
+    return API_NULL;
+}
+
+
+// API for animation loop
+void sofaPhysicsAPI_start(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->start();
+    }
+}
+
+void sofaPhysicsAPI_stop(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->stop();
+    }
+}
+
+
+void sofaPhysicsAPI_step(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->step();
+    }
+}
+
+
+void sofaPhysicsAPI_reset(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->reset();
+    }
+}
+
+
+
+float sofaPhysicsAPI_time(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->getTime();
+    }
+    else
+        return -1.0;
+}
+
+
+float sofaPhysicsAPI_timeStep(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->getTime();
+    }
+    else
+        return -1.0;
+}
+
+
+void sofaPhysicsAPI_setTimeStep(void* ptr, double value)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->setTimeStep(value);
+    }
+}
+
+
+
+int sofaPhysicsAPI_getGravity(void* ptr, double* values)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->getGravity(values);
+    }
+    else
+        return API_NULL;
+}
+
+
+int sofaPhysicsAPI_setGravity(void* ptr, double* values)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        api->setGravity(values);
+        return API_SUCCESS;
+    }
+    else
+        return API_NULL;
+}
+
+
+
+
+//////////////////////////////////////////////////////////
+//////////////    VisualModel Bindings    ////////////////
+//////////////////////////////////////////////////////////
+
+int sofaPhysicsAPI_getNbrVisualModel(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->getNbOutputMeshes();
+    }
+    else
+        return API_NULL;
+}
+
+
+const char* sofaVisualModel_getName(void* ptr, int VModelID)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(VModelID);
+        std::string value = mesh->getName();
+
+        char* cstr = new char[value.length() + 1];
+#if defined(_MSC_VER)
+        std::strcpy(cstr, value.c_str());
+#endif
+        return cstr;
+    }
+    else
+        return "Error: SAPAPI_NULL_API";
+}
+
+
+
+int sofaVisualModel_getNbVertices(void* ptr, const char* name)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getNbVertices();
+    }
+
+    return API_NULL;
+}
+
+
+int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer)
+{
+    //TODO
+
+    return API_NULL;
+}
+
+
+int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer)
+{
+    //TODO
+
+    return API_NULL;
+}
+
+
+int sofaVisualModel_getTexCoords(void* ptr, const char* name, float* buffer)
+{
+    //TODO
+
+    return API_NULL;
+}
+
+
+
+int sofaVisualModel_getNbEdges(void* ptr, const char* name)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getNbLines();
+    }
+
+    return API_NULL;
+}
+
+
+int sofaVisualModel_getEdges(void* ptr, const char* name, int* buffer)
+{
+    //TODO
+
+    return API_NULL;
+}
+
+
+
+int sofaVisualModel_getNbTriangles(void* ptr, const char* name)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getNbTriangles();
+    }
+
+    return API_NULL;
+}
+
+
+int sofaVisualModel_getTriangles(void* ptr, const char* name, int* buffer)
+{
+    //TODO
+
+    return API_NULL;
+}
+
+
+
+int sofaVisualModel_getNbQuads(void* ptr, const char* name)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getNbQuads();
+    }
+
+    return API_NULL;
+}
+
+
+int sofaVisualModel_getQuads(void* ptr, const char* name, int* buffer)
+{
+    //TODO
+
+    return API_NULL;
+}
+

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include "SofaPhysicsBindings.h"
 #include "SofaPhysicsAPI.h"
+#include <string.h>
 
 /// Test API
 int test_getAPI_ID()

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -231,7 +231,10 @@ int sofaVisualModel_getNbVertices(void* ptr, const char* name)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getNbVertices();
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getNbVertices();
     }
 
     return API_NULL;
@@ -244,7 +247,10 @@ int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getVPositions(buffer);
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getVPositions(buffer);
     }
 
     return API_NULL;
@@ -257,7 +263,10 @@ int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getVNormals(buffer);
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getVNormals(buffer);
     }
 
     return API_NULL;
@@ -270,7 +279,10 @@ int sofaVisualModel_getTexCoords(void* ptr, const char* name, float* buffer)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getVTexCoords(buffer);
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getVTexCoords(buffer);
     }
 
     return API_NULL;
@@ -284,7 +296,10 @@ int sofaVisualModel_getNbEdges(void* ptr, const char* name)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getNbLines();
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getNbLines();
     }
 
     return API_NULL;
@@ -306,7 +321,10 @@ int sofaVisualModel_getNbTriangles(void* ptr, const char* name)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getNbTriangles();
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getNbTriangles();
     }
 
     return API_NULL;
@@ -319,7 +337,10 @@ int sofaVisualModel_getTriangles(void* ptr, const char* name, int* buffer)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getTriangles(buffer);
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getTriangles(buffer);
     }
 
     return API_NULL;
@@ -333,7 +354,10 @@ int sofaVisualModel_getNbQuads(void* ptr, const char* name)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getNbQuads();
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getNbQuads();
     }
 
     return API_NULL;
@@ -346,7 +370,10 @@ int sofaVisualModel_getQuads(void* ptr, const char* name, int* buffer)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
-        return mesh->getQuads(buffer);
+        if (mesh == nullptr)
+            return API_MESH_NULL;
+        else
+            return mesh->getQuads(buffer);
     }
 
     return API_NULL;

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -22,12 +22,6 @@
 #include "SofaPhysicsBindings.h"
 #include "SofaPhysicsAPI.h"
 
-// Exit code
-#define API_SUCCESS EXIT_SUCCESS
-
-#define API_NULL -1
-
-
 /// Test API
 int test_getAPI_ID()
 {
@@ -246,7 +240,12 @@ int sofaVisualModel_getNbVertices(void* ptr, const char* name)
 
 int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer)
 {
-    //TODO
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getVPositions(buffer);
+    }
 
     return API_NULL;
 }
@@ -254,7 +253,12 @@ int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer)
 
 int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer)
 {
-    //TODO
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getVNormals(buffer);
+    }
 
     return API_NULL;
 }
@@ -262,7 +266,12 @@ int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer)
 
 int sofaVisualModel_getTexCoords(void* ptr, const char* name, float* buffer)
 {
-    //TODO
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getVTexCoords(buffer);
+    }
 
     return API_NULL;
 }
@@ -306,7 +315,12 @@ int sofaVisualModel_getNbTriangles(void* ptr, const char* name)
 
 int sofaVisualModel_getTriangles(void* ptr, const char* name, int* buffer)
 {
-    //TODO
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getTriangles(buffer);
+    }
 
     return API_NULL;
 }
@@ -328,7 +342,12 @@ int sofaVisualModel_getNbQuads(void* ptr, const char* name)
 
 int sofaVisualModel_getQuads(void* ptr, const char* name, int* buffer)
 {
-    //TODO
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(name);
+        return mesh->getQuads(buffer);
+    }
 
     return API_NULL;
 }

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -79,11 +79,7 @@ int sofaPhysicsAPI_loadScene(void* ptr, const char* filename)
 {
     SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
     if (api) {
-        bool loaded = api->load(filename);
-        if (loaded)
-            return API_SUCCESS;
-        else
-            return API_SCENE_FAILED;
+        return api->load(filename);
     }
     else
         return API_NULL;

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
@@ -34,7 +34,6 @@
 #pragma warning Unknown dynamic link import/export semantics.
 #endif
 
-#include <string>
 
 ////////////////////////////////////////////////////////////
 ///////////////   Global API C Bindings   //////////////////

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
@@ -36,54 +36,56 @@
 
 #include <string>
 
-//////////////////////////////////////////////////////////
-///////////////   Global API Bindings   //////////////////
-//////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////
+///////////////   Global API C Bindings   //////////////////
+////////////////////////////////////////////////////////////
 
-/// Test API
+/// Test API method. This is just a very simple method returning number 2022 to check connection with API
 EXPORT_API int test_getAPI_ID();
 
 // API creation/destruction methods
-EXPORT_API void* sofaPhysicsAPI_create();
-EXPORT_API int sofaPhysicsAPI_delete(void* ptr);
-EXPORT_API const char* sofaPhysicsAPI_APIName(void* ptr);
+EXPORT_API void* sofaPhysicsAPI_create(); ///< Create a SofaPhysicsAPI instance and return pointer to it
+EXPORT_API int sofaPhysicsAPI_delete(void* api_ptr); ///< Method to delete the instance of SofaPhysicsAPI given as input @param api_ptr. Return error code.
+EXPORT_API const char* sofaPhysicsAPI_APIName(void* api_ptr); ///< Method to get the api name of @param api_ptr
 
 // API for scene creation/loading
-EXPORT_API int sofaPhysicsAPI_createScene(void* ptr);
-EXPORT_API int sofaPhysicsAPI_loadScene(void* ptr, const char* filename);
-EXPORT_API int sofaPhysicsAPI_unloadScene(void* ptr);
+EXPORT_API int sofaPhysicsAPI_createScene(void* api_ptr); ///< Method to create a SOFA scene (scene will be empty with valid Root Node). Return error code.
+EXPORT_API int sofaPhysicsAPI_loadScene(void* api_ptr, const char* filename); ///< Method to load a SOFA (.scn) file given by @param filename inside the given instance @param api_ptr. Return error code.
+EXPORT_API int sofaPhysicsAPI_unloadScene(void* api_ptr); ///< Method to unload the current SOFA scene and create empty Root Node inside the given instance @param api_ptr. Return error code.
 
 // API for animation loop
-EXPORT_API void sofaPhysicsAPI_start(void* ptr);
-EXPORT_API void sofaPhysicsAPI_stop(void* ptr);
-EXPORT_API void sofaPhysicsAPI_step(void* ptr);
-EXPORT_API void sofaPhysicsAPI_reset(void* ptr);
+EXPORT_API void sofaPhysicsAPI_start(void* api_ptr); ///< Method to start simulation
+EXPORT_API void sofaPhysicsAPI_stop(void* api_ptr); ///< Method to stop simulation
+EXPORT_API void sofaPhysicsAPI_step(void* api_ptr); ///< Method to perform a single simulation step
+EXPORT_API void sofaPhysicsAPI_reset(void* api_ptr); ///< Method to reset current simulation
 
-EXPORT_API float sofaPhysicsAPI_time(void* ptr);
-EXPORT_API float sofaPhysicsAPI_timeStep(void* ptr);
-EXPORT_API void sofaPhysicsAPI_setTimeStep(void* ptr, double value);
+EXPORT_API float sofaPhysicsAPI_time(void* api_ptr); ///< Getter to the current simulation time
+EXPORT_API float sofaPhysicsAPI_timeStep(void* api_ptr); ///< Getter to the current simulation time stepping
+EXPORT_API void sofaPhysicsAPI_setTimeStep(void* api_ptr, double value); ///< Setter to the current simulation time stepping
 
-EXPORT_API int sofaPhysicsAPI_getGravity(void* ptr, double* values);
-EXPORT_API int sofaPhysicsAPI_setGravity(void* ptr, double* values);
+EXPORT_API int sofaPhysicsAPI_getGravity(void* api_ptr, double* values); ///< Getter of scene gravity using the ouptut @param values which is a double[3]. Return error code.
+EXPORT_API int sofaPhysicsAPI_setGravity(void* api_api_ptr, double* values); ///< Setter of current scene gravity using the input @param gravity which is a double[3]. Return error code.
 
 
 //////////////////////////////////////////////////////////
 //////////////    VisualModel Bindings    ////////////////
 //////////////////////////////////////////////////////////
 
-EXPORT_API int sofaPhysicsAPI_getNbrVisualModel(void* ptr);
-EXPORT_API const char* sofaVisualModel_getName(void* ptr, int VModelID);
+EXPORT_API int sofaPhysicsAPI_getNbrVisualModel(void* api_api_ptr); ///< Return the number of SofaPhysicsOutputMesh in the current simulation
+EXPORT_API const char* sofaVisualModel_getName(void* api_api_ptr, int VModelID); ///< Return the name of the SofaPhysicsOutputMesh with id @param VModelID in the current simulation
 
-EXPORT_API int sofaVisualModel_getNbVertices(void* ptr, const char* name);
-EXPORT_API int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer);
-EXPORT_API int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer);
-EXPORT_API int sofaVisualModel_getTexCoords(void* ptr, const char* name, float* buffer);
+/// API to get SofaPhysicsOutputMesh position and topology information. 
+/// SofaPhysicsOutputMesh Name is used as identifier as the index of registration could change from one loading to another. Or if scene is modified.
+EXPORT_API int sofaVisualModel_getNbVertices(void* api_api_ptr, const char* name); ///< Return the number of vertices of the SofaPhysicsOutputMesh with name: @param name
+EXPORT_API int sofaVisualModel_getVertices(void* api_api_ptr, const char* name, float* buffer); ///< Get the positions/vertices using ouput @param values (type float[ 3*nbVertices ]) of the SofaPhysicsOutputMesh with name: @param name. Return error code.
+EXPORT_API int sofaVisualModel_getNormals(void* api_ptr, const char* name, float* buffer); ///< Get the normals using ouput @param values (type float[ 3*nbVertices ]) of the SofaPhysicsOutputMesh with name: @param name. Return error code.
+EXPORT_API int sofaVisualModel_getTexCoords(void* api_ptr, const char* name, float* buffer); ///< Get the texture coordinates using ouput @param values (type float[ 2*nbVertices ]) of the SofaPhysicsOutputMesh with name: @param name. Return error code.
 
-EXPORT_API int sofaVisualModel_getNbEdges(void* ptr, const char* name);
-EXPORT_API int sofaVisualModel_getEdges(void* ptr, const char* name, int* buffer);
+EXPORT_API int sofaVisualModel_getNbEdges(void* api_ptr, const char* name); ///< Return the number of edges of the SofaPhysicsOutputMesh with name: @param name
+EXPORT_API int sofaVisualModel_getEdges(void* api_ptr, const char* name, int* buffer); ///< Get the edges using ouput @param values (type int[ 2*nbEdges ]) of the SofaPhysicsOutputMesh with name: @param name. Return error code.
 
-EXPORT_API int sofaVisualModel_getNbTriangles(void* ptr, const char* name);
-EXPORT_API int sofaVisualModel_getTriangles(void* ptr, const char* name, int* buffer);
+EXPORT_API int sofaVisualModel_getNbTriangles(void* api_ptr, const char* name); ///< Return the number of triangles of the SofaPhysicsOutputMesh with name: @param name
+EXPORT_API int sofaVisualModel_getTriangles(void* api_ptr, const char* name, int* buffer); ///< Get the triangles using ouput @param values (type int[ 3*nbTriangles ]) of the SofaPhysicsOutputMesh with name: @param name. Return error code.
 
-EXPORT_API int sofaVisualModel_getNbQuads(void* ptr, const char* name);
-EXPORT_API int sofaVisualModel_getQuads(void* ptr, const char* name, int* buffer);
+EXPORT_API int sofaVisualModel_getNbQuads(void* api_ptr, const char* name); ///< Return the number of quads of the SofaPhysicsOutputMesh with name: @param name
+EXPORT_API int sofaVisualModel_getQuads(void* api_ptr, const char* name, int* buffer); ///< Get the quads using ouput @param values (type int[ 4*nbQuads ]) of the SofaPhysicsOutputMesh with name: @param name. Return error code.

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
@@ -1,0 +1,89 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#if defined(_MSC_VER)
+#define EXPORT_API extern "C" __declspec(dllexport)
+#elif defined(UNITY_METRO)
+#define EXPORT_API __declspec(dllexport) __stdcall
+#elif defined(UNITY_WIN)
+#define EXPORT_API __declspec(dllexport)
+#elif defined(__GNUC__)
+#define EXPORT_API __attribute__((visibility("default")))
+#else
+#define EXPORT
+#pragma warning Unknown dynamic link import/export semantics.
+#endif
+
+#include <string>
+
+//////////////////////////////////////////////////////////
+///////////////   Global API Bindings   //////////////////
+//////////////////////////////////////////////////////////
+
+/// Test API
+EXPORT_API int test_getAPI_ID();
+
+// API creation/destruction methods
+EXPORT_API void* sofaPhysicsAPI_create();
+EXPORT_API int sofaPhysicsAPI_delete(void* ptr);
+EXPORT_API const char* sofaPhysicsAPI_APIName(void* ptr);
+
+// API for scene creation/loading
+EXPORT_API int sofaPhysicsAPI_createScene(void* ptr);
+EXPORT_API int sofaPhysicsAPI_loadScene(void* ptr, const char* filename);
+EXPORT_API int sofaPhysicsAPI_unloadScene(void* ptr);
+
+// API for animation loop
+EXPORT_API void sofaPhysicsAPI_start(void* ptr);
+EXPORT_API void sofaPhysicsAPI_stop(void* ptr);
+EXPORT_API void sofaPhysicsAPI_step(void* ptr);
+EXPORT_API void sofaPhysicsAPI_reset(void* ptr);
+
+EXPORT_API float sofaPhysicsAPI_time(void* ptr);
+EXPORT_API float sofaPhysicsAPI_timeStep(void* ptr);
+EXPORT_API void sofaPhysicsAPI_setTimeStep(void* ptr, double value);
+
+EXPORT_API int sofaPhysicsAPI_getGravity(void* ptr, double* values);
+EXPORT_API int sofaPhysicsAPI_setGravity(void* ptr, double* values);
+
+
+//////////////////////////////////////////////////////////
+//////////////    VisualModel Bindings    ////////////////
+//////////////////////////////////////////////////////////
+
+EXPORT_API int sofaPhysicsAPI_getNbrVisualModel(void* ptr);
+EXPORT_API const char* sofaVisualModel_getName(void* ptr, int VModelID);
+
+EXPORT_API int sofaVisualModel_getNbVertices(void* ptr, const char* name);
+EXPORT_API int sofaVisualModel_getVertices(void* ptr, const char* name, float* buffer);
+EXPORT_API int sofaVisualModel_getNormals(void* ptr, const char* name, float* buffer);
+EXPORT_API int sofaVisualModel_getTexCoords(void* ptr, const char* name, float* buffer);
+
+EXPORT_API int sofaVisualModel_getNbEdges(void* ptr, const char* name);
+EXPORT_API int sofaVisualModel_getEdges(void* ptr, const char* name, int* buffer);
+
+EXPORT_API int sofaVisualModel_getNbTriangles(void* ptr, const char* name);
+EXPORT_API int sofaVisualModel_getTriangles(void* ptr, const char* name, int* buffer);
+
+EXPORT_API int sofaVisualModel_getNbQuads(void* ptr, const char* name);
+EXPORT_API int sofaVisualModel_getQuads(void* ptr, const char* name, int* buffer);

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
@@ -189,9 +189,6 @@ SofaPhysicsOutputMesh::Impl::~Impl()
 
 void SofaPhysicsOutputMesh::Impl::setObject(SofaOutputMesh* o)
 {
-	if (!sObj)
-		return;
-
     sObj = o;
     sVA.clear();
     sofa::core::objectmodel::BaseContext* context = sObj->getContext();
@@ -217,7 +214,8 @@ const std::string& SofaPhysicsOutputMesh::Impl::getNameStr() const
 
 const char* SofaPhysicsOutputMesh::Impl::getName() ///< (non-unique) name of this object
 {
-    if (!sObj) return "";
+    if (!sObj) 
+        return "None";
     return sObj->getName().c_str();
 }
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -318,7 +318,7 @@ int SofaPhysicsSimulation::load(const char* cfilename)
     {
         sceneFileName = filename;
         m_Simulation->init(m_RootNode.get());
-        return updateOutputMeshes();
+        updateOutputMeshes();
 
         if ( useGUI ) {
           sofa::gui::common::GUIManager::SetScene(m_RootNode.get(),cfilename);
@@ -484,7 +484,6 @@ void SofaPhysicsSimulation::setGravity(double* gravity)
 
 void SofaPhysicsSimulation::start()
 {
-    std::cout << "FROM APP: start()" << std::endl;
     if (isAnimated()) return;
     if (getScene())
     {
@@ -495,7 +494,6 @@ void SofaPhysicsSimulation::start()
 
 void SofaPhysicsSimulation::stop()
 {
-    std::cout << "FROM APP: stop()" << std::endl;
     if (!isAnimated()) return;
     if (getScene())
     {
@@ -507,7 +505,6 @@ void SofaPhysicsSimulation::stop()
 
 void SofaPhysicsSimulation::reset()
 {
-    std::cout << "FROM APP: reset()" << std::endl;
     if (getScene())
     {
         getSimulation()->reset(getScene());

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -83,7 +83,6 @@ int SofaPhysicsAPI::unload()
 
 void SofaPhysicsAPI::createScene()
 {
-    std::cout << "SofaPhysicsAPI::createScene" <<std::endl;
     return impl->createScene();
 }
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -318,7 +318,7 @@ int SofaPhysicsSimulation::load(const char* cfilename)
     {
         sceneFileName = filename;
         m_Simulation->init(m_RootNode.get());
-        updateOutputMeshes();
+        return updateOutputMeshes();
 
         if ( useGUI ) {
           sofa::gui::common::GUIManager::SetScene(m_RootNode.get(),cfilename);


### PR DESCRIPTION
Add file `SofaPhysicsBinding` to provide C functions to access the SofaPhysicsAPI  methods
Add bindings for:
- SofaPhysicsAPI  instance creation/destruction
- creating/loading/unloading SOFA scene (only .scn)
- Simulation control: start/stop/step/reset, time stepping, gravity
- Access to SofaPhysicsOutputMesh (aka VisualModel) topology and positions/normals/texcoords

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
