### PR TITLE
[Geomagic] Fix potential crash at exit when device has not been init

### DIFF
--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
@@ -216,7 +216,8 @@ void GeomagicDriver::init()
 void GeomagicDriver::clearDevice()
 {
 #if GEOMAGIC_HAVE_OPENHAPTICS
-    hdMakeCurrentDevice(m_hHD);
+    if (m_hHD != HD_INVALID_HANDLE)
+        hdMakeCurrentDevice(m_hHD);
 
     // stop scheduler first only if some works are registered
     if (!m_hStateHandles.empty() && s_schedulerRunning) {
@@ -261,7 +262,7 @@ void GeomagicDriver::initDevice()
     if (catchHDError(false) == HD_DEVICE_ALREADY_INITIATED)
     {
         // double initialisation, this can occure if device has not been release due to bad program exit
-        msg_warning() << "Device has already been initialized. Will clear driver and reinit the device properly.";
+        msg_warning() << "Device has already been initialized. SOFA Will clear current device using 'hdDisableDevice' and re-init the device properly using 'hdInitDevice'.";
         
         // Will Try clear and reinit device (10 times max): get device id in the current HD servo loop and try to release it and iterate on init
         HDerror tmpError = HD_DEVICE_ALREADY_INITIATED;
@@ -293,7 +294,7 @@ void GeomagicDriver::initDevice()
     if (hdCheckCalibration() != HD_CALIBRATION_OK)
     {
         // Possible values are : HD_CALIBRATION_OK || HD_CALIBRATION_NEEDS_UPDATE || HD_CALIBRATION_NEEDS_MANUAL_INPUT
-        msg_error() << "GeomagicDriver initialisation failed becase device " << d_deviceName.getValue() << " is not calibrated. Calibration should be done before using Geomagic device in SOFA simulation.";
+        msg_error() << "GeomagicDriver initialisation failed because device " << d_deviceName.getValue() << " is not calibrated. Calibration should be done using Geomagic Touch setup before using it in SOFA.";
         return;
     }
     


### PR DESCRIPTION
- Check that device ID is valid before making it current in destruction method.
- Small updates on warning messages



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
