### PR TITLE
[Simulation] Error when trying to load a non-existing file

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -1014,7 +1014,11 @@ void Node::printComponents()
 
 Node::SPtr Node::create( const std::string& name )
 {
-    return getSimulation()->createNewNode(name);
+    if (Simulation* simulation = getSimulation())
+    {
+        return simulation->createNewNode(name);
+    }
+    return nullptr;
 }
 
 void Node::setSleeping(bool val)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.inl
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.inl
@@ -19,24 +19,23 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#pragma once
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/Simulation.h>
 
-namespace sofa
-{
-
-namespace simulation
+namespace sofa::simulation
 {
 
 template <class RealObject>
 Node::SPtr Node::create( RealObject*, sofa::core::objectmodel::BaseObjectDescription* arg)
 {
-    Node::SPtr obj=getSimulation()->createNewNode(arg->getName());
-    obj->parse(arg);
-    return obj;
-}
-
-
+    if (Simulation* simulation = getSimulation())
+    {
+        Node::SPtr obj = simulation->createNewNode(arg->getName());
+        obj->parse(arg);
+        return obj;
+    }
+    return nullptr;
 }
 
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
@@ -62,6 +62,7 @@
 
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
+#include <sofa/helper/system/FileSystem.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalProjectPositionAndVelocityVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalProjectPositionAndVelocityVisitor;
@@ -439,9 +440,23 @@ void Simulation::dumpState ( Node* root, std::ofstream& out )
 /// Load a scene from a file
 Node::SPtr Simulation::load ( const std::string& filename, bool reload, const std::vector<std::string>& sceneArgs )
 {
-    if( sofa::helper::system::SetDirectory::GetFileName(filename.c_str()).empty() || // no filename
-            sofa::helper::system::SetDirectory::GetExtension(filename.c_str()).empty() ) // filename with no extension
+    if( sofa::helper::system::SetDirectory::GetFileName(filename.c_str()).empty())
+    {
+        msg_error() << "Cannot load file '" << filename << "': filename cannot be extracted from the given path";
         return nullptr;
+    }
+
+    if (sofa::helper::system::SetDirectory::GetExtension(filename.c_str()).empty() )
+    {
+        msg_error() << "Cannot load file '" << filename << "': extension cannot be extracted from the given path";
+        return nullptr;
+    }
+
+    if (!sofa::helper::system::FileSystem::exists(filename))
+    {
+        msg_error() << "Cannot load file '" << filename << "': file cannot be found";
+        return nullptr;
+    }
 
     SceneLoader *loader = SceneLoaderFactory::getInstance()->getEntryFileName(filename);
 

--- a/Sofa/framework/Simulation/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/test/CMakeLists.txt
@@ -5,11 +5,12 @@ project(Sofa.Simulation.Core_test)
 set(SOURCE_FILES
     ParallelForEach_test.cpp
     RequiredPlugin_test.cpp
-    TaskSchedulerTests.cpp
-    TaskSchedulerTestTasks.h
-    TaskSchedulerTestTasks.cpp
-    TaskSchedulerFactory_test.cpp
     SceneCheckRegistry_test.cpp
+    Simulation_test.cpp
+    TaskSchedulerFactory_test.cpp
+    TaskSchedulerTestTasks.cpp
+    TaskSchedulerTestTasks.h
+    TaskSchedulerTests.cpp
     )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/Sofa/framework/Simulation/Core/test/Simulation_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/Simulation_test.cpp
@@ -39,11 +39,11 @@ TEST(simulationLoad, existingFilename)
     constexpr std::string_view filename { "Demos/caduceus.scn" };
     const std::string path = helper::system::DataRepository.getFile(std::string{filename});
 
-    sofa::simulation::setSimulation(new simulation::graph::DAGSimulation());
-    ASSERT_NE(sofa::simulation::getSimulation(), nullptr);
-    const simulation::Node::SPtr groot = sofa::simulation::getSimulation()->load(path, false, {});
+    simulation::Simulation* simulation = sofa::simulation::graph::getSimulation();
+    ASSERT_NE(simulation, nullptr);
+    const simulation::Node::SPtr groot = simulation->load(path, false, {});
     EXPECT_NE(groot, nullptr);
-    sofa::simulation::getSimulation()->unload(groot);
+    simulation->unload(groot);
 }
 
 
@@ -55,11 +55,11 @@ TEST(simulationLoad, nonExistingFilename)
 
     constexpr std::string_view filename { "aFileThatDoesNotExist.scn" };
 
-    sofa::simulation::setSimulation(new simulation::graph::DAGSimulation());
-    ASSERT_NE(sofa::simulation::getSimulation(), nullptr);
-    const simulation::Node::SPtr groot = sofa::simulation::getSimulation()->load(std::string{filename}, false, {});
+    simulation::Simulation* simulation = sofa::simulation::graph::getSimulation();
+    ASSERT_NE(simulation, nullptr);
+    const simulation::Node::SPtr groot = simulation->load(std::string{filename}, false, {});
     EXPECT_EQ(groot, nullptr);
-    sofa::simulation::getSimulation()->unload(groot);
+    simulation->unload(groot);
 }
 
 }

--- a/Sofa/framework/Simulation/Core/test/Simulation_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/Simulation_test.cpp
@@ -1,0 +1,65 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/helper/system/FileRepository.h>
+#include <sofa/simulation/fwd.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/graph/DAGSimulation.h>
+#include <sofa/testing/TestMessageHandler.h>
+
+namespace sofa
+{
+
+TEST(simulationLoad, existingFilename)
+{
+    // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+    EXPECT_MSG_NOEMIT(Error);
+
+    constexpr std::string_view filename { "Demos/caduceus.scn" };
+    const std::string path = helper::system::DataRepository.getFile(std::string{filename});
+
+    sofa::simulation::setSimulation(new simulation::graph::DAGSimulation());
+    ASSERT_NE(sofa::simulation::getSimulation(), nullptr);
+    const simulation::Node::SPtr groot = sofa::simulation::getSimulation()->load(path, false, {});
+    EXPECT_NE(groot, nullptr);
+    sofa::simulation::getSimulation()->unload(groot);
+}
+
+
+TEST(simulationLoad, nonExistingFilename)
+{
+    // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+    EXPECT_MSG_EMIT(Error);
+
+    constexpr std::string_view filename { "aFileThatDoesNotExist.scn" };
+
+    sofa::simulation::setSimulation(new simulation::graph::DAGSimulation());
+    ASSERT_NE(sofa::simulation::getSimulation(), nullptr);
+    const simulation::Node::SPtr groot = sofa::simulation::getSimulation()->load(std::string{filename}, false, {});
+    EXPECT_EQ(groot, nullptr);
+    sofa::simulation::getSimulation()->unload(groot);
+}
+
+}


### PR DESCRIPTION
I don't think that anything triggers when a non-existing file is trying to be load. So I added an error. I think it could have detected the error from https://github.com/sofa-framework/sofa/pull/3674.

Unit tests are added.

Changes in Node are just nullptr checks to prevent crashes when `getSimulation()` returns `nullptr`.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
