### PR TITLE
[Collision] Make the (CubeModel) BoundingTree deterministic

### DIFF
--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CubeModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CubeModel.cpp
@@ -303,7 +303,7 @@ void CubeCollisionModel::computeBoundingTree(int maxDepth)
 
                     // Separate cells on each side of the median cell
                     CubeSortPredicate sortpred(splitAxis);
-                    std::sort(elems.begin() + subcells.first.getIndex(), elems.begin() + subcells.second.getIndex(), sortpred);
+                    std::stable_sort(elems.begin() + subcells.first.getIndex(), elems.begin() + subcells.second.getIndex(), sortpred);
 
                     // Create the two new subcells
                     Cube cmiddle(this, middle);


### PR DESCRIPTION
"Solve" the discrepancy of the regression test of MeshSpringForceField.
Sorting the bboxes of the different levels needs a predicate (a boolean function) to compare two bboxes
https://github.com/fredroy/sofa/blob/master/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CubeModel.h#L72

But it can happen that v1 == v2 ; and std::sort does not guarantee stability in these cases.
I suppose the result will depend of the implementation of the STL so it would explain the difference between msvc, gcc, clang/lin and clang/mac.

By using stable_sort, we can get stability and thus the same results between the different platforms.
Questions are:
- stable_sort is a bit slower than sort https://stackoverflow.com/a/34668459 so set the stability as an option?
- the stability itself seems only relevant is some cases (scenes using penalities?)

And this will certainly need to regenerate some regression files... (at least MeshSpringForceField)

EDIT:
[ci-depends-on https://github.com/sofa-framework/Regression/pull/39]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
