### PR TITLE
[Spring] Remove duplicated code

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.inl
@@ -194,26 +194,12 @@ void StiffSpringForceField<DataTypes>::addSpringDForce(VecDeriv& df1,const  VecD
 }
 
 template<class DataTypes>
-void StiffSpringForceField<DataTypes>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& data_f1, DataVecDeriv& data_f2, const DataVecCoord& data_x1, const DataVecCoord& data_x2, const DataVecDeriv& data_v1, const DataVecDeriv& data_v2 )
+void StiffSpringForceField<DataTypes>::addForce(const core::MechanicalParams* mparams, DataVecDeriv& data_f1, DataVecDeriv& data_f2, const DataVecCoord& data_x1, const DataVecCoord& data_x2, const DataVecDeriv& data_v1, const DataVecDeriv& data_v2 )
 {
-    VecDeriv&       f1 = *data_f1.beginEdit();
-    const VecCoord& x1 =  data_x1.getValue();
-    const VecDeriv& v1 =  data_v1.getValue();
-    VecDeriv&       f2 = *data_f2.beginEdit();
-    const VecCoord& x2 =  data_x2.getValue();
-    const VecDeriv& v2 =  data_v2.getValue();
-
-    const type::vector<Spring>& springs= this->springs.getValue();
+    const type::vector<Spring>& springs = this->springs.getValue();
     this->dfdx.resize(springs.size());
-    f1.resize(x1.size());
-    f2.resize(x2.size());
-    this->m_potentialEnergy = 0;
-    for (sofa::Index i=0; i<springs.size(); i++)
-    {
-        this->addSpringForce(this->m_potentialEnergy,f1,x1,v1,f2,x2,v2, i, springs[i]);
-    }
-    data_f1.endEdit();
-    data_f2.endEdit();
+
+    Inherit::addForce(mparams, data_f1, data_f2, data_x1, data_x2, data_v1, data_v2);
 }
 
 template<class DataTypes>


### PR DESCRIPTION
`StiffSpringForceField<DataTypes>::addForce` was duplicated from `SpringForceField<DataTypes>::addForce`, its base class. Only the resize of `dfdx` differed.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
