### PR TITLE
[Core] TLink: Fix warnings about comparisons between unnamed enums

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
@@ -298,17 +298,15 @@ class TLink : public BaseLink
 public:
     typedef TOwnerType OwnerType;
     typedef TDestType DestType;
-    enum { ActiveFlags = TFlags };
-#define ACTIVEFLAG(f) ((ActiveFlags & (f)) != 0)
-    typedef LinkTraitsDestPtr<DestType, ACTIVEFLAG(FLAG_STRONGLINK)> TraitsDestPtr;
+    static constexpr unsigned ActiveFlags = TFlags;
+    typedef LinkTraitsDestPtr<DestType, ActiveFlags & FLAG_STRONGLINK> TraitsDestPtr;
     typedef typename TraitsDestPtr::T DestPtr;
-    typedef LinkTraitsValueType<DestType, DestPtr, ACTIVEFLAG(FLAG_STRONGLINK), ACTIVEFLAG(FLAG_STOREPATH)> TraitsValueType;
+    typedef LinkTraitsValueType<DestType, DestPtr, ActiveFlags & FLAG_STRONGLINK, ActiveFlags & FLAG_STOREPATH> TraitsValueType;
     typedef typename TraitsValueType::T ValueType;
-    typedef LinkTraitsContainer<DestType, DestPtr, ValueType, ACTIVEFLAG(FLAG_MULTILINK)> TraitsContainer;
+    typedef LinkTraitsContainer<DestType, DestPtr, ValueType, ActiveFlags & FLAG_MULTILINK> TraitsContainer;
     typedef typename TraitsContainer::T Container;
     typedef typename Container::const_iterator const_iterator;
     typedef typename Container::const_reverse_iterator const_reverse_iterator;
-#undef ACTIVEFLAG
 
     TLink()
         : BaseLink(ActiveFlags)

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
@@ -299,11 +299,15 @@ public:
     typedef TOwnerType OwnerType;
     typedef TDestType DestType;
     static constexpr unsigned ActiveFlags = TFlags;
-    typedef LinkTraitsDestPtr<DestType, ActiveFlags & FLAG_STRONGLINK> TraitsDestPtr;
+    static constexpr bool IsStrongLink = ActiveFlags & FLAG_STRONGLINK;
+    static constexpr bool IsMultiLink = ActiveFlags & FLAG_MULTILINK;
+    static constexpr bool StorePath = ActiveFlags & FLAG_STOREPATH;
+
+    typedef LinkTraitsDestPtr<DestType, IsStrongLink> TraitsDestPtr;
     typedef typename TraitsDestPtr::T DestPtr;
-    typedef LinkTraitsValueType<DestType, DestPtr, ActiveFlags & FLAG_STRONGLINK, ActiveFlags & FLAG_STOREPATH> TraitsValueType;
+    typedef LinkTraitsValueType<DestType, DestPtr, IsStrongLink, StorePath> TraitsValueType;
     typedef typename TraitsValueType::T ValueType;
-    typedef LinkTraitsContainer<DestType, DestPtr, ValueType, ActiveFlags & FLAG_MULTILINK> TraitsContainer;
+    typedef LinkTraitsContainer<DestType, DestPtr, ValueType, IsMultiLink> TraitsContainer;
     typedef typename TraitsContainer::T Container;
     typedef typename Container::const_iterator const_iterator;
     typedef typename Container::const_reverse_iterator const_reverse_iterator;


### PR DESCRIPTION
Bitwise comparison between different unnamed enum seems to be be deprecated (at least for gcc12) and it was spamming a lot of warnings in a private plugin. 
```
/linuxdata/sofa/src/current/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h:302: warning: bitwise operation between different enumeration types ‘sofa::core::objectmodel::TLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, 7>::<unnamed enum>’ and ‘sofa::core::objectmodel::BaseLink::LinkFlagsEnum’ is deprecated [-Wdeprecated-enum-enum-conversion]
/linuxdata/sofa/src/current/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h:302:37: warning: bitwise operation between different enumeration types ‘sofa::core::objectmodel::TLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, 7>::<unnamed enum>’ and ‘sofa::core::objectmodel::BaseLink::LinkFlagsEnum’ is deprecated [-Wdeprecated-enum-enum-conversion]
  302 | #define ACTIVEFLAG(f) ((ActiveFlags & (f)) != 0)
      |                        ~~~~~~~~~~~~~^~~~~~
/linuxdata/sofa/src/current/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h:305:81: note: in expansion of macro ‘ACTIVEFLAG’
  305 |     typedef LinkTraitsValueType<DestType, DestPtr, ACTIVEFLAG(FLAG_STRONGLINK), ACTIVEFLAG(FLAG_STOREPATH)> TraitsValueType;
      |                                                                                 ^~~~~~~~~~
```
(I dont know why it was only appearing only for the plugin compilation, maybe some warnings flags are added by an external cmake target)
Anyway the macro to enable flags was quite dirty to me so I have changed it a little bit



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
