### PR TITLE
[IO.Mesh] Fix mesh creation if load called multiple times

### DIFF
--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/StringMeshCreator.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/StringMeshCreator.cpp
@@ -54,7 +54,8 @@ StringMeshCreator::StringMeshCreator(): MeshLoader()
 
 void StringMeshCreator::doClearBuffers()
 {
-
+    sofa::helper::getWriteOnlyAccessor(d_positions).clear();
+    sofa::helper::getWriteOnlyAccessor(d_edges).clear();
 }
 
 
@@ -64,9 +65,6 @@ bool StringMeshCreator::doLoad()
     auto my_edges = sofa::helper::getWriteOnlyAccessor(d_edges);
 
     const unsigned numX = resolution.getValue();
-
-    my_positions.clear();
-    my_edges.clear();
 
     // Warning: Vertex creation order must be consistent with method vert.
     for(unsigned x=0; x<numX; x++)

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/StringMeshCreator.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/StringMeshCreator.cpp
@@ -61,19 +61,23 @@ void StringMeshCreator::doClearBuffers()
 bool StringMeshCreator::doLoad()
 {
     auto my_positions = sofa::helper::getWriteOnlyAccessor(d_positions);
-    unsigned numX = resolution.getValue();
+    auto my_edges = sofa::helper::getWriteOnlyAccessor(d_edges);
+
+    const unsigned numX = resolution.getValue();
+
+    my_positions.clear();
+    my_edges.clear();
 
     // Warning: Vertex creation order must be consistent with method vert.
     for(unsigned x=0; x<numX; x++)
     {
         my_positions.push_back( Vec3(x * 1./(numX-1), 0, 0) );
     }
-    type::vector<Edge >& my_edges = *(d_edges.beginEdit());
+
     for( unsigned e=1; e<numX; e++ )
     {
         my_edges.push_back( Edge(e-1,e) );
     }
-    d_edges.endEdit();
 
     return true;
 


### PR DESCRIPTION
The position and edges vectors were not cleared if load() is called multiple times


[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/337]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
