### PR TITLE
[StateContainer] Avoid code duplication in MechanicalObject

### DIFF
--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
@@ -371,9 +371,9 @@ protected :
     /// @name Integration-related data
     /// @{
 
-    sofa::type::vector< Data< VecCoord >		* > vectorsCoord;		///< Coordinates DOFs vectors table (static and dynamic allocated)
-    sofa::type::vector< Data< VecDeriv >		* > vectorsDeriv;		///< Derivates DOFs vectors table (static and dynamic allocated)
-    sofa::type::vector< Data< MatrixDeriv >	* > vectorsMatrixDeriv; ///< Constraint vectors table
+    sofa::type::vector< Data< VecCoord >    * > vectorsCoord; ///< Coordinates DOFs vectors table (static and dynamic allocated)
+    sofa::type::vector< Data< VecDeriv >    * > vectorsDeriv; ///< Derivates DOFs vectors table (static and dynamic allocated)
+    sofa::type::vector< Data< MatrixDeriv > * > vectorsMatrixDeriv; ///< Constraint vectors table
 
     /**
      * @brief Inserts VecCoord DOF coordinates vector at index in the vectorsCoord container.
@@ -392,6 +392,45 @@ protected :
 
 
     /// @}
+
+    /// Generic implementation of the method vAvail
+    template<core::VecType vtype>
+    void vAvailImpl(
+        core::TVecId<vtype, core::V_WRITE>& v,
+        sofa::type::vector< Data< core::StateVecType_t<DataTypes, vtype> >* >& dataContainer);
+
+    /// Generic implementation of the method vAlloc
+    template<core::VecType vtype>
+    void vAllocImpl(core::TVecId<vtype, core::V_WRITE> v, const core::VecIdProperties& properties);
+
+    /// Generic implementation of the method vRealloc
+    template<core::VecType vtype>
+    void vReallocImpl(core::TVecId<vtype, core::V_WRITE> v, const core::VecIdProperties& properties);
+
+    /// Generic implementation of the method vFree
+    template<core::VecType vtype>
+    void vFreeImpl(core::TVecId<vtype, core::V_WRITE> v);
+
+    /// Generic implementation of the method vInit
+    template<core::VecType vtype>
+    void vInitImpl(const core::ExecParams* params,
+                   core::TVecId<vtype, core::V_WRITE> vId,
+                   core::TVecId<vtype, core::V_READ> vSrcId);
+
+    /// Shortcut to get a write-only accessor corresponding to the provided VecType from a VecId
+    template<core::VecType vtype>
+    helper::WriteOnlyAccessor<core::objectmodel::Data<core::StateVecType_t<DataTypes, vtype> > >
+        getWriteOnlyAccessor(core::VecId v);
+
+    /// Shortcut to get a write accessor corresponding to the provided VecType from a VecId
+    template<core::VecType vtype>
+    helper::WriteAccessor<core::objectmodel::Data<core::StateVecType_t<DataTypes, vtype> > >
+        getWriteAccessor(core::VecId v);
+
+    /// Shortcut to get a read accessor corresponding to the provided VecType from a VecId
+    template<core::VecType vtype>
+    helper::ReadAccessor<core::objectmodel::Data<core::StateVecType_t<DataTypes, vtype> > >
+        getReadAccessor(core::ConstVecId v);
 
     /**
     * @brief Internal function : Draw indices in 3d coordinates.

--- a/Sofa/framework/Core/src/sofa/core/VecId.h
+++ b/Sofa/framework/Core/src/sofa/core/VecId.h
@@ -275,11 +275,11 @@ public:
     VecType getType() const { return type; }
     unsigned int getIndex() const { return index; }
 
-	VecType type;
+    VecType type;
     unsigned int index;
 
 protected:
-	BaseVecId(VecType t, unsigned int i) : type(t), index(i) {}
+    BaseVecId(VecType t, unsigned int i) : type(t), index(i) {}
 };
 
 /// This class is only here as fix for a VC2010 compiler otherwise padding TVecId<V_ALL,?> with 4 more bytes than TVecId<?,?>, 
@@ -315,7 +315,7 @@ public:
         static_assert(vaccess2 >= vaccess, "Copy from a read-only vector id into a read/write vector id is forbidden.");
     }
 
-	template<VecAccess vaccess2>
+    template<VecAccess vaccess2>
     explicit TVecId(const TVecId<V_ALL, vaccess2>& v) : BaseVecId(vtype, v.getIndex())
     {
         static_assert(vaccess2 >= vaccess, "Copy from a read-only vector id into a read/write vector id is forbidden.");
@@ -448,12 +448,56 @@ typedef TVecId<V_ALL, V_READ> ConstVecId;
 typedef TVecId<V_ALL, V_WRITE> VecId;
 
 /// Typedefs for each type of state vectors
-typedef TVecId<V_COORD, V_READ> ConstVecCoordId;
-typedef TVecId<V_COORD, V_WRITE>     VecCoordId;
-typedef TVecId<V_DERIV, V_READ> ConstVecDerivId;
-typedef TVecId<V_DERIV, V_WRITE>     VecDerivId;
-typedef TVecId<V_MATDERIV, V_READ> ConstMatrixDerivId;
-typedef TVecId<V_MATDERIV, V_WRITE>     MatrixDerivId;
+typedef TVecId<V_COORD   , V_READ > ConstVecCoordId;
+typedef TVecId<V_COORD   , V_WRITE>      VecCoordId;
+typedef TVecId<V_DERIV   , V_READ > ConstVecDerivId;
+typedef TVecId<V_DERIV   , V_WRITE>      VecDerivId;
+typedef TVecId<V_MATDERIV, V_READ > ConstMatrixDerivId;
+typedef TVecId<V_MATDERIV, V_WRITE>      MatrixDerivId;
 
 static_assert(sizeof(VecId) == sizeof(VecCoordId), "");
+
+
+/// Maps a VecType to a DataTypes member typedef representing the state variables
+/// Example: StateType_t<DataTypes, core::V_COORD> returns the type DataTypes::Coord
+template<class DataTypes, core::VecType vtype> struct StateType {};
+template<class DataTypes, core::VecType vtype> using StateType_t = typename StateType<DataTypes, vtype>::type;
+
+template<class DataTypes> struct StateType<DataTypes, core::V_COORD>
+{
+    using type = typename DataTypes::Coord;
+};
+template<class DataTypes> struct StateType<DataTypes, core::V_DERIV>
+{
+    using type = typename DataTypes::Deriv;
+};
+
+/// Maps a VecType to a DataTypes member static variable representing the size of the state variables
+/// Example: StateTypeSize_v<DataTypes, core::V_COORD> is the value of DataTypes::coord_total_size
+template<class DataTypes, core::VecType vtype> struct StateTypeSize {};
+template<class DataTypes, core::VecType vtype> inline constexpr sofa::Size StateTypeSize_v = typename StateTypeSize<DataTypes, vtype>::total_size;
+
+template<class DataTypes> struct StateTypeSize<DataTypes, core::V_COORD>
+{
+    static constexpr sofa::Size total_size = typename DataTypes::coord_total_size;
+};
+template<class DataTypes> struct StateTypeSize<DataTypes, core::V_DERIV>
+{
+    static constexpr sofa::Size total_size = typename DataTypes::deriv_total_size;
+};
+
+/// Maps a VecType to a DataTypes member typedef representing a vector of state variables
+/// Example: StateVecType_t<DataTypes, core::V_COORD> returns the type DataTypes::VecCoord
+template<class DataTypes, core::VecType vtype> struct StateVecType {};
+template<class DataTypes, core::VecType vtype> using StateVecType_t = typename StateVecType<DataTypes, vtype>::type;
+
+template<class DataTypes> struct StateVecType<DataTypes, core::V_COORD>
+{
+    using type = typename DataTypes::VecCoord;
+};
+template<class DataTypes> struct StateVecType<DataTypes, core::V_DERIV>
+{
+    using type = typename DataTypes::VecDeriv;
+};
+
 } // namespace sofa::core

--- a/Sofa/framework/Core/src/sofa/core/VecId.h
+++ b/Sofa/framework/Core/src/sofa/core/VecId.h
@@ -475,15 +475,15 @@ template<class DataTypes> struct StateType<DataTypes, core::V_DERIV>
 /// Maps a VecType to a DataTypes member static variable representing the size of the state variables
 /// Example: StateTypeSize_v<DataTypes, core::V_COORD> is the value of DataTypes::coord_total_size
 template<class DataTypes, core::VecType vtype> struct StateTypeSize {};
-template<class DataTypes, core::VecType vtype> inline constexpr sofa::Size StateTypeSize_v = typename StateTypeSize<DataTypes, vtype>::total_size;
+template<class DataTypes, core::VecType vtype> inline constexpr sofa::Size StateTypeSize_v = StateTypeSize<DataTypes, vtype>::total_size;
 
 template<class DataTypes> struct StateTypeSize<DataTypes, core::V_COORD>
 {
-    static constexpr sofa::Size total_size = typename DataTypes::coord_total_size;
+    static constexpr sofa::Size total_size = DataTypes::coord_total_size;
 };
 template<class DataTypes> struct StateTypeSize<DataTypes, core::V_DERIV>
 {
-    static constexpr sofa::Size total_size = typename DataTypes::deriv_total_size;
+    static constexpr sofa::Size total_size = DataTypes::deriv_total_size;
 };
 
 /// Maps a VecType to a DataTypes member typedef representing a vector of state variables

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Data.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Data.h
@@ -71,6 +71,8 @@ template < class T = void* >
 class Data : public BaseData
 {
 public:
+    using value_type = T;
+
     using BaseData::m_counter;
     using BaseData::m_isSet;
     using BaseData::setDirtyOutputs;


### PR DESCRIPTION
A lot of code was duplicated to apply the same algorithm on both Coord and Deriv types. I factorized those pieces of code. Most of the new code relies of generic lambdas (since C++14).



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
