### PR TITLE
[MultiThreading] Introduce ParallelTetrahedronFEMForceField

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -106,9 +106,6 @@ protected:
 
     void clearConstraintProblemLocks();
 
-    void parallelBuildSystem_matrixAssembly(const core::ConstraintParams* cParams);
-    void sequentialBuildSystem_matrixAssembly(const core::ConstraintParams* cParams);
-
     enum { CP_BUFFER_SIZE = 10 };
     sofa::type::fixed_array<GenericConstraintProblem,CP_BUFFER_SIZE> m_cpBuffer;
     sofa::type::fixed_array<bool,CP_BUFFER_SIZE> m_cpIsLocked;
@@ -124,29 +121,23 @@ protected:
 
 private:
 
-    class ComputeComplianceTask : public simulation::CpuTask
+    struct ComplianceWrapper
     {
-    public:
-        ComputeComplianceTask(simulation::CpuTask::Status* status): CpuTask(status) {}
-        ~ComputeComplianceTask() override {}
+        using ComplianceMatrixType = sofa::linearalgebra::LPtrFullMatrix<SReal>;
 
-        MemoryAlloc run() final {
-            cc->addComplianceInConstraintSpace(&cparams, &W);
-            return MemoryAlloc::Stack;
-        }
+        ComplianceWrapper(ComplianceMatrixType& complianceMatrix, bool isMultiThreaded)
+        : m_isMultiThreaded(isMultiThreaded), m_complianceMatrix(complianceMatrix) {}
 
-        void set(core::behavior::BaseConstraintCorrection* _cc, core::ConstraintParams _cparams, int dim){
-            cc = _cc;
-            cparams = _cparams;
-            W.resize(dim,dim);
-        }
+        ComplianceMatrixType& matrix();
+
+        void assembleMatrix() const;
 
     private:
-        core::behavior::BaseConstraintCorrection* cc { nullptr };
-        sofa::linearalgebra::LPtrFullMatrix<SReal> W;
-        core::ConstraintParams cparams;
-        friend class GenericConstraintSolver;
+        bool m_isMultiThreaded { false };
+        ComplianceMatrixType& m_complianceMatrix;
+        std::unique_ptr<ComplianceMatrixType> m_threadMatrix;
     };
+
 };
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -1707,11 +1707,14 @@ inline void TetrahedronFEMForceField<DataTypes>::addForce (const core::Mechanica
 template<class DataTypes>
 inline void TetrahedronFEMForceField<DataTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
 {
-    VecDeriv& df = *d_df.beginEdit();
-    const VecDeriv& dx = d_dx.getValue();
-    Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
+    auto dfAccessor = sofa::helper::getWriteAccessor(d_df);
+    VecDeriv& df = dfAccessor.wref();
 
+    const VecDeriv& dx = d_dx.getValue();
     df.resize(dx.size());
+
+    const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
+
     unsigned int i;
     typename VecElement::const_iterator it;
 
@@ -1739,8 +1742,6 @@ inline void TetrahedronFEMForceField<DataTypes>::addDForce(const core::Mechanica
             applyStiffnessCorotational( df,dx, i, a,b,c,d, kFactor );
         }
     }
-
-    d_df.endEdit();
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/MutationListener.h
     ${SRC_ROOT}/Node.h
     ${SRC_ROOT}/Node.inl
+    ${SRC_ROOT}/ParallelForEach.h
     ${SRC_ROOT}/ParallelVisitorScheduler.h
     ${SRC_ROOT}/PauseEvent.h
     ${SRC_ROOT}/PipelineImpl.h

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
@@ -1,0 +1,197 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/CpuTaskStatus.h>
+#include <sofa/type/vector_T.h>
+
+namespace sofa::simulation
+{
+
+/**
+ * Represents an iterable sequence in a container
+ */
+template<class InputIt>
+struct Range
+{
+    InputIt start;
+    InputIt end;
+
+    Range(InputIt s, InputIt e) : start(s), end(e) {}
+};
+
+/**
+ * Function returning a list of ranges from an iterable container.
+ * The number of ranges depends on:
+ *  1) the desired number of ranges provided in a parameter
+ *  2) the number of elements in the container
+ * The number of elements in each range is homogenous, except for the last range which may contain
+ * more elements.
+ */
+template<class InputIt>
+sofa::type::vector<Range<InputIt> >
+makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nbRangesHint)
+{
+    sofa::type::vector<Range<InputIt> > ranges;
+
+    if (first == last)
+    {
+        return ranges;
+    }
+
+    const auto nbElements = static_cast<unsigned int>(std::distance(first, last));
+
+    const unsigned int nbRanges = std::min(nbRangesHint, nbElements);
+    ranges.reserve(nbRanges);
+
+    const auto nbElementsPerRange = nbElements / nbRanges;
+
+    Range<InputIt> r { first, first};
+    std::advance(r.end, nbElementsPerRange);
+
+    for (unsigned int i = 0; i < nbRanges - 1; ++i)
+    {
+        ranges.emplace_back(r);
+
+        std::advance(r.start, nbElementsPerRange);
+        std::advance(r.end, nbElementsPerRange);
+    }
+
+    ranges.emplace_back(r.start, last);
+
+    return ranges;
+}
+
+/**
+ * Applies the given function object f to the result of dereferencing every iterator in the
+ * range [first, last), in order.
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEach(InputIt first, InputIt last, UnaryFunction f)
+{
+    return std::for_each(first, last, f);
+}
+
+/**
+ * Applies the given function object f to the Range [first, last)
+ *
+ * The signature of the function f should be equivalent to the following:
+ * void fun(const Range<InputIt>& a);
+ * The signature does not need to have const &
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEachRange(InputIt first, InputIt last, UnaryFunction f)
+{
+    Range<InputIt> r{ first, last};
+    f(r);
+
+    return f;
+}
+
+/**
+ * Applies in parallel the given function object f to a list of ranges generated from [first, last)
+ *
+ * The signature of the function f should be equivalent to the following:
+ * void fun(const Range<InputIt>& a);
+ * The signature does not need to have const &.
+ *
+ * A task scheduler must be provided and correctly initiallized. The number of generated ranges
+ * depends on the threads available in the task scheduler.
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction parallelForEachRange(TaskScheduler& taskScheduler, InputIt first, InputIt last, UnaryFunction f)
+{
+    if (first != last)
+    {
+        const auto taskSchedulerThreadCount = taskScheduler.getThreadCount();
+        if (taskSchedulerThreadCount == 0)
+        {
+            msg_error("parallelForEach") << "Task scheduler does not appear to be initialized. Cannot perform parallel tasks.";
+            return forEachRange(first, last, f);
+        }
+
+        CpuTaskStatus status;
+
+        const auto ranges = makeRangesForLoop<InputIt>(first, last, taskSchedulerThreadCount);
+
+        for (const Range<InputIt>& r : ranges)
+        {
+            taskScheduler.addTask(status, [&r, &f]()
+            {
+                f(r);
+            });
+        }
+
+        taskScheduler.workUntilDone(&status);
+    }
+    return f;
+}
+
+/**
+ * Applies the given function object f to the result of dereferencing every iterator in the
+ * range [first, last), in parallel.
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction parallelForEach(TaskScheduler& taskScheduler, InputIt first, InputIt last, UnaryFunction f)
+{
+    parallelForEachRange(taskScheduler, first, last,
+        [&f](const Range<InputIt>& r)
+        {
+            forEach(r.start, r.end, f);
+        });
+    return f;
+}
+
+
+enum class ForEachExecutionPolicy : bool
+{
+    SEQUENTIAL = false,
+    PARALLEL
+};
+
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEachRange(const ForEachExecutionPolicy execution, TaskScheduler& taskScheduler,
+                      InputIt first,
+                      InputIt last, UnaryFunction f)
+{
+    if (execution == ForEachExecutionPolicy::PARALLEL)
+    {
+        return parallelForEachRange(taskScheduler, first, last, f);
+    }
+    return forEachRange(first, last, f);
+}
+
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEach(const ForEachExecutionPolicy execution, TaskScheduler& taskScheduler,
+                      InputIt first,
+                      InputIt last, UnaryFunction f)
+{
+    if (execution == ForEachExecutionPolicy::PARALLEL)
+    {
+        return parallelForEach(taskScheduler, first, last, f);
+    }
+    return forEach(first, last, f);
+}
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
@@ -41,6 +41,19 @@ struct Range
     Range(InputIt s, InputIt e) : start(s), end(e) {}
 };
 
+template<class InputIt, class Distance>
+void advance(InputIt& it, Distance n)
+{
+    if constexpr (std::is_integral_v<InputIt>)
+    {
+        it += n;
+    }
+    else
+    {
+        std::advance(it, n);
+    }
+}
+
 /**
  * Function returning a list of ranges from an iterable container.
  * The number of ranges depends on:
@@ -60,7 +73,15 @@ makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nb
         return ranges;
     }
 
-    const auto nbElements = static_cast<unsigned int>(std::distance(first, last));
+    unsigned int nbElements = 0;
+    if constexpr (std::is_integral_v<InputIt>)
+    {
+        nbElements = static_cast<unsigned int>(last - first);
+    }
+    else
+    {
+        nbElements = static_cast<unsigned int>(std::distance(first, last));
+    }
 
     const unsigned int nbRanges = std::min(nbRangesHint, nbElements);
     ranges.reserve(nbRanges);
@@ -68,14 +89,14 @@ makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nb
     const auto nbElementsPerRange = nbElements / nbRanges;
 
     Range<InputIt> r { first, first};
-    std::advance(r.end, nbElementsPerRange);
+    sofa::simulation::advance(r.end, nbElementsPerRange);
 
     for (unsigned int i = 0; i < nbRanges - 1; ++i)
     {
         ranges.emplace_back(r);
 
-        std::advance(r.start, nbElementsPerRange);
-        std::advance(r.end, nbElementsPerRange);
+        sofa::simulation::advance(r.start, nbElementsPerRange);
+        sofa::simulation::advance(r.end, nbElementsPerRange);
     }
 
     ranges.emplace_back(r.start, last);
@@ -90,7 +111,18 @@ makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nb
 template<class InputIt, class UnaryFunction>
 UnaryFunction forEach(InputIt first, InputIt last, UnaryFunction f)
 {
-    return std::for_each(first, last, f);
+    if constexpr (std::is_integral_v<InputIt>)
+    {
+        for (; first != last; ++first)
+        {
+            f(first);
+        }
+        return f;
+    }
+    else
+    {
+        return std::for_each(first, last, f);
+    }
 }
 
 /**

--- a/Sofa/framework/Simulation/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/test/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(Sofa.Simulation.Core_test)
 
 set(SOURCE_FILES
+    ParallelForEach_test.cpp
     RequiredPlugin_test.cpp
     TaskSchedulerTests.cpp
     TaskSchedulerTestTasks.h

--- a/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
@@ -146,6 +146,31 @@ TEST(ParallelForEach, emptyContainer) //just making sure it does not crash
     }
 }
 
+TEST(ParallelForEach, integers)
+{
+    std::vector<int> integers = makeTestData();
+    std::vector<int> integers2 = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, static_cast<std::size_t>(0), integers.size(),
+        [&integers, &integers2](const std::size_t& i)
+        {
+            integers[i]++;
+            integers2[i]--;
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers2[i], static_cast<int>(i) - 1);
+    }
+}
+
 TEST(ParallelForEachRange, nonInitializedTaskScheduler)
 {
     sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
@@ -192,6 +217,34 @@ TEST(ParallelForEachRange, incrementVectorLambda)
     for (std::size_t i = 0; i < integers.size(); ++i)
     {
         EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEachRange, integers)
+{
+    std::vector<int> integers = makeTestData();
+    std::vector<int> integers2 = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEachRange(*scheduler, static_cast<std::size_t>(0), integers.size(),
+        [&integers, &integers2](const auto& range)
+        {
+            for (auto it = range.start; it != range.end; ++it)
+            {
+                ++integers[it];
+                --integers2[it];
+            }
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers2[i], static_cast<int>(i) - 1);
     }
 }
 

--- a/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
@@ -1,0 +1,198 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/simulation/DefaultTaskScheduler.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <sofa/simulation/ParallelForEach.h>
+#include <sofa/testing/TestMessageHandler.h>
+
+#include <numeric>
+
+
+namespace sofa
+{
+
+std::vector<int> makeTestData(std::size_t nbIntegers = 1024)
+{
+    std::vector<int> integers(nbIntegers);
+    std::iota(integers.begin(), integers.end(), 0);
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i);
+    }
+
+    return integers;
+}
+
+TEST(ParallelForEach, makeRangesForLoop)
+{
+    std::vector<int> integers = makeTestData();
+
+    auto ranges = simulation::makeRangesForLoop(integers.begin(), integers.end(), 8u);
+    EXPECT_EQ(ranges.size(), 8);
+
+    for (const auto& r : ranges)
+    {
+        EXPECT_EQ(std::distance(r.start, r.end), integers.size() / 8)
+            << "start: " << std::distance(integers.begin(), r.start)
+            << ", end: " << std::distance(integers.begin(), r.end);
+    }
+
+
+    ranges = simulation::makeRangesForLoop(integers.begin(), integers.end(), 7u);
+    EXPECT_EQ(ranges.size(), 7);
+
+    for (unsigned int i = 0; i < ranges.size() - 1; ++i)
+    {
+        EXPECT_EQ(std::distance(ranges[i].start, ranges[i].end), integers.size() / 7);
+    }
+    EXPECT_EQ(std::distance(ranges.back().start, ranges.back().end), integers.size() - 6 * static_cast<std::size_t>(integers.size() / 7));
+
+
+    ranges = simulation::makeRangesForLoop(integers.begin(), integers.end(), 2048u);
+    EXPECT_EQ(ranges.size(), integers.size());
+
+    for (const auto& r : ranges)
+    {
+        EXPECT_EQ(std::distance(r.start, r.end), 1);
+    }
+}
+
+TEST(ParallelForEach, incrementVectorLambda)
+{
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), [](int& i) { ++i; });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEach, incrementVectorFunctor)
+{
+    struct Functor
+    {
+        void operator()(int& n)
+        {
+            ++n;
+        }
+    };
+
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), Functor{});
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEach, nbElementsLessThanThreads)
+{
+    std::vector<int> integers = makeTestData(3);
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(4);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), [](int& i) { ++i; });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEach, emptyContainer) //just making sure it does not crash
+{
+    std::vector<int> integers;
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), [](int& i) { ++i; });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEachRange, nonInitializedTaskScheduler)
+{
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler =
+        simulation::MainTaskSchedulerFactory::instantiate(simulation::DefaultTaskScheduler::name());
+
+    EXPECT_MSG_EMIT(Error);
+    simulation::parallelForEachRange(*scheduler, integers.begin(), integers.end(),
+        [](const auto& range)
+        {
+            for (auto it = range.start; it != range.end; ++it)
+            {
+                int& i = *it;
+                ++i;
+            }
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEachRange, incrementVectorLambda)
+{
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEachRange(*scheduler, integers.begin(), integers.end(),
+        [](const auto& range)
+        {
+            for (auto it = range.start; it != range.end; ++it)
+            {
+                int& i = *it;
+                ++i;
+            }
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+}

--- a/applications/plugins/MultiThreading/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/CMakeLists.txt
@@ -16,6 +16,8 @@ set(HEADER_FILES
     src/MultiThreading/ParallelBVHNarrowPhase.h
     src/MultiThreading/ParallelHexahedronFEMForceField.h
     src/MultiThreading/ParallelHexahedronFEMForceField.inl
+    src/MultiThreading/ParallelTetrahedronFEMForceField.h
+    src/MultiThreading/ParallelTetrahedronFEMForceField.inl
     )
 
 set(SOURCE_FILES
@@ -28,6 +30,7 @@ set(SOURCE_FILES
     src/MultiThreading/ParallelBruteForceBroadPhase.cpp
     src/MultiThreading/ParallelBVHNarrowPhase.cpp
     src/MultiThreading/ParallelHexahedronFEMForceField.cpp
+    src/MultiThreading/ParallelTetrahedronFEMForceField.cpp
     )
 
 find_package(Sofa.Simulation.Common REQUIRED)

--- a/applications/plugins/MultiThreading/examples/ParallelTetrahedronFEMForceField.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelTetrahedronFEMForceField.scn
@@ -16,7 +16,7 @@
 
     <Node name="BeamFEM_LARGE">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9"/>
 
         <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
         <MechanicalObject template="Vec3d" translation="11 0 0"/>

--- a/applications/plugins/MultiThreading/examples/ParallelTetrahedronFEMForceField.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelTetrahedronFEMForceField.scn
@@ -17,19 +17,19 @@
     <Node name="BeamFEM_LARGE">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        
+
         <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
         <MechanicalObject template="Vec3d" translation="11 0 0"/>
-        
+
         <TetrahedronSetTopologyContainer name="Tetra_topo"/>
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
-        
+
         <DiagonalMass massDensity="0.2" />
-        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false" 
-        method="large" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
-        
+        <ParallelTetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="large" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+
         <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
     </Node>

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
@@ -80,6 +80,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addForce(const core::Mechanical
     auto *taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
 
+    const auto* indexedElements = this->getIndexedElements();
     this->m_potentialEnergy = 0;
 
     const auto& elementStiffnesses = this->_elementStiffnesses.getValue();
@@ -96,7 +97,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addForce(const core::Mechanical
     std::mutex mutex;
 
     simulation::parallelForEachRange(*taskScheduler,
-        this->getIndexedElements()->begin(), this->getIndexedElements()->end(),
+        indexedElements->begin(), indexedElements->end(),
         [this, &_p, &elementStiffnesses, &mutex, &_f](const auto& range)
         {
             auto elementId = std::distance(this->getIndexedElements()->begin(), range.start);

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.cpp
@@ -1,0 +1,38 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFA_MULTITHREADING_PARALLELTETRAHEDRONFEMFORCEFIELD_CPP
+#include <MultiThreading/ParallelTetrahedronFEMForceField.inl>
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/ObjectFactory.h>
+
+namespace sofa::component::forcefield
+{
+
+using namespace sofa::defaulttype;
+
+// Register in the Factory
+int ParallelTetrahedronFEMForceFieldClass = core::RegisterObject("Parallel tetrahedral finite elements")
+                                           .add < ParallelTetrahedronFEMForceField < Vec3Types > > ();
+
+template class SOFA_MULTITHREADING_PLUGIN_API ParallelTetrahedronFEMForceField<Vec3Types>;
+
+}

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.h
@@ -1,0 +1,111 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <MultiThreading/config.h>
+
+#include <sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h>
+#include <sofa/simulation/CpuTask.h>
+#include <sofa/simulation/TaskScheduler.h>
+
+#include <thread>
+
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+class AccumulateForceLargeTasks;
+
+template<class DataTypes>
+class AddDForceTask;
+
+/**
+ * Parallel implementation of TetrahedronFEMForceField
+ *
+ * This implementation is the most efficient when:
+ * 1) the number of tetrahedron is large (> 1000)
+ * 2) the global system matrix is not assembled. It is usually the case with a CGLinearSolver templated with GraphScattered types.
+ * 3) the method is 'large'. If the method is 'polar' or 'small', addForce is executed sequentially, but addDForce in parallel.
+ *
+ * The following methods are executed in parallel:
+ * - addForce for method 'large'.
+ * - addDForce
+ *
+ * The method addKToMatrix is not executed in parallel. This method is called with an assembled system, usually with
+ * a direct solver or a CGLinearSolver templated with types different from GraphScattered. In this case, the most
+ * time-consumming step is to invert the matrix. This is where efforts should be put to accelerate the simulation.
+ */
+template<class DataTypes>
+class SOFA_MULTITHREADING_PLUGIN_API ParallelTetrahedronFEMForceField : virtual public sofa::component::solidmechanics::fem::elastic::TetrahedronFEMForceField<DataTypes>
+{
+public:
+    SOFA_CLASS(SOFA_TEMPLATE(ParallelTetrahedronFEMForceField, DataTypes), SOFA_TEMPLATE(sofa::component::solidmechanics::fem::elastic::TetrahedronFEMForceField, DataTypes));
+
+    using VecCoord = typename DataTypes::VecCoord;
+    using VecDeriv = typename DataTypes::VecDeriv;
+    using VecReal = typename DataTypes::VecReal;
+    using Coord = typename DataTypes::Coord;
+    using Deriv = typename DataTypes::Deriv;
+    using Real = typename Coord::value_type;
+
+    using DataVecDeriv = core::objectmodel::Data<VecDeriv>;
+    using DataVecCoord = core::objectmodel::Data<VecCoord>;
+
+    using VecElement = core::topology::BaseMeshTopology::SeqTetrahedra;
+
+
+
+    void init() override;
+
+    void addForce (const core::MechanicalParams* mparams, DataVecDeriv& d_f,
+                   const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
+
+
+
+
+    void addDForce (const core::MechanicalParams* mparams, DataVecDeriv& d_df,
+                    const DataVecDeriv& d_dx) override;
+
+protected:
+
+    template<class Function>
+    void addDForceGeneric(VecDeriv& df, const VecDeriv& dx, Real kFactor,
+                           const VecElement& indexedElements, Function f);
+
+    void addDForceSmall(VecDeriv& df, const VecDeriv& dx, Real kFactor,
+                           const VecElement& indexedElements);
+    void addDForceCorotational(VecDeriv& df, const VecDeriv& dx, Real kFactor,
+                           const VecElement& indexedElements);
+
+    void initTaskScheduler();
+
+    sofa::simulation::TaskScheduler* m_taskScheduler { nullptr };
+
+    std::map<std::thread::id, VecDeriv> m_threadLocal_df;
+
+};
+
+#if  !defined(SOFA_MULTITHREADING_PARALLELTETRAHEDRONFEMFORCEFIELD_CPP)
+extern template class SOFA_MULTITHREADING_PLUGIN_API ParallelTetrahedronFEMForceField<defaulttype::Vec3Types>;
+#endif
+
+} //namespace sofa::component::forcefield

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.inl
@@ -1,0 +1,141 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <MultiThreading/ParallelTetrahedronFEMForceField.h>
+#include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <sofa/simulation/ParallelForEach.h>
+
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+void ParallelTetrahedronFEMForceField<DataTypes>::init()
+{
+    Inherit1::init();
+    initTaskScheduler();
+}
+
+template<class DataTypes>
+void ParallelTetrahedronFEMForceField<DataTypes>::initTaskScheduler()
+{
+    m_taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
+    assert(m_taskScheduler != nullptr);
+    if (m_taskScheduler->getThreadCount() < 1)
+    {
+        m_taskScheduler->init(0);
+        msg_info() << "Task scheduler initialized on " << m_taskScheduler->getThreadCount() << " threads";
+    }
+    else
+    {
+        msg_info() << "Task scheduler already initialized on " << m_taskScheduler->getThreadCount() << " threads";
+    }
+}
+
+template<class DataTypes>
+void ParallelTetrahedronFEMForceField<DataTypes>::addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f,
+              const DataVecCoord& d_x, const DataVecDeriv& d_v)
+{
+    Inherit1::addForce(mparams, d_f, d_x, d_v);
+}
+
+template <class DataTypes>
+template <class Function>
+void ParallelTetrahedronFEMForceField<DataTypes>::addDForceGeneric(VecDeriv& df, const VecDeriv& dx,
+    Real kFactor, const VecElement& indexedElements, Function f)
+{
+    std::mutex mutex;
+    sofa::simulation::parallelForEachRange(*m_taskScheduler, indexedElements.begin(), indexedElements.end(),
+           [&indexedElements, this, kFactor, &dx, &df, &f, &mutex](const auto& range)
+           {
+               auto elementId = std::distance(indexedElements.begin(), range.start);
+
+               VecDeriv& threadLocal_df = m_threadLocal_df[std::this_thread::get_id()];
+               threadLocal_df.clear();
+               threadLocal_df.resize(df.size());
+
+               for (auto it = range.start; it != range.end; ++it, ++elementId)
+               {
+                   Index a = (*it)[0];
+                   Index b = (*it)[1];
+                   Index c = (*it)[2];
+                   Index d = (*it)[3];
+
+                   f( threadLocal_df, dx, elementId, a,b,c,d, kFactor );
+               }
+
+               std::lock_guard guard(mutex);
+
+               auto it = df.begin();
+               for (const auto& d : threadLocal_df)
+               {
+                   *it++ += d;
+               }
+           });
+}
+
+template <class DataTypes>
+void ParallelTetrahedronFEMForceField<DataTypes>::addDForceSmall(VecDeriv& df, const VecDeriv& dx, const Real kFactor, const VecElement& indexedElements)
+{
+    addDForceGeneric(df, dx, kFactor, indexedElements,
+        [this](VecDeriv& f, const VecDeriv& x, Index i, Index a, Index b, Index c, Index d, SReal fact)
+        {
+            this->applyStiffnessSmall(f, x, i, a, b, c, d, fact);
+        });
+}
+
+template <class DataTypes>
+void ParallelTetrahedronFEMForceField<DataTypes>::addDForceCorotational(VecDeriv& df, const VecDeriv& dx, const Real kFactor, const VecElement& indexedElements)
+{
+    addDForceGeneric(df, dx, kFactor, indexedElements,
+        [this](VecDeriv& f, const VecDeriv& x, Index i, Index a, Index b, Index c, Index d, SReal fact)
+        {
+            this->applyStiffnessCorotational(f, x, i, a, b, c, d, fact);
+        });
+}
+
+template<class DataTypes>
+void ParallelTetrahedronFEMForceField<DataTypes>::addDForce (const core::MechanicalParams *mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
+{
+    auto dfAccessor = sofa::helper::getWriteAccessor(d_df);
+    VecDeriv& df = dfAccessor.wref();
+
+    const VecDeriv& dx = d_dx.getValue();
+    df.resize(dx.size());
+
+    const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
+
+    const auto& indexedElements = *this->_indexedElements;
+
+    if( this->method == Inherit1::SMALL )
+    {
+        addDForceSmall(df, dx, kFactor, indexedElements);
+    }
+    else
+    {
+        addDForceCorotational(df, dx, kFactor, indexedElements);
+    }
+}
+
+
+} //namespace sofa::component::forcefield

--- a/examples/Components/forcefield/TetrahedronFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronFEMForceField.scn
@@ -14,22 +14,83 @@
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
 
-    <Node name="BeamFEM_LARGE">
+    <Node name="BeamFEM_SMALL">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9"/>
+
         <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
-        <MechanicalObject template="Vec3d" translation="11 0 0"/>
-        
+        <MechanicalObject template="Vec3d" />
+
         <TetrahedronSetTopologyContainer name="Tetra_topo"/>
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
-        
+
         <DiagonalMass massDensity="0.2" />
-        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false" 
-        method="large" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
-        
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="small" computeVonMisesStress="2" showVonMisesStressPerElement="true"/>
+
+        <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
+    </Node>
+
+
+    <Node name="BeamFEM_LARGE">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3d" translation="11 0 0"/>
+
+        <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+
+        <DiagonalMass massDensity="0.2" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="large" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+
+        <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
+    </Node>
+
+    <Node name="BeamFEM_POLAR">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3d" translation="22 0 0"/>
+
+        <TetrahedronSetTopologyContainer name="Tetra_topo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+
+        <DiagonalMass massDensity="0.2" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="polar" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+
+        <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
+    </Node>
+
+    <Node name="BeamFEM_SVD">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3d" translation="33 0 0"/>
+
+        <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+
+        <DiagonalMass massDensity="0.2" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="svd" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+
         <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
     </Node>


### PR DESCRIPTION
Based on #3548 

Similar to ParallelHexahedronFEMForceField.

`addDForce` and `addKToMatrix` are the parallelized functions.
`addForce` is not parallelized. It would require to duplicate code from the base class. Hence a refactoring is needed for a proper implementation (in another PR). Note that `addForce` is usually not the bottleneck.

Quick benchmarks show performances improvement on the provided example.

I think there is still room for improvement in `addDForce`. But it would require a few changes in the base class. Instead of having a force vector for each task, I suggest to store only the force on the DoFs that have been visited during the task. I am not sure if it will bring more perfs improvements.

In this PR, `addKToMatrix` is parallelized. It is not in `ParallelHexahedronFEMForceField`, but the same principle can be applied (in another PR).


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
