### PR TITLE
[Type] Fix massive warning due to Mat.h

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -89,7 +89,7 @@ public:
     /// or
     /// sofa::type::Mat<3, 1, int> M {1, 2, 3}
     /// Initializer-list must match matrix column size, otherwise an assert is triggered.
-    template<sofa::Size TL = L, sofa::Size TC = C, typename = std::enable_if_t<TL == 1 && TC != 1 || TC == 1 && TL != 1> >
+    template<sofa::Size TL = L, sofa::Size TC = C, typename = std::enable_if_t<(TL == 1 && TC != 1) || (TC == 1 && TL != 1)> >
     constexpr Mat(std::initializer_list<Real>&& scalars) noexcept
     {
         if constexpr (L == 1 && C != 1)


### PR DESCRIPTION
Replacing 
`std::enable_if_t<TL == 1 && TC != 1 || TC == 1 && TL != 1> >`
by
`std::enable_if_t<(TL == 1 && TC != 1) || (TC == 1 && TL != 1)> >`


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
