### PR TITLE
[GUI.Common] Cmake: Fix message when searching for Sofa.GL

### DIFF
--- a/Sofa/GUI/Common/CMakeLists.txt
+++ b/Sofa/GUI/Common/CMakeLists.txt
@@ -18,12 +18,6 @@ if(NOT cxxopts_POPULATED)
     add_subdirectory(${cxxopts_SOURCE_DIR} ${cxxopts_BINARY_DIR})
 endif()
 
-if(Sofa.GL_FOUND)
-    message("-- ${PROJECT_NAME}: Sofa.GL dependent features enabled.")
-else()
-    message("-- ${PROJECT_NAME}: Sofa.GL dependent features disabled.")
-endif()
-
 set(SOFAGUICOMMON_ROOT src/sofa/gui/common)
 
 set(HEADER_FILES
@@ -79,6 +73,12 @@ sofa_find_package(Sofa.Component.Setting REQUIRED)
 sofa_find_package(Sofa.Component.Collision.Response.Contact REQUIRED)
 sofa_find_package(Sofa.GUI.Component REQUIRED)
 sofa_find_package(Sofa.GL QUIET) # ColourPickingVisitor
+
+if(Sofa.GL_FOUND)
+    message(STATUS "-- ${PROJECT_NAME}: Sofa.GL dependent features enabled.")
+else()
+    message(WARNING "-- ${PROJECT_NAME}: Sofa.GL dependent features disabled.")
+endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${COMPAT_HEADER_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Common)


### PR DESCRIPTION
Message was always saying that Sofa.GL was not found as the find_package() was done later
Set a STATUS/WARNING level in the same time


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
