### PR TITLE
[Helper] ArgumentParser: Fix map insertion when parsing more than once

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
@@ -94,7 +94,7 @@ void ArgumentParser::parse()
     // copy result
     for (const auto& arg : vecArg)
     {
-        m_parseResult.insert({ arg.key(), arg.value() });
+        m_parseResult[arg.key()] = arg.value();
         if(arg.key() == "argv")
             extra.push_back(arg.value());
 


### PR DESCRIPTION
The second parsing values were not updated because insert() of (unordered_)map does not overwrite values.

This bug was actually making all the scene tests (using runSofa) successful... 🤐

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
