### PR TITLE
[Simulation.Graph] SimpleAPI: Remove reference to Node argument in createChild()

### DIFF
--- a/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/SimpleApi.cpp
+++ b/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/SimpleApi.cpp
@@ -111,7 +111,7 @@ BaseObject::SPtr createObject(Node::SPtr parent, const std::string& type, const 
     return createObject(parent, desc);
 }
 
-Node::SPtr createChild(Node::SPtr& node, const std::string& name, const std::map<std::string, std::string>& params)
+Node::SPtr createChild(Node::SPtr node, const std::string& name, const std::map<std::string, std::string>& params)
 {
     BaseObjectDescription desc(name.c_str(), "Node");
     for(auto& kv : params)

--- a/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/SimpleApi.h
+++ b/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/SimpleApi.h
@@ -58,7 +58,7 @@ sofa::core::sptr<BaseObject> SOFA_SIMULATION_GRAPH_API createObject( NodeSPtr no
 
 ///@brief create a child to the provided nodeof given name.
 ///The parameter "params" is for passing specific data argument to the created object.
-NodeSPtr SOFA_SIMULATION_GRAPH_API createChild( NodeSPtr& node, const std::string& name,
+NodeSPtr SOFA_SIMULATION_GRAPH_API createChild( NodeSPtr node, const std::string& name,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 ///@brief create a child to the provided node.


### PR DESCRIPTION
Most likely a typo, as using ref to shared_ptr is weird


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
