### PR TITLE
[LinearAlgebra] Fix crash when matrix has no nonzero values

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrix.h
@@ -390,9 +390,12 @@ public:
             for (; j<=(decltype(j))oldRowIndex[i]; ++j)
                 rowBegin[j] = b;
         }
-        b = oldRowBegin[oldRowBegin.size()-1];
-        for (; j<=nRow; ++j)
-            rowBegin[j] = b;
+        if (!oldRowBegin.empty())
+        {
+            b = oldRowBegin.back();
+            for (; j<=nRow; ++j)
+                rowBegin[j] = b;
+        }
     }
 
     /// Make sure all diagonal entries are present even if they are zero

--- a/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrix_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrix_test.cpp
@@ -184,3 +184,37 @@ TEST(CompressedRowSparseMatrix, transposeProduct)
         }
     }
 }
+
+TEST(CompressedRowSparseMatrix, fullRowsNoEntries)
+{
+    sofa::linearalgebra::CompressedRowSparseMatrix<SReal> A;
+    A.resize(1321, 3556);
+    EXPECT_TRUE(A.getRowIndex().empty());
+    EXPECT_NO_THROW(A.fullRows());
+    EXPECT_EQ(A.getRowIndex().size(), 1321);
+
+    //make sure that we can iterate, but the content is empty
+
+    std::vector<std::tuple<int, int, SReal> > triplets_CRS;
+    for (unsigned int it_rows_k=0; it_rows_k < A.rowIndex.size() ; it_rows_k ++)
+    {
+        const auto row = A.rowIndex[it_rows_k];
+        decltype(A)::Range rowRange( A.rowBegin[it_rows_k], A.rowBegin[it_rows_k+1] );
+        for(auto xj = rowRange.begin() ; xj < rowRange.end() ; ++xj )
+        {
+            const auto col = A.colsIndex[xj];
+            const auto k = A.colsValue[xj];
+            triplets_CRS.emplace_back(row, col, k);
+        }
+    }
+    EXPECT_TRUE(triplets_CRS.empty());
+}
+
+TEST(CompressedRowSparseMatrix, fullRowsWithEntries)
+{
+    sofa::linearalgebra::CompressedRowSparseMatrix<SReal> A;
+    generateMatrix(A, 1321, 3556, 0.0003, 12);
+    EXPECT_FALSE(A.getRowIndex().empty());
+    EXPECT_NO_THROW(A.fullRows());
+    EXPECT_EQ(A.getRowIndex().size(), 1321);
+}


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
