### PR TITLE
[MechanicalLoad] Stupid check for consistency between state and topology

### DIFF
--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/OscillatingTorsionPressureForceField.h
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/OscillatingTorsionPressureForceField.h
@@ -127,13 +127,13 @@ protected :
     Coord getVecFromRotAxis( const Coord &x );
     Real getAngle( const Coord &v1, const Coord &v2 );
 
-    std::vector<Real> relMomentToApply;   // estimated share of moment to apply to each point
-    std::vector<bool> pointActive;        // true if moment is applied to specific point (surface)
-    std::vector<Coord> vecFromCenter;     // vector from rotation axis for all points
-    std::vector<Real> distFromCenter;     // norm of vecFromCenter
-    std::vector<Coord> momentDir;         // direction in which to apply a moment
-    std::vector<Coord> origVecFromCenter; // vector from rotation axis for all points in original state
-    std::vector<Coord> origCenter;        // center of rotation for original points
+    sofa::type::vector<Real> relMomentToApply;   // estimated share of moment to apply to each point
+    sofa::type::vector<bool> pointActive;        // true if moment is applied to specific point (surface)
+    sofa::type::vector<Coord> vecFromCenter;     // vector from rotation axis for all points
+    sofa::type::vector<Real> distFromCenter;     // norm of vecFromCenter
+    sofa::type::vector<Coord> momentDir;         // direction in which to apply a moment
+    sofa::type::vector<Coord> origVecFromCenter; // vector from rotation axis for all points in original state
+    sofa::type::vector<Coord> origCenter;        // center of rotation for original points
     SReal rotationAngle;
 
     sofa::core::topology::BaseMeshTopology* m_topology; ///< Pointer to the current topology

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/OscillatingTorsionPressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/OscillatingTorsionPressureForceField.inl
@@ -97,6 +97,8 @@ void OscillatingTorsionPressureForceField<DataTypes>::init()
     trianglePressureMap.createTopologyHandler(m_topology);
 
     initTriangleInformation();
+
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 
@@ -112,8 +114,18 @@ SReal OscillatingTorsionPressureForceField<DataTypes>::getAmplitude()
 template <class DataTypes>
 void OscillatingTorsionPressureForceField<DataTypes>::addForce(const core::MechanicalParams* /* mparams */, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& /* d_v */)
 {
+    if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+        return;
+
     VecDeriv& f = *d_f.beginEdit();
     const VecCoord& x = d_x.getValue();
+
+    if (pointActive.size() < x.size())
+    {
+        msg_error() << "The component reads a position size different from the size used in the initialization: cannot continue.";
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
 
     Deriv force;
     Coord deltaPos;
@@ -121,7 +133,8 @@ void OscillatingTorsionPressureForceField<DataTypes>::addForce(const core::Mecha
     Real totalDist = 0;
 
     // calculate average rotation angle:
-    for (unsigned int i=0; i<x.size(); i++) if (pointActive[i])
+    for (unsigned int i=0; i<x.size(); i++)
+        if (pointActive[i])
         {
             vecFromCenter[i] = getVecFromRotAxis( x[i] );
             distFromCenter[i] = vecFromCenter[i].norm();
@@ -131,6 +144,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::addForce(const core::Mecha
                 totalDist += distFromCenter[i];
             }
         }
+
     avgRotAngle /= totalDist;
 
     rotationAngle = avgRotAngle;


### PR DESCRIPTION
I call it stupid because I don't know how the discrepancy occurred.
Since I think that this component is not that important, I did not want to spend more time on it. At least, now it does not crash.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
