### PR TITLE
[Collision.Response.Contact] Implement addKToMatrix for PenalityContactForceField

### DIFF
--- a/Sofa/Component/Collision/Response/Contact/CMakeLists.txt
+++ b/Sofa/Component/Collision/Response/Contact/CMakeLists.txt
@@ -61,3 +61,11 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
 )
+
+# Tests
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(SOFA_COMPONENT_COLLISION_RESPONSE_CONTACT_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(SOFA_COMPONENT_COLLISION_RESPONSE_CONTACT_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.h
@@ -109,6 +109,8 @@ public:
 
     void addDForce(const sofa::core::MechanicalParams* mparams, DataVecDeriv& data_df1, DataVecDeriv& data_df2, const DataVecDeriv& data_dx1, const DataVecDeriv& data_dx2) override;
 
+    void addKToMatrix(const sofa::core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+
     SReal getPotentialEnergy(const sofa::core::MechanicalParams*, const DataVecCoord&, const DataVecCoord& ) const override;
 
     const type::vector< Contact >& getContact() const { return contacts.getValue();}

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.inl
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.inl
@@ -156,11 +156,11 @@ void PenalityContactForceField<DataTypes>::addKToMatrix(const sofa::core::Mechan
                 {
                     for (sofa::Index j = 0; j < N; ++j)
                     {
-                        const Real stiffness = -k * contact.norm[i] * contact.norm[j];
-                        mat.matrix->add(p1 + i, p1 + j,  stiffness);
-                        mat.matrix->add(p1 + i, p2 + j, -stiffness);
-                        mat.matrix->add(p2 + i, p1 + j, -stiffness);
-                        mat.matrix->add(p2 + i, p2 + j,  stiffness);
+                        const Real stiffness = k * contact.norm[i] * contact.norm[j];
+                        mat.matrix->add(p1 + i, p1 + j, -stiffness);
+                        mat.matrix->add(p1 + i, p2 + j,  stiffness);
+                        mat.matrix->add(p2 + i, p1 + j,  stiffness);
+                        mat.matrix->add(p2 + i, p2 + j, -stiffness);
                     }
                 }
             }
@@ -186,11 +186,11 @@ void PenalityContactForceField<DataTypes>::addKToMatrix(const sofa::core::Mechan
                 {
                     for (sofa::Index j = 0; j < N; ++j)
                     {
-                        const Real stiffness = -k * contact.norm[i] * contact.norm[j];
-                        mat11.matrix->add(mat11.offset + p1 + i, mat11.offset + p1 + j,  stiffness);
-                        mat12.matrix->add(mat12.offRow + p1 + i, mat12.offCol + p2 + j, -stiffness);
-                        mat21.matrix->add(mat21.offRow + p2 + i, mat21.offCol + p1 + j, -stiffness);
-                        mat22.matrix->add(mat22.offset + p2 + i, mat22.offset + p2 + j,  stiffness);
+                        const Real stiffness = k * contact.norm[i] * contact.norm[j];
+                        mat11.matrix->add(mat11.offset + p1 + i, mat11.offset + p1 + j, -stiffness);
+                        mat12.matrix->add(mat12.offRow + p1 + i, mat12.offCol + p2 + j,  stiffness);
+                        mat21.matrix->add(mat21.offRow + p2 + i, mat21.offCol + p1 + j,  stiffness);
+                        mat22.matrix->add(mat22.offset + p2 + i, mat22.offset + p2 + j, -stiffness);
                     }
                 }
             }

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.inl
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.inl
@@ -21,7 +21,9 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/component/collision/response/contact/PenalityContactForceField.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/linearalgebra/BaseMatrix.h>
 #include <sofa/type/RGBAColor.h>
 
 namespace sofa::component::collision::response::contact
@@ -127,6 +129,73 @@ void PenalityContactForceField<DataTypes>::addDForce(const sofa::core::Mechanica
     data_df1.endEdit();
     data_df2.endEdit();
 
+}
+
+template <class DataTypes>
+void PenalityContactForceField<DataTypes>::addKToMatrix(const sofa::core::MechanicalParams* mparams,
+    const sofa::core::behavior::MultiMatrixAccessor* matrix)
+{
+    static constexpr auto N = DataTypes::spatial_dimensions;
+    const Real kFact = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams,this->rayleighStiffness.getValue());
+
+    const type::vector<Contact>& cc = contacts.getValue();
+
+    if (this->mstate1 == this->mstate2)
+    {
+        sofa::core::behavior::MultiMatrixAccessor::MatrixRef mat = matrix->getMatrix(this->mstate1);
+        if (!mat) return;
+
+        for (const auto& contact : cc)
+        {
+            if (contact.pen > 0)
+            {
+                const Real k = contact.ks * kFact;
+                const sofa::Index p1 = mat.offset + Deriv::total_size * contact.m1;
+                const sofa::Index p2 = mat.offset + Deriv::total_size * contact.m2;
+                for(sofa::Index i = 0; i < N; ++i)
+                {
+                    for (sofa::Index j = 0; j < N; ++j)
+                    {
+                        const Real stiffness = -k * contact.norm[i] * contact.norm[j];
+                        mat.matrix->add(p1 + i, p1 + j,  stiffness);
+                        mat.matrix->add(p1 + i, p2 + j, -stiffness);
+                        mat.matrix->add(p2 + i, p1 + j, -stiffness);
+                        mat.matrix->add(p2 + i, p2 + j,  stiffness);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        sofa::core::behavior::MultiMatrixAccessor::MatrixRef mat11 = matrix->getMatrix(this->mstate1);
+        sofa::core::behavior::MultiMatrixAccessor::MatrixRef mat22 = matrix->getMatrix(this->mstate2);
+        sofa::core::behavior::MultiMatrixAccessor::InteractionMatrixRef mat12 = matrix->getMatrix(this->mstate1, this->mstate2);
+        sofa::core::behavior::MultiMatrixAccessor::InteractionMatrixRef mat21 = matrix->getMatrix(this->mstate2, this->mstate1);
+
+        if (!mat11 && !mat22 && !mat12 && !mat21) return;
+
+        for (const auto& contact : cc)
+        {
+            if (contact.pen > 0)
+            {
+                const Real k = contact.ks * kFact;
+                const sofa::Index p1 = Deriv::total_size * contact.m1;
+                const sofa::Index p2 = Deriv::total_size * contact.m2;
+                for(sofa::Index i = 0; i < N; ++i)
+                {
+                    for (sofa::Index j = 0; j < N; ++j)
+                    {
+                        const Real stiffness = -k * contact.norm[i] * contact.norm[j];
+                        mat11.matrix->add(mat11.offset + p1 + i, mat11.offset + p1 + j,  stiffness);
+                        mat12.matrix->add(mat12.offRow + p1 + i, mat12.offCol + p2 + j, -stiffness);
+                        mat21.matrix->add(mat21.offRow + p2 + i, mat21.offCol + p1 + j, -stiffness);
+                        mat22.matrix->add(mat22.offset + p2 + i, mat22.offset + p2 + j,  stiffness);
+                    }
+                }
+            }
+        }
+    }
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Collision/Response/Contact/tests/CMakeLists.txt
+++ b/Sofa/Component/Collision/Response/Contact/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(Sofa.Component.Collision.Response.Contact_test)
+
+set(SOURCE_FILES
+    PenalityContactForceField_test.cpp
+)
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Component.Collision.Testing Sofa.Component.SolidMechanics.Testing)
+target_link_libraries(${PROJECT_NAME} Sofa.Component.Collision.Response.Contact)
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/Sofa/Component/Collision/Response/Contact/tests/PenalityContactForceField_test.cpp
+++ b/Sofa/Component/Collision/Response/Contact/tests/PenalityContactForceField_test.cpp
@@ -1,0 +1,81 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/component/collision/response/contact/PenalityContactForceField.h>
+#include <sofa/component/solidmechanics/testing/ForceFieldTestCreation.h>
+
+using sofa::component::collision::response::contact::PenalityContactForceField;
+
+struct PenalityContactForceField_test : public sofa::ForceField_test<PenalityContactForceField<sofa::defaulttype::Vec3Types> >
+{
+    void test_2particles( Real stiffness, Real contactDistance,
+                          sofa::type::Vec3 x0,sofa::type:: Vec3 v0,
+                          sofa::type::Vec3 x1, sofa::type:: Vec3 v1,
+                          sofa::type::Vec3 f0)
+    {
+        // potential energy is not implemented and won't be tested
+        this->flags &= ~TEST_POTENTIAL_ENERGY;
+
+        VecCoord x(2);
+        DataTypes::set( x[0], x0[0],x0[1],x0[2]);
+        DataTypes::set( x[1], x1[0],x1[1],x1[2]);
+        VecDeriv v(2);
+        DataTypes::set( v[0], v0[0],v0[1],v0[2]);
+        DataTypes::set( v[1], v1[0],v1[1],v1[2]);
+        VecDeriv f(2);
+        DataTypes::set( f[0],  f0[0], f0[1], f0[2]);
+        DataTypes::set( f[1], -f0[0],-f0[1],-f0[2]);
+
+        this->force->addContact(0, 1, 0, 0, (x1 - x0).normalized(), contactDistance, stiffness);
+
+        this->run_test( x, v, f );
+    }
+};
+
+TEST_F(PenalityContactForceField_test, twoParticles)
+{
+    sofa::type::Vec3
+            x0(0,0,0), // position of the first particle
+            v0(0,0,0), // velocity of the first particle
+            x1(2,0,0), // position of the second particle
+            v1(0,0,0), // velocity of the second particle
+            f0(-1,0,0); // expected force on the first particleá
+
+    SReal k = 1.0;  // stiffness
+    SReal contactDistance = 3.;
+
+    this->test_2particles(k, contactDistance, x0, v0, x1,v1, f0);
+    this->force->clear();
+
+    k = 2.0;
+    f0 = {-2., 0., 0.};
+
+    this->test_2particles(k, contactDistance, x0, v0, x1,v1, f0);
+    this->force->clear();
+
+    x1 = { 4.8, -0.4, -2.3};
+    contactDistance = 6.;
+    f0 = {-1.19136193691474900901994260494, 0.0992801614095624312961163582258, 0.57086092810498378913308670235};
+
+    this->test_2particles(k, contactDistance, x0, v0, x1,v1, f0);
+    this->force->clear();
+}


### PR DESCRIPTION
and add unit tests
The case `(this->mstate1 != this->mstate2)` is not tested.

Note that this implementation is not yet useful when the force field is associated to a mapped mechanical object. However, it will become useful for #2777 





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
