### PR TITLE
[LinearSolver.Direct] Make sure the matrix is factorized in SparseCholeskySolver

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseCholeskySolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseCholeskySolver.inl
@@ -56,19 +56,31 @@ void SparseCholeskySolver<TMatrix,TVector>::solve (Matrix& /*M*/, Vector& x, Vec
     {
     case 0://None->identity
     case 1://SuiteSparse
-
-        cs_ipvec (n, S->Pinv,  (double*)b.ptr() , tmp.data() );	//x = P*b , permutation on rows
-        cs_lsolve (N->L, tmp.data() );			//x = L\x
-        cs_ltsolve (N->L, tmp.data() );			//x = L'\x/
-        cs_pvec (n, S->Pinv, tmp.data() , (double*)x.ptr() );	 //x = P'*x , permutation on columns
+        if(N)
+        {
+            cs_ipvec (n, S->Pinv,  (double*)b.ptr() , tmp.data() );	//x = P*b , permutation on rows
+            cs_lsolve (N->L, tmp.data() );			//x = L\x
+            cs_ltsolve (N->L, tmp.data() );			//x = L'\x/
+            cs_pvec (n, S->Pinv, tmp.data() , (double*)x.ptr() );	 //x = P'*x , permutation on columns
+        }
+        else
+        {
+            msg_error() << "Cannot solve system";
+        }
         break;
 
     case 2://METIS
-
-        cs_ipvec (n, perm.data(),  (double*)b.ptr() , tmp.data() );	//x = P*b , permutation on rows
-        cs_lsolve (N->L, tmp.data() );			//x = L\x
-        cs_ltsolve (N->L, tmp.data() );			//x = L'\x/
-        cs_pvec (n, perm.data() , tmp.data() , (double*)x.ptr() );	 //x = P'*x , permutation on columns
+        if(N)
+        {
+            cs_ipvec (n, perm.data(),  (double*)b.ptr() , tmp.data() );	//x = P*b , permutation on rows
+            cs_lsolve (N->L, tmp.data() );			//x = L\x
+            cs_ltsolve (N->L, tmp.data() );			//x = L'\x/
+            cs_pvec (n, perm.data() , tmp.data() , (double*)x.ptr() );	 //x = P'*x , permutation on columns
+        }
+        else
+        {
+            msg_error() << "Cannot solve system due to invalid factorization";
+        }
         break;
 
     default:
@@ -107,7 +119,7 @@ void SparseCholeskySolver<TMatrix,TVector>::invert(Matrix& M)
         switch (d_typePermutation.getValue().getSelectedId() )
         {
             case 0:
-            default:// None->identity 
+            default:// None->identity
                 suiteSparseFactorization(false);
                 break;
 
@@ -120,19 +132,20 @@ void SparseCholeskySolver<TMatrix,TVector>::invert(Matrix& M)
                 {
                     perm.resize(A.n);
                     iperm.resize(A.n);
-                    
+
                     fillReducingPermutation( A , iperm.data(), perm.data() ); // compute the fill reducing permutation
                 }
-                
+
                 permuted_A = cs_permute( &A , perm.data() , iperm.data() , 1);
-                
-                if ( notSameShape ) 
-                { 
+
+                if ( notSameShape )
+                {
                     if (S) cs_sfree(S);
-                    S = symbolic_Chol( permuted_A ); 
-                } // symbolic analysis 
-        
-                N = cs_chol (permuted_A, S) ;		// numeric Cholesky factorization 
+                    S = symbolic_Chol( permuted_A );
+                } // symbolic analysis
+
+                N = cs_chol (permuted_A, S) ;		// numeric Cholesky factorization
+                assert(N);
 
                 cs_free(permuted_A);
                 break;
@@ -169,7 +182,11 @@ void SparseCholeskySolver<TMatrix, TVector>::suiteSparseFactorization(bool apply
         const auto order = applyPermutation ? 0 : -1;
         S = cs_schol (&A, order);
     }
+    assert(S);
+    assert(S->cp);
+    assert(S->parent);
     N = cs_chol (&A, S) ;		// numeric Cholesky factorization
+    msg_error_when(!N) << "Matrix could not be factorized: possibly not positive-definite";
 }
 
 template<class TMatrix, class TVector>

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseCholeskySolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseCholeskySolver.inl
@@ -65,7 +65,7 @@ void SparseCholeskySolver<TMatrix,TVector>::solve (Matrix& /*M*/, Vector& x, Vec
         }
         else
         {
-            msg_error() << "Cannot solve system";
+            msg_error() << "Cannot solve system due to invalid factorization";
         }
         break;
 


### PR DESCRIPTION
It avoids a crash if the matrix is not positive definite





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
