### PR TITLE
[Type] Quat: small optimization for axisToQuat()

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Quat.inl
+++ b/Sofa/framework/Type/src/sofa/type/Quat.inl
@@ -224,7 +224,8 @@ void Quat<Real>::fromMatrix(const Mat3x3 &m)
 template<class Real>
 auto Quat<Real>::axisToQuat(Vec3 a, Real phi) -> Quat
 {
-    if( a.norm() < std::numeric_limits<Real>::epsilon() )
+    const auto aNorm = a.norm();
+    if(aNorm < std::numeric_limits<Real>::epsilon() )
     {
         _q[0] = _q[1] = _q[2] = Real(0.0);
         _q[3] = Real(1.0);
@@ -232,16 +233,14 @@ auto Quat<Real>::axisToQuat(Vec3 a, Real phi) -> Quat
         return Quat();
     }
 
-    a = a / a.norm();
-    _q[0] = a.x();
-    _q[1] = a.y();
-    _q[2] = a.z();
+    a = a / aNorm;
+    const auto sp = sin(phi / Real(2.0));
+    const auto cp = cos(phi / Real(2.0));
 
-    _q[0] = _q[0] * sin(phi / Real(2.0));
-    _q[1] = _q[1] * sin(phi / Real(2.0));
-    _q[2] = _q[2] * sin(phi / Real(2.0));
-
-    _q[3] = cos(phi / Real(2.0));
+    _q[0] = a.x() * sp;
+    _q[1] = a.y() * sp;
+    _q[2] = a.z() * sp;
+    _q[3] = cp;
 
     return *this;
 }


### PR DESCRIPTION
Avoiding doing unnecessary duplicate operations (norm and sin())
At first, I thought the compiler (msvc in my case) would be smart enough to do it by itself while optimizing, but apparently not:

before:
```
BM_Quat_axisToQuat/8192         106 us         85.4 us         8960
BM_Quat_axisToQuat/16384        210 us          154 us         4978
BM_Quat_axisToQuat/32768        348 us          220 us         3200
```

after:
```
BM_Quat_axisToQuat/8192        74.5 us         60.9 us        10000
BM_Quat_axisToQuat/16384        150 us         97.7 us         6400
BM_Quat_axisToQuat/32768        255 us          167 us         4480
```

----

Note: if we knew before-hand that the vec was normalized/not-null, the perf would be:
```
BM_Quat_axisToQuat/8192        69.0 us         52.7 us        16000
BM_Quat_axisToQuat/16384        138 us          103 us         7467
BM_Quat_axisToQuat/32768        239 us          171 us         4480
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
