### PR TITLE
[SofaCUDA] Remove BeamLinearMapping<Rigid3fTypes,.>

### DIFF
--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaBeamLinearMapping.cpp
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaBeamLinearMapping.cpp
@@ -37,12 +37,10 @@ using namespace core::behavior;
 // Register in the Factory
 int BeamLinearMappingCudaClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
 
-        .add< BeamLinearMapping<Rigid3fTypes, CudaVec3fTypes> >()
         .add< BeamLinearMapping<Rigid3Types, CudaVec3Types> >()
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-        .add< BeamLinearMapping<Rigid3fTypes, CudaVec3dTypes> >()
-        .add< BeamLinearMapping<Rigid3dTypes, CudaVec3dTypes> >()
+        .add< BeamLinearMapping<Rigid3Types, CudaVec3dTypes> >()
 #endif
         ;
 
@@ -55,13 +53,11 @@ using namespace defaulttype;
 using namespace core;
 using namespace core::behavior;
 
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3fTypes, sofa::gpu::cuda::CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3Types>;
 
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3fTypes, sofa::gpu::cuda::CudaVec3dTypes>;
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3dTypes, sofa::gpu::cuda::CudaVec3dTypes>;
+template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3dTypes>;
 #endif
 
 


### PR DESCRIPTION
Because it cannot be created since it requires a `MechanicalObject<Rigid3fTypes>` (`float`)






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
