### PR TITLE
[MultiThreading] ParallelBruteForceBroadPhase: Fix assertion error

### DIFF
--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
@@ -129,8 +129,12 @@ void ParallelBruteForceBroadPhase::addCollisionModels(const sofa::type::vector<c
             }
             m_tasks.emplace_back(&status, first, last, intersectionMethod);
             taskScheduler->addTask(&m_tasks.back());
-            first += nbElements;
-            last += nbElements;
+
+            if (i < nbThreads - 1)
+            {
+                first += nbElements;
+                last += nbElements;
+            }
         }
     }
 


### PR DESCRIPTION
At the last stage of the loop, the iterator is already at end() value but it is  still being incremented.
(throwing an assertion error in Debug mode)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
