### PR TITLE
[SofaPhysicsAPI] Add methods and C bindings to load SOFA ini file, plugins and messageHandler

### DIFF
--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -38,6 +38,10 @@ typedef void* ID;           ///< Type used for IDs
 #define API_MESH_NULL -2         ///< If SofaPhysicsOutputMesh requested/accessed is null
 #define API_SCENE_NULL -10       ///< Scene creation failed. I.e Root node is null
 #define API_SCENE_FAILED -11     ///< Scene loading failed. I.e root node is null but scene is still empty
+#define API_PLUGIN_INVALID_LOADING -20
+#define API_PLUGIN_MISSING_SYMBOL -21
+#define API_PLUGIN_FILE_NOT_FOUND -22
+#define API_PLUGIN_LOADING_FAILED -23
 
 /// Internal implementation sub-class
 class SofaPhysicsSimulation;
@@ -55,6 +59,7 @@ public:
     /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
     std::string loadSofaIni(const char* pathIni);
+    int loadPlugin(const char* pluginName);
 
     /// Get the current api Name behind this interface.
     virtual const char* APIName();

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -21,8 +21,11 @@
 ******************************************************************************/
 #pragma once
 
-#include <SofaPhysicsAPI/config.h>
-#include <string>
+#ifdef SOFA_BUILD_SOFAPHYSICSAPI
+#  define SOFA_SOFAPHYSICSAPI_API __declspec(dllexport)
+#else
+#  define SOFA_SOFAPHYSICSAPI_API __declspec( dllimport )
+#endif
 
 class SofaPhysicsOutputMesh;
 class SofaPhysicsDataMonitor;
@@ -33,7 +36,7 @@ typedef float Real;         ///< Type used for coordinates
 typedef void* ID;           ///< Type used for IDs
 
 /// List of error code to be used to translate methods return values without logging system
-#define API_SUCCESS EXIT_SUCCESS        ///< success value
+#define API_SUCCESS 0                   ///< success value
 #define API_NULL -1                     ///< SofaPhysicsAPI created is null
 #define API_MESH_NULL -2                ///< If SofaPhysicsOutputMesh requested/accessed is null
 #define API_SCENE_NULL -10              ///< Scene creation failed. I.e Root node is null
@@ -59,7 +62,7 @@ public:
     /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
     /// Method to load a SOFA .ini config file at given path @param pathIniFile to define resource/example paths. Return share path.
-    std::string loadSofaIni(const char* pathIniFile);
+    const char* loadSofaIni(const char* pathIniFile);
     /// Method to load a specific SOFA plugin using it's full path @param pluginPath. Return error code.
     int loadPlugin(const char* pluginPath);
 
@@ -148,7 +151,7 @@ public:
     /// Method to get the number of messages in queue
     int getNbMessages();
     /// Method to return the queued message of index @param messageId and its type level inside @param msgType
-    std::string getMessage(int messageId, int& msgType);
+    const char* getMessage(int messageId, int& msgType);
     /// Method clear the list of queued messages. Return Error code.
     int clearMessages();
 
@@ -177,7 +180,6 @@ public:
     SofaPhysicsOutputMesh();
     ~SofaPhysicsOutputMesh();
 
-    const std::string& getNameStr() const;
     const char* getName(); ///< (non-unique) name of this object
     ID          getID();   ///< unique ID of this object
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -135,6 +135,13 @@ public:
     /// Set the current scene gravity using the input @param gravity which is a double[3]
     void setGravity(double* gravity);
 
+    // message API
+    int activateMessageHandler(bool value);
+    int getNbMessages();
+    std::string getMessage(int messageId, int& msgType);
+    int clearMessages();
+
+
     /// Return the number of currently active data monitors
     unsigned int getNbDataMonitors();
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -33,15 +33,15 @@ typedef float Real;         ///< Type used for coordinates
 typedef void* ID;           ///< Type used for IDs
 
 /// List of error code to be used to translate methods return values without logging system
-#define API_SUCCESS EXIT_SUCCESS ///< success value
-#define API_NULL -1              ///< SofaPhysicsAPI created is null
-#define API_MESH_NULL -2         ///< If SofaPhysicsOutputMesh requested/accessed is null
-#define API_SCENE_NULL -10       ///< Scene creation failed. I.e Root node is null
-#define API_SCENE_FAILED -11     ///< Scene loading failed. I.e root node is null but scene is still empty
-#define API_PLUGIN_INVALID_LOADING -20
-#define API_PLUGIN_MISSING_SYMBOL -21
-#define API_PLUGIN_FILE_NOT_FOUND -22
-#define API_PLUGIN_LOADING_FAILED -23
+#define API_SUCCESS EXIT_SUCCESS        ///< success value
+#define API_NULL -1                     ///< SofaPhysicsAPI created is null
+#define API_MESH_NULL -2                ///< If SofaPhysicsOutputMesh requested/accessed is null
+#define API_SCENE_NULL -10              ///< Scene creation failed. I.e Root node is null
+#define API_SCENE_FAILED -11            ///< Scene loading failed. I.e root node is null but scene is still empty
+#define API_PLUGIN_INVALID_LOADING -20  ///< Error while loading SOFA plugin. Plugin library file is invalid.
+#define API_PLUGIN_MISSING_SYMBOL -21   ///< Error while loading SOFA plugin. Plugin library has missing symbol such as: initExternalModule
+#define API_PLUGIN_FILE_NOT_FOUND -22   ///< Error while loading SOFA plugin. Plugin library file not found
+#define API_PLUGIN_LOADING_FAILED -23   ///< Error while loading SOFA plugin. Plugin library loading fail for another unknown reason.
 
 /// Internal implementation sub-class
 class SofaPhysicsSimulation;
@@ -58,8 +58,10 @@ public:
     int load(const char* filename);
     /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
-    std::string loadSofaIni(const char* pathIni);
-    int loadPlugin(const char* pluginName);
+    /// Method to load a SOFA .ini config file at given path @param pathIniFile to define resource/example paths. Return share path.
+    std::string loadSofaIni(const char* pathIniFile);
+    /// Method to load a specific SOFA plugin using it's full path @param pluginPath. Return error code.
+    int loadPlugin(const char* pluginPath);
 
     /// Get the current api Name behind this interface.
     virtual const char* APIName();
@@ -140,10 +142,14 @@ public:
     /// Set the current scene gravity using the input @param gravity which is a double[3]
     void setGravity(double* gravity);
 
-    // message API
+    /// message API
+    /// Method to activate/deactivate SOFA MessageHandler according to @param value. Return Error code.
     int activateMessageHandler(bool value);
+    /// Method to get the number of messages in queue
     int getNbMessages();
+    /// Method to return the queued message of index @param messageId and its type level inside @param msgType
     std::string getMessage(int messageId, int& msgType);
+    /// Method clear the list of queued messages. Return Error code.
     int clearMessages();
 
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -21,10 +21,22 @@
 ******************************************************************************/
 #pragma once
 
-#ifdef SOFA_BUILD_SOFAPHYSICSAPI
-#  define SOFA_SOFAPHYSICSAPI_API __declspec(dllexport)
+#ifndef WIN32
+    #ifdef SOFA_BUILD_SOFAPHYSICSAPI
+    #	define SOFA_SOFAPHYSICSAPI_API __attribute__ ((visibility ("default")))
+    #else
+    #   define SOFA_SOFAPHYSICSAPI_API
+    #endif
 #else
-#  define SOFA_SOFAPHYSICSAPI_API __declspec( dllimport )
+#ifdef SOFA_BUILD_SOFAPHYSICSAPI
+    #	define SOFA_SOFAPHYSICSAPI_API __declspec( dllexport )
+    #else
+    #   define SOFA_SOFAPHYSICSAPI_API __declspec( dllimport )
+    #endif
+    #   ifdef _MSC_VER
+    #       pragma warning(disable : 4231)
+    #       pragma warning(disable : 4910)
+    #   endif
 #endif
 
 class SofaPhysicsOutputMesh;

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsAPI.h
@@ -54,6 +54,7 @@ public:
     int load(const char* filename);
     /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
+    std::string loadSofaIni(const char* pathIni);
 
     /// Get the current api Name behind this interface.
     virtual const char* APIName();

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -96,6 +96,21 @@ int sofaPhysicsAPI_unloadScene(void* api_ptr)
         return API_NULL;
 }
 
+const char* sofaPhysicsAPI_loadSofaIni(void* ptr, const char* pathIni)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        std::string value = api->loadSofaIni(pathIni);
+        char* cstr = new char[value.length() + 1];
+#if defined(_MSC_VER)
+        std::strcpy(cstr, value.c_str());
+#endif
+        return cstr;
+    }
+    else
+        return "Error: API_NULL";
+}
+
 
 // API for animation loop
 void sofaPhysicsAPI_start(void* api_ptr)

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -205,6 +205,50 @@ int sofaPhysicsAPI_setGravity(void* api_ptr, double* values)
 
 
 
+int sofaPhysicsAPI_activateMessageHandler(void* ptr, bool value)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+        return api->activateMessageHandler(value);
+    else
+        return API_NULL;
+}
+
+int sofaPhysicsAPI_getNbMessages(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+        return api->getNbMessages();
+    else
+        return API_NULL;
+}
+
+const char* sofaPhysicsAPI_getMessage(void* ptr, int messageId, int* msgType)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+    {
+        std::string value = api->getMessage(messageId, msgType[0]);
+
+        char* cstr = new char[value.length() + 1];
+#if defined(_MSC_VER)
+        std::strcpy(cstr, value.c_str());
+#endif
+        return cstr;
+    }
+    else
+        return "Error: API_NULL";
+}
+
+int sofaPhysicsAPI_clearMessages(void* ptr)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api)
+        return api->clearMessages();
+    else
+        return API_NULL;
+}
+
 
 //////////////////////////////////////////////////////////
 //////////////    VisualModel Bindings    ////////////////

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -111,6 +111,16 @@ const char* sofaPhysicsAPI_loadSofaIni(void* ptr, const char* pathIni)
         return "Error: API_NULL";
 }
 
+int sofaPhysicsAPI_loadPlugin(void* ptr, const char* pluginName)
+{
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    if (api) {
+        return api->loadPlugin(pluginName);
+    }
+    else
+        return API_NULL;
+}
+
 
 // API for animation loop
 void sofaPhysicsAPI_start(void* api_ptr)

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -52,12 +52,7 @@ const char* sofaPhysicsAPI_APIName(void* api_ptr)
     SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
-        std::string apiName = api->APIName();
-        char* cstr = new char[apiName.length() + 1];
-#if defined(_MSC_VER)
-        std::strcpy(cstr, apiName.c_str());
-#endif
-        return cstr;
+        return api->APIName();
     }
     else
         return "none";
@@ -100,12 +95,7 @@ const char* sofaPhysicsAPI_loadSofaIni(void* api_ptr, const char* filePath)
 {
     SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
-        std::string value = api->loadSofaIni(filePath);
-        char* cstr = new char[value.length() + 1];
-#if defined(_MSC_VER)
-        std::strcpy(cstr, value.c_str());
-#endif
-        return cstr;
+        return api->loadSofaIni(filePath);
     }
     else
         return "Error: API_NULL";
@@ -238,13 +228,7 @@ const char* sofaPhysicsAPI_getMessage(void* api_ptr, int messageId, int* msgType
     SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
-        std::string value = api->getMessage(messageId, msgType[0]);
-
-        char* cstr = new char[value.length() + 1];
-#if defined(_MSC_VER)
-        std::strcpy(cstr, value.c_str());
-#endif
-        return cstr;
+        return api->getMessage(messageId, msgType[0]);
     }
     else
         return "Error: API_NULL";
@@ -281,13 +265,7 @@ const char* sofaVisualModel_getName(void* api_ptr, int VModelID)
     if (api)
     {
         SofaPhysicsOutputMesh* mesh = api->getOutputMeshPtr(VModelID);
-        std::string value = mesh->getName();
-
-        char* cstr = new char[value.length() + 1];
-#if defined(_MSC_VER)
-        std::strcpy(cstr, value.c_str());
-#endif
-        return cstr;
+        return mesh->getName();
     }
     else
         return "Error: SAPAPI_NULL_API";

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.cpp
@@ -96,11 +96,11 @@ int sofaPhysicsAPI_unloadScene(void* api_ptr)
         return API_NULL;
 }
 
-const char* sofaPhysicsAPI_loadSofaIni(void* ptr, const char* pathIni)
+const char* sofaPhysicsAPI_loadSofaIni(void* api_ptr, const char* filePath)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
-        std::string value = api->loadSofaIni(pathIni);
+        std::string value = api->loadSofaIni(filePath);
         char* cstr = new char[value.length() + 1];
 #if defined(_MSC_VER)
         std::strcpy(cstr, value.c_str());
@@ -111,11 +111,11 @@ const char* sofaPhysicsAPI_loadSofaIni(void* ptr, const char* pathIni)
         return "Error: API_NULL";
 }
 
-int sofaPhysicsAPI_loadPlugin(void* ptr, const char* pluginName)
+int sofaPhysicsAPI_loadPlugin(void* api_ptr, const char* pluginPath)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api) {
-        return api->loadPlugin(pluginName);
+        return api->loadPlugin(pluginPath);
     }
     else
         return API_NULL;
@@ -215,27 +215,27 @@ int sofaPhysicsAPI_setGravity(void* api_ptr, double* values)
 
 
 
-int sofaPhysicsAPI_activateMessageHandler(void* ptr, bool value)
+int sofaPhysicsAPI_activateMessageHandler(void* api_ptr, bool value)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
         return api->activateMessageHandler(value);
     else
         return API_NULL;
 }
 
-int sofaPhysicsAPI_getNbMessages(void* ptr)
+int sofaPhysicsAPI_getNbMessages(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
         return api->getNbMessages();
     else
         return API_NULL;
 }
 
-const char* sofaPhysicsAPI_getMessage(void* ptr, int messageId, int* msgType)
+const char* sofaPhysicsAPI_getMessage(void* api_ptr, int messageId, int* msgType)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
     {
         std::string value = api->getMessage(messageId, msgType[0]);
@@ -250,9 +250,9 @@ const char* sofaPhysicsAPI_getMessage(void* ptr, int messageId, int* msgType)
         return "Error: API_NULL";
 }
 
-int sofaPhysicsAPI_clearMessages(void* ptr)
+int sofaPhysicsAPI_clearMessages(void* api_ptr)
 {
-    SofaPhysicsAPI* api = (SofaPhysicsAPI*)ptr;
+    SofaPhysicsAPI* api = (SofaPhysicsAPI*)api_ptr;
     if (api)
         return api->clearMessages();
     else

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
@@ -66,6 +66,12 @@ EXPORT_API void sofaPhysicsAPI_setTimeStep(void* api_ptr, double value); ///< Se
 EXPORT_API int sofaPhysicsAPI_getGravity(void* api_ptr, double* values); ///< Getter of scene gravity using the ouptut @param values which is a double[3]. Return error code.
 EXPORT_API int sofaPhysicsAPI_setGravity(void* api_api_ptr, double* values); ///< Setter of current scene gravity using the input @param gravity which is a double[3]. Return error code.
 
+// API for message logging
+EXPORT_API int sofaPhysicsAPI_activateMessageHandler(void* ptr, bool value);
+EXPORT_API int sofaPhysicsAPI_getNbMessages(void* ptr);
+EXPORT_API const char* sofaPhysicsAPI_getMessage(void* ptr, int messageId, int* msgType);
+EXPORT_API int sofaPhysicsAPI_clearMessages(void* ptr);
+
 
 //////////////////////////////////////////////////////////
 //////////////    VisualModel Bindings    ////////////////

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
@@ -51,8 +51,8 @@ EXPORT_API const char* sofaPhysicsAPI_APIName(void* api_ptr); ///< Method to get
 EXPORT_API int sofaPhysicsAPI_createScene(void* api_ptr); ///< Method to create a SOFA scene (scene will be empty with valid Root Node). Return error code.
 EXPORT_API int sofaPhysicsAPI_loadScene(void* api_ptr, const char* filename); ///< Method to load a SOFA (.scn) file given by @param filename inside the given instance @param api_ptr. Return error code.
 EXPORT_API int sofaPhysicsAPI_unloadScene(void* api_ptr); ///< Method to unload the current SOFA scene and create empty Root Node inside the given instance @param api_ptr. Return error code.
-EXPORT_API const char* sofaPhysicsAPI_loadSofaIni(void* ptr, const char* pluginName);
-EXPORT_API int sofaPhysicsAPI_loadPlugin(void* ptr, const char* pluginName);
+EXPORT_API const char* sofaPhysicsAPI_loadSofaIni(void* api_ptr, const char* filePath); ///< Method to load a SOFA .ini config file at given path @filePath to define resource/example paths. Return share path.
+EXPORT_API int sofaPhysicsAPI_loadPlugin(void* api_ptr, const char* pluginPath); ///< Method to load a specific SOFA plugin using it's full path @param pluginPath. Return error code. 
 
 // API for animation loop
 EXPORT_API void sofaPhysicsAPI_start(void* api_ptr); ///< Method to start simulation
@@ -65,13 +65,13 @@ EXPORT_API float sofaPhysicsAPI_timeStep(void* api_ptr); ///< Getter to the curr
 EXPORT_API void sofaPhysicsAPI_setTimeStep(void* api_ptr, double value); ///< Setter to the current simulation time stepping
 
 EXPORT_API int sofaPhysicsAPI_getGravity(void* api_ptr, double* values); ///< Getter of scene gravity using the ouptut @param values which is a double[3]. Return error code.
-EXPORT_API int sofaPhysicsAPI_setGravity(void* api_api_ptr, double* values); ///< Setter of current scene gravity using the input @param gravity which is a double[3]. Return error code.
+EXPORT_API int sofaPhysicsAPI_setGravity(void* api_ptr, double* values); ///< Setter of current scene gravity using the input @param gravity which is a double[3]. Return error code.
 
 // API for message logging
-EXPORT_API int sofaPhysicsAPI_activateMessageHandler(void* ptr, bool value);
-EXPORT_API int sofaPhysicsAPI_getNbMessages(void* ptr);
-EXPORT_API const char* sofaPhysicsAPI_getMessage(void* ptr, int messageId, int* msgType);
-EXPORT_API int sofaPhysicsAPI_clearMessages(void* ptr);
+EXPORT_API int sofaPhysicsAPI_activateMessageHandler(void* api_ptr, bool value); ///< Method to activate/deactivate SOFA MessageHandler according to @param value. Return Error code.
+EXPORT_API int sofaPhysicsAPI_getNbMessages(void* api_ptr); ///< Method to get the number of messages in queue
+EXPORT_API const char* sofaPhysicsAPI_getMessage(void* api_ptr, int messageId, int* msgType); ///< Method to return the queued message of index @param messageId and its type level inside @param msgType
+EXPORT_API int sofaPhysicsAPI_clearMessages(void* api_ptr); ///< Method clear the list of queued messages. Return Error code.
 
 
 //////////////////////////////////////////////////////////

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
@@ -52,6 +52,7 @@ EXPORT_API int sofaPhysicsAPI_createScene(void* api_ptr); ///< Method to create 
 EXPORT_API int sofaPhysicsAPI_loadScene(void* api_ptr, const char* filename); ///< Method to load a SOFA (.scn) file given by @param filename inside the given instance @param api_ptr. Return error code.
 EXPORT_API int sofaPhysicsAPI_unloadScene(void* api_ptr); ///< Method to unload the current SOFA scene and create empty Root Node inside the given instance @param api_ptr. Return error code.
 EXPORT_API const char* sofaPhysicsAPI_loadSofaIni(void* ptr, const char* pluginName);
+EXPORT_API int sofaPhysicsAPI_loadPlugin(void* ptr, const char* pluginName);
 
 // API for animation loop
 EXPORT_API void sofaPhysicsAPI_start(void* api_ptr); ///< Method to start simulation

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsBindings.h
@@ -51,6 +51,7 @@ EXPORT_API const char* sofaPhysicsAPI_APIName(void* api_ptr); ///< Method to get
 EXPORT_API int sofaPhysicsAPI_createScene(void* api_ptr); ///< Method to create a SOFA scene (scene will be empty with valid Root Node). Return error code.
 EXPORT_API int sofaPhysicsAPI_loadScene(void* api_ptr, const char* filename); ///< Method to load a SOFA (.scn) file given by @param filename inside the given instance @param api_ptr. Return error code.
 EXPORT_API int sofaPhysicsAPI_unloadScene(void* api_ptr); ///< Method to unload the current SOFA scene and create empty Root Node inside the given instance @param api_ptr. Return error code.
+EXPORT_API const char* sofaPhysicsAPI_loadSofaIni(void* ptr, const char* pluginName);
 
 // API for animation loop
 EXPORT_API void sofaPhysicsAPI_start(void* api_ptr); ///< Method to start simulation

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsOutputMesh.cpp
@@ -32,11 +32,6 @@ SofaPhysicsOutputMesh::~SofaPhysicsOutputMesh()
     delete impl;
 }
 
-const std::string& SofaPhysicsOutputMesh::getNameStr() const
-{
-    return impl->getNameStr();
-}
-
 const char* SofaPhysicsOutputMesh::getName() ///< (non-unique) name of this object
 {
     return impl->getName();
@@ -216,7 +211,11 @@ const char* SofaPhysicsOutputMesh::Impl::getName() ///< (non-unique) name of thi
 {
     if (!sObj) 
         return "None";
-    return sObj->getName().c_str();
+
+    std::string value = sObj->getName();
+    char* cstr = new char[value.length() + 1];
+    std::strcpy(cstr, value.c_str()); // force copy to avoid possible segfault if object is destroyed
+    return cstr;
 }
 
 ID SofaPhysicsOutputMesh::Impl::getID() ///< unique ID of this object

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -83,9 +83,9 @@ int SofaPhysicsAPI::unload()
     return impl->unload();
 }
 
-std::string SofaPhysicsAPI::loadSofaIni(const char* pathIni)
+std::string SofaPhysicsAPI::loadSofaIni(const char* pathIniFile)
 {
-    const std::string sofaIniFilePath = std::string(pathIni);
+    auto sofaIniFilePath = std::string(pathIniFile);
 
     std::map<std::string, std::string> iniFileValues = sofa::helper::Utils::readBasicIniFile(sofaIniFilePath);
     std::string shareDir = "SHARE_DIR Path Not found";
@@ -115,9 +115,9 @@ std::string SofaPhysicsAPI::loadSofaIni(const char* pathIni)
     return shareDir;
 }
 
-int SofaPhysicsAPI::loadPlugin(const char* pluginName)
+int SofaPhysicsAPI::loadPlugin(const char* pluginPath)
 {
-    return impl->loadPlugin(pluginName);
+    return impl->loadPlugin(pluginPath);
 }
 
 void SofaPhysicsAPI::createScene()
@@ -432,9 +432,9 @@ int SofaPhysicsSimulation::unload()
     return API_SUCCESS;
 }
 
-int SofaPhysicsSimulation::loadPlugin(const char* pluginName)
+int SofaPhysicsSimulation::loadPlugin(const char* pluginPath)
 {
-    sofa::helper::system::PluginManager::PluginLoadStatus plugres = sofa::helper::system::PluginManager::getInstance().loadPlugin(pluginName);
+    sofa::helper::system::PluginManager::PluginLoadStatus plugres = sofa::helper::system::PluginManager::getInstance().loadPlugin(pluginPath);
     if (plugres == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS || plugres == sofa::helper::system::PluginManager::PluginLoadStatus::ALREADY_LOADED)
         return API_SUCCESS;
     else if (plugres == sofa::helper::system::PluginManager::PluginLoadStatus::INVALID_LOADING)

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -83,7 +83,7 @@ int SofaPhysicsAPI::unload()
     return impl->unload();
 }
 
-std::string SofaPhysicsAPI::loadSofaIni(const char* pathIniFile)
+const char* SofaPhysicsAPI::loadSofaIni(const char* pathIniFile)
 {
     auto sofaIniFilePath = std::string(pathIniFile);
 
@@ -112,7 +112,10 @@ std::string SofaPhysicsAPI::loadSofaIni(const char* pathIniFile)
         sofa::helper::system::DataRepository.addFirstPath(pythonDir);
     }
 
-    return shareDir;
+    char* cstr = new char[shareDir.length() + 1];
+    std::strcpy(cstr, shareDir.c_str());
+
+    return cstr;
 }
 
 int SofaPhysicsAPI::loadPlugin(const char* pluginPath)
@@ -240,9 +243,12 @@ int SofaPhysicsAPI::getNbMessages()
     return impl->getNbMessages();
 }
 
-std::string SofaPhysicsAPI::getMessage(int messageId, int& msgType)
+const char* SofaPhysicsAPI::getMessage(int messageId, int& msgType)
 {
-    return impl->getMessage(messageId, msgType);
+    std::string value = impl->getMessage(messageId, msgType);
+    char* cstr = new char[value.length() + 1];
+    std::strcpy(cstr, value.c_str());
+    return cstr;
 }
 
 int SofaPhysicsAPI::clearMessages()
@@ -727,9 +733,10 @@ SofaPhysicsOutputMesh* SofaPhysicsSimulation::getOutputMeshPtr(unsigned int mesh
 
 SofaPhysicsOutputMesh* SofaPhysicsSimulation::getOutputMeshPtr(const char* name) const
 {
+    const auto nameStr = std::string(name);
     for (SofaPhysicsOutputMesh* mesh : outputMeshes)
     {
-        if (std::string(name).compare(mesh->getNameStr()) == 0)
+        if (nameStr.compare(std::string(mesh->getName())) == 0)
             return mesh;
     }
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -227,7 +227,6 @@ void SofaPhysicsAPI::setGravity(double* gravity)
 
 int SofaPhysicsAPI::activateMessageHandler(bool value)
 {
-    return 99;
     return impl->activateMessageHandler(value);
 }
 
@@ -392,7 +391,7 @@ int SofaPhysicsSimulation::load(const char* cfilename)
     {
         sceneFileName = filename;
         m_Simulation->init(m_RootNode.get());
-        updateOutputMeshes();
+        return updateOutputMeshes();
 
         if ( useGUI ) {
           sofa::gui::common::GUIManager::SetScene(m_RootNode.get(),cfilename);
@@ -736,10 +735,10 @@ SofaPhysicsOutputMesh** SofaPhysicsSimulation::getOutputMeshes()
 
 int SofaPhysicsSimulation::activateMessageHandler(bool value)
 {
-    /*if (value)
+    if (value)
         m_msgHandler->activate();
     else
-        m_msgHandler->deactivate();*/
+        m_msgHandler->deactivate();
 
     m_msgIsActivated = value;
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -115,6 +115,11 @@ std::string SofaPhysicsAPI::loadSofaIni(const char* pathIni)
     return shareDir;
 }
 
+int SofaPhysicsAPI::loadPlugin(const char* pluginName)
+{
+    return impl->loadPlugin(pluginName);
+}
+
 void SofaPhysicsAPI::createScene()
 {
     return impl->createScene();
@@ -425,6 +430,21 @@ int SofaPhysicsSimulation::unload()
     }
 
     return API_SUCCESS;
+}
+
+int SofaPhysicsSimulation::loadPlugin(const char* pluginName)
+{
+    sofa::helper::system::PluginManager::PluginLoadStatus plugres = sofa::helper::system::PluginManager::getInstance().loadPlugin(pluginName);
+    if (plugres == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS || plugres == sofa::helper::system::PluginManager::PluginLoadStatus::ALREADY_LOADED)
+        return API_SUCCESS;
+    else if (plugres == sofa::helper::system::PluginManager::PluginLoadStatus::INVALID_LOADING)
+        return API_PLUGIN_INVALID_LOADING;
+    else if (plugres == sofa::helper::system::PluginManager::PluginLoadStatus::MISSING_SYMBOL)
+        return API_PLUGIN_MISSING_SYMBOL;
+    else if (plugres == sofa::helper::system::PluginManager::PluginLoadStatus::PLUGIN_FILE_NOT_FOUND)
+        return API_PLUGIN_FILE_NOT_FOUND;
+    else
+        return API_PLUGIN_LOADING_FAILED;
 }
 
 void SofaPhysicsSimulation::createScene()

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -27,6 +27,8 @@
 #include <sofa/helper/io/Image.h>
 #include <sofa/gl/RAII.h>
 
+#include <sofa/helper/system/FileSystem.h>
+#include <sofa/helper/Utils.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
 #include <sofa/helper/system/PluginManager.h>
@@ -79,6 +81,38 @@ int SofaPhysicsAPI::load(const char* filename)
 int SofaPhysicsAPI::unload()
 {
     return impl->unload();
+}
+
+std::string SofaPhysicsAPI::loadSofaIni(const char* pathIni)
+{
+    const std::string sofaIniFilePath = std::string(pathIni);
+
+    std::map<std::string, std::string> iniFileValues = sofa::helper::Utils::readBasicIniFile(sofaIniFilePath);
+    std::string shareDir = "SHARE_DIR Path Not found";
+    // and add them to DataRepository
+    if (iniFileValues.find("SHARE_DIR") != iniFileValues.end())
+    {
+        shareDir = iniFileValues["SHARE_DIR"];
+        if (!sofa::helper::system::FileSystem::isAbsolute(shareDir))
+            shareDir = "./" + shareDir;
+        sofa::helper::system::DataRepository.addFirstPath(shareDir);
+    }
+    if (iniFileValues.find("EXAMPLES_DIR") != iniFileValues.end())
+    {
+        std::string examplesDir = iniFileValues["EXAMPLES_DIR"];
+        if (!sofa::helper::system::FileSystem::isAbsolute(examplesDir))
+            examplesDir = "./" + examplesDir;
+        sofa::helper::system::DataRepository.addFirstPath(examplesDir);
+    }
+    if (iniFileValues.find("PYTHON_DIR") != iniFileValues.end())
+    {
+        std::string pythonDir = iniFileValues["PYTHON_DIR"];
+        if (!sofa::helper::system::FileSystem::isAbsolute(pythonDir))
+            pythonDir = "./" + pythonDir;
+        sofa::helper::system::DataRepository.addFirstPath(pythonDir);
+    }
+
+    return shareDir;
 }
 
 void SofaPhysicsAPI::createScene()

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <SofaPhysicsAPI/config.h>
 #include "SofaPhysicsAPI.h"
 #include "SofaPhysicsOutputMesh_impl.h"
 

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -53,6 +53,8 @@ public:
 
     /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
+
+    int loadPlugin(const char* pluginName);
     void createScene();
 
     void start();

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -31,6 +31,7 @@
 #include <sofa/component/visual/InteractiveCamera.h>
 #include <sofa/gl/Texture.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/helper/logging/LoggingMessageHandler.h>
 
 #include <map>
 
@@ -85,6 +86,12 @@ public:
 
     void setGravity(double* gravity);
 
+    // message API
+    int activateMessageHandler(bool value);
+    int getNbMessages();
+    std::string getMessage(int messageId, int& msgType);
+    int clearMessages();
+
     unsigned int getNbDataMonitors();
     SofaPhysicsDataMonitor** getDataMonitors();
 
@@ -103,6 +110,9 @@ protected:
     sofa::simulation::Simulation* m_Simulation;
     sofa::simulation::Node::SPtr m_RootNode;
     std::string sceneFileName;
+    sofa::helper::logging::LoggingMessageHandler* m_msgHandler;
+    bool m_msgIsActivated;
+
     sofa::component::visual::BaseCamera::SPtr currentCamera;
 
     std::map<SofaOutputMesh*, SofaPhysicsOutputMesh*> outputMeshMap;

--- a/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/src/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -54,7 +54,8 @@ public:
     /// Call unload of the current scene graph. Will return API_SUCCESS or API_SCENE_NULL if scene is null
     int unload();
 
-    int loadPlugin(const char* pluginName);
+    /// Method to load a specific SOFA plugin using it's full path @param pluginPath. Return error code.
+    int loadPlugin(const char* pluginPath);
     void createScene();
 
     void start();
@@ -88,10 +89,14 @@ public:
 
     void setGravity(double* gravity);
 
-    // message API
+    /// message API
+    /// Method to activate/deactivate SOFA MessageHandler according to @param value. Will store status in @sa m_msgIsActivated. Return Error code.
     int activateMessageHandler(bool value);
+    /// Method to get the number of messages in queue
     int getNbMessages();
+    /// Method to return the queued message of index @param messageId and its type level inside @param msgType
     std::string getMessage(int messageId, int& msgType);
+    /// Method clear the list of queued messages. Return Error code.
     int clearMessages();
 
     unsigned int getNbDataMonitors();
@@ -112,7 +117,9 @@ protected:
     sofa::simulation::Simulation* m_Simulation;
     sofa::simulation::Node::SPtr m_RootNode;
     std::string sceneFileName;
+    /// Pointer to the LoggingMessageHandler
     sofa::helper::logging::LoggingMessageHandler* m_msgHandler;
+    /// Status of the LoggingMessageHandler
     bool m_msgIsActivated;
 
     sofa::component::visual::BaseCamera::SPtr currentCamera;


### PR DESCRIPTION
Based on previous PR #3539 

Add methods and binding for:
- loading sofa.ini file to set resources/example path
- loading SOFA plugin given the file path
- activate/deactivate SOFA messageHandler, get the number of queued message and get the message with its priority

edit:
- Avoid using string as it can produce memory bad access from other software integration. 
- Also remove use of config.h inside SofaPhysicsAPI .h to be able to easily include it in third library

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
