### PR TITLE
[SofaCUDA] Missing support for double precision floating-points

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaConstantForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaConstantForceField.cpp
@@ -36,6 +36,15 @@ namespace sofa::gpu::cuda
         .add< ConstantForceField<CudaVec6Types> >()
         .add< ConstantForceField<CudaRigid3Types> >()
         .add< ConstantForceField<CudaRigid2Types> >()
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+        .add< ConstantForceField<CudaVec3dTypes> >()
+        .add< ConstantForceField<CudaVec2dTypes> >()
+        .add< ConstantForceField<CudaVec1dTypes> >()
+        .add< ConstantForceField<CudaVec6dTypes> >()
+        .add< ConstantForceField<CudaRigid3dTypes> >()
+        .add< ConstantForceField<CudaRigid2dTypes> >()
+#endif
     ;
 } // namespace sofa::gpu::cuda
 
@@ -54,4 +63,19 @@ namespace sofa::component::mechanicalload
     template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec6Types>;
     template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid3Types>;
     template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid2Types>;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+
+    template <> SOFA_GPU_CUDA_API
+    SReal ConstantForceField<CudaRigid3dTypes>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord& ) const { return 0; }
+    template <> SOFA_GPU_CUDA_API
+    SReal ConstantForceField<CudaRigid2dTypes>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord& ) const { return 0; }
+
+    template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec3dTypes>;
+    template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec2dTypes>;
+    template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec1dTypes>;
+    template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec6dTypes>;
+    template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid3dTypes>;
+    template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid2dTypes>;
+#endif
 } // namespace sofa::component::mechanicalload

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearSolverConstraintCorrection.cpp
@@ -31,6 +31,11 @@ using namespace sofa::gpu::cuda;
 template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3fTypes >;
 template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3f1Types >;
 
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3dTypes >;
+template class SOFA_GPU_CUDA_API LinearSolverConstraintCorrection< CudaVec3d1Types >;
+#endif
+
 } // namespace sofa::component::constraint::lagrangian::correction
 
 
@@ -41,6 +46,10 @@ namespace sofa::gpu::cuda
 const int CudaLinearSolverConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
     .add< LinearSolverConstraintCorrection< CudaVec3fTypes > >()
     .add< LinearSolverConstraintCorrection< CudaVec3f1Types > >()
+#ifdef SOFA_GPU_CUDA_DOUBLE
+    .add< LinearSolverConstraintCorrection< CudaVec3dTypes > >()
+    .add< LinearSolverConstraintCorrection< CudaVec3d1Types > >()
+#endif
     ;
 
 } // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMultiMapping.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMultiMapping.cpp
@@ -36,4 +36,17 @@ namespace sofa::core
     template class SOFA_GPU_CUDA_API MultiMapping< CudaRigid3Types, CudaVec3Types >;
     template class SOFA_GPU_CUDA_API MultiMapping< CudaRigid3Types, CudaVec6Types >;
     template class SOFA_GPU_CUDA_API MultiMapping< CudaRigid3Types, CudaRigid3Types >;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaVec1dTypes, CudaVec1dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaVec2dTypes, CudaVec1dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaVec3dTypes, CudaVec3dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaVec3dTypes, CudaVec2dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaVec3dTypes, CudaVec1dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaVec6dTypes, CudaVec1dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaRigid3dTypes, CudaVec1dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaRigid3dTypes, CudaVec3dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaRigid3dTypes, CudaVec6dTypes >;
+    template class SOFA_GPU_CUDA_API MultiMapping< CudaRigid3dTypes, CudaRigid3dTypes >;
+#endif
 } // namespace sofa::core

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.cpp
@@ -29,6 +29,11 @@ using namespace sofa::gpu::cuda;
 template class SOFA_GPU_CUDA_API PenalityContactForceField< CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API PenalityContactForceField< CudaVec3f1Types>;
 
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API PenalityContactForceField< CudaVec3dTypes>;
+template class SOFA_GPU_CUDA_API PenalityContactForceField< CudaVec3d1Types>;
+#endif
+
 } // sofa::component::collision::response::contact
 namespace sofa::gpu::cuda
 {
@@ -36,6 +41,10 @@ namespace sofa::gpu::cuda
 int PenalityContactForceFieldCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< sofa::component::collision::response::contact::PenalityContactForceField<CudaVec3fTypes> >()
         .add< sofa::component::collision::response::contact::PenalityContactForceField<CudaVec3f1Types> >()
+#ifdef SOFA_GPU_CUDA_DOUBLE
+        .add< sofa::component::collision::response::contact::PenalityContactForceField<CudaVec3dTypes> >()
+        .add< sofa::component::collision::response::contact::PenalityContactForceField<CudaVec3d1Types> >()
+#endif
         ;
 
 } // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPrecomputedConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPrecomputedConstraintCorrection.cpp
@@ -31,6 +31,11 @@ using namespace sofa::gpu::cuda;
 template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3fTypes >;
 template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3f1Types >;
 
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3dTypes >;
+template class SOFA_GPU_CUDA_API PrecomputedConstraintCorrection< CudaVec3d1Types >;
+#endif
+
 } // namespace sofa::component::constraint::lagrangian::correction
 
 namespace sofa::gpu::cuda
@@ -40,6 +45,10 @@ namespace sofa::gpu::cuda
 const int CudaPrecomputedConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
     .add< PrecomputedConstraintCorrection< CudaVec3fTypes > >()
     .add< PrecomputedConstraintCorrection< CudaVec3f1Types > >()
+#ifdef SOFA_GPU_CUDA_DOUBLE
+    .add< PrecomputedConstraintCorrection< CudaVec3dTypes > >()
+    .add< PrecomputedConstraintCorrection< CudaVec3d1Types > >()
+#endif
     ;
 
 } // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereForceField.cpp
@@ -24,12 +24,27 @@
 #include <sofa/core/behavior/ForceField.inl>
 #include <sofa/core/ObjectFactory.h>
 
+namespace sofa::component::mechanicalload
+{
+template class SOFA_GPU_CUDA_API SphereForceField< CudaVec3fTypes >;
+template class SOFA_GPU_CUDA_API SphereForceField< CudaVec3f1Types >;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API SphereForceField< CudaVec3dTypes >;
+template class SOFA_GPU_CUDA_API SphereForceField< CudaVec3d1Types >;
+#endif
+}
+
 namespace sofa::gpu::cuda
 {
 
 int SphereForceFieldCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< component::mechanicalload::SphereForceField<CudaVec3fTypes> >()
         .add< component::mechanicalload::SphereForceField<CudaVec3f1Types> >()
+#ifdef SOFA_GPU_CUDA_DOUBLE
+        .add< component::mechanicalload::SphereForceField<CudaVec3dTypes> >()
+        .add< component::mechanicalload::SphereForceField<CudaVec3d1Types> >()
+#endif
         ;
 
 } // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMultiMapping.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMultiMapping.cpp
@@ -33,6 +33,13 @@ namespace sofa::gpu::cuda
         .add< SubsetMultiMapping< CudaVec1Types, CudaVec1Types > >()
         .add< SubsetMultiMapping< CudaRigid3Types, CudaRigid3Types > >()
         .add< SubsetMultiMapping< CudaRigid3Types, CudaVec3Types > >()
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+        .add< SubsetMultiMapping< CudaVec3dTypes, CudaVec3dTypes > >()
+        .add< SubsetMultiMapping< CudaVec1dTypes, CudaVec1dTypes > >()
+        .add< SubsetMultiMapping< CudaRigid3dTypes, CudaRigid3dTypes > >()
+        .add< SubsetMultiMapping< CudaRigid3dTypes, CudaVec3dTypes > >()
+#endif
     ;
 }
 
@@ -44,6 +51,13 @@ namespace sofa::component::mapping::linear
     template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaVec1Types, CudaVec1Types >;
     template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3Types, CudaRigid3Types >;
     template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3Types, CudaVec3Types >;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+    template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaVec3dTypes, CudaVec3dTypes >;
+    template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaVec1dTypes, CudaVec1dTypes >;
+    template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3dTypes, CudaRigid3dTypes >;
+    template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3dTypes, CudaVec3dTypes >;
+#endif
 
 
 } // namespace sofa::component::mapping::linear

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUncoupledConstraintCorrection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUncoupledConstraintCorrection.cpp
@@ -32,6 +32,11 @@ using namespace sofa::gpu::cuda;
 template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3fTypes >;
 template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3f1Types >;
 
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3dTypes >;
+template class SOFA_GPU_CUDA_API UncoupledConstraintCorrection< CudaVec3d1Types >;
+#endif
+
 } // namespace sofa::component::constraint::lagrangian::correction
 
 namespace sofa::gpu::cuda
@@ -41,6 +46,10 @@ using namespace sofa::component::constraint::lagrangian::correction;
 const int CudaUncoupledConstraintCorrectionClass = core::RegisterObject("Supports GPU-side computations using CUDA.")
 .add< UncoupledConstraintCorrection< CudaVec3fTypes > >()
 .add< UncoupledConstraintCorrection< CudaVec3f1Types > >()
+#ifdef SOFA_GPU_CUDA_DOUBLE
+.add< UncoupledConstraintCorrection< CudaVec3dTypes > >()
+.add< UncoupledConstraintCorrection< CudaVec3d1Types > >()
+#endif
 ;
 
 } // namespace sofa::gpu::cuda


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
