### PR TITLE
[Testing] Fix CMake config after removal of compat

### DIFF
--- a/Sofa/framework/Testing/CMakeLists.txt
+++ b/Sofa/framework/Testing/CMakeLists.txt
@@ -39,10 +39,6 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Helper Sofa.DefaultType Sofa.Core Sofa.Simulation.Graph gtest SofaGTestMain )
 set(SOFA_TESTING_RESOURCES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/resources")
 
-target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${COMPATSRC_ROOT}>")
-target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/Sofa.Testing/Sofa.Testing/compat>")
-source_group("compat" FILES ${COMPAT_HEADER_FILES} )
-
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(


### PR DESCRIPTION
CMake configuration of out-of-tree plugins using Sofa.Testing is broken after
- #3655 

The compat/ dir has been removed but not its reference for the target config.

Error log: (from beamadapter CI):

```
CMake Error in BeamAdapter_test/CMakeLists.txt:
  Imported target "Sofa.Testing" includes non-existent path

    "/home/runner/work/BeamAdapter/BeamAdapter/sofa/include/Sofa.Testing/Sofa.Testing/compat"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
