### PR TITLE
[Topology.Container.Grid] RegularGrid: Fix rounding errors with SReal=float

### DIFF
--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.cpp
@@ -239,9 +239,9 @@ RegularGridTopology::Index RegularGridTopology::findCube(const type::Vec3& pos)
     SReal x = p*dx*inv_dx2;
     SReal y = p*dy*inv_dy2;
     SReal z = p*dz*inv_dz2;
-    int ix = int(x+1000000)-1000000; // Do not round toward 0...
-    int iy = int(y+1000000)-1000000;
-    int iz = int(z+1000000)-1000000;
+    int ix = int(std::floor(x));
+    int iy = int(std::floor(y));
+    int iz = int(std::floor(z));
     if (   (unsigned)ix <= (unsigned)n[0]-2
             && (unsigned)iy <= (unsigned)n[1]-2
             && (unsigned)iz <= (unsigned)n[2]-2 )
@@ -263,9 +263,9 @@ RegularGridTopology::Index RegularGridTopology::findNearestCube(const type::Vec3
     SReal x = p*dx*inv_dx2;
     SReal y = p*dy*inv_dy2;
     SReal z = p*dz*inv_dz2;
-    int ix = int(x+1000000)-1000000; // Do not round toward 0...
-    int iy = int(y+1000000)-1000000;
-    int iz = int(z+1000000)-1000000;
+    int ix = int(std::floor(x));
+    int iy = int(std::floor(y));
+    int iz = int(std::floor(z));
     if (ix<0) ix=0; else if (ix>n[0]-2) ix=n[0]-2;
     if (iy<0) iy=0; else if (iy>n[1]-2) iy=n[1]-2;
     if (iz<0) iz=0; else if (iz>n[2]-2) iz=n[2]-2;
@@ -311,9 +311,9 @@ RegularGridTopology::Index RegularGridTopology::findNearestCube(const type::Vec3
     SReal x = p*dx*inv_dx2;
     SReal y = p*dy*inv_dy2;
     SReal z = p*dz*inv_dz2;
-    int ix = int(x+1000000)-1000000; // Do not round toward 0...
-    int iy = int(y+1000000)-1000000;
-    int iz = int(z+1000000)-1000000;
+    int ix = int(std::floor(x));
+    int iy = int(std::floor(y));
+    int iz = int(std::floor(z));
     if (ix<0) ix=0; else if (ix>n[0]-2) ix=n[0]-2;
     if (iy<0) iy=0; else if (iy>n[1]-2) iy=n[1]-2;
     if (iz<0) iz=0; else if (iz>n[2]-2) iz=n[2]-2;


### PR DESCRIPTION
Already spotted in https://github.com/sofa-framework/sofa/pull/2560 but not propagated to other functions.

Reminder: https://godbolt.org/z/no6hss6jr



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
