### PR TITLE
[FEM.Elastic] Consistent default values for poisson's ratio and Young's modulus

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -139,8 +139,8 @@ FastTetrahedralCorotationalForceField<DataTypes>::FastTetrahedralCorotationalFor
     , tetrahedronInfo(initData(&tetrahedronInfo, "tetrahedronInfo", "Internal tetrahedron data"))
     , _initialPoints(0)
     , f_method(initData(&f_method,std::string("qr"),"method"," method for rotation computation :\"qr\" (by QR) or \"polar\" or \"polar2\" or \"none\" (Linear elastic) "))
-    , f_poissonRatio(initData(&f_poissonRatio,Real(0.3),"poissonRatio","Poisson ratio in Hooke's law"))
-    , f_youngModulus(initData(&f_youngModulus,Real(1000.),"youngModulus","Young modulus in Hooke's law"))
+    , f_poissonRatio(initData(&f_poissonRatio,Real(0.45),"poissonRatio","Poisson ratio in Hooke's law"))
+    , f_youngModulus(initData(&f_youngModulus,Real(5000.),"youngModulus","Young modulus in Hooke's law"))
     , lambda(0)
     , mu(0)
     , f_drawing(initData(&f_drawing, true, "drawing", " draw the forcefield if true"))
@@ -166,6 +166,9 @@ template <class DataTypes>
 void FastTetrahedralCorotationalForceField<DataTypes>::init()
 {
     this->Inherited::init();
+
+    msg_warning_when(!f_poissonRatio.isSet()) << "The default value of the Data " << f_poissonRatio.getName() << " changed in v23.06 from 0.3 to 0.45.";
+    msg_warning_when(!f_youngModulus.isSet()) << "The default value of the Data " << f_youngModulus.getName() << " changed in v23.06 from 1000 to 5000";
 
     if (l_topology.empty())
     {

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedronFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedronFEMForceField_test.cpp
@@ -441,8 +441,8 @@ public:
         {
             typename FastTetraCorotationalFEM::SPtr tetraFEM = m_root->getTreeObject<FastTetraCorotationalFEM>();
             ASSERT_TRUE(tetraFEM.get() != nullptr);
-            ASSERT_FLOATINGPOINT_EQ(tetraFEM->f_poissonRatio.getValue(), static_cast<Real>(0.3)); // TODO need to unify this value with other tetrahedronFEM
-            ASSERT_FLOATINGPOINT_EQ(tetraFEM->f_youngModulus.getValue(), static_cast<Real>(1000)); // TODO need to unify this value with other tetrahedronFEM
+            ASSERT_FLOATINGPOINT_EQ(tetraFEM->f_poissonRatio.getValue(), static_cast<Real>(0.45));
+            ASSERT_FLOATINGPOINT_EQ(tetraFEM->f_youngModulus.getValue(), static_cast<Real>(5000));
             ASSERT_EQ(tetraFEM->f_method.getValue(), "qr");
         }
     }


### PR DESCRIPTION
FastTetrahedralCorotationalForceField initialized its Poisson's ratio and Young's modulus with different values than the other tet FEM force fields.


TODO:

- [x] Update tests
- [x] Update doc: https://github.com/sofa-framework/doc/pull/83





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
