### PR TITLE
[MultiThreading] Empty string instead of null pointer in DataExchange

### DIFF
--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.h
@@ -91,10 +91,8 @@ public:
 
         if(arg)
         {
-
-            fromPath = arg->getAttribute(std::string("from"), NULL );
-            toPath = arg->getAttribute(std::string("to"), NULL );
-
+            fromPath = arg->getAttribute(std::string("from"), "" );
+            toPath = arg->getAttribute(std::string("to"), "" );
         }
 
         //context->findLinkDest(stout, fromPath, NULL);


### PR DESCRIPTION
If either `from` or `to` is not provided, the second argument is assigned to a `std::string`. It is an undefined behavior



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
