### PR TITLE
[Core] Fix UB (misaligned address) when comparing string

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
@@ -143,11 +143,8 @@ void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* 
 /// Helper method used by initData()
 void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* name, const char* help, BaseData::DataFlags dataFlags )
 {
-    // Questionnable optimization: test a single 'uint32_t' rather that four 'char'
-    static const char *draw_str = "draw";
-    static const char *show_str = "show";
-    static uint32_t draw_prefix = *reinterpret_cast<const uint32_t*>(draw_str);
-    static uint32_t show_prefix = *reinterpret_cast<const uint32_t*>(show_str);
+    static constexpr std::string_view draw_prefix = "draw";
+    static constexpr std::string_view show_prefix = "show";
 
     res.owner = this;
     res.data = field;
@@ -157,7 +154,7 @@ void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* 
 
     if (strlen(name) >= 3)
     {
-        uint32_t prefix = *reinterpret_cast<const uint32_t*>(name);
+        std::string_view prefix = std::string_view(name).substr(0, 4);
 
         if (prefix == draw_prefix || prefix == show_prefix)
             res.group = "Visualization";

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
@@ -152,7 +152,7 @@ void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* 
     res.helpMsg = help;
     res.dataFlags = dataFlags;
 
-    if (strlen(name) >= 3)
+    if (strlen(name) >= 4)
     {
         std::string_view prefix = std::string_view(name).substr(0, 4);
 


### PR DESCRIPTION
Playing with UndefinedBehaviorSanitizer and came across UBs at the very start...

This first one is triggered because of misaligned adress when reinterpret_cast a a pointer of char to a a pointer of uintr32_t.

```
Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp:149:35: runtime error: load of misaligned address 0x7f5e01822917 for type 'const uint32_t', which requires 4 byte alignment
0x7f5e01822917: note: pointer points here
 6c 2e 68 00 64  72 61 77 00 73 68 6f 77  00 56 69 73 75 61 6c 69  7a 61 74 69 6f 6e 00 22  20 00 4c
```

This is easily fixed by removing this `questionnable` (sic 😅) "optimized" test for comparing strings, and convert to a more readable (and modern) code
I dont really see the need to optimize (and in this way...) this part .

 For those curious about the optimization, it comes from
 https://github.com/sofa-framework/sofa/blame/b3fdf7e4619536941e9cfdd6d4bc6f3e7169af0b/framework/sofa/core/objectmodel/Base.cpp#L96
 and
 https://learn.microsoft.com/en-us/windows/win32/directshow/fourcc-codes
apparently



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
