### PR TITLE
[GUI.Qt] Register meta type to fix asynchronous Qt call

### DIFF
--- a/Sofa/GUI/Qt/CMakeLists.txt
+++ b/Sofa/GUI/Qt/CMakeLists.txt
@@ -132,6 +132,7 @@ set(MOC_HEADER_FILES
     ${SRC_ROOT}/QSofaListView.h
     ${SRC_ROOT}/QSofaStatWidget.h
     ${SRC_ROOT}/QTabulationModifyObject.h
+    ${SRC_ROOT}/QtMessageRedirection.h
     ${SRC_ROOT}/QTransformationWidget.h
     ${SRC_ROOT}/RealGUI.h
     ${SRC_ROOT}/SimpleDataWidget.h
@@ -184,6 +185,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/QSofaListView.cpp
     ${SRC_ROOT}/QSofaStatWidget.cpp
     ${SRC_ROOT}/QTabulationModifyObject.cpp
+    ${SRC_ROOT}/QtMessageRedirection.cpp
     ${SRC_ROOT}/QTransformationWidget.cpp
     ${SRC_ROOT}/RealGUI.cpp
     ${SRC_ROOT}/SimpleDataWidget.cpp

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QtMessageRedirection.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QtMessageRedirection.cpp
@@ -19,60 +19,32 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/gui/qt/init.h>
-
-#include <sofa/gui/common/GUIManager.h>
-#include <sofa/gui/qt/RealGUI.h>
 #include <sofa/gui/qt/QtMessageRedirection.h>
+#include <sofa/config.h>
+#include <sofa/helper/logging/Messaging.h>
 
-namespace sofa::gui::qt
+void sofa::gui::qt::redirectQtMessages(QtMsgType type,
+                                       const QMessageLogContext& context,
+                                       const QString& msg)
 {
-
-    extern "C" {
-        SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
-        SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
-        SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    }
-
-    void initExternalModule()
+    SOFA_UNUSED(context);
+    const QByteArray localMsg = msg.toLocal8Bit();
+    switch (type)
     {
-        init();
+        case QtDebugMsg:
+            msg_info("Qt") << localMsg.constData();
+            break;
+        case QtInfoMsg:
+            msg_info("Qt") << localMsg.constData();
+            break;
+        case QtWarningMsg:
+            msg_warning("Qt") << localMsg.constData();
+            break;
+        case QtCriticalMsg:
+            msg_error("Qt") << localMsg.constData();
+            break;
+        case QtFatalMsg:
+            msg_fatal("Qt") << localMsg.constData();
+            break;
     }
-
-    const char* getModuleName()
-    {
-        return MODULE_NAME;
-    }
-
-    const char* getModuleVersion()
-    {
-        return MODULE_VERSION;
-    }
-
-    void init()
-    {
-        static bool first = true;
-        if (first)
-        {
-#if SOFA_GUI_QT_ENABLE_QGLVIEWER
-            sofa::gui::common::GUIManager::RegisterGUI("qglviewer", &sofa::gui::qt::RealGUI::CreateGUI, nullptr, 3);
-#endif
-
-#if SOFA_GUI_QT_ENABLE_QTVIEWER
-            sofa::gui::common::GUIManager::RegisterGUI("qt", &sofa::gui::qt::RealGUI::CreateGUI, nullptr, 2);
-#endif
-
-            // if ObjectStateListener is triggered (either by changing the message number, or by
-            // changing the component name) in a thread different than the main thread (=UI thread),
-            // a Qt event is launched through the queued connection system. For that, the event
-            // parameters must be known to Qt's meta-object system. This is what qRegisterMetaType
-            // does in the following instruction.
-            qRegisterMetaType<QVector<int> >("QVector<int>");
-
-            qInstallMessageHandler(redirectQtMessages);
-
-            first = false;
-        }
-    }
-
-} // namespace sofa::gui::qt
+}

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QtMessageRedirection.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QtMessageRedirection.h
@@ -19,60 +19,11 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/gui/qt/init.h>
+#pragma once
 
-#include <sofa/gui/common/GUIManager.h>
-#include <sofa/gui/qt/RealGUI.h>
-#include <sofa/gui/qt/QtMessageRedirection.h>
+#include <QString>
 
 namespace sofa::gui::qt
 {
-
-    extern "C" {
-        SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
-        SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
-        SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    }
-
-    void initExternalModule()
-    {
-        init();
-    }
-
-    const char* getModuleName()
-    {
-        return MODULE_NAME;
-    }
-
-    const char* getModuleVersion()
-    {
-        return MODULE_VERSION;
-    }
-
-    void init()
-    {
-        static bool first = true;
-        if (first)
-        {
-#if SOFA_GUI_QT_ENABLE_QGLVIEWER
-            sofa::gui::common::GUIManager::RegisterGUI("qglviewer", &sofa::gui::qt::RealGUI::CreateGUI, nullptr, 3);
-#endif
-
-#if SOFA_GUI_QT_ENABLE_QTVIEWER
-            sofa::gui::common::GUIManager::RegisterGUI("qt", &sofa::gui::qt::RealGUI::CreateGUI, nullptr, 2);
-#endif
-
-            // if ObjectStateListener is triggered (either by changing the message number, or by
-            // changing the component name) in a thread different than the main thread (=UI thread),
-            // a Qt event is launched through the queued connection system. For that, the event
-            // parameters must be known to Qt's meta-object system. This is what qRegisterMetaType
-            // does in the following instruction.
-            qRegisterMetaType<QVector<int> >("QVector<int>");
-
-            qInstallMessageHandler(redirectQtMessages);
-
-            first = false;
-        }
-    }
-
-} // namespace sofa::gui::qt
+void redirectQtMessages(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+}


### PR DESCRIPTION
This is a fix for a very specific situation. Here is what happens:

1. A `msg_warning` is called in a component from a thread different from the main thread. It could be also `msg_error` or `msg_info`, as long as the message count of the element changes. It could be a change of name as well.
2. The `ObjectStateListener` associated to the component updates the associated `QTreeWidgetItem` (this class is not a `QObject`).
3. The icon is updated, so it warns the `QTreeWidget` (this class is a QObject) through a signal.
4. Since the call happens in a thread different from the main thread, the queued connection is used. For that, all signals/slots parameters must be known to Qt's meta-object system. This PR registers the class `QVector<int>`, so it can be used in the queued connection.

It partially fixes https://github.com/sofa-framework/sofa/issues/3610. The warning is no longer triggered by Qt. Therefore, the mutex is locked only once in one thread. I say it solves partially, because any other Qt error would trigger the same crash.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
