### PR TITLE
[defaulttype] Fix cuda template instantiation

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
@@ -126,8 +126,8 @@ static RegisterTemplateAlias Vec1fAlias("Vec1f", sofa::defaulttype::Vec1Types::N
 static RegisterTemplateAlias Vec2fAlias("Vec2f", sofa::defaulttype::Vec2Types::Name(), isSRealDouble());
 static RegisterTemplateAlias Vec3fAlias("Vec3f", sofa::defaulttype::Vec3Types::Name(), isSRealDouble());
 static RegisterTemplateAlias Vec6fAlias("Vec6f", sofa::defaulttype::Vec6Types::Name(), isSRealDouble());
-static RegisterTemplateAlias CompressedRowSparseMatrixfAlias("CompressedRowSparseMatrixf", sofa::linearalgebra::CompressedRowSparseMatrix<SReal>::Name(), isSRealDouble());
-static RegisterTemplateAlias CompressedRowSparseMatrixMat3x3fAlias("CompressedRowSparseMatrixMat3x3f", sofa::linearalgebra::CompressedRowSparseMatrix<type::Mat<3, 3, SReal>>::Name(), isSRealDouble());
+//static RegisterTemplateAlias CompressedRowSparseMatrixfAlias("CompressedRowSparseMatrixf", sofa::linearalgebra::CompressedRowSparseMatrix<SReal>::Name(), isSRealDouble());
+//static RegisterTemplateAlias CompressedRowSparseMatrixMat3x3fAlias("CompressedRowSparseMatrixMat3x3f", sofa::linearalgebra::CompressedRowSparseMatrix<type::Mat<3, 3, SReal>>::Name(), isSRealDouble());
 
 static RegisterTemplateAlias Vec1dAlias("Vec1d", sofa::defaulttype::Vec1Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Vec2dAlias("Vec2d", sofa::defaulttype::Vec2Types::Name(), isSRealFloat());
@@ -135,8 +135,8 @@ static RegisterTemplateAlias Vec3dAlias("Vec3d", sofa::defaulttype::Vec3Types::N
 static RegisterTemplateAlias Vec6dAlias("Vec6d", sofa::defaulttype::Vec6Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Rigid2dAlias("Rigid2d", sofa::defaulttype::Rigid2Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Rigid3dAlias("Rigid3d", sofa::defaulttype::Rigid3Types::Name(), isSRealFloat());
-static RegisterTemplateAlias CompressedRowSparseMatrixdAlias("CompressedRowSparseMatrixd", sofa::linearalgebra::CompressedRowSparseMatrix<SReal>::Name(), isSRealFloat());
-static RegisterTemplateAlias CompressedRowSparseMatrixMat3x3dAlias("CompressedRowSparseMatrixMat3x3d", sofa::linearalgebra::CompressedRowSparseMatrix<type::Mat<3, 3, SReal>>::Name(), isSRealFloat());
+//static RegisterTemplateAlias CompressedRowSparseMatrixdAlias("CompressedRowSparseMatrixd", sofa::linearalgebra::CompressedRowSparseMatrix<SReal>::Name(), isSRealFloat());
+//static RegisterTemplateAlias CompressedRowSparseMatrixMat3x3dAlias("CompressedRowSparseMatrixMat3x3d", sofa::linearalgebra::CompressedRowSparseMatrix<type::Mat<3, 3, SReal>>::Name(), isSRealFloat());
 
 // Compatibility aliases used previously in DataExchange (see PR#3380)
 static RegisterTemplateAlias floatAlias("float", sofa::defaulttype::DataTypeName<float>::name(), true);

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
@@ -126,8 +126,6 @@ static RegisterTemplateAlias Vec1fAlias("Vec1f", sofa::defaulttype::Vec1Types::N
 static RegisterTemplateAlias Vec2fAlias("Vec2f", sofa::defaulttype::Vec2Types::Name(), isSRealDouble());
 static RegisterTemplateAlias Vec3fAlias("Vec3f", sofa::defaulttype::Vec3Types::Name(), isSRealDouble());
 static RegisterTemplateAlias Vec6fAlias("Vec6f", sofa::defaulttype::Vec6Types::Name(), isSRealDouble());
-//static RegisterTemplateAlias CompressedRowSparseMatrixfAlias("CompressedRowSparseMatrixf", sofa::linearalgebra::CompressedRowSparseMatrix<SReal>::Name(), isSRealDouble());
-//static RegisterTemplateAlias CompressedRowSparseMatrixMat3x3fAlias("CompressedRowSparseMatrixMat3x3f", sofa::linearalgebra::CompressedRowSparseMatrix<type::Mat<3, 3, SReal>>::Name(), isSRealDouble());
 
 static RegisterTemplateAlias Vec1dAlias("Vec1d", sofa::defaulttype::Vec1Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Vec2dAlias("Vec2d", sofa::defaulttype::Vec2Types::Name(), isSRealFloat());
@@ -135,8 +133,6 @@ static RegisterTemplateAlias Vec3dAlias("Vec3d", sofa::defaulttype::Vec3Types::N
 static RegisterTemplateAlias Vec6dAlias("Vec6d", sofa::defaulttype::Vec6Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Rigid2dAlias("Rigid2d", sofa::defaulttype::Rigid2Types::Name(), isSRealFloat());
 static RegisterTemplateAlias Rigid3dAlias("Rigid3d", sofa::defaulttype::Rigid3Types::Name(), isSRealFloat());
-//static RegisterTemplateAlias CompressedRowSparseMatrixdAlias("CompressedRowSparseMatrixd", sofa::linearalgebra::CompressedRowSparseMatrix<SReal>::Name(), isSRealFloat());
-//static RegisterTemplateAlias CompressedRowSparseMatrixMat3x3dAlias("CompressedRowSparseMatrixMat3x3d", sofa::linearalgebra::CompressedRowSparseMatrix<type::Mat<3, 3, SReal>>::Name(), isSRealFloat());
 
 // Compatibility aliases used previously in DataExchange (see PR#3380)
 static RegisterTemplateAlias floatAlias("float", sofa::defaulttype::DataTypeName<float>::name(), true);


### PR DESCRIPTION
Replacing automatically the deprecated template at the begining of the createObject method of the factory doesn't work for CUDA implementation using Matrices when compiling sofa in Double and CUDA in Float.

 See #3644 for more context 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
