### PR TITLE
[FEM.Elastic] Check for nullptr in BeamFEMForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
@@ -142,6 +142,9 @@ void BeamFEMForceField<DataTypes>::init()
 template <class DataTypes>
 void BeamFEMForceField<DataTypes>::reinit()
 {
+    if (!m_indexedElements)
+        return;
+
     unsigned int n = m_indexedElements->size();
     m_forces.resize( this->mstate->getSize() );
 
@@ -154,6 +157,9 @@ void BeamFEMForceField<DataTypes>::reinit()
 template <class DataTypes>
 void BeamFEMForceField<DataTypes>::reinitBeam(Index i)
 {
+    if (!m_indexedElements)
+        return;
+
     SReal stiffness, length, radius, poisson, radiusInner;
     Index a = (*m_indexedElements)[i][0];
     Index b = (*m_indexedElements)[i][1];
@@ -201,6 +207,9 @@ void BeamFEMForceField<DataTypes>::addForce(const sofa::core::MechanicalParams* 
     SOFA_UNUSED(mparams);
     SOFA_UNUSED(dataV);
 
+    if (!m_indexedElements)
+        return;
+
     VecDeriv& f = *(dataF.beginEdit());
     const VecCoord& p=dataX.getValue();
     f.resize(p.size());
@@ -241,6 +250,9 @@ void BeamFEMForceField<DataTypes>::addForce(const sofa::core::MechanicalParams* 
 template<class DataTypes>
 void BeamFEMForceField<DataTypes>::addDForce(const sofa::core::MechanicalParams *mparams, DataVecDeriv& datadF , const DataVecDeriv& datadX)
 {
+    if (!m_indexedElements)
+        return;
+
     VecDeriv& df = *(datadF.beginEdit());
     const VecDeriv& dx=datadX.getValue();
     Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
@@ -512,6 +524,9 @@ void BeamFEMForceField<DataTypes>::addKToMatrix(const sofa::core::MechanicalPara
     Real k = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
     linearalgebra::BaseMatrix* mat = r.matrix;
 
+    if (!m_indexedElements)
+        return;
+
     if (r)
     {
         unsigned int i=0;
@@ -636,6 +651,8 @@ void BeamFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
 {
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
+    if (!m_indexedElements)
+        return;
 
     const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
@@ -143,7 +143,10 @@ template <class DataTypes>
 void BeamFEMForceField<DataTypes>::reinit()
 {
     if (!m_indexedElements)
+    {
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
+    }
 
     unsigned int n = m_indexedElements->size();
     m_forces.resize( this->mstate->getSize() );

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
@@ -135,10 +135,15 @@ public:
         EXPECT_MSG_EMIT(Error);
 
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "EulerImplicitSolver");
+        createObject(m_root, "CGLinearSolver", { { "iterations", "20" }, { "threshold", "1e-8" }, {"tolerance", "1e-5"} });
         createObject(m_root, "MechanicalObject", { {"template", rigidTypeName}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
         createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", rigidTypeName} });
 
         sofa::simulation::getSimulation()->init(m_root.get());
+
+        m_simulation->animate(m_root.get(), 0.01);
     }
 
 


### PR DESCRIPTION
It avoids crashes when animate after initialization in a Node where no topology is found. See unit test that I also modified.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
