### PR TITLE
[Helper,Geometry] Move proximity classes into free functions

### DIFF
--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
@@ -22,9 +22,9 @@
 #define SOFA_COMPONENT_COLLISION_LOCALMINDISTANCE_CPP
 #include <sofa/component/collision/detection/intersection/LocalMinDistance.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/proximity.h>
 #include <sofa/core/collision/Intersection.inl>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/geometry/proximity/SegmentTriangle.h>
 #include <sofa/simulation/Node.h>
 
 #define EMIT_EXTRA_DEBUG_MESSAGE false
@@ -1072,7 +1072,6 @@ int LocalMinDistance::computeIntersection(Sphere& e1, Sphere& e2, OutputVector* 
 bool LocalMinDistance::testIntersection(Ray &t1,Triangle &t2)
 {
     type::Vec3 P,Q;
-    static DistanceSegTri proximitySolver;
 
     const SReal alarmDist = getAlarmDistance() + t1.getProximity() + t2.getProximity();
 
@@ -1082,7 +1081,10 @@ bool LocalMinDistance::testIntersection(Ray &t1,Triangle &t2)
     Vec3 A = t1.origin();
     Vec3 B = A + t1.direction() * t1.l();
 
-    proximitySolver.NewComputation( t2.p1(), t2.p2(), t2.p3(), A, B,P,Q);
+    const auto r = sofa::geometry::proximity::computeClosestPointsSegmentAndTriangle(t2.p1(), t2.p2(), t2.p3(), A, B,P,Q);
+    msg_warning_when(!r, "RayNewProximityIntersection") << "Failed to compute distance between ray ["
+        << A << "," << B <<"] and triangle [" << t2.p1() << ", " << t2.p2() << ", " << t2.p3() << "]";
+
     auto PQ=Q-P;
 
     if (PQ.norm2() < alarmDist*alarmDist)
@@ -1105,9 +1107,11 @@ int LocalMinDistance::computeIntersection(Ray &t1, Triangle &t2, OutputVector* c
     Vec3 B = A + t1.direction() * t1.l();
 
     Vec3 P,Q;
-    static DistanceSegTri proximitySolver;
 
-    proximitySolver.NewComputation( t2.p1(), t2.p2(), t2.p3(), A,B,P,Q);
+    const auto r = sofa::geometry::proximity::computeClosestPointsSegmentAndTriangle(t2.p1(), t2.p2(), t2.p3(), A, B,P,Q);
+    msg_warning_when(!r, "RayNewProximityIntersection") << "Failed to compute distance between ray ["
+        << A << "," << B <<"] and triangle [" << t2.p1() << ", " << t2.p2() << ", " << t2.p3() << "]";
+
     Vec3 PQ=Q-P;
 
     if (PQ.norm2() >= alarmDist*alarmDist)

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/RayDiscreteIntersection.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/RayDiscreteIntersection.cpp
@@ -22,7 +22,6 @@
 #include <sofa/component/collision/detection/intersection/RayDiscreteIntersection.inl>
 
 #include <sofa/core/collision/Intersection.inl>
-#include <sofa/helper/proximity.h>
 #include <iostream>
 #include <algorithm>
 #include <sofa/core/collision/IntersectorFactory.h>

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/RayDiscreteIntersection.inl
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/RayDiscreteIntersection.inl
@@ -23,7 +23,6 @@
 #include <sofa/component/collision/detection/intersection/RayDiscreteIntersection.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/proximity.h>
 #include <algorithm>
 
 

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/TetrahedronDiscreteIntersection.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/TetrahedronDiscreteIntersection.cpp
@@ -23,7 +23,6 @@
 
 #include <sofa/component/collision/detection/intersection/DiscreteIntersection.h>
 #include <sofa/core/collision/Intersection.inl>
-#include <sofa/helper/proximity.h>
 #include <sofa/core/collision/IntersectorFactory.h>
 
 namespace sofa::component::collision::detection::intersection

--- a/Sofa/framework/Geometry/CMakeLists.txt
+++ b/Sofa/framework/Geometry/CMakeLists.txt
@@ -6,16 +6,20 @@ set(SOFAGEOMETRYSRC_ROOT "src/sofa/geometry")
 set(HEADER_FILES
     ${SOFAGEOMETRYSRC_ROOT}/config.h.in
     ${SOFAGEOMETRYSRC_ROOT}/init.h
-    ${SOFAGEOMETRYSRC_ROOT}/ElementType.h
-    ${SOFAGEOMETRYSRC_ROOT}/ElementInfo.h
-    ${SOFAGEOMETRYSRC_ROOT}/Point.h
     ${SOFAGEOMETRYSRC_ROOT}/Edge.h
-    ${SOFAGEOMETRYSRC_ROOT}/Triangle.h
+    ${SOFAGEOMETRYSRC_ROOT}/ElementInfo.h
+    ${SOFAGEOMETRYSRC_ROOT}/ElementType.h
+    ${SOFAGEOMETRYSRC_ROOT}/Hexahedron.h
+    ${SOFAGEOMETRYSRC_ROOT}/Pentahedron.h
+    ${SOFAGEOMETRYSRC_ROOT}/Point.h
+    ${SOFAGEOMETRYSRC_ROOT}/Pyramid.h
     ${SOFAGEOMETRYSRC_ROOT}/Quad.h
     ${SOFAGEOMETRYSRC_ROOT}/Tetrahedron.h
-    ${SOFAGEOMETRYSRC_ROOT}/Pentahedron.h
-    ${SOFAGEOMETRYSRC_ROOT}/Pyramid.h
-    ${SOFAGEOMETRYSRC_ROOT}/Hexahedron.h
+    ${SOFAGEOMETRYSRC_ROOT}/Triangle.h
+
+    ${SOFAGEOMETRYSRC_ROOT}/proximity/PointTriangle.h
+    ${SOFAGEOMETRYSRC_ROOT}/proximity/SegmentTriangle.h
+    ${SOFAGEOMETRYSRC_ROOT}/proximity/TriangleTriangle.h
 )
 
 set(SOURCE_FILES

--- a/Sofa/framework/Geometry/src/sofa/geometry/proximity/SegmentTriangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/proximity/SegmentTriangle.h
@@ -1,0 +1,88 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/geometry/config.h>
+#include <sofa/type/Mat.h>
+#include <sofa/type/Mat_solve_LCP.h>
+
+#include <type_traits>
+
+namespace sofa::geometry::proximity
+{
+
+template<typename Node,
+     typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+     typename = std::enable_if_t<std::is_scalar_v<T>>
+>
+[[nodiscard]]
+constexpr bool computeClosestPointsSegmentAndTriangle(
+    const Node& triangleP_0, const Node& triangleP_1, const Node& triangleP_2,
+    const Node& segmentQ_0, const Node& segmentQ_1,
+    Node &closestPointInP, Node &closestPointInQ)
+{
+    type::MatNoInit<5, 5, T> A;
+    type::VecNoInit<5, T> b;
+    type::VecNoInit<10, T> result;
+
+    const Node Q0Q1 { segmentQ_1 - segmentQ_0 };
+    const Node P0P1 { triangleP_1 - triangleP_0 };
+    const Node P0P2 { triangleP_2 - triangleP_0 };
+    const Node P0Q0 { segmentQ_0 - triangleP_0 };
+
+    constexpr T zero = static_cast<T>(0);
+    constexpr T one = static_cast<T>(1);
+
+    A[0][3] = one; A[0][4] = zero;
+    A[1][3] = one; A[1][4] = zero;
+    A[2][3] = zero; A[2][4] = one;
+    A[3][0] = -one; A[3][1] = -one; A[3][2] = zero; A[3][3] = zero; A[3][4] = zero;
+    A[4][0] = zero; A[4][1] = zero; A[4][2] = -one; A[4][3] = zero; A[4][4] = zero;
+
+    A[0][0] =  dot(P0P1,P0P1);  A[0][1] =  dot(P0P2,P0P1);  A[0][2] = -dot(Q0Q1,P0P1);
+    A[1][0] =  dot(P0P1,P0P2);  A[1][1] =  dot(P0P2,P0P2);  A[1][2] = -dot(Q0Q1,P0P2);
+    A[2][0] = -dot(P0P1,Q0Q1);  A[2][1] = -dot(P0P2,Q0Q1);  A[2][2] =  dot(Q0Q1,Q0Q1);
+
+    b[3] = one;
+    b[4] = one;
+    b[0] = -dot(P0Q0,P0P1);
+    b[1] = -dot(P0Q0,P0P2);
+    b[2] =  dot(P0Q0,Q0Q1);
+
+    if (type::solveLCP(b, A, result))
+    {
+        const T alpha = result[5];
+        const T beta = result[6];
+        const T gamma = result[7];
+
+        closestPointInP = triangleP_0 + P0P1*alpha + P0P2*beta;
+        closestPointInQ = segmentQ_0 + Q0Q1*gamma;
+        return true;
+    }
+
+    closestPointInP = triangleP_0;
+    closestPointInQ = segmentQ_0;
+
+    return false;
+}
+
+}

--- a/Sofa/framework/Geometry/src/sofa/geometry/proximity/TriangleTriangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/proximity/TriangleTriangle.h
@@ -1,0 +1,97 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/geometry/config.h>
+#include <sofa/type/Mat.h>
+#include <sofa/type/Mat_solve_LCP.h>
+
+#include <type_traits>
+
+namespace sofa::geometry::proximity
+{
+
+template<typename Node,
+     typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+     typename = std::enable_if_t<std::is_scalar_v<T>>
+>
+[[nodiscard]]
+constexpr bool computeClosestPointsInTwoTriangles(
+    const Node& triangleP_0, const Node& triangleP_1, const Node& triangleP_2,
+    const Node& triangleQ_0, const Node& triangleQ_1, const Node& triangleQ_2,
+    Node &closestPointInP, Node &closestPointInQ)
+{
+    type::MatNoInit<6, 6, T> A;
+    type::VecNoInit<6, T> b;
+    type::VecNoInit<12, T> result;
+
+    const Node P0P1 { triangleP_1 - triangleP_0 };
+    const Node P0P2 { triangleP_2 - triangleP_0 };
+    const Node Q0Q1 { triangleQ_1 - triangleQ_0 };
+    const Node Q0Q2 { triangleQ_2 - triangleQ_0 };
+    const Node P0Q0 { triangleQ_0 - triangleP_0 };
+
+    constexpr T zero = static_cast<T>(0);
+    constexpr T one = static_cast<T>(1);
+
+    A[0][4] = one; A[4][0] = -one;
+    A[1][4] = one; A[4][1] = -one;
+    A[2][4] = zero; A[4][2] = zero;
+    A[3][4] = zero; A[4][3] = zero;
+
+    A[0][5] = zero; A[5][0] = zero;
+    A[1][5] = zero; A[5][1] = zero;
+    A[2][5] = one; A[5][2] = -one;
+    A[3][5] = one; A[5][3] = -one;
+
+    A[4][4] = zero; A[5][5] = zero;
+    A[4][5] = zero; A[5][4] = zero;
+
+    A[0][0] =  dot(P0P1,P0P1);  A[0][1] =  dot(P0P2,P0P1);  A[0][2] = -dot(Q0Q1,P0P1);  A[0][3] = -dot(Q0Q2,P0P1);
+    A[1][0] =  dot(P0P1,P0P2);  A[1][1] =  dot(P0P2,P0P2);  A[1][2] = -dot(Q0Q1,P0P2);  A[1][3] = -dot(Q0Q2,P0P2);
+    A[2][0] = -dot(P0P1,Q0Q1);  A[2][1] = -dot(P0P2,Q0Q1);  A[2][2] =  dot(Q0Q1,Q0Q1);  A[2][3] =  dot(Q0Q2,Q0Q1);
+    A[3][0] = -dot(P0P1,Q0Q2);  A[3][1] = -dot(P0P2,Q0Q2);  A[3][2] =  dot(Q0Q1,Q0Q2);  A[3][3] =  dot(Q0Q2,Q0Q2);
+
+    b[0]=-dot(P0Q0,P0P1);
+    b[1]=-dot(P0Q0,P0P2);
+    b[2]= dot(P0Q0,Q0Q1);
+    b[3]= dot(P0Q0,Q0Q2);
+    b[4]= one;
+    b[5]= one;
+
+    if (type::solveLCP(b, A, result))
+    {
+        const T alphaP = result[6];
+        const T betaP = result[7];
+        const T alphaQ = result[8];
+        const T betaQ = result[9];
+        closestPointInP = triangleP_0 + P0P1 * alphaP + P0P2 * betaP;
+        closestPointInQ = triangleQ_0 + Q0Q1 * alphaQ + Q0Q2 * betaQ;
+        return true;
+    }
+
+    closestPointInP = triangleP_0;
+    closestPointInQ = triangleQ_0;
+    return false;
+}
+
+}

--- a/Sofa/framework/Helper/src/sofa/helper/proximity.h
+++ b/Sofa/framework/Helper/src/sofa/helper/proximity.h
@@ -25,7 +25,7 @@
 #include <sofa/type/Vec.h>
 #include <sofa/helper/config.h>
 
-SOFA_DEPRECATED_HEADER_NOT_REPLACED("v23.06", "v23.12")
+SOFA_DEPRECATED_HEADER("v23.06", "v23.12", "sofa/geometry/proximity/PointTriangle.h, sofa/geometry/proximity/SegmentTriangle.h or sofa/geometry/proximity/TriangleTriangle.h")
 
 namespace sofa
 {
@@ -46,7 +46,8 @@ public:
 
     // init the solver with the new coordinates of the triangle & the segment
     // solve the lcp
-    void SOFA_PROXIMITY_CLASSES_DEPRECATED() NewComputation(const sofa::type::Vec3& P1, const sofa::type::Vec3& P2, const sofa::type::Vec3& P3, const sofa::type::Vec3& Q1, const sofa::type::Vec3& Q2, const sofa::type::Vec3& Q3, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
+    SOFA_PROXIMITY_CLASSES_DEPRECATED()
+    void NewComputation(const sofa::type::Vec3& P1, const sofa::type::Vec3& P2, const sofa::type::Vec3& P3, const sofa::type::Vec3& Q1, const sofa::type::Vec3& Q2, const sofa::type::Vec3& Q3, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
 
 };
 
@@ -63,7 +64,8 @@ public:
 
     // init the solver with the new coordinates of the triangle & the segment
     // solve the lcp
-    void SOFA_PROXIMITY_CLASSES_DEPRECATED() NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q1, const sofa::type::Vec3 &Q2, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
+    SOFA_PROXIMITY_CLASSES_DEPRECATED()
+    void NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q1, const sofa::type::Vec3 &Q2, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
 };
 
 //-----------------------------------------------------------------------------
@@ -79,7 +81,8 @@ public:
 
     // init the solver with the new coordinates of the triangle & the segment
     // solve the lcp
-    void SOFA_PROXIMITY_CLASSES_DEPRECATED() NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q, sofa::type::Vec3 &Presult);
+    SOFA_PROXIMITY_CLASSES_DEPRECATED()
+    void NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q, sofa::type::Vec3 &Presult);
 };
 
 } // namespace helper

--- a/Sofa/framework/Helper/src/sofa/helper/proximity.h
+++ b/Sofa/framework/Helper/src/sofa/helper/proximity.h
@@ -25,6 +25,8 @@
 #include <sofa/type/Vec.h>
 #include <sofa/helper/config.h>
 
+SOFA_DEPRECATED_HEADER_NOT_REPLACED("v23.06", "v23.12")
+
 namespace sofa
 {
 
@@ -44,7 +46,7 @@ public:
 
     // init the solver with the new coordinates of the triangle & the segment
     // solve the lcp
-    void NewComputation(const sofa::type::Vec3& P1, const sofa::type::Vec3& P2, const sofa::type::Vec3& P3, const sofa::type::Vec3& Q1, const sofa::type::Vec3& Q2, const sofa::type::Vec3& Q3, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
+    void SOFA_PROXIMITY_CLASSES_DEPRECATED() NewComputation(const sofa::type::Vec3& P1, const sofa::type::Vec3& P2, const sofa::type::Vec3& P3, const sofa::type::Vec3& Q1, const sofa::type::Vec3& Q2, const sofa::type::Vec3& Q3, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
 
 };
 
@@ -61,7 +63,7 @@ public:
 
     // init the solver with the new coordinates of the triangle & the segment
     // solve the lcp
-    void NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q1, const sofa::type::Vec3 &Q2, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
+    void SOFA_PROXIMITY_CLASSES_DEPRECATED() NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q1, const sofa::type::Vec3 &Q2, sofa::type::Vec3 &Presult, sofa::type::Vec3 &Qresult);
 };
 
 //-----------------------------------------------------------------------------
@@ -77,7 +79,7 @@ public:
 
     // init the solver with the new coordinates of the triangle & the segment
     // solve the lcp
-    void NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q, sofa::type::Vec3 &Presult);
+    void SOFA_PROXIMITY_CLASSES_DEPRECATED() NewComputation(const sofa::type::Vec3 &P1, const sofa::type::Vec3 &P2, const sofa::type::Vec3 &P3, const sofa::type::Vec3 &Q, sofa::type::Vec3 &Presult);
 };
 
 } // namespace helper


### PR DESCRIPTION
The code in `proximity.h` has several problems:

- The classes names are misleading. It makes think that it computes the distance, but it computes the closest points.
- Classes with a single function that could be static. It could be a free function.
- Difficult to find this file in Helper. To me, it makes more sense to put it in Geometry.
- Types mismatch

I separated the 3 functions in dedicated files.
I deprecated the classes and the header.

Note: I don't think the LCP approach is the fastest one to compute closest points. 
Not2: `Mat_solve_LCP.h` would deserve a bit of cleaning



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
