### PR TITLE
[Helper] Fix FileRepository::relativeToPath

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/DataFileName.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/DataFileName.cpp
@@ -145,7 +145,7 @@ void DataFileName::updatePath()
             {
                 if( m_fullpath.find(path) == 0 )
                 {
-                    m_relativepath = DataRepository.relativeToPath(m_fullpath, path);
+                    m_relativepath = sofa::helper::system::FileRepository::relativeToPath(m_fullpath, path);
                     break;
                 }
             }

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
@@ -320,36 +320,26 @@ const std::string FileRepository::getPathsJoined()
     return implodedStr;
 }
 
-/*static*/
 std::string FileRepository::relativeToPath(std::string path, std::string refPath)
 {
-    /// This condition replace the #ifdef in the code.
-    /// The advantage is that the code is compiled and is
-    /// removed by the optimization pass.
-    if( ! ON_WIN32 )
-    {
-        /// Case sensitive OS.
-        std::string::size_type loc = path.find( refPath, 0 );
-        if (loc==0)
-            path = path.substr(refPath.size()+1);
-
-        return path;
-    }
-
-    /// WIN32 is a pain here because of mixed case formatting with randomly
-    /// picked slash and backslash to separate dirs.
-    std::string tmppath;
     std::replace(path.begin(),path.end(),'\\' , '/' );
     std::replace(refPath.begin(),refPath.end(),'\\' , '/' );
 
     std::transform(refPath.begin(), refPath.end(), refPath.begin(), ::tolower );
 
-    tmppath = path ;
+    std::string tmppath=path;
     std::transform(tmppath.begin(), tmppath.end(), tmppath.begin(), ::tolower );
 
     std::string::size_type loc = tmppath.find( refPath, 0 );
-    if (loc==0)
-        path = path.substr(refPath.size()+1);
+    if (loc != std::string::npos)
+    {
+        path = path.substr(refPath.size());
+
+        while(!path.empty() && (path.front() == '/' || path.front() == '\\' ))
+        {
+            path = path.substr(1);
+        }
+    }
 
     return path;
 }

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.h
@@ -117,9 +117,6 @@ public:
 
     /// Returns a string such as refPath + string = path if path contains refPath.
     /// Otherwise returns path.
-    /// On WIN32 the implementation was also returning the path in lower case. This behavior is now
-    /// deprecated and should be remove the 2018-05-01. Until this date new implementation can be
-    /// used by setting doLowerCaseOnWin32=false;
     static std::string relativeToPath(std::string path, std::string refPath);
 
     const std::vector< std::string > &getPaths() const {return vpath;}

--- a/Sofa/framework/Helper/test/system/FileRepository_test.cpp
+++ b/Sofa/framework/Helper/test/system/FileRepository_test.cpp
@@ -85,3 +85,24 @@ TEST_F(FileRepository_test, findFileWithAccents )
     ASSERT_TRUE( fileRepository.findFile(filename) );
     ASSERT_TRUE( filename == std::string(SOFA_TESTING_RESOURCES_DIR) + "/dir_é_with_è_accents_à/file.txt" );
 }
+
+TEST(FileRepository_relativeToPath, emptyAbsoluteFilename)
+{
+    EXPECT_TRUE(FileRepository::relativeToPath("", "").empty());
+    EXPECT_EQ(FileRepository::relativeToPath("", "fdsfadsfasd"), "");
+    EXPECT_EQ(FileRepository::relativeToPath("", "fdsfaAdDsfaPsd"), "");
+    EXPECT_EQ(FileRepository::relativeToPath("", "fds/fads/fasd"), "");
+}
+
+TEST(FileRepository_relativeToPath, notMatchingAbsoluteFilename)
+{
+    EXPECT_EQ(FileRepository::relativeToPath("hgfdsgfdsgfd", "fdsfadsfasd"), "hgfdsgfdsgfd");
+    EXPECT_EQ(FileRepository::relativeToPath("hg/fds/gfdsgfd", "fdsfadsfasd"), "hg/fds/gfdsgfd");
+}
+
+TEST(FileRepository_relativeToPath, matching)
+{
+    EXPECT_EQ(FileRepository::relativeToPath("hg/fds/gfdsgfd", "hg/fds/"), "gfdsgfd");
+    EXPECT_EQ(FileRepository::relativeToPath("hg/fds/gfdsgfd", "hg/fds"), "gfdsgfd");
+    EXPECT_EQ(FileRepository::relativeToPath("hFg/fFQQEWds/gfQdsEWQRgfd", "hFg/fFQQEWds"), "gfQdsEWQRgfd");
+}


### PR DESCRIPTION
This function crashed in some cases covered by the added unit tests.
I changed the behavior:
- No difference between platforms
- Check if the returned path starts with a slash or backslash and remove it



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
