### PR TITLE
[MultiThreading] Implement domain decomposition for a lock-free parallelism

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -106,9 +106,6 @@ protected:
 
     void clearConstraintProblemLocks();
 
-    void parallelBuildSystem_matrixAssembly(const core::ConstraintParams* cParams);
-    void sequentialBuildSystem_matrixAssembly(const core::ConstraintParams* cParams);
-
     enum { CP_BUFFER_SIZE = 10 };
     sofa::type::fixed_array<GenericConstraintProblem,CP_BUFFER_SIZE> m_cpBuffer;
     sofa::type::fixed_array<bool,CP_BUFFER_SIZE> m_cpIsLocked;
@@ -124,29 +121,23 @@ protected:
 
 private:
 
-    class ComputeComplianceTask : public simulation::CpuTask
+    struct ComplianceWrapper
     {
-    public:
-        ComputeComplianceTask(simulation::CpuTask::Status* status): CpuTask(status) {}
-        ~ComputeComplianceTask() override {}
+        using ComplianceMatrixType = sofa::linearalgebra::LPtrFullMatrix<SReal>;
 
-        MemoryAlloc run() final {
-            cc->addComplianceInConstraintSpace(&cparams, &W);
-            return MemoryAlloc::Stack;
-        }
+        ComplianceWrapper(ComplianceMatrixType& complianceMatrix, bool isMultiThreaded)
+        : m_isMultiThreaded(isMultiThreaded), m_complianceMatrix(complianceMatrix) {}
 
-        void set(core::behavior::BaseConstraintCorrection* _cc, core::ConstraintParams _cparams, int dim){
-            cc = _cc;
-            cparams = _cparams;
-            W.resize(dim,dim);
-        }
+        ComplianceMatrixType& matrix();
+
+        void assembleMatrix() const;
 
     private:
-        core::behavior::BaseConstraintCorrection* cc { nullptr };
-        sofa::linearalgebra::LPtrFullMatrix<SReal> W;
-        core::ConstraintParams cparams;
-        friend class GenericConstraintSolver;
+        bool m_isMultiThreaded { false };
+        ComplianceMatrixType& m_complianceMatrix;
+        std::unique_ptr<ComplianceMatrixType> m_threadMatrix;
     };
+
 };
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
@@ -191,6 +191,12 @@ protected:
     HexahedronFEMForceFieldInternalData<DataTypes> *data;
     friend class HexahedronFEMForceFieldInternalData<DataTypes>;
 
+    /**
+     * Computation of constant data that will be then reused during time steps:
+     * material stiffness matrices, rotations...
+     */
+    virtual void computeCachedData(const VecElement& elements);
+
 protected:
     HexahedronFEMForceField();
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
@@ -147,13 +147,19 @@ void HexahedronFEMForceField<DataTypes>::init()
 template <class DataTypes>
 void HexahedronFEMForceField<DataTypes>::reinit()
 {
+    computeCachedData(*this->getIndexedElements());
+}
+
+template <class DataTypes>
+void HexahedronFEMForceField<DataTypes>::computeCachedData(const VecElement& elements)
+{
     const VecCoord& p = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
     _initialPoints.setValue(p);
 
-    _materialsStiffnesses.resize(this->getIndexedElements()->size() );
-    _rotations.resize( this->getIndexedElements()->size() );
-    _rotatedInitialElements.resize(this->getIndexedElements()->size());
-    _initialrotations.resize( this->getIndexedElements()->size() );
+    _materialsStiffnesses.resize(elements.size() );
+    _rotations.resize( elements.size() );
+    _rotatedInitialElements.resize(elements.size());
+    _initialrotations.resize( elements.size() );
 
     if (f_method.getValue() == "large")
         this->setMethod(LARGE);
@@ -168,7 +174,7 @@ void HexahedronFEMForceField<DataTypes>::reinit()
     {
         sofa::Index i=0;
         typename VecElement::const_iterator it;
-        for(it = this->getIndexedElements()->begin() ; it != this->getIndexedElements()->end() ; ++it, ++i)
+        for(it = elements.begin() ; it != elements.end() ; ++it, ++i)
         {
             computeMaterialStiffness(i);
             initLarge(i,*it);
@@ -179,7 +185,7 @@ void HexahedronFEMForceField<DataTypes>::reinit()
     {
         sofa::Index i=0;
         typename VecElement::const_iterator it;
-        for(it = this->getIndexedElements()->begin() ; it != this->getIndexedElements()->end() ; ++it, ++i)
+        for(it = elements.begin() ; it != elements.end() ; ++it, ++i)
         {
             computeMaterialStiffness(i);
             initPolar(i,*it);
@@ -190,7 +196,7 @@ void HexahedronFEMForceField<DataTypes>::reinit()
     {
         sofa::Index i=0;
         typename VecElement::const_iterator it;
-        for(it = this->getIndexedElements()->begin() ; it != this->getIndexedElements()->end() ; ++it, ++i)
+        for(it = elements.begin() ; it != elements.end() ; ++it, ++i)
         {
             computeMaterialStiffness(i);
             initSmall(i,*it);

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/MutationListener.h
     ${SRC_ROOT}/Node.h
     ${SRC_ROOT}/Node.inl
+    ${SRC_ROOT}/ParallelForEach.h
     ${SRC_ROOT}/ParallelVisitorScheduler.h
     ${SRC_ROOT}/PauseEvent.h
     ${SRC_ROOT}/PipelineImpl.h

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
@@ -1,0 +1,197 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/CpuTaskStatus.h>
+#include <sofa/type/vector_T.h>
+
+namespace sofa::simulation
+{
+
+/**
+ * Represents an iterable sequence in a container
+ */
+template<class InputIt>
+struct Range
+{
+    InputIt start;
+    InputIt end;
+
+    Range(InputIt s, InputIt e) : start(s), end(e) {}
+};
+
+/**
+ * Function returning a list of ranges from an iterable container.
+ * The number of ranges depends on:
+ *  1) the desired number of ranges provided in a parameter
+ *  2) the number of elements in the container
+ * The number of elements in each range is homogenous, except for the last range which may contain
+ * more elements.
+ */
+template<class InputIt>
+sofa::type::vector<Range<InputIt> >
+makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nbRangesHint)
+{
+    sofa::type::vector<Range<InputIt> > ranges;
+
+    if (first == last)
+    {
+        return ranges;
+    }
+
+    const auto nbElements = static_cast<unsigned int>(std::distance(first, last));
+
+    const unsigned int nbRanges = std::min(nbRangesHint, nbElements);
+    ranges.reserve(nbRanges);
+
+    const auto nbElementsPerRange = nbElements / nbRanges;
+
+    Range<InputIt> r { first, first};
+    std::advance(r.end, nbElementsPerRange);
+
+    for (unsigned int i = 0; i < nbRanges - 1; ++i)
+    {
+        ranges.emplace_back(r);
+
+        std::advance(r.start, nbElementsPerRange);
+        std::advance(r.end, nbElementsPerRange);
+    }
+
+    ranges.emplace_back(r.start, last);
+
+    return ranges;
+}
+
+/**
+ * Applies the given function object f to the result of dereferencing every iterator in the
+ * range [first, last), in order.
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEach(InputIt first, InputIt last, UnaryFunction f)
+{
+    return std::for_each(first, last, f);
+}
+
+/**
+ * Applies the given function object f to the Range [first, last)
+ *
+ * The signature of the function f should be equivalent to the following:
+ * void fun(const Range<InputIt>& a);
+ * The signature does not need to have const &
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEachRange(InputIt first, InputIt last, UnaryFunction f)
+{
+    Range<InputIt> r{ first, last};
+    f(r);
+
+    return f;
+}
+
+/**
+ * Applies in parallel the given function object f to a list of ranges generated from [first, last)
+ *
+ * The signature of the function f should be equivalent to the following:
+ * void fun(const Range<InputIt>& a);
+ * The signature does not need to have const &.
+ *
+ * A task scheduler must be provided and correctly initiallized. The number of generated ranges
+ * depends on the threads available in the task scheduler.
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction parallelForEachRange(TaskScheduler& taskScheduler, InputIt first, InputIt last, UnaryFunction f)
+{
+    if (first != last)
+    {
+        const auto taskSchedulerThreadCount = taskScheduler.getThreadCount();
+        if (taskSchedulerThreadCount == 0)
+        {
+            msg_error("parallelForEach") << "Task scheduler does not appear to be initialized. Cannot perform parallel tasks.";
+            return forEachRange(first, last, f);
+        }
+
+        CpuTaskStatus status;
+
+        const auto ranges = makeRangesForLoop<InputIt>(first, last, taskSchedulerThreadCount);
+
+        for (const Range<InputIt>& r : ranges)
+        {
+            taskScheduler.addTask(status, [&r, &f]()
+            {
+                f(r);
+            });
+        }
+
+        taskScheduler.workUntilDone(&status);
+    }
+    return f;
+}
+
+/**
+ * Applies the given function object f to the result of dereferencing every iterator in the
+ * range [first, last), in parallel.
+ */
+template<class InputIt, class UnaryFunction>
+UnaryFunction parallelForEach(TaskScheduler& taskScheduler, InputIt first, InputIt last, UnaryFunction f)
+{
+    parallelForEachRange(taskScheduler, first, last,
+        [&f](const Range<InputIt>& r)
+        {
+            forEach(r.start, r.end, f);
+        });
+    return f;
+}
+
+
+enum class ForEachExecutionPolicy : bool
+{
+    SEQUENTIAL = false,
+    PARALLEL
+};
+
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEachRange(const ForEachExecutionPolicy execution, TaskScheduler& taskScheduler,
+                      InputIt first,
+                      InputIt last, UnaryFunction f)
+{
+    if (execution == ForEachExecutionPolicy::PARALLEL)
+    {
+        return parallelForEachRange(taskScheduler, first, last, f);
+    }
+    return forEachRange(first, last, f);
+}
+
+template<class InputIt, class UnaryFunction>
+UnaryFunction forEach(const ForEachExecutionPolicy execution, TaskScheduler& taskScheduler,
+                      InputIt first,
+                      InputIt last, UnaryFunction f)
+{
+    if (execution == ForEachExecutionPolicy::PARALLEL)
+    {
+        return parallelForEach(taskScheduler, first, last, f);
+    }
+    return forEach(first, last, f);
+}
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelForEach.h
@@ -41,6 +41,19 @@ struct Range
     Range(InputIt s, InputIt e) : start(s), end(e) {}
 };
 
+template<class InputIt, class Distance>
+void advance(InputIt& it, Distance n)
+{
+    if constexpr (std::is_integral_v<InputIt>)
+    {
+        it += n;
+    }
+    else
+    {
+        std::advance(it, n);
+    }
+}
+
 /**
  * Function returning a list of ranges from an iterable container.
  * The number of ranges depends on:
@@ -60,7 +73,15 @@ makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nb
         return ranges;
     }
 
-    const auto nbElements = static_cast<unsigned int>(std::distance(first, last));
+    unsigned int nbElements = 0;
+    if constexpr (std::is_integral_v<InputIt>)
+    {
+        nbElements = static_cast<unsigned int>(last - first);
+    }
+    else
+    {
+        nbElements = static_cast<unsigned int>(std::distance(first, last));
+    }
 
     const unsigned int nbRanges = std::min(nbRangesHint, nbElements);
     ranges.reserve(nbRanges);
@@ -68,14 +89,14 @@ makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nb
     const auto nbElementsPerRange = nbElements / nbRanges;
 
     Range<InputIt> r { first, first};
-    std::advance(r.end, nbElementsPerRange);
+    sofa::simulation::advance(r.end, nbElementsPerRange);
 
     for (unsigned int i = 0; i < nbRanges - 1; ++i)
     {
         ranges.emplace_back(r);
 
-        std::advance(r.start, nbElementsPerRange);
-        std::advance(r.end, nbElementsPerRange);
+        sofa::simulation::advance(r.start, nbElementsPerRange);
+        sofa::simulation::advance(r.end, nbElementsPerRange);
     }
 
     ranges.emplace_back(r.start, last);
@@ -90,7 +111,18 @@ makeRangesForLoop(const InputIt first, const InputIt last, const unsigned int nb
 template<class InputIt, class UnaryFunction>
 UnaryFunction forEach(InputIt first, InputIt last, UnaryFunction f)
 {
-    return std::for_each(first, last, f);
+    if constexpr (std::is_integral_v<InputIt>)
+    {
+        for (; first != last; ++first)
+        {
+            f(first);
+        }
+        return f;
+    }
+    else
+    {
+        return std::for_each(first, last, f);
+    }
 }
 
 /**

--- a/Sofa/framework/Simulation/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/test/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(Sofa.Simulation.Core_test)
 
 set(SOURCE_FILES
+    ParallelForEach_test.cpp
     RequiredPlugin_test.cpp
     TaskSchedulerTests.cpp
     TaskSchedulerTestTasks.h

--- a/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
@@ -146,6 +146,31 @@ TEST(ParallelForEach, emptyContainer) //just making sure it does not crash
     }
 }
 
+TEST(ParallelForEach, integers)
+{
+    std::vector<int> integers = makeTestData();
+    std::vector<int> integers2 = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, static_cast<std::size_t>(0), integers.size(),
+        [&integers, &integers2](const std::size_t& i)
+        {
+            integers[i]++;
+            integers2[i]--;
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers2[i], static_cast<int>(i) - 1);
+    }
+}
+
 TEST(ParallelForEachRange, nonInitializedTaskScheduler)
 {
     sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
@@ -192,6 +217,34 @@ TEST(ParallelForEachRange, incrementVectorLambda)
     for (std::size_t i = 0; i < integers.size(); ++i)
     {
         EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEachRange, integers)
+{
+    std::vector<int> integers = makeTestData();
+    std::vector<int> integers2 = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEachRange(*scheduler, static_cast<std::size_t>(0), integers.size(),
+        [&integers, &integers2](const auto& range)
+        {
+            for (auto it = range.start; it != range.end; ++it)
+            {
+                ++integers[it];
+                --integers2[it];
+            }
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers2[i], static_cast<int>(i) - 1);
     }
 }
 

--- a/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/ParallelForEach_test.cpp
@@ -1,0 +1,198 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/simulation/DefaultTaskScheduler.h>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <sofa/simulation/ParallelForEach.h>
+#include <sofa/testing/TestMessageHandler.h>
+
+#include <numeric>
+
+
+namespace sofa
+{
+
+std::vector<int> makeTestData(std::size_t nbIntegers = 1024)
+{
+    std::vector<int> integers(nbIntegers);
+    std::iota(integers.begin(), integers.end(), 0);
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i);
+    }
+
+    return integers;
+}
+
+TEST(ParallelForEach, makeRangesForLoop)
+{
+    std::vector<int> integers = makeTestData();
+
+    auto ranges = simulation::makeRangesForLoop(integers.begin(), integers.end(), 8u);
+    EXPECT_EQ(ranges.size(), 8);
+
+    for (const auto& r : ranges)
+    {
+        EXPECT_EQ(std::distance(r.start, r.end), integers.size() / 8)
+            << "start: " << std::distance(integers.begin(), r.start)
+            << ", end: " << std::distance(integers.begin(), r.end);
+    }
+
+
+    ranges = simulation::makeRangesForLoop(integers.begin(), integers.end(), 7u);
+    EXPECT_EQ(ranges.size(), 7);
+
+    for (unsigned int i = 0; i < ranges.size() - 1; ++i)
+    {
+        EXPECT_EQ(std::distance(ranges[i].start, ranges[i].end), integers.size() / 7);
+    }
+    EXPECT_EQ(std::distance(ranges.back().start, ranges.back().end), integers.size() - 6 * static_cast<std::size_t>(integers.size() / 7));
+
+
+    ranges = simulation::makeRangesForLoop(integers.begin(), integers.end(), 2048u);
+    EXPECT_EQ(ranges.size(), integers.size());
+
+    for (const auto& r : ranges)
+    {
+        EXPECT_EQ(std::distance(r.start, r.end), 1);
+    }
+}
+
+TEST(ParallelForEach, incrementVectorLambda)
+{
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), [](int& i) { ++i; });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEach, incrementVectorFunctor)
+{
+    struct Functor
+    {
+        void operator()(int& n)
+        {
+            ++n;
+        }
+    };
+
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), Functor{});
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEach, nbElementsLessThanThreads)
+{
+    std::vector<int> integers = makeTestData(3);
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(4);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), [](int& i) { ++i; });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEach, emptyContainer) //just making sure it does not crash
+{
+    std::vector<int> integers;
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEach(*scheduler, integers.begin(), integers.end(), [](int& i) { ++i; });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEachRange, nonInitializedTaskScheduler)
+{
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler =
+        simulation::MainTaskSchedulerFactory::instantiate(simulation::DefaultTaskScheduler::name());
+
+    EXPECT_MSG_EMIT(Error);
+    simulation::parallelForEachRange(*scheduler, integers.begin(), integers.end(),
+        [](const auto& range)
+        {
+            for (auto it = range.start; it != range.end; ++it)
+            {
+                int& i = *it;
+                ++i;
+            }
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+TEST(ParallelForEachRange, incrementVectorLambda)
+{
+    std::vector<int> integers = makeTestData();
+
+    simulation::TaskScheduler* scheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    scheduler->init(0);
+
+    simulation::parallelForEachRange(*scheduler, integers.begin(), integers.end(),
+        [](const auto& range)
+        {
+            for (auto it = range.start; it != range.end; ++it)
+            {
+                int& i = *it;
+                ++i;
+            }
+        });
+
+    for (std::size_t i = 0; i < integers.size(); ++i)
+    {
+        EXPECT_EQ(integers[i], i + 1);
+    }
+}
+
+}

--- a/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField_domainDecomposition.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField_domainDecomposition.scn
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<Node name="root" dt="0.02">
+    <RequiredPlugin name="MultiThreading"/> <!-- Needed to use components [ParallelHexahedronFEMForceField] -->
+    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
+    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
+    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <Node name="M1">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <MechanicalObject />
+        <UniformMass vertexMass="1" />
+        <RegularGridTopology nx="16" ny="16" nz="80" xmin="-1.5" xmax="1.5" ymin="-1.5" ymax="1.5" zmin="0" zmax="19" />
+        <BoxROI box="-1.5 -1.5 0 1.5 1.5 0.0001" name="box"/>
+        <FixedConstraint indices="@box.indices" />
+        <ParallelHexahedronFEMForceField name="FEM" youngModulus="400000" poissonRatio="0.4" method="large" updateStiffnessMatrix="false"
+                                         domainDecomposition="true"/>
+    </Node>
+</Node>

--- a/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField_domainDecomposition.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField_domainDecomposition.scn
@@ -9,8 +9,14 @@
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
     <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [HexahedronSetTopologyContainer, HexahedronSetTopologyModifier, QuadSetTopologyContainer, QuadSetTopologyModifier] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2QuadTopologicalMapping] -->
+    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
 
-    <VisualStyle displayFlags="showBehaviorModels hideForceFields showWireFrame" />
+
+    <DefaultAnimationLoop computeBoundingBox="false"/>
+    <VisualStyle displayFlags="showBehaviorModels hideForceFields showWireframe" />
 
     <Node name="M1">
         <EulerImplicitSolver name="cg_odesolver" printLog="false" rayleighStiffness="0.1" rayleighMass="0.1" />

--- a/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField_domainDecomposition.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField_domainDecomposition.scn
@@ -10,17 +10,33 @@
     <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
 
-    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+    <VisualStyle displayFlags="showBehaviorModels hideForceFields showWireFrame" />
 
     <Node name="M1">
         <EulerImplicitSolver name="cg_odesolver" printLog="false" rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MechanicalObject />
+        <MechanicalObject name="Volume" template="Vec3"/>
         <UniformMass vertexMass="1" />
-        <RegularGridTopology nx="16" ny="16" nz="80" xmin="-1.5" xmax="1.5" ymin="-1.5" ymax="1.5" zmin="0" zmax="19" />
+
+        <RegularGridTopology name="grid" nx="16" ny="16" nz="80" xmin="-1.5" xmax="1.5" ymin="-1.5" ymax="1.5" zmin="0" zmax="19" />
+
+        <HexahedronSetTopologyContainer name="Container" src="@grid"/>
+        <HexahedronSetTopologyModifier name="Modifier" />
+
         <BoxROI box="-1.5 -1.5 0 1.5 1.5 0.0001" name="box"/>
         <FixedConstraint indices="@box.indices" />
         <ParallelHexahedronFEMForceField name="FEM" youngModulus="400000" poissonRatio="0.4" method="large" updateStiffnessMatrix="false"
                                          domainDecomposition="true"/>
+
+        <Node name="surface">
+            <QuadSetTopologyContainer name="Container" />
+            <QuadSetTopologyModifier name="Modifier" />
+
+            <Hexa2QuadTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
     </Node>
 </Node>

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.h
@@ -91,6 +91,16 @@ protected:
                                type::Vec<8, Deriv>& OutF);
 
 
+    void addForceDomainDecomposition(WDataRefVecDeriv& _f, RDataRefVecCoord& _p,
+                         simulation::TaskScheduler* taskScheduler,
+                         const VecElementStiffness& elementStiffnesses);
+
+    void addForceLockBasedMethod(WDataRefVecDeriv& _f, RDataRefVecCoord& _p,
+                             simulation::TaskScheduler* taskScheduler,
+                             const VecElementStiffness& elementStiffnesses);
+
+
+
     void addDForceDomainDecomposition(WDataRefVecDeriv& _df, RDataRefVecCoord& _dx, Real kFactor,
                                       simulation::TaskScheduler* taskScheduler,
                                       const VecElementStiffness& elementStiffnesses);

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.h
@@ -111,6 +111,8 @@ protected:
 
     void initTaskScheduler();
 
+    void computeCachedData(const VecElement& elements) override;
+
     /**
      * Divide the model into smaller subdomains which can be solved independently.
      *
@@ -120,11 +122,14 @@ protected:
      */
     void decomposeDomain();
 
-    using Domain = sofa::type::vector<VecElement::const_iterator> ;
+    using ElementId = sofa::Index;
+    using Domain = sofa::type::vector<ElementId>;
     sofa::type::vector<Domain> m_domains;
 
+    VecElement m_reorderedElements;
+
     type::Vec<8, Deriv> computeDf(
-        std::size_t elementId, Element element, Real kFactor,
+        std::size_t elementId, const Element& element, Real kFactor,
         RDataRefVecCoord dx, const VecElementStiffness& elementStiffnesses);
 
 private:

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.inl
@@ -80,6 +80,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addForce(const core::Mechanical
     auto *taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler != nullptr);
 
+    const auto* indexedElements = this->getIndexedElements();
     this->m_potentialEnergy = 0;
 
     const auto& elementStiffnesses = this->_elementStiffnesses.getValue();
@@ -96,7 +97,7 @@ void ParallelHexahedronFEMForceField<DataTypes>::addForce(const core::Mechanical
     std::mutex mutex;
 
     simulation::parallelForEachRange(*taskScheduler,
-        this->getIndexedElements()->begin(), this->getIndexedElements()->end(),
+        indexedElements->begin(), indexedElements->end(),
         [this, &_p, &elementStiffnesses, &mutex, &_f](const auto& range)
         {
             auto elementId = std::distance(this->getIndexedElements()->begin(), range.start);


### PR DESCRIPTION
Based on https://github.com/sofa-framework/sofa/pull/3548

In the `addDForce` method, the parallel algorithm consists in computing a thread-specific `dF` and then combine them all in the main `dF`. It requires a synchronisation mechanism as it may create race conditions.

This PR introduce an alternative method which is lock-free. It divides the model into smaller subdomains that can be solved in parallel without synchronization.

Since the domains are visited sequentially (it's the elements of each domain that are visited in parallel), it comes with an overhead. Therefore, this method is particularly suited for large models where the overhead can be amortized.

I have the following results on the provided example:

```
1000 steps 
17775 elements (hexa)

domain decomposition:
35.1703 s ( 28.4331 FPS).

naive:
76.5666 s ( 13.0605 FPS)

sequential:
192.688 s ( 5.18974 FPS).
```

That's right: 17k elements simulated in real-time on a laptop CPU

As a comparison with the same scene where everything is on GPU, not only the `addDForce` method of `HexahedronFEMForceField`, but also the other components:
```
21.7437 s ( 45.9904 FPS).
```
with a RTX A3000 Laptop GPU
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
