### PR TITLE
[Core] Missing include in SingleStateAccessor

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/core/behavior/StateAccessor.h>
+#include <sofa/core/behavior/MechanicalState.h>
 
 namespace sofa::core::behavior
 {


### PR DESCRIPTION
This include is actually required in some cases outside of SOFA



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
