### PR TITLE
[GUI.Qt] Clean and fix in the "inspector" panel

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -48,9 +48,6 @@ using sofa::helper::logging::Message;
 #include <QApplication>
 #include <QScreen>
 
-// uncomment to show traces of GUI operations in this file
-// #define DEBUG_GUI
-
 namespace sofa::gui::qt
 {
 
@@ -85,16 +82,7 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
     {
         return;
     }
-#ifdef DEBUG_GUI
-    std::cout << "GUI: (base) createDialog(" << base->getClassName() << " " << base->getName() << ")" << std::endl;
-#endif
-#ifdef DEBUG_GUI
-    std::cout << "GUI>emit beginObjectModification(" << base->getName() << ")" << std::endl;
-#endif
     emit beginObjectModification(base);
-#ifdef DEBUG_GUI
-    std::cout << "GUI<emit beginObjectModification(" << base->getName() << ")" << std::endl;
-#endif
     basenode = base;
     data_ = nullptr;
 
@@ -171,9 +159,6 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
             if (currentGroup == "Infos")
                 continue;
 
-#ifdef DEBUG_GUI
-            std::cout << "GUI: add Data " << data->getName() << " in " << currentGroup << std::endl;
-#endif
             QTabulationModifyObject* currentTab=nullptr;
 
             std::vector<QTabulationModifyObject* > &tabs=groupTabulation[currentGroup];
@@ -202,14 +187,7 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
                 connect(currentTab, SIGNAL( TabDirty(bool) ), buttonUpdate, SLOT( setEnabled(bool) ) );
                 connect(currentTab, SIGNAL( TabDirty(bool) ), this, SIGNAL( componentDirty(bool) ) );
             }
-
-#ifdef DEBUG_GUI
-            std::cout << "GUI: added Data " << data->getName() << " in " << currentGroup << std::endl;
-#endif
         }
-#ifdef DEBUG_GUI
-        std::cout << "GUI: end Data" << std::endl;
-#endif
 
         for( sofa::core::objectmodel::Base::VecLink::const_iterator it = links.begin(); it!=links.end(); ++it)
         {
@@ -221,10 +199,6 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
             //For each Link of the current Object
             //We determine where it belongs:
             std::string currentGroup="Links";
-
-#ifdef DEBUG_GUI
-            std::cout << "GUI: add Link " << link->getName() << " in " << currentGroup << std::endl;
-#endif
 
             QTabulationModifyObject* currentTab=nullptr;
 
@@ -245,9 +219,6 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
             connect(currentTab, SIGNAL( TabDirty(bool) ), buttonUpdate, SLOT( setEnabled(bool) ) );
             connect(currentTab, SIGNAL( TabDirty(bool) ), this, SIGNAL( componentDirty(bool) ) );
         }
-#ifdef DEBUG_GUI
-        std::cout << "GUI: end Link" << std::endl;
-#endif
 
         for (std::vector<std::string>::const_iterator it = tabNames.begin(), itend = tabNames.end(); it != itend; ++it)
         {
@@ -259,9 +230,6 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
                 QString nameTab;
                 if (tabs.size() == 1) nameTab=groupName.c_str();
                 else                  nameTab=QString(groupName.c_str())+ " " + QString::number(tabs[i]->getIndex()) + "/" + QString::number(tabs.size());
-#ifdef DEBUG_GUI
-                std::cout << "GUI: add Tab " << nameTab.toStdString() << std::endl;
-#endif
                 dialogTab->addTab(tabs[i],nameTab);
                 tabs[i]->addStretch();
             }
@@ -353,17 +321,7 @@ void ModifyObject::createDialog(core::objectmodel::BaseData* data)
     data_ = data;
     basenode = nullptr;
 
-#ifdef DEBUG_GUI
-    std::cout << "GUI>emit beginDataModification("<<data->getName()<<")" << std::endl;
-#endif
     emit beginDataModification(data);
-#ifdef DEBUG_GUI
-    std::cout << "GUI<emit beginDataModification("<<data->getName()<<")" << std::endl;
-#endif
-
-#ifdef DEBUG_GUI
-    std::cout << "GUI: createDialog( Data<" << data->getValueTypeString() << "> " << data->getName() << ")" << std::endl;
-#endif
 
     QVBoxLayout *generalLayout = new QVBoxLayout(this);
     generalLayout->setContentsMargins(0, 0, 0, 0);
@@ -529,30 +487,12 @@ void ModifyObject::updateValues()
 
         }
 
-#ifdef DEBUG_GUI
-        std::cout << "GUI>emit objectUpdated()" << std::endl;
-#endif
         emit (objectUpdated());
-#ifdef DEBUG_GUI
-        std::cout << "GUI<emit objectUpdated()" << std::endl;
-#endif
 
         if (basenode)
         {
-#ifdef DEBUG_GUI
-            std::cout << "GUI>emit endObjectModification("<<node->getName()<<")" << std::endl;
-#endif
             emit endObjectModification(basenode);
-#ifdef DEBUG_GUI
-            std::cout << "GUI<emit endObjectModification("<<node->getName()<<")" << std::endl;
-#endif
-#ifdef DEBUG_GUI
-            std::cout << "GUI>emit beginObjectModification("<<node->getName()<<")" << std::endl;
-#endif
             emit beginObjectModification(basenode);
-#ifdef DEBUG_GUI
-            std::cout << "GUI<emit beginObjectModification("<<node->getName()<<")" << std::endl;
-#endif
         }
 
         buttonUpdate->setEnabled(false);
@@ -563,13 +503,7 @@ void ModifyObject::updateValues()
 //Called each time a new step of the simulation if computed
 void ModifyObject::updateTables()
 {
-#ifdef DEBUG_GUI
-    std::cout << "GUI>emit updateDataWidgets()" << std::endl;
-#endif
     emit updateDataWidgets();
-#ifdef DEBUG_GUI
-    std::cout << "GUI<emit updateDataWidgets()" << std::endl;
-#endif
 #if SOFA_GUI_QT_HAVE_QT_CHARTS
     if (energy)
     {
@@ -592,13 +526,7 @@ void ModifyObject::reject   ()
 {
     if (basenode)
     {
-#ifdef DEBUG_GUI
-        std::cout << "GUI>emit endObjectModification(" << node->getName() << ")" << std::endl;
-#endif
         emit endObjectModification(basenode);
-#ifdef DEBUG_GUI
-        std::cout << "GUI<emit endObjectModification(" << node->getName() << ")" << std::endl;
-#endif
     }
 
     const QString dataModifiedString = parseDataModified();
@@ -624,13 +552,7 @@ void ModifyObject::accept   ()
 
     if (basenode)
     {
-#ifdef DEBUG_GUI
-        std::cout << "GUI>emit endObjectModification(" << node->getName() << ")" << std::endl;
-#endif
         emit endObjectModification(basenode);
-#ifdef DEBUG_GUI
-        std::cout << "GUI<emit endObjectModification(" << node->getName() << ")" << std::endl;
-#endif
     }
     emit(dialogClosed(Id_));
     deleteLater();

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -64,8 +64,7 @@ ModifyObject::ModifyObject(void *Id,
       data_(nullptr),
       dialogFlags_(dialogFlags),
       messageTab(nullptr),
-      messageEdit(nullptr),
-      transformation(nullptr)
+      messageEdit(nullptr)
     #if SOFA_GUI_QT_HAVE_QT_CHARTS
     ,energy(nullptr)
     ,momentum(nullptr)
@@ -460,17 +459,6 @@ void ModifyObject::updateValues()
     // if the selected object is a node
     if (node)
     {
-        // and there is a transformation widget associated
-        if(transformation)
-        {
-            // then do some dirty hack to change the value
-            if (!transformation->isDefaultValues())
-            {
-                transformation->applyTransformation(node);
-            }
-            transformation->setDefaultValues();
-        }
-        // call the reinit function on the node to take the into account the applied transformation
         node->reinit(sofa::core::execparams::defaultInstance());
     }
     else if (object)                 //< if the selected is an object

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -456,35 +456,31 @@ void ModifyObject::updateValues()
         core::objectmodel::BaseObject* object = sofa::core::castTo<core::objectmodel::BaseObject*>(basenode);
         if(dialogFlags_.REINIT_FLAG)
         {
+            // if the selected object is a node
             if (node)
             {
-                // if the selected object is a node
-                if (node)
+                // and there is a transformation widget associated
+                if(transformation)
                 {
-                    // and there is a transformation widget associated
-                    if(transformation)
+                    // then do some dirty hack to change the value
+                    if (!transformation->isDefaultValues())
                     {
-                        // then do some dirty hack to change the value
-                        if (!transformation->isDefaultValues())
-                        {
-                            transformation->applyTransformation(node);
-                        }
-                        transformation->setDefaultValues();
+                        transformation->applyTransformation(node);
                     }
-                    // call the reinit function on the node
-                    node->reinit(sofa::core::execparams::defaultInstance());
+                    transformation->setDefaultValues();
                 }
-                else if (object)                 //< if the selected is an object
-                {
-                    object->reinit();            //< we need to fully re-initialize the object to be sure it is ok.
-                }
-                else
-                {
-                    throw std::runtime_error("Invalid type, only Node and BaseObject are supported. "
-                                         "This is a BUG, please report to https://github.com/sofa-framework/sofa/issues");
-                }
+                // call the reinit function on the node
+                node->reinit(sofa::core::execparams::defaultInstance());
             }
-
+            else if (object)                 //< if the selected is an object
+            {
+                object->reinit();            //< we need to fully re-initialize the object to be sure it is ok.
+            }
+            else
+            {
+                throw std::runtime_error("Invalid type, only Node and BaseObject are supported. "
+                                         "This is a BUG, please report to https://github.com/sofa-framework/sofa/issues");
+            }
         }
 
         emit (objectUpdated());

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -518,7 +518,7 @@ void ModifyObject::reject   ()
         emit  dataModified( dataModifiedString  );
     }
 
-    emit(dialogClosed(Id_));
+    emit dialogClosed(Id_);
     deleteLater();
     QDialog::reject();
 } //When closing a window, inform the parent.
@@ -537,7 +537,7 @@ void ModifyObject::accept   ()
     {
         emit endObjectModification(basenode);
     }
-    emit(dialogClosed(Id_));
+    emit dialogClosed(Id_);
     deleteLater();
     QDialog::accept();
 } //if closing by using Ok button, update the values

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -471,8 +471,10 @@ void ModifyObject::updateValues()
                                  "This is a BUG, please report to https://github.com/sofa-framework/sofa/issues");
     }
 
-    emit (objectUpdated());
+    // trigger the internal updates (eg: updateDataCallback),
+    basenode->d_componentState.updateIfDirty();
 
+    emit objectUpdated();
     emit endObjectModification(basenode);
     emit beginObjectModification(basenode);
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -447,7 +447,7 @@ void ModifyObject::updateConsole()
 void ModifyObject::updateValues()
 {
     // this is controlling if we need to re-init (eg: not in the Modeller)
-    if(dialogFlags_.REINIT_FLAG)
+    if(!dialogFlags_.REINIT_FLAG)
         return;
 
     if (basenode == nullptr)

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.cpp
@@ -447,52 +447,49 @@ void ModifyObject::updateConsole()
 //*******************************************************************************************************************
 void ModifyObject::updateValues()
 {
-    if (buttonUpdate == nullptr) return;
+    if (buttonUpdate == nullptr)
+        return;
 
-    //Make the update of all the values
-    if (basenode)
+    if (basenode == nullptr)
+        return;
+
+    simulation::Node* node = sofa::core::castTo<sofa::simulation::Node*>(basenode);
+    core::objectmodel::BaseObject* object = sofa::core::castTo<core::objectmodel::BaseObject*>(basenode);
+    if(dialogFlags_.REINIT_FLAG)
     {
-        simulation::Node* node = sofa::core::castTo<sofa::simulation::Node*>(basenode);
-        core::objectmodel::BaseObject* object = sofa::core::castTo<core::objectmodel::BaseObject*>(basenode);
-        if(dialogFlags_.REINIT_FLAG)
+        // if the selected object is a node
+        if (node)
         {
-            // if the selected object is a node
-            if (node)
+            // and there is a transformation widget associated
+            if(transformation)
             {
-                // and there is a transformation widget associated
-                if(transformation)
+                // then do some dirty hack to change the value
+                if (!transformation->isDefaultValues())
                 {
-                    // then do some dirty hack to change the value
-                    if (!transformation->isDefaultValues())
-                    {
-                        transformation->applyTransformation(node);
-                    }
-                    transformation->setDefaultValues();
+                    transformation->applyTransformation(node);
                 }
-                // call the reinit function on the node
-                node->reinit(sofa::core::execparams::defaultInstance());
+                transformation->setDefaultValues();
             }
-            else if (object)                 //< if the selected is an object
-            {
-                object->reinit();            //< we need to fully re-initialize the object to be sure it is ok.
-            }
-            else
-            {
-                throw std::runtime_error("Invalid type, only Node and BaseObject are supported. "
-                                         "This is a BUG, please report to https://github.com/sofa-framework/sofa/issues");
-            }
+            // call the reinit function on the node
+            node->reinit(sofa::core::execparams::defaultInstance());
         }
-
-        emit (objectUpdated());
-
-        if (basenode)
+        else if (object)                 //< if the selected is an object
         {
-            emit endObjectModification(basenode);
-            emit beginObjectModification(basenode);
+            object->reinit();            //< we need to fully re-initialize the object to be sure it is ok.
         }
-
-        buttonUpdate->setEnabled(false);
+        else
+        {
+            throw std::runtime_error("Invalid type, only Node and BaseObject are supported. "
+                                     "This is a BUG, please report to https://github.com/sofa-framework/sofa/issues");
+        }
     }
+
+    emit (objectUpdated());
+
+    emit endObjectModification(basenode);
+    emit beginObjectModification(basenode);
+
+    buttonUpdate->setEnabled(false);
 }
 
 //**************************************************************************************************************************************

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/ModifyObject.h
@@ -172,9 +172,6 @@ protected:
     QPushButton *buttonUpdate;
     int m_numMessages;
 
-    //Widget specific to Node:
-    //Transformation widget: translation, rotation, scale ( only experimental and deactivated)
-    QTransformationWidget* transformation;
 #if SOFA_GUI_QT_HAVE_QT_CHARTS
     //Energy widget: plot the kinetic & potential energy
     QEnergyStatWidget* energy;

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QTabulationModifyObject.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QTabulationModifyObject.cpp
@@ -30,9 +30,6 @@
 #include <QScrollArea>
 #include <QScreen>
 
-// uncomment to show traces of GUI operations in this file
-//#define DEBUG_GUI
-
 namespace sofa::gui::qt
 {
 
@@ -59,15 +56,8 @@ void QTabulationModifyObject::addData(sofa::core::objectmodel::BaseData *data, c
 
     if (  (!data->isDisplayed()) && flags.HIDE_FLAG )
     {
-#ifdef DEBUG_GUI
-        std::cout << "GUI: data " << data->getName() << " is hidden." << std::endl;
-#endif
         return;
     }
-
-#ifdef DEBUG_GUI
-    std::cout << "GUI> addData " << data->getName() << std::endl;
-#endif
 
     data->setDisplayed(true);
 
@@ -79,23 +69,15 @@ void QTabulationModifyObject::addData(sofa::core::objectmodel::BaseData *data, c
     pixelSize += displaydatawidget->sizeHint().height();
     displaydatawidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 
-
     connect(displaydatawidget, SIGNAL( WidgetDirty(bool) ), this, SLOT( setTabDirty(bool) ) );
     connect(this, SIGNAL(UpdateDatas()), displaydatawidget, SLOT( UpdateData()));
     connect(this, SIGNAL(UpdateDataWidgets()), displaydatawidget, SLOT( UpdateWidgets()));
     connect(displaydatawidget, SIGNAL( dataValueChanged(QString) ), SLOT(dataValueChanged(QString) ) );
-#ifdef DEBUG_GUI
-    std::cout << "GUI< addData " << data->getName() << std::endl;
-#endif
 }
 
 
 void QTabulationModifyObject::addLink(sofa::core::objectmodel::BaseLink *link, const ModifyObjectFlags& flags)
 {
-    //if (  (!link->isDisplayed()) && flags.HIDE_FLAG ) return;
-
-    //link->setDisplayed(true);
-
     const std::string name=link->getName();
     QDisplayLinkWidget* displaylinkwidget = new QDisplayLinkWidget(this,link,flags);
     this->layout()->addWidget(displaylinkwidget);
@@ -152,7 +134,6 @@ bool QTabulationModifyObject::isDirty() const
 bool QTabulationModifyObject::isFull() const
 {
     return pixelSize >= pixelMaxSize;
-    //return size >= maxSize;
 }
 
 bool QTabulationModifyObject::isEmpty() const


### PR DESCRIPTION
It was pointed by @EulalieCoevoet  that the callbacks update are only called when the modified data is accessed for reading. This has a consequence in the UX, when a data field value is changed in the inspector, the callback is only executed when data is accessed... but not when we click on the "update" or "ok" button. 

It was thus suggested to trigger the callback by accessing the component state.
All other change are just cleaning and refactoring of the function. 





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
