### PR TITLE
[SofaCUDA] Fix compilation with CUDA12

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -60,14 +60,13 @@ set(HEADER_FILES
     ### FEM
     sofa/gpu/cuda/CudaHexahedronFEMForceField.h
     sofa/gpu/cuda/CudaHexahedronFEMForceField.inl
-    sofa/gpu/cuda/CudaHexahedronTLEDForceField.h
+
     sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.h
     sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.inl
     sofa/gpu/cuda/CudaTetrahedralTensorMassForceField.h
     sofa/gpu/cuda/CudaTetrahedralTensorMassForceField.inl
     sofa/gpu/cuda/CudaTetrahedronFEMForceField.h
     sofa/gpu/cuda/CudaTetrahedronFEMForceField.inl
-    sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
     sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.h
     sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.inl
 
@@ -134,11 +133,9 @@ set(SOURCE_FILES
 
     ### FEM
     sofa/gpu/cuda/CudaHexahedronFEMForceField.cpp
-    sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
     sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cpp
     sofa/gpu/cuda/CudaTetrahedralTensorMassForceField.cpp
     sofa/gpu/cuda/CudaTetrahedronFEMForceField.cpp
-    sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp
     sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.cpp
 
     ### ForceFields
@@ -201,11 +198,9 @@ set(CUDA_SOURCES
 
     ### FEM
     sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
-    sofa/gpu/cuda/CudaHexahedronTLEDForceField.cu
     sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cu
     sofa/gpu/cuda/CudaTetrahedralTensorMassForceField.cu
     sofa/gpu/cuda/CudaTetrahedronFEMForceField.cu
-    sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
     sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.cu
 
     ### ForceFields
@@ -221,9 +216,17 @@ set(CUDA_SOURCES
     ### Constraints
     sofa/gpu/cuda/CudaFixedConstraint.cu
     sofa/gpu/cuda/CudaLinearMovementConstraint.cu
-    
-    
 )
+
+if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.00)
+  # https://forums.developer.nvidia.com/t/cuda-12-0-still-support-for-texture-reference-support-for-pascal-architecture-warp-synchronous-programming/237284/2
+  # Used texture API has been deprecated for a long time and is is removed since CUDA12
+  message("Your CUDA compiler cannot compile TLED Forcefields due the removal of the legacy texture API (since CUDA v12).")
+else()
+  list(APPEND HEADER_FILES sofa/gpu/cuda/CudaHexahedronTLEDForceField.h sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h)
+  list(APPEND SOURCE_FILES sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp)
+  list(APPEND CUDA_SOURCES sofa/gpu/cuda/CudaHexahedronTLEDForceField.cu sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu)
+endif()
 
 sofa_find_package(Sofa.GL QUIET)
 if(NOT Sofa.GL_FOUND)

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
@@ -21,9 +21,12 @@
 ******************************************************************************/
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
-#include <sofa/gpu/cuda/CudaTexture.h>
 #include <cuda.h>
 #include <stdio.h>
+
+#ifdef USE_TEXTURE_X
+#include <sofa/gpu/cuda/CudaTexture.h>
+#endif
 
 #if defined(__cplusplus)
 namespace sofa

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpringForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpringForceField.cu
@@ -22,7 +22,10 @@
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
 #include "cuda.h"
+
+#ifdef USE_TEXTURE
 #include "CudaTexture.h"
+#endif
 
 #if defined(__cplusplus) && CUDA_VERSION < 2000
 namespace sofa

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronFEMForceField.cu
@@ -21,10 +21,13 @@
 ******************************************************************************/
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
-#include "CudaTexture.h"
 #include "cuda.h"
 #include "mycuda.h"
 #include <stdio.h>
+
+#ifdef USE_TEXTURE_X
+#include "CudaTexture.h"
+#endif
 
 #if defined(__cplusplus)
 namespace sofa

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.cu
@@ -21,8 +21,12 @@
 ******************************************************************************/
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
-#include "CudaTexture.h"
+
 #include "cuda.h"
+
+#ifdef USE_TEXTURE
+#include "CudaTexture.h"
+#endif
 
 #if defined(__cplusplus) && CUDA_VERSION < 2000
 namespace sofa


### PR DESCRIPTION
CUDA12 disabled the usage of a deprecated texture API, obviously used in our code 😅

Actually only TLED classes used necessarily texturing so no choice other than disable the compilation of these 2 classes if CUDA>=v12 at the cmake stage.

Other files were including CudaTexture.h and were using the old API in code only activated with Macros (which I suspect, were never enabled anymore....) so I enclosed the include with the same `#ifdef` tests.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
