### PR TITLE
[Simulation] SceneCheck can be added in plugins

### DIFF
--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -76,6 +76,9 @@ set(HEADER_FILES
     ${SRC_ROOT}/Locks.h
     ${SRC_ROOT}/MainTaskSchedulerFactory.h
     ${SRC_ROOT}/MainTaskSchedulerRegistry.h
+    ${SRC_ROOT}/SceneCheck.h
+    ${SRC_ROOT}/SceneCheckRegistry.h
+    ${SRC_ROOT}/SceneCheckMainRegistry.h
     ${SRC_ROOT}/WorkerThread.h
     ${SRC_ROOT}/events/BuildConstraintSystemEndEvent.h
     ${SRC_ROOT}/events/SimulationInitDoneEvent.h
@@ -179,6 +182,9 @@ set(SOURCE_FILES
     ${SRC_ROOT}/RequiredPlugin.cpp
     ${SRC_ROOT}/ResetVisitor.cpp
     ${SRC_ROOT}/SceneLoaderFactory.cpp
+    ${SRC_ROOT}/SceneCheck.cpp
+    ${SRC_ROOT}/SceneCheckRegistry.cpp
+    ${SRC_ROOT}/SceneCheckMainRegistry.cpp
     ${SRC_ROOT}/Simulation.cpp
     ${SRC_ROOT}/SolveVisitor.cpp
     ${SRC_ROOT}/StateChangeVisitor.cpp

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#include <sofa/simulation/SceneCheck.h>
 
-namespace sofa
+namespace sofa::simulation
 {
 
-namespace component
-{
+SceneCheck::~SceneCheck() = default;
+void SceneCheck::doPrintSummary() {}
+void SceneCheck::doInit(sofa::simulation::Node* node) { SOFA_UNUSED(node); }
 
-namespace mapping
-{
-
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
-
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
-
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,28 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#pragma once
 
-namespace sofa
+#include <sofa/simulation/config.h>
+
+#include <string>
+#include <memory>
+
+namespace sofa::simulation
 {
+class Node;
 
-namespace component
+class SOFA_SIMULATION_CORE_API SceneCheck
 {
+public:
+    virtual ~SceneCheck();
 
-namespace mapping
-{
+    typedef std::shared_ptr<SceneCheck> SPtr;
+    virtual const std::string getName() = 0;
+    virtual const std::string getDesc() = 0;
+    virtual void doInit(sofa::simulation::Node* node);
+    virtual void doCheckOn(sofa::simulation::Node* node) = 0;
+    virtual void doPrintSummary();
+};
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
-
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
-
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+} // namespace sofa::simulation

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckMainRegistry.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckMainRegistry.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,41 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
 
-namespace sofa
+namespace sofa::simulation
 {
 
-namespace component
+std::mutex SceneCheckMainRegistry::s_mutex;
+
+bool SceneCheckMainRegistry::addToRegistry(const SceneCheck::SPtr& sceneCheck)
 {
+    std::lock_guard lock(s_mutex);
+    return getInstance().addToRegistry(sceneCheck);
+}
 
-namespace mapping
+void SceneCheckMainRegistry::removeFromRegistry(const SceneCheck::SPtr& sceneCheck)
 {
+    std::lock_guard lock(s_mutex);
+    getInstance().removeFromRegistry(sceneCheck);
+}
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
+void SceneCheckMainRegistry::clearRegistry()
+{
+    std::lock_guard lock(s_mutex);
+    getInstance().clearRegistry();
+}
 
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
+const type::vector<SceneCheck::SPtr>& SceneCheckMainRegistry::getRegisteredSceneChecks()
+{
+    std::lock_guard lock(s_mutex);
+    return getInstance().getRegisteredSceneChecks();
+}
 
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
+SceneCheckRegistry& SceneCheckMainRegistry::getInstance()
+{
+    static SceneCheckRegistry registry;
+    return registry;
+}
 
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckMainRegistry.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckMainRegistry.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,25 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#pragma once
 
-namespace sofa
+#include <sofa/simulation/SceneCheckRegistry.h>
+#include <mutex>
+
+namespace sofa::simulation
 {
 
-namespace component
+class SOFA_SIMULATION_CORE_API SceneCheckMainRegistry
 {
+public:
+    static bool addToRegistry(const SceneCheck::SPtr& sceneCheck);
+    static void removeFromRegistry(const SceneCheck::SPtr& sceneCheck);
+    static void clearRegistry();
+    static const type::vector<SceneCheck::SPtr>& getRegisteredSceneChecks();
 
-namespace mapping
-{
+private:
+    static std::mutex s_mutex;
+    static SceneCheckRegistry& getInstance();
+};
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
-
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
-
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,34 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#include <sofa/simulation/SceneCheckRegistry.h>
 
-namespace sofa
+namespace sofa::simulation
 {
 
-namespace component
+bool SceneCheckRegistry::addToRegistry(const SceneCheck::SPtr& sceneCheck)
 {
+    if( std::find(m_registeredSceneChecks.begin(), m_registeredSceneChecks.end(), sceneCheck) == m_registeredSceneChecks.end() )
+    {
+        m_registeredSceneChecks.push_back(sceneCheck) ;
+        return true;
+    }
+    return false;
+}
 
-namespace mapping
+void SceneCheckRegistry::removeFromRegistry(const SceneCheck::SPtr& sceneCheck)
 {
+    m_registeredSceneChecks.erase( std::remove( m_registeredSceneChecks.begin(), m_registeredSceneChecks.end(), sceneCheck ), m_registeredSceneChecks.end() );
+}
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
+void SceneCheckRegistry::clearRegistry()
+{
+    m_registeredSceneChecks.clear();
+}
 
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
+const type::vector<SceneCheck::SPtr>& SceneCheckRegistry::getRegisteredSceneChecks() const
+{
+    return m_registeredSceneChecks;
+}
 
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
-
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.cpp
@@ -26,12 +26,13 @@ namespace sofa::simulation
 
 bool SceneCheckRegistry::addToRegistry(const SceneCheck::SPtr& sceneCheck)
 {
-    if( std::find(m_registeredSceneChecks.begin(), m_registeredSceneChecks.end(), sceneCheck) == m_registeredSceneChecks.end() )
+    const auto it = std::find(m_registeredSceneChecks.begin(), m_registeredSceneChecks.end(), sceneCheck);
+    const auto found = it != m_registeredSceneChecks.end();
+    if(!found)
     {
-        m_registeredSceneChecks.push_back(sceneCheck) ;
-        return true;
+        m_registeredSceneChecks.push_back(sceneCheck);
     }
-    return false;
+    return !found;
 }
 
 void SceneCheckRegistry::removeFromRegistry(const SceneCheck::SPtr& sceneCheck)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/SceneCheckRegistry.h>
+#include <algorithm>
 
 namespace sofa::simulation
 {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckRegistry.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,27 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#pragma once
 
-namespace sofa
+#include <sofa/simulation/SceneCheck.h>
+#include <sofa/type/vector.h>
+
+namespace sofa::simulation
 {
 
-namespace component
+class SOFA_SIMULATION_CORE_API SceneCheckRegistry
 {
+public:
+    bool addToRegistry(const SceneCheck::SPtr& sceneCheck);
+    void removeFromRegistry(const SceneCheck::SPtr& sceneCheck);
+    void clearRegistry();
 
-namespace mapping
-{
+    [[nodiscard]]
+    const type::vector<SceneCheck::SPtr>& getRegisteredSceneChecks() const;
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
-
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
-
+private:
+    type::vector<SceneCheck::SPtr> m_registeredSceneChecks;
+};
 
 
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+}

--- a/Sofa/framework/Simulation/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCE_FILES
     TaskSchedulerTestTasks.h
     TaskSchedulerTestTasks.cpp
     TaskSchedulerFactory_test.cpp
+    SceneCheckRegistry_test.cpp
     )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/Sofa/framework/Simulation/Core/test/SceneCheckRegistry_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/SceneCheckRegistry_test.cpp
@@ -1,0 +1,59 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/simulation/SceneCheckRegistry.h>
+
+namespace sofa
+{
+
+class DummySceneCheck : public sofa::simulation::SceneCheck
+{
+    const std::string getName() override { return "DummySceneCheck"; }
+    const std::string getDesc() override { return "For tests"; }
+    void doCheckOn(sofa::simulation::Node*) override {}
+};
+
+TEST(SceneCheckRegistry, addToRegistry)
+{
+    simulation::SceneCheckRegistry registry;
+
+    EXPECT_TRUE(registry.getRegisteredSceneChecks().empty());
+
+    const auto sceneCheck = std::make_shared<DummySceneCheck>();
+    EXPECT_TRUE(registry.addToRegistry(sceneCheck));
+
+    EXPECT_FALSE(registry.getRegisteredSceneChecks().empty());
+    EXPECT_EQ(registry.getRegisteredSceneChecks().size(), 1);
+
+    const auto anotherSceneCheck = std::make_shared<DummySceneCheck>();
+    EXPECT_TRUE(registry.addToRegistry(anotherSceneCheck));
+
+    EXPECT_FALSE(registry.getRegisteredSceneChecks().empty());
+    EXPECT_EQ(registry.getRegisteredSceneChecks().size(), 2);
+
+    EXPECT_FALSE(registry.addToRegistry(sceneCheck));
+    EXPECT_EQ(registry.getRegisteredSceneChecks().size(), 2);
+
+    registry.removeFromRegistry(anotherSceneCheck);
+    EXPECT_EQ(registry.getRegisteredSceneChecks().size(), 1);
+}
+}

--- a/applications/plugins/MultiThreading/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/CMakeLists.txt
@@ -18,6 +18,8 @@ set(HEADER_FILES
     src/MultiThreading/ParallelHexahedronFEMForceField.inl
     src/MultiThreading/ParallelTetrahedronFEMForceField.h
     src/MultiThreading/ParallelTetrahedronFEMForceField.inl
+    src/MultiThreading/SceneCheckMultithreading.h
+    src/MultiThreading/ParallelImplementationsRegistry.h
     )
 
 set(SOURCE_FILES
@@ -31,6 +33,8 @@ set(SOURCE_FILES
     src/MultiThreading/ParallelBVHNarrowPhase.cpp
     src/MultiThreading/ParallelHexahedronFEMForceField.cpp
     src/MultiThreading/ParallelTetrahedronFEMForceField.cpp
+    src/MultiThreading/SceneCheckMultithreading.cpp
+    src/MultiThreading/ParallelImplementationsRegistry.cpp
     )
 
 find_package(Sofa.Simulation.Common REQUIRED)

--- a/applications/plugins/MultiThreading/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/CMakeLists.txt
@@ -3,6 +3,7 @@ project(MultiThreading VERSION 0.1)
 
 set(HEADER_FILES
     src/MultiThreading/config.h
+    src/MultiThreading/initMultiThreading.h
     src/MultiThreading/AnimationLoopParallelScheduler.h
     src/MultiThreading/AnimationLoopTasks.h
     src/MultiThreading/BeamLinearMapping_mt.h

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
@@ -28,9 +28,14 @@
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <MultiThreading/ParallelImplementationsRegistry.h>
 
 namespace sofa::component::collision
 {
+
+const bool isParallelBVHNarrowPhaseImplementationRegistered =
+    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BVHNarrowPhase", "ParallelBVHNarrowPhase");
+
 
 using sofa::helper::ScopedAdvancedTimer;
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBruteForceBroadPhase.cpp
@@ -26,9 +26,13 @@
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <MultiThreading/ParallelImplementationsRegistry.h>
 
 namespace sofa::component::collision
 {
+
+const bool isParallelParallelBruteForceBroadPhaseImplementationRegistered =
+    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BruteForceBroadPhase", "ParallelBruteForceBroadPhase");
 
 using sofa::helper::ScopedAdvancedTimer;
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelHexahedronFEMForceField.cpp
@@ -23,10 +23,14 @@
 #include <MultiThreading/ParallelHexahedronFEMForceField.inl>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
-#include "ParallelHexahedronFEMForceField.h"
+
+#include <MultiThreading/ParallelImplementationsRegistry.h>
 
 namespace sofa::component::forcefield
 {
+
+const bool isParallelHexahedronFEMForceFieldImplementationRegistered =
+    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("HexahedronFEMForceField", "ParallelHexahedronFEMForceField");
 
 using namespace sofa::defaulttype;
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.cpp
@@ -1,0 +1,88 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <MultiThreading/ParallelImplementationsRegistry.h>
+#include <sofa/helper/logging/Messaging.h>
+
+namespace multithreading
+{
+
+sofa::type::vector<ParallelImplementationsRegistry::Implementation> ParallelImplementationsRegistry::s_implementations;
+
+bool ParallelImplementationsRegistry::addEquivalentImplementations(
+    const std::string& sequentialImplementation, const std::string& parallelImplementation)
+{
+    const Implementation implementation{sequentialImplementation, parallelImplementation};
+
+    const auto it = findParallelImplementationImpl(sequentialImplementation);
+
+    if (it == s_implementations.end())
+    {
+        s_implementations.push_back(implementation);
+        return true;
+    }
+
+    if (parallelImplementation != it->parallel)
+    {
+        msg_error("ParallelImplementationsRegistry")
+            << "Trying to register the sequential implementation '"
+            << sequentialImplementation << "' with the parallel implementation ''"
+            << parallelImplementation << "' but it has already been registered with the parallel implementation: '"
+            << it->parallel << "'";
+    }
+    else
+    {
+        msg_warning("ParallelImplementationsRegistry")
+            << "The sequential implementation '" << sequentialImplementation << "' has already "
+            << "been registered to the parallel implementation '" << parallelImplementation << "'";
+    }
+    return false;
+}
+
+std::string ParallelImplementationsRegistry::findParallelImplementation(
+    const std::string& sequentialImplementation)
+{
+    const auto it = findParallelImplementationImpl(sequentialImplementation);
+
+    if (it != s_implementations.end())
+    {
+        return it->parallel;
+    }
+    return {};
+}
+
+const sofa::type::vector<ParallelImplementationsRegistry::Implementation>&
+ParallelImplementationsRegistry::getImplementations()
+{
+    return s_implementations;
+}
+
+sofa::type::vector<ParallelImplementationsRegistry::Implementation>::const_iterator
+ParallelImplementationsRegistry::findParallelImplementationImpl(
+    const std::string& sequentialImplementation)
+{
+    return std::find_if(s_implementations.begin(), s_implementations.end(),
+        [&sequentialImplementation](const Implementation& i)
+        {
+            return i.sequential == sequentialImplementation;
+        });
+}
+}

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,34 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#pragma once
 
-namespace sofa
+#include <MultiThreading/config.h>
+#include <sofa/type/vector.h>
+
+#include <mutex>
+#include <string>
+
+namespace multithreading
 {
 
-namespace component
+class SOFA_MULTITHREADING_PLUGIN_API ParallelImplementationsRegistry
 {
+public:
+    struct Implementation
+    {
+        std::string sequential;
+        std::string parallel;
+    };
 
-namespace mapping
-{
+    static bool addEquivalentImplementations(const std::string& sequentialImplementation, const std::string& parallelImplementation);
+    static std::string findParallelImplementation(const std::string& sequentialImplementation);
+    static const sofa::type::vector<Implementation>& getImplementations();
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
+private:
+    static sofa::type::vector<Implementation> s_implementations;
 
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
+    static sofa::type::vector<Implementation>::const_iterator findParallelImplementationImpl(const std::string& sequentialImplementation);
+};
 
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
-
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+}

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelTetrahedronFEMForceField.cpp
@@ -24,10 +24,15 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
 
+#include <MultiThreading/ParallelImplementationsRegistry.h>
+
 namespace sofa::component::forcefield
 {
 
 using namespace sofa::defaulttype;
+
+const bool isParallelTetrahedronFEMForceFieldImplementationRegistered =
+    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("TetrahedronFEMForceField", "ParallelTetrahedronFEMForceField");
 
 // Register in the Factory
 int ParallelTetrahedronFEMForceFieldClass = core::RegisterObject("Parallel tetrahedral finite elements")

--- a/applications/plugins/MultiThreading/src/MultiThreading/SceneCheckMultithreading.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/SceneCheckMultithreading.cpp
@@ -1,0 +1,115 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <MultiThreading/SceneCheckMultithreading.h>
+#include <sofa/simulation/Node.h>
+
+#include <MultiThreading/ParallelImplementationsRegistry.h>
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
+
+namespace multithreading::_scenechecking_
+{
+
+const bool SceneCheckMultithreadingRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckMultithreading::newSPtr());
+
+std::shared_ptr<SceneCheckMultithreading> SceneCheckMultithreading::newSPtr()
+{
+    return std::make_shared<SceneCheckMultithreading>();
+}
+
+const std::string SceneCheckMultithreading::getName()
+{
+    return "SceneCheckMultithreading";
+}
+
+const std::string SceneCheckMultithreading::getDesc()
+{
+    return "Check if there are opportunities to use multithreading, and potentially improve the performances,"
+           " by replacing components by their parallel implementations";
+}
+
+void SceneCheckMultithreading::doInit(sofa::simulation::Node* node)
+{
+    m_summary.clear();
+}
+
+void SceneCheckMultithreading::doCheckOn(sofa::simulation::Node* node)
+{
+    if (node == nullptr)
+        return;
+
+    for (auto& object : node->object )
+    {
+        if (object)
+        {
+            const auto parallelImplementation =
+                multithreading::ParallelImplementationsRegistry::findParallelImplementation(object->getClassName());
+
+            if (!parallelImplementation.empty())
+            {
+                if (sofa::core::ObjectFactory::getInstance()->hasCreator(parallelImplementation))
+                {
+                    const auto& entry = sofa::core::ObjectFactory::getInstance()->getEntry(parallelImplementation);
+                    auto it = entry.creatorMap.find(object->getTemplateName());
+                    if (it != entry.creatorMap.end())
+                    {
+                        std::string seq = object->getClassName();
+                        if (!object->getTemplateName().empty())
+                        {
+                            seq += "[" + object->getTemplateName() + "]";
+                        }
+                        std::string par = entry.className;
+                        if (!it->first.empty())
+                        {
+                            par += "[" + it->first + "]";
+                        }
+                        m_summary.insert({seq, par });
+                    }
+                }
+                else
+                {
+                    msg_error(object.get()) << "The component has a equivalent parallel implementation '"
+                        << parallelImplementation << "' but it cannot be found in the object factory";
+                }
+            }
+        }
+    }
+}
+
+void SceneCheckMultithreading::doPrintSummary()
+{
+    if (!m_summary.empty())
+    {
+        std::stringstream ss;
+        for (const auto& [seq, par] : m_summary)
+        {
+            ss << "\t" << seq << " -> " << par << msgendl;
+        }
+        msg_advice(this->getName()) << "This scene is using components implemented sequentially while "
+            << "a parallel implementation is available. Using the parallel implementation may improve "
+            "the performances. Here is the list of sequential components in your scene and "
+            "their parallel equivalent: " << msgendl << ss.str();
+    }
+}
+}
+
+

--- a/applications/plugins/MultiThreading/src/MultiThreading/SceneCheckMultithreading.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/SceneCheckMultithreading.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,33 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
-#include <MultiThreading/ParallelImplementationsRegistry.h>
+#pragma once
 
-namespace sofa
+#include <MultiThreading/config.h>
+#include <sofa/simulation/SceneCheck.h>
+
+#include <set>
+
+namespace multithreading::_scenechecking_
 {
 
-namespace component
+class SOFA_MULTITHREADING_PLUGIN_API SceneCheckMultithreading : public sofa::simulation::SceneCheck
 {
+public:
+    virtual ~SceneCheckMultithreading() {}
 
-namespace mapping
-{
+    typedef std::shared_ptr<SceneCheckMultithreading> SPtr;
+    static std::shared_ptr<SceneCheckMultithreading> newSPtr();
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
+    const std::string getName() override;
+    const std::string getDesc() override;
+    void doInit(sofa::simulation::Node* node) override;
+    void doCheckOn(sofa::simulation::Node* node) override;
+    void doPrintSummary() override;
 
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
+private:
 
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
+    std::set<std::pair<std::string, std::string> > m_summary;
+};
 
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+} //namespace sofa::_scenechecking_

--- a/applications/plugins/MultiThreading/src/MultiThreading/initMultiThreading.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/initMultiThreading.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,58 +19,11 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#pragma once
+
 #include <MultiThreading/config.h>
-#include <MultiThreading/initMultiThreading.h>
 
 namespace multithreading
 {
-
-extern "C" {
-SOFA_MULTITHREADING_PLUGIN_API void initExternalModule();
-SOFA_MULTITHREADING_PLUGIN_API const char* getModuleName();
-SOFA_MULTITHREADING_PLUGIN_API const char* getModuleVersion();
-SOFA_MULTITHREADING_PLUGIN_API const char* getModuleLicense();
-SOFA_MULTITHREADING_PLUGIN_API const char* getModuleDescription();
-SOFA_MULTITHREADING_PLUGIN_API const char* getModuleComponentList();
-}
-
-void init()
-{
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
-}
-
-void initExternalModule()
-{
-    init();
-}
-
-const char* getModuleName()
-{
-    return "MultiThreading";
-}
-
-const char* getModuleVersion()
-{
-    return "1.0";
-}
-
-const char* getModuleLicense()
-{
-    return "LGPL";
-}
-
-const char* getModuleDescription()
-{
-    return "MultiThreading SOFA Framework";
-}
-
-const char* getModuleComponentList()
-{
-    return "DataExchange, AnimationLoopParallelScheduler ";
-}
-
+SOFA_MULTITHREADING_PLUGIN_API void init();
 }

--- a/applications/plugins/MultiThreading/test/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set ( HEADER_FILES
 set(SOURCE_FILES
     DataExchange_test.cpp
     MeanComputation_test.cpp
+    ParallelImplementationsRegistry_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})

--- a/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
+++ b/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <gtest/gtest.h>
+#include <MultiThreading/initMultiThreading.h>
 #include <MultiThreading/ParallelImplementationsRegistry.h>
 #include <sofa/core/ObjectFactory.h>
 
@@ -28,6 +29,8 @@ namespace multithreading
 
 TEST(ParallelImplementationsRegistry, existInObjectFactory)
 {
+    multithreading::init();
+
     const auto implementations = ParallelImplementationsRegistry::getImplementations();
     ASSERT_FALSE(implementations.empty());
 

--- a/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
+++ b/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,42 +19,25 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "BeamLinearMapping_mt.inl"
-#include <sofa/core/ObjectFactory.h>
-//#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
+#include <gtest/gtest.h>
 #include <MultiThreading/ParallelImplementationsRegistry.h>
+#include <sofa/core/ObjectFactory.h>
 
-namespace sofa
+namespace multithreading
 {
 
-namespace component
+TEST(ParallelImplementationsRegistry, existInObjectFactory)
 {
+    const auto implementations = ParallelImplementationsRegistry::getImplementations();
+    ASSERT_FALSE(implementations.empty());
 
-namespace mapping
-{
+    for (const auto& [seq, par] : implementations)
+    {
+        ASSERT_FALSE(seq.empty());
+        ASSERT_FALSE(par.empty());
 
-const bool isBeamLinearMapping_mtImplementationRegistered =
-    multithreading::ParallelImplementationsRegistry::addEquivalentImplementations("BeamLinearMapping", "BeamLinearMapping_mt");
-
-//using namespace defaulttype;
-// Register in the Factory
-int BeamLinearMapping_mtClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping_mt< Rigid3Types, Vec3dTypes > >()
-
-
-
-        ;
-
-template class BeamLinearMapping_mt< Rigid3Types, Vec3dTypes >;
-
-
-
-
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
+        EXPECT_TRUE(sofa::core::ObjectFactory::getInstance()->hasCreator(seq));
+        EXPECT_TRUE(sofa::core::ObjectFactory::getInstance()->hasCreator(par));
+    }
+}
+}

--- a/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
+++ b/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
@@ -29,10 +29,7 @@ namespace multithreading
 
 TEST(ParallelImplementationsRegistry, existInObjectFactory)
 {
-    multithreading::init();
-
     const auto implementations = ParallelImplementationsRegistry::getImplementations();
-    ASSERT_FALSE(implementations.empty());
 
     for (const auto& [seq, par] : implementations)
     {

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheck.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheck.h
@@ -22,36 +22,14 @@
 #pragma once
 
 #include <SceneChecking/config.h>
-
-#include <iostream>
-#include <string>
-#include <map>
-#include <memory>
-
-namespace sofa::simulation
-{
-    class Node;
-} // namespace sofa::simulation
+SOFA_DEPRECATED_HEADER("v23.06", "v23.12", "sofa/simulation/SceneCheck.h")
+#include <sofa/simulation/SceneCheck.h>
 
 namespace sofa::_scenechecking_
 {
-
-class SOFA_SCENECHECKING_API SceneCheck
-{
-public:
-    virtual ~SceneCheck() {}
-
-    typedef std::shared_ptr<SceneCheck> SPtr;
-    virtual const std::string getName() = 0;
-    virtual const std::string getDesc() = 0;
-    virtual void doInit(sofa::simulation::Node* node) { SOFA_UNUSED(node); }
-    virtual void doCheckOn(sofa::simulation::Node* node) = 0;
-    virtual void doPrintSummary() {}
-};
-
-} // namespace sofa::_scenechecking_
-
+    using sofa::simulation::SceneCheck;
+}
 namespace sofa::scenechecking
 {
-    using _scenechecking_::SceneCheck;
+    using sofa::simulation::SceneCheck;
 } // namespace sofa::scenechecking

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.cpp
@@ -33,8 +33,12 @@ using sofa::simulation::Node;
 #include <sofa/component/sceneutility/APIVersion.h>
 using sofa::component::sceneutility::APIVersion;
 
+#include <sofa/simulation/SceneCheckMainRegistry.h>
+
 namespace sofa::_scenechecking_
 {
+
+// const bool SceneCheckAPIChangeRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckAPIChange::newSPtr());
 
 SceneCheckAPIChange::SceneCheckAPIChange()
 {

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.h
@@ -23,13 +23,12 @@
 
 #include <SceneChecking/config.h>
 
-#include <SceneChecking/SceneCheck.h>
-
 #include <sofa/version.h>
 #include <string>
 #include <map>
 #include <vector>
 #include <functional>
+#include <sofa/simulation/SceneCheck.h>
 
 namespace sofa::simulation
 {
@@ -46,7 +45,7 @@ namespace sofa::_scenechecking_
 
 typedef std::function<void(sofa::core::objectmodel::Base*)>     ChangeSetHookFunction;
 
-class SOFA_SCENECHECKING_API SceneCheckAPIChange : public SceneCheck
+class SOFA_SCENECHECKING_API SceneCheckAPIChange : public sofa::simulation::SceneCheck
 {
 public:
     SceneCheckAPIChange();

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
@@ -25,9 +25,12 @@
 #include <sofa/component/collision/response/contact/DefaultContactManager.h>
 #include <sofa/core/behavior/BaseAnimationLoop.h>
 #include <sofa/core/behavior/ConstraintSolver.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
 
 namespace sofa::_scenechecking_
 {
+
+const bool SceneCheckCollisionResponseRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckCollisionResponse::newSPtr());
 
 using sofa::simulation::Node;
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <SceneChecking/config.h>
-#include <SceneChecking/SceneCheck.h>
+#include <sofa/simulation/SceneCheck.h>
 
 #include <map>
 #include <sstream>
@@ -30,7 +30,7 @@
 namespace sofa::_scenechecking_
 {
     
-class SOFA_SCENECHECKING_API SceneCheckCollisionResponse : public SceneCheck
+class SOFA_SCENECHECKING_API SceneCheckCollisionResponse : public sofa::simulation::SceneCheck
 {
 public:
     virtual ~SceneCheckCollisionResponse() {}

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
@@ -22,6 +22,7 @@
 #include <SceneChecking/SceneCheckDeprecatedComponents.h>
 
 #include <sofa/simulation/Node.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
 using sofa::simulation::Node;
 
 #include <sofa/helper/ComponentChange.h>
@@ -29,6 +30,8 @@ using sofa::helper::lifecycle::deprecatedComponents;
 
 namespace sofa::_scenechecking_
 {
+
+const bool SceneCheckDeprecatedComponentsRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckDeprecatedComponents::newSPtr());
 
 const std::string SceneCheckDeprecatedComponents::getName()
 {

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.h
@@ -22,12 +22,12 @@
 #pragma once
 
 #include <SceneChecking/config.h>
-#include <SceneChecking/SceneCheck.h>
+#include <sofa/simulation/SceneCheck.h>
 
 namespace sofa::_scenechecking_
 {
 
-class SOFA_SCENECHECKING_API SceneCheckDeprecatedComponents : public SceneCheck
+class SOFA_SCENECHECKING_API SceneCheckDeprecatedComponents : public sofa::simulation::SceneCheck
 {
 public:
     virtual ~SceneCheckDeprecatedComponents() {}
@@ -40,4 +40,4 @@ public:
     void doPrintSummary() override;
 };
 
-} //namespace sofa::_scenechecking_
+}

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
@@ -22,9 +22,12 @@
 #include "SceneCheckDuplicatedName.h"
 
 #include <sofa/simulation/Node.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
 
 namespace sofa::_scenechecking_
 {
+
+const bool SceneCheckDuplicatedNameRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckDuplicatedName::newSPtr());
 
 using sofa::simulation::Node;
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <SceneChecking/config.h>
-#include <SceneChecking/SceneCheck.h>
+#include <sofa/simulation/SceneCheck.h>
 
 #include <map>
 #include <sstream>
@@ -30,7 +30,7 @@
 namespace sofa::_scenechecking_
 {
     
-class SOFA_SCENECHECKING_API SceneCheckDuplicatedName : public SceneCheck
+class SOFA_SCENECHECKING_API SceneCheckDuplicatedName : public sofa::simulation::SceneCheck
 {
 public:
     virtual ~SceneCheckDuplicatedName() {}

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
@@ -27,9 +27,12 @@
 
 #include <sofa/simulation/RequiredPlugin.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
 
 namespace sofa::_scenechecking_
 {
+
+const bool SceneCheckMissingRequiredPluginRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckMissingRequiredPlugin::newSPtr());
 
 using sofa::core::objectmodel::Base;
 using sofa::simulation::RequiredPlugin;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <SceneChecking/config.h>
-#include <SceneChecking/SceneCheck.h>
+#include <sofa/simulation/SceneCheck.h>
 
 #include <map>
 #include <vector>
@@ -36,7 +36,7 @@ namespace sofa::simulation
 namespace sofa::_scenechecking_
 {
 
-class SOFA_SCENECHECKING_API SceneCheckMissingRequiredPlugin : public SceneCheck
+class SOFA_SCENECHECKING_API SceneCheckMissingRequiredPlugin : public sofa::simulation::SceneCheck
 {
 public:
     typedef std::shared_ptr<SceneCheckMissingRequiredPlugin> SPtr;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.cpp
@@ -24,10 +24,13 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/helper/ComponentChange.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
 
 
 namespace sofa::_scenechecking_
 {
+
+const bool SceneCheckUsingAliasRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckUsingAlias::newSPtr());
 
 using sofa::core::objectmodel::Base;
 using sofa::core::objectmodel::BaseObjectDescription;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <SceneChecking/config.h>
-#include <SceneChecking/SceneCheck.h>
+#include <sofa/simulation/SceneCheck.h>
 
 #include <map>
 #include <vector>
@@ -30,7 +30,7 @@
 namespace sofa::_scenechecking_
 {
     
-class SOFA_SCENECHECKING_API SceneCheckUsingAlias : public SceneCheck
+class SOFA_SCENECHECKING_API SceneCheckUsingAlias : public sofa::simulation::SceneCheck
 {
 public:
     SceneCheckUsingAlias();

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.cpp
@@ -22,23 +22,11 @@
 #include "SceneCheckerListener.h"
 
 #include <sofa/simulation/Node.h>
-#include <SceneChecking/SceneCheckMissingRequiredPlugin.h>
-#include <SceneChecking/SceneCheckDuplicatedName.h>
-#include <SceneChecking/SceneCheckUsingAlias.h>
-#include <SceneChecking/SceneCheckDeprecatedComponents.h>
-#include <SceneChecking/SceneCheckCollisionResponse.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
+#include <SceneChecking/SceneCheckerVisitor.h>
 
 namespace sofa::_scenechecking_
 {
-
-SceneCheckerListener::SceneCheckerListener()
-{
-    m_sceneChecker.addCheck(SceneCheckDuplicatedName::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckUsingAlias::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckDeprecatedComponents::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckCollisionResponse::newSPtr());
-}
 
 SceneCheckerListener* SceneCheckerListener::getInstance()
 {
@@ -49,7 +37,16 @@ SceneCheckerListener* SceneCheckerListener::getInstance()
 void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr node)
 {
     if(node.get())
-        m_sceneChecker.validate(node.get());
+    {
+        sofa::scenechecking::SceneCheckerVisitor sceneCheckerVisitor;
+
+        for (const auto& sceneCheck : sofa::simulation::SceneCheckMainRegistry::getRegisteredSceneChecks())
+        {
+            sceneCheckerVisitor.addCheck(sceneCheck);
+        }
+
+        sceneCheckerVisitor.validate(node.get());
+    }
 }
 
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.h
@@ -26,8 +26,7 @@
 #include <sofa/simulation/SceneLoaderFactory.h>
 #include <sofa/simulation/Visitor.h>
 
-#include <SceneChecking/SceneCheckerVisitor.h>
-using sofa::scenechecking::SceneCheckerVisitor;
+
 
 
 namespace sofa::_scenechecking_
@@ -50,8 +49,7 @@ public:
     }
 
 private:
-    SceneCheckerListener();
-    SceneCheckerVisitor m_sceneChecker;
+    SceneCheckerListener() = default;
 };
 
 } // namespace sofa::_scenechecking_

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.cpp
@@ -39,14 +39,14 @@ SceneCheckerVisitor::~SceneCheckerVisitor()
 }
 
 
-void SceneCheckerVisitor::addCheck(SceneCheck::SPtr check)
+void SceneCheckerVisitor::addCheck(sofa::simulation::SceneCheck::SPtr check)
 {
     if( std::find(m_checkset.begin(), m_checkset.end(), check) == m_checkset.end() )
         m_checkset.push_back(check) ;
 }
 
 
-void SceneCheckerVisitor::removeCheck(SceneCheck::SPtr check)
+void SceneCheckerVisitor::removeCheck(sofa::simulation::SceneCheck::SPtr check)
 {
     m_checkset.erase( std::remove( m_checkset.begin(), m_checkset.end(), check ), m_checkset.end() );
 }
@@ -55,21 +55,21 @@ void SceneCheckerVisitor::validate(sofa::simulation::Node* node)
 {
     std::stringstream tmp;
     bool first = true;
-    for(SceneCheck::SPtr& check : m_checkset)
+    for(sofa::simulation::SceneCheck::SPtr& check : m_checkset)
     {
         tmp << (first ? "" : ", ") << check->getName() ;
         first = false;
     }
     msg_info("SceneCheckerVisitor") << "Validating node \""<< node->getName() << "\" with checks: [" << tmp.str() << "]" ;
 
-    for(SceneCheck::SPtr& check : m_checkset)
+    for(sofa::simulation::SceneCheck::SPtr& check : m_checkset)
     {
         check->doInit(node) ;
     }
 
     execute(node) ;
 
-    for(SceneCheck::SPtr& check : m_checkset)
+    for(sofa::simulation::SceneCheck::SPtr& check : m_checkset)
     {
         check->doPrintSummary() ;
     }
@@ -79,7 +79,7 @@ void SceneCheckerVisitor::validate(sofa::simulation::Node* node)
 
 sofa::simulation::Visitor::Result SceneCheckerVisitor::processNodeTopDown(sofa::simulation::Node* node)
 {
-    for(SceneCheck::SPtr& check : m_checkset)
+    for(sofa::simulation::SceneCheck::SPtr& check : m_checkset)
     {
         check->doCheckOn(node) ;
     }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <SceneChecking/config.h>
-#include <SceneChecking/SceneCheck.h>
+#include <sofa/simulation/SceneCheck.h>
 #include <sofa/core/ExecParams.h>
 #include <functional>
 #include <map>
@@ -41,11 +41,11 @@ public:
     void validate(sofa::simulation::Node* node) ;
     Result processNodeTopDown(sofa::simulation::Node* node) override ;
 
-    void addCheck(SceneCheck::SPtr check) ;
-    void removeCheck(SceneCheck::SPtr check) ;
+    void addCheck(sofa::simulation::SceneCheck::SPtr check) ;
+    void removeCheck(sofa::simulation::SceneCheck::SPtr check) ;
 
 private:
-    std::vector<SceneCheck::SPtr> m_checkset ;
+    std::vector<sofa::simulation::SceneCheck::SPtr> m_checkset ;
 };
 
 } // namespace sofa::_scenechecking_


### PR DESCRIPTION
SceneChecks were isolated in a project. But we may want that plugins add their own SceneCheck. An example with MultiThreading is provided here.

The class `SceneCheck` is now available in Sofa.Simulation.Core. Tools to register a SceneCheck are also available in the module.

The newly introduced SceneCheck checks if there are opportunities to use a multi-threaded component. It advices the user with a message looking like:

```
[SUGGESTION] [SceneCheckMultithreading] This scene is using components implemented sequentially while a parallel implementation is available. Using the parallel implementation may improve the performances. Here is the list of sequen
tial components in your scene and their parallel equivalent:
        BVHNarrowPhase -> ParallelBVHNarrowPhase
        BruteForceBroadPhase -> ParallelBruteForceBroadPhase
        HexahedronFEMForceField[Vec3d] -> ParallelHexahedronFEMForceField[Vec3d]
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
