### PR TITLE
[Core] Give threads a name on Windows

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/WorkerThread.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/WorkerThread.cpp
@@ -25,6 +25,10 @@
 #include <cassert>
 #include <mutex>
 
+#ifdef WIN32
+#include <processthreadsapi.h>
+#endif
+
 namespace sofa::simulation
 {
 
@@ -69,6 +73,13 @@ std::thread *WorkerThread::create_and_attach(DefaultTaskScheduler *const &taskSc
 
 void WorkerThread::run(void)
 {
+#ifdef WIN32
+    const std::wstring widestr = std::wstring(m_name.begin(), m_name.end());
+    HRESULT r = SetThreadDescription(
+        GetCurrentThread(),
+        widestr.c_str()
+        );
+#endif
 
     //workerThreadIndex = this;
     //TaskSchedulerDefault::_threads[std::this_thread::get_id()] = this;


### PR DESCRIPTION
This is to ease debugging by identifying threads managed by the task scheduler (Windows only).
Source: https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2022

![image](https://user-images.githubusercontent.com/10572752/208109683-d20496a6-0d0c-4b4e-ad97-b139150d4c76.png)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
