### PR TITLE
[Core] Use std::function for Link's Validator (and fix UB)

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
@@ -143,11 +143,8 @@ void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* 
 /// Helper method used by initData()
 void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* name, const char* help, BaseData::DataFlags dataFlags )
 {
-    // Questionnable optimization: test a single 'uint32_t' rather that four 'char'
-    static const char *draw_str = "draw";
-    static const char *show_str = "show";
-    static uint32_t draw_prefix = *reinterpret_cast<const uint32_t*>(draw_str);
-    static uint32_t show_prefix = *reinterpret_cast<const uint32_t*>(show_str);
+    static constexpr std::string_view draw_prefix = "draw";
+    static constexpr std::string_view show_prefix = "show";
 
     res.owner = this;
     res.data = field;
@@ -157,7 +154,7 @@ void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* 
 
     if (strlen(name) >= 3)
     {
-        uint32_t prefix = *reinterpret_cast<const uint32_t*>(name);
+        std::string_view prefix = std::string_view(name).substr(0, 4);
 
         if (prefix == draw_prefix || prefix == show_prefix)
             res.group = "Visualization";

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
@@ -45,9 +45,9 @@ BaseObject::BaseObject()
     , l_slaves(initLink("slaves","Sub-objects used internally by this object"))
     , l_master(initLink("master","nullptr for regular objects, or master object for which this object is one sub-objects"))
 {
-    l_context.setValidator(&sofa::core::objectmodel::BaseObject::changeContextLink);
+    l_context.setValidator(std::bind(&sofa::core::objectmodel::BaseObject::changeContextLink, this, std::placeholders::_1, std::placeholders::_2));
     l_context.set(BaseContext::getDefault());
-    l_slaves.setValidator(&sofa::core::objectmodel::BaseObject::changeSlavesLink);
+    l_slaves.setValidator(std::bind(&sofa::core::objectmodel::BaseObject::changeSlavesLink, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     f_listening.setAutoLink(false);
 }
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
@@ -45,9 +45,12 @@ BaseObject::BaseObject()
     , l_slaves(initLink("slaves","Sub-objects used internally by this object"))
     , l_master(initLink("master","nullptr for regular objects, or master object for which this object is one sub-objects"))
 {
-    l_context.setValidator(std::bind(&sofa::core::objectmodel::BaseObject::changeContextLink, this, std::placeholders::_1, std::placeholders::_2));
+    auto bindChangeContextLink = [this](auto&& before, auto&& after) { return this->changeContextLink(before, after); };
+    l_context.setValidator(bindChangeContextLink);
     l_context.set(BaseContext::getDefault());
-    l_slaves.setValidator(std::bind(&sofa::core::objectmodel::BaseObject::changeSlavesLink, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+
+    auto bindChangeSlavesLink = [this](auto&& ptr, auto&& index, auto&& add) { return this->changeSlavesLink(ptr, index, add); };
+    l_slaves.setValidator(bindChangeSlavesLink);
     f_listening.setAutoLink(false);
 }
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
@@ -27,6 +27,8 @@
 #include <sofa/core/sptr.h>
 #include <sofa/core/fwd.h>
 
+#include <functional>
+
 namespace sofa
 {
 namespace core::objectmodel
@@ -564,7 +566,7 @@ public:
     typedef typename Inherit::TraitsContainer TraitsContainer;
     typedef typename Inherit::Container Container;
 
-    typedef void (OwnerType::*ValidatorFn)(DestPtr v, std::size_t index, bool add);
+    using ValidatorFn = std::function<void(DestPtr, std::size_t, bool)>;
 
     MultiLink() : m_validator{nullptr} {}
 
@@ -610,13 +612,13 @@ protected:
     void added(DestPtr val, std::size_t index)
     {
         if (m_validator)
-            (this->m_owner->*m_validator)(val, index, true);
+            m_validator(val, index, true);
     }
 
     void removed(DestPtr val, std::size_t index)
     {
         if (m_validator)
-            (this->m_owner->*m_validator)(val, index, false);
+            m_validator(val, index, false);
     }
 };
 
@@ -641,7 +643,7 @@ public:
     using Inherit::m_value;
     using Inherit::m_owner;
 
-    typedef void (OwnerType::*ValidatorFn)(DestPtr before, DestPtr& after);
+    using ValidatorFn = std::function<void(DestPtr, DestPtr&)>;
 
     SingleLink()
         : m_validator(nullptr)
@@ -745,7 +747,7 @@ protected:
         if (m_validator)
         {
             DestPtr after = val;
-            (m_owner->*m_validator)(nullptr, after);
+            m_validator(nullptr, after);
             if (after != val)
                 TraitsValueType::set(m_value.get(), after);
         }
@@ -756,7 +758,7 @@ protected:
         if (m_validator)
         {
             DestPtr after = nullptr;
-            (m_owner->*m_validator)(val, after);
+            m_validator(val, after);
             if (after)
                 TraitsValueType::set(m_value.get(), after);
         }
@@ -767,7 +769,7 @@ protected:
         if (m_validator)
         {
             DestPtr after = val;
-            (m_owner->*m_validator)(before, after);
+            m_validator(before, after);
             if (after != val)
                 TraitsValueType::set(this->m_value.get(), after);
         }


### PR DESCRIPTION
Based on 
#3664 

2nd UB detected just after starting runSofa.

```
/linuxdata/sofa/src/current/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h:770:14: runtime error: member access within address 0x55dcc8e551e8 which does not point to an object of type 'TLink'
0x55dcc8e551e8: note: object has invalid vptr
 dc 55 00 00  06 00 00 00 00 00 00 00  00 00 00 00 65 72 00 00  00 63 e5 c8 dc 55 00 00  a0 61 e5 c8
              ^~~~~~~~~~~~~~~~~~~~~~~
              invalid vptr
/linuxdata/sofa/src/current/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h:770:36: runtime error: member call on address 0x55dcc8e55fa8 which does not point to an object of type 'BaseObject'
0x55dcc8e55fa8: note: object has invalid vptr
 dc 55 00 00  c0 6c 7f f7 5d 7f 00 00  00 00 00 00 00 00 00 00  51 00 00 00 00 00 00 00  00 00 00 00
```

I dont really understand the problem here, but it could be because 
https://stackoverflow.com/a/57304113

Anway, In my case, I found the synxtax of ValidatorFn and its use `(m_owner->*m_validator)(nullptr, after);` really incomprehensible ; I thought it was calling m_validator from m_owner 🤐....
I rewrote the alias to pointer of a non-static method of a class to use std::function, and std::bind for binding, hence the breaking flag 😑.
IMO this is more readable, and more modern c++.

And icing on the cake, fix the Undefined Behavior error 😏

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
