### PR TITLE
[Multithreading] 2 steps to maximize coalescing memory access

### DIFF
--- a/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelHexahedronFEMForceField.scn
@@ -9,17 +9,37 @@
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
     <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [HexahedronSetTopologyContainer, HexahedronSetTopologyModifier, QuadSetTopologyContainer, QuadSetTopologyModifier] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2QuadTopologicalMapping] -->
+    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
 
-    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <VisualStyle displayFlags="showBehaviorModels hideForceFields showWireframe" />
 
     <Node name="M1">
         <EulerImplicitSolver name="cg_odesolver" printLog="false" rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MechanicalObject />
+        <MechanicalObject name="Volume" template="Vec3"/>
         <UniformMass vertexMass="1" />
-        <RegularGridTopology nx="8" ny="8" nz="40" xmin="-1.5" xmax="1.5" ymin="-1.5" ymax="1.5" zmin="0" zmax="19" />
+        <RegularGridTopology name="grid" nx="8" ny="8" nz="40" xmin="-1.5" xmax="1.5" ymin="-1.5" ymax="1.5" zmin="0" zmax="19" />
+
+        <HexahedronSetTopologyContainer name="Container" src="@grid"/>
+        <HexahedronSetTopologyModifier name="Modifier" />
+
         <BoxROI box="-1.5 -1.5 0 1.5 1.5 0.0001" name="box"/>
         <FixedConstraint indices="@box.indices" />
         <ParallelHexahedronFEMForceField name="FEM" youngModulus="400000" poissonRatio="0.4" method="large" updateStiffnessMatrix="false"/>
+
+        <Node name="surface">
+            <QuadSetTopologyContainer name="Container" />
+            <QuadSetTopologyModifier name="Modifier" />
+
+            <Hexa2QuadTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
     </Node>
 </Node>


### PR DESCRIPTION
`addDForce` is now divided in 2 steps:
1) Elements are visited in parallel: a force derivative is computed inside each element
2) Vertices are visited in parallel: the force derivative in all adjacent hexahedra are accumulated in the vertices

This new organization allows to write the force derivative such as it maximize coalescing memory access.

Benchmark (the cantilever beam in the examples):

```
 before (8x8x40)
 4.62651 s ( 216.146 FPS).

 before (16x16x80)
73.1133 s ( 13.6774 FPS)

 
 after (8x8x40)
 3.9425 s ( 253.646 FPS).

 after (16x16x80)
 65.4055 s ( 15.2892 FPS)


```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
