### PR TITLE
[Helper, GL] Fix various memleaks

### DIFF
--- a/Sofa/GL/src/sofa/gl/Axis.cpp
+++ b/Sofa/GL/src/sofa/gl/Axis.cpp
@@ -35,7 +35,7 @@ const int Axis::quadricDiscretisation = 16;
 
 //GLuint Axis::displayList;
 //GLUquadricObj *Axis::quadratic = nullptr;
-std::map < std::pair<std::pair<float,float>,float>, Axis* > Axis::axisMap; // great idea but no more valid when creating a new opengl context when switching sofa viewer
+std::map < type::Vec3f, Axis::AxisSPtr > Axis::axisMap; // great idea but no more valid when creating a new opengl context when switching sofa viewer
 
 void Axis::initDraw()
 {
@@ -255,52 +255,52 @@ Axis::~Axis()
         gluDeleteQuadric(quadratic);
 }
 
-Axis* Axis::get(const type::Vec3& len)
+Axis::AxisSPtr Axis::get(const type::Vec3& len)
 {
-    Axis*& a = axisMap[std::make_pair(std::make_pair((float)len[0],(float)len[1]),(float)len[2])];
+    auto& a = axisMap[ { float(len[0]),float(len[1]),float(len[2]) }];
     if (a==nullptr)
-        a = new Axis(len);
+        a = std::make_shared<Axis>(len);
     return a;
 }
 
 void Axis::draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ )
 {
-    Axis* a = get(len);
+    auto a = get(len);
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
 void Axis::draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
 {
-    Axis* a = get(len);
+    auto a = get(len);
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
 void Axis::draw(const double *mat, const type::Vec3& len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
 {
-    Axis* a = get(len);
+    auto a = get(len);
     a->update(mat);
     a->draw( colorX, colorY, colorZ );
 }
 
 void Axis::draw(const type::Vec3& center, const Quaternion& orient, SReal len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
 {
-    Axis* a = get(type::Vec3(len,len,len));
+    auto a = get(type::Vec3(len,len,len));
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
 void Axis::draw(const type::Vec3& center, const double orient[4][4], SReal len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
 {
-    Axis* a = get(type::Vec3(len,len,len));
+    auto a = get(type::Vec3(len,len,len));
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
 void Axis::draw(const double *mat, SReal len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
 {
-    Axis* a = get(type::Vec3(len,len,len));
+    auto a = get(type::Vec3(len,len,len));
     a->update(mat);
     a->draw( colorX, colorY, colorZ );
 }

--- a/Sofa/GL/src/sofa/gl/Axis.h
+++ b/Sofa/GL/src/sofa/gl/Axis.h
@@ -27,6 +27,7 @@
 #include <sofa/gl/glu.h>
 
 #include <map>
+#include <memory>
 
 #include <sofa/gl/config.h>
 
@@ -79,8 +80,10 @@ private:
 
     void initDraw();
 
-    static std::map < std::pair<std::pair<float,float>,float>, Axis* > axisMap;
-    static Axis* get(const type::Vec3& len);
+    using AxisSPtr = std::shared_ptr<Axis>;
+
+    static std::map < type::Vec3f, AxisSPtr > axisMap;
+    static AxisSPtr get(const type::Vec3& len);
 public:
     static void clear() { axisMap.clear(); } // need to be called when display list has been created in another opengl context
 

--- a/Sofa/framework/Helper/src/sofa/helper/io/MeshTopologyLoader.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/io/MeshTopologyLoader.cpp
@@ -261,7 +261,7 @@ bool MeshTopologyLoader::load(const char *filename)
 		return false;
 	}
 
-	bool fileLoaded;
+    bool fileLoaded = false;
 
 	// check the extension of the filename
 	if ((strlen(filename) > 4 && !strcmp(filename + strlen(filename) - 4, ".obj"))
@@ -282,9 +282,18 @@ bool MeshTopologyLoader::load(const char *filename)
 		file.close();
 	}
        
-    if(!fileLoaded)
-        msg_error() << "Unable to load mesh file '" << fname << "'" ;
+    if(fileLoaded)
+    {
+        // topology has been filled, so the Mesh is not needed anymore
+        assert(m_mesh);
 
+        delete m_mesh;
+        m_mesh = nullptr;
+    }
+    else
+    {
+        msg_error() << "Unable to load mesh file '" << fname << "'" ;
+    }
     return fileLoaded;
 }
 


### PR DESCRIPTION
- Axis : storing raw pointer in a static map, and there are never deleted afterwards (-> use shared_ptr) + removing the ugly pair of pair.
- MeshTopologyLoader : the io::Mesh used to read the mesh (from a file) is never deleted after filling the topology (its purpose)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
