### PR TITLE
[SofaCUDA] No longer use deprecated texture references in TetraTLED

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
@@ -38,8 +38,8 @@ namespace cuda
 
 extern "C"
 {
-    void CudaTetrahedronTLEDForceField3f_addForce(int4* nodesPerElement, float Lambda, float Mu, unsigned int nbElem, unsigned int nbVertex, unsigned int nbElemPerVertex, unsigned int viscoelasticity, unsigned int anisotropy, const void* x, const void* x0, void* f);
-    void InitGPU_TetrahedronTLED(float* DhC0, float* DhC1, float* DhC2, float* Volume, int* FCrds, int valence, int nbVertex, int nbElements);
+    void CudaTetrahedronTLEDForceField3f_addForce(int4* nodesPerElement, float4* DhC0, float4* DhC1, float4* DhC2, float Lambda, float Mu, unsigned int nbElem, unsigned int nbVertex, unsigned int nbElemPerVertex, unsigned int viscoelasticity, unsigned int anisotropy, const void* x, const void* x0, void* f);
+    void InitGPU_TetrahedronTLED(float* Volume, int* FCrds, int valence, int nbVertex, int nbElements);
     void InitGPU_TetrahedronVisco(float * Ai, float * Av, int Ni, int Nv);
     void InitGPU_TetrahedronAniso(float* A);
     void ClearGPU_TetrahedronTLED(void);
@@ -68,9 +68,6 @@ static __constant__ float Av_gpu[2];
 static __constant__ int Eta_gpu;
 
 // References on textures - TLED first kernel
-static texture <float4, 1, cudaReadModeElementType> texDhC0;
-static texture <float4, 1, cudaReadModeElementType> texDhC1;
-static texture <float4, 1, cudaReadModeElementType> texDhC2;
 static texture <float, 1, cudaReadModeElementType> texVolume;
 
 // Constant used with anisotropic formulation
@@ -92,10 +89,6 @@ static texture <float4, 1, cudaReadModeElementType> texF3;
 /**
  * GPU pointers
  */
-// Shape function derivatives arrays
-static float4* DhC0_gpu = 0;
-static float4* DhC1_gpu = 0;
-static float4* DhC2_gpu = 0;
 // Force coordinates for each node
 static int2* FCrds_gpu = 0;
 // Element volume array
@@ -191,7 +184,7 @@ static void setX0(const void* x0)
 /**
  * This version is valid for tetrahedral meshes and uses an elastic formulation
  */
-__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0(int4* nodesPerElement, float Lambda, float Mu, int nbElem, float4* F0, float4* F1, float4* F2, float4* F3)
+__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0(int4* nodesPerElement, float4* DhC0, float4* DhC1, float4* DhC2, float Lambda, float Mu, int nbElem, float4* F0, float4* F1, float4* F2, float4* F3)
 {
     int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
@@ -200,9 +193,9 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0(int4* node
     if (index < nbElem)
     {
         /// Shape function derivatives matrix
-        float4 Dh0 = tex1Dfetch(texDhC0, index);
-        float4 Dh1 = tex1Dfetch(texDhC1, index);
-        float4 Dh2 = tex1Dfetch(texDhC2, index);
+        float4 Dh0 = DhC0[index];
+        float4 Dh1 = DhC1[index];
+        float4 Dh2 = DhC2[index];
 
         int4 NodesPerElement = nodesPerElement[index];
         CudaVec3f Node1Disp = getX(NodesPerElement.x) - getX0(NodesPerElement.x);
@@ -327,7 +320,7 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0(int4* node
 /**
  * This version is valid for tetrahedral meshes and uses a transversely isotropic and elastic formulation
  */
-__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1(int4* nodesPerElement, float Lambda, float Mu, int nbElem, float4* F0, float4* F1, float4* F2, float4* F3)
+__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1(int4* nodesPerElement, float4* DhC0, float4* DhC1, float4* DhC2, float Lambda, float Mu, int nbElem, float4* F0, float4* F1, float4* F2, float4* F3)
 {
     int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
@@ -336,9 +329,9 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1(int4* node
     if (index < nbElem)
     {
         /// Shape function derivatives matrix
-        float4 Dh0 = tex1Dfetch(texDhC0, index);
-        float4 Dh1 = tex1Dfetch(texDhC1, index);
-        float4 Dh2 = tex1Dfetch(texDhC2, index);
+        float4 Dh0 = DhC0[index];
+        float4 Dh1 = DhC1[index];
+        float4 Dh2 = DhC2[index];
 
         int4 NodesPerElement = nodesPerElement[index];
         CudaVec3f Node1Disp = getX(NodesPerElement.x) - getX0(NodesPerElement.x);
@@ -471,7 +464,7 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1(int4* node
 /**
  * This version is valid for tetrahedral meshes and uses a viscoelastic formulation based on separated isochoric and volumetric terms. The model is isotropic.
  */
-__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2(int4* nodesPerElement, float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0, float4* F1, float4* F2, float4* F3)
+__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2(int4* nodesPerElement, float4* DhC0, float4* DhC1, float4* DhC2, float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0, float4* F1, float4* F2, float4* F3)
 {
     int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
@@ -481,9 +474,9 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2(int4* node
     {
 
         /// Shape function derivatives matrix
-        float4 Dh0 = tex1Dfetch(texDhC0, index);
-        float4 Dh1 = tex1Dfetch(texDhC1, index);
-        float4 Dh2 = tex1Dfetch(texDhC2, index);
+        float4 Dh0 = DhC0[index];
+        float4 Dh1 = DhC1[index];
+        float4 Dh2 = DhC2[index];
 
         int4 NodesPerElement = nodesPerElement[index];
         CudaVec3f Node1Disp = getX(NodesPerElement.x) - getX0(NodesPerElement.x);
@@ -653,7 +646,7 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2(int4* node
 /**
  * This version is valid for tetrahedral meshes and uses an viscoelastic and anisotropic formulation
  */
-__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3(int4* nodesPerElement, float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0, float4* F1, float4* F2, float4* F3)
+__global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3(int4* nodesPerElement, float4* DhC0, float4* DhC1, float4* DhC2, float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0, float4* F1, float4* F2, float4* F3)
 {
     int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
@@ -663,9 +656,9 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3(int4* node
     {
 
         /// Shape function derivatives matrix
-        float4 Dh0 = tex1Dfetch(texDhC0, index);
-        float4 Dh1 = tex1Dfetch(texDhC1, index);
-        float4 Dh2 = tex1Dfetch(texDhC2, index);
+        float4 Dh0 = DhC0[index];
+        float4 Dh1 = DhC1[index];
+        float4 Dh2 = DhC2[index];
 
         int4 NodesPerElement = nodesPerElement[index];
         CudaVec3f Node1Disp = getX(NodesPerElement.x) - getX0(NodesPerElement.x);
@@ -1017,31 +1010,15 @@ __global__ void CudaTetrahedronTLEDForceField3f_addForce_kernel(int nbVertex, un
 /**
  * Initialises GPU textures with the precomputed arrays for the TLED algorithm
  */
-void InitGPU_TetrahedronTLED(float* DhC0, float* DhC1, float* DhC2, float* Volume, int* FCrds, int valence, int nbVertex, int nbElements)
+void InitGPU_TetrahedronTLED(float* Volume, int* FCrds, int valence, int nbVertex, int nbElements)
 {
     // Sizes in bytes of different arrays
     sizeNodesInt = nbVertex*sizeof(int);
     sizeElsFloat = nbElements*sizeof(float);
     sizeElsInt = nbElements*sizeof(int);
 
-    // First shape function derivatives array (first column for each element)
-    cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc(32, 32, 32, 32, cudaChannelFormatKindFloat);
-    mycudaMalloc((void**)&DhC0_gpu, 4*sizeElsFloat);
-    mycudaMemcpyHostToDevice(DhC0_gpu, DhC0, 4*sizeElsFloat);
-    cudaBindTexture(0, texDhC0, DhC0_gpu, channelDesc);
-
-    // Second shape function derivatives array (second column for each element)
-    mycudaMalloc((void**)&DhC1_gpu, 4*sizeElsFloat);
-    mycudaMemcpyHostToDevice(DhC1_gpu, DhC1, 4*sizeElsFloat);
-    cudaBindTexture(0, texDhC1, DhC1_gpu, channelDesc);
-
-    // Third shape function derivatives array (third column for each element)
-    mycudaMalloc((void**)&DhC2_gpu, 4*sizeElsFloat);
-    mycudaMemcpyHostToDevice(DhC2_gpu, DhC2, 4*sizeElsFloat);
-    cudaBindTexture(0, texDhC2, DhC2_gpu, channelDesc);
-
     // Jacobian determinant array
-    channelDesc = cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
+    cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
     mycudaMalloc((void**)&Volume_gpu, sizeElsFloat);
     mycudaMemcpyHostToDevice(Volume_gpu, Volume, sizeElsFloat);
     cudaBindTexture(0, texVolume, Volume_gpu, channelDesc);
@@ -1141,9 +1118,6 @@ void InitGPU_TetrahedronAniso(float* A)
  */
 void ClearGPU_TetrahedronTLED(void)
 {
-    mycudaFree(DhC0_gpu);
-    mycudaFree(DhC1_gpu);
-    mycudaFree(DhC2_gpu);
     mycudaFree(Volume_gpu);
     mycudaFree(FCrds_gpu);
     mycudaFree(F0_gpu);
@@ -1180,7 +1154,7 @@ void ClearGPU_TetrahedronAniso(void)
 /**
  * Calls the two kernels to compute the internal forces
  */
-void CudaTetrahedronTLEDForceField3f_addForce(int4* nodesPerElement, float Lambda, float Mu, unsigned int nbElem, unsigned int nbVertex, unsigned int nbElemPerVertex, unsigned int viscoelasticity, unsigned int anisotropy, const void* x, const void* x0, void* f)
+void CudaTetrahedronTLEDForceField3f_addForce(int4* nodesPerElement, float4* DhC0, float4* DhC1, float4* DhC2, float Lambda, float Mu, unsigned int nbElem, unsigned int nbVertex, unsigned int nbElemPerVertex, unsigned int viscoelasticity, unsigned int anisotropy, const void* x, const void* x0, void* f)
 {
     setX(x);
     setX0(x0);
@@ -1198,22 +1172,22 @@ void CudaTetrahedronTLEDForceField3f_addForce(int4* nodesPerElement, float Lambd
     {
     case 0 :
         // Isotropic
-    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0<<< grid1, threads1>>>(nodesPerElement, Lambda, Mu, nbElem, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0");}
+    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0<<< grid1, threads1>>>(nodesPerElement, DhC0, DhC1, DhC2, Lambda, Mu, nbElem, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0");}
     break;
 
     case 1 :
         // Anisotropic
-    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1<<< grid1, threads1>>>(nodesPerElement, Lambda, Mu, nbElem, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1");}
+    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1<<< grid1, threads1>>>(nodesPerElement, DhC0, DhC1, DhC2, Lambda, Mu, nbElem, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1");}
     break;
 
     case 2 :
         // Viscoelastic
-    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2<<< grid1, threads1>>>(nodesPerElement, Lambda, Mu, nbElem, Di1_gpu, Di2_gpu, Dv1_gpu, Dv2_gpu, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2");}
+    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2<<< grid1, threads1>>>(nodesPerElement, DhC0, DhC1, DhC2, Lambda, Mu, nbElem, Di1_gpu, Di2_gpu, Dv1_gpu, Dv2_gpu, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2");}
     break;
 
     case 3 :
         // Viscoelastic and anisotropic
-    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3<<< grid1, threads1>>>(nodesPerElement, Lambda, Mu, nbElem, Di1_gpu, Di2_gpu, Dv1_gpu, Dv2_gpu, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3");}
+    {CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3<<< grid1, threads1>>>(nodesPerElement, DhC0, DhC1, DhC2, Lambda, Mu, nbElem, Di1_gpu, Di2_gpu, Dv1_gpu, Dv2_gpu, F0_gpu, F1_gpu, F2_gpu, F3_gpu); mycudaDebugError("CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3");}
     break;
     }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
@@ -78,9 +78,6 @@ __device__ float4 computeForce_tet(const int node, const float4 DhC0, const floa
         const float3 Node1Disp, const float3 Node2Disp, const float3 Node3Disp,
         const float3 Node4Disp, const float * SPK, const int tid);
 
-// A few global constants
-static int sizeNodesInt, sizeElsFloat, sizeElsInt;
-
 // Device function returning the position of vertex i as a float3
 __device__ CudaVec3f getX(const float* x, int i)
 {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -132,6 +132,8 @@ protected:
 
     float* m_device_volume { nullptr };
 
+    float3* m_device_preferredDirection { nullptr };
+
 };
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -65,7 +65,7 @@ Year = {2009}                                                                   
 #include <sofa/gpu/cuda/CudaTypes.h>
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/component/topology/container/constant/MeshTopology.h>
-
+#include "vector_types.h"
 
 namespace sofa
 {
@@ -77,6 +77,9 @@ namespace cuda
 {
 
 using namespace sofa::defaulttype;
+
+template<class T>
+class CudaTextureObject;
 
 class CudaTetrahedronTLEDForceField : public core::behavior::ForceField<CudaVec3fTypes>
 {
@@ -120,6 +123,8 @@ public:
     void ComputeDhDxTetra(const Element& e, const VecCoord& x, float DhDr[4][3], float DhDx[4][3]);
 
 protected:
+
+    int4* m_device_nodesPerElement { nullptr };
 
 };
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -130,6 +130,8 @@ protected:
     float4* m_device_DhC1 { nullptr };
     float4* m_device_DhC2 { nullptr };
 
+    float* m_device_volume { nullptr };
+
 };
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -144,6 +144,11 @@ protected:
     float4* m_device_Dv1 { nullptr };
     float4* m_device_Dv2 { nullptr };
 
+    float4* m_device_F0 { nullptr };
+    float4* m_device_F1 { nullptr };
+    float4* m_device_F2 { nullptr };
+    float4* m_device_F3 { nullptr };
+
 };
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -132,6 +132,8 @@ protected:
 
     float* m_device_volume { nullptr };
 
+    int2* m_device_forceCoordinates { nullptr };
+
     float3* m_device_preferredDirection { nullptr };
 
     // Rate-dependant stress (isochoric part)

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -126,6 +126,10 @@ protected:
 
     int4* m_device_nodesPerElement { nullptr };
 
+    float4* m_device_DhC0 { nullptr };
+    float4* m_device_DhC1 { nullptr };
+    float4* m_device_DhC2 { nullptr };
+
 };
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -134,6 +134,14 @@ protected:
 
     float3* m_device_preferredDirection { nullptr };
 
+    // Rate-dependant stress (isochoric part)
+    float4* m_device_Di1 { nullptr };
+    float4* m_device_Di2 { nullptr };
+
+    // Rate-dependant stress (volumetric part)
+    float4* m_device_Dv1 { nullptr };
+    float4* m_device_Dv2 { nullptr };
+
 };
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -124,6 +124,9 @@ public:
 
 protected:
 
+    /// Device data
+    //@{
+
     int4* m_device_nodesPerElement { nullptr };
 
     float4* m_device_DhC0 { nullptr };
@@ -148,6 +151,8 @@ protected:
     float4* m_device_F1 { nullptr };
     float4* m_device_F2 { nullptr };
     float4* m_device_F3 { nullptr };
+
+    //@}
 
 };
 


### PR DESCRIPTION
Instead, I use raw gpu pointers.

I measured the performances on the scene `applications\plugins\SofaCUDA\scenes\benchmarks\CudaTetrahedronTLEDForceField_beam10x10x40_gpu.scn` on 50k time steps:

```
before
[INFO]    [BatchGUI] 50000 iterations done in 11.9961 s ( 4168.04 FPS)

after
[INFO]    [BatchGUI] 50000 iterations done in 10.3888 s ( 4812.87 FPS).
```

Note that I did not change anything in the algorithm, except the following check:

```cpp
if (FCrds.y < 0 || FCrds.y >= nbElements)
{
    FCrds.y = 0;
}
```

I had to add this check because `FCrds.y` was often equal to `-1`, which then leads to out-of-bounds vector access. This check was not required before, because out-of-bounds texture returns 0.
I don't know if this behavior is intended or not.

TODO:

- [x] Test that `CudaTetrahedronTLEDForceField` now compiles with CUDA 12.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
