### PR TITLE
[Type] Support structured binding for type::fixed_array

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/fixed_array.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array.h
@@ -281,6 +281,34 @@ operator>(const fixed_array<T, N>& v1, const fixed_array<T, N>& v2 ) noexcept
     return v2 < v1;
 }
 
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr T& get( ::sofa::type::fixed_array<T, N>& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return a[I];
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr const T& get( const ::sofa::type::fixed_array<T, N>& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return a[I];
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr T&& get( ::sofa::type::fixed_array<T, N>&& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return std::move(a[I]);
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr const T&& get( const ::sofa::type::fixed_array<T, N>&& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return std::move(a[I]);
+}
+
 #ifndef FIXED_ARRAY_CPP
 extern template class SOFA_TYPE_API fixed_array<float, 2>;
 extern template class SOFA_TYPE_API fixed_array<double, 2>;
@@ -313,32 +341,4 @@ struct tuple_element<I, ::sofa::type::fixed_array<T, N> >
 {
     using type = T;
 };
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr T& get( ::sofa::type::fixed_array<T, N>& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return a[I];
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr const T& get( const ::sofa::type::fixed_array<T, N>& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return a[I];
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr T&& get( ::sofa::type::fixed_array<T, N>&& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return std::move(a[I]);
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr const T&& get( const ::sofa::type::fixed_array<T, N>&& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return std::move(a[I]);
-}
 }

--- a/Sofa/framework/Type/src/sofa/type/fixed_array.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array.h
@@ -281,34 +281,6 @@ operator>(const fixed_array<T, N>& v1, const fixed_array<T, N>& v2 ) noexcept
     return v2 < v1;
 }
 
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr T& get( ::sofa::type::fixed_array<T, N>& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return a[I];
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr const T& get( const ::sofa::type::fixed_array<T, N>& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return a[I];
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr T&& get( ::sofa::type::fixed_array<T, N>&& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return std::move(a[I]);
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr const T&& get( const ::sofa::type::fixed_array<T, N>&& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return std::move(a[I]);
-}
-
 #ifndef FIXED_ARRAY_CPP
 extern template class SOFA_TYPE_API fixed_array<float, 2>;
 extern template class SOFA_TYPE_API fixed_array<double, 2>;
@@ -341,4 +313,33 @@ struct tuple_element<I, ::sofa::type::fixed_array<T, N> >
 {
     using type = T;
 };
+}
+
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr T& get( ::sofa::type::fixed_array<T, N>& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return a[I];
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr const T& get( const ::sofa::type::fixed_array<T, N>& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return a[I];
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr T&& get( ::sofa::type::fixed_array<T, N>&& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return std::move(a[I]);
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr const T&& get( const ::sofa::type::fixed_array<T, N>&& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return std::move(a[I]);
 }

--- a/Sofa/framework/Type/src/sofa/type/fixed_array.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array.h
@@ -57,6 +57,7 @@
 #include <iostream>
 #include <type_traits>
 #include <algorithm>
+#include <utility>
 
 
 namespace sofa::type
@@ -301,3 +302,43 @@ extern template class SOFA_TYPE_API fixed_array<double, 7>;
 #endif //FIXED_ARRAY_CPP
 
 } // namespace sofa::type
+
+namespace std
+{
+template<typename T, sofa::Size N>
+struct tuple_size<::sofa::type::fixed_array<T, N> > : integral_constant<size_t, N> {};
+
+template<std::size_t I, typename T, sofa::Size N>
+struct tuple_element<I, ::sofa::type::fixed_array<T, N> >
+{
+    using type = T;
+};
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr T& get( ::sofa::type::fixed_array<T, N>& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return a[I];
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr const T& get( const ::sofa::type::fixed_array<T, N>& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return a[I];
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr T&& get( ::sofa::type::fixed_array<T, N>&& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return std::move(a[I]);
+}
+
+template< std::size_t I, class T, std::size_t N >
+[[nodiscard]] constexpr const T&& get( const ::sofa::type::fixed_array<T, N>&& a ) noexcept
+{
+    static_assert(I < N, "array index out of bounds");
+    return std::move(a[I]);
+}
+}

--- a/Sofa/framework/Type/src/sofa/type/fixed_array.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array.h
@@ -140,6 +140,35 @@ public:
         return elems[i];
     }
 
+    template< std::size_t I >
+    [[nodiscard]] constexpr T& get() noexcept
+    {
+        static_assert(I < N, "array index out of bounds");
+        return elems[I];
+    }
+
+    template< std::size_t I >
+    [[nodiscard]] constexpr const T& get() noexcept
+    {
+        static_assert(I < N, "array index out of bounds");
+        return elems[I];
+    }
+
+    template< std::size_t I >
+    [[nodiscard]] constexpr T&& get() noexcept
+    {
+        static_assert(I < N, "array index out of bounds");
+        return std::move(elems[I]);
+    }
+
+    template< std::size_t I >
+    [[nodiscard]] constexpr const T&& get() noexcept
+    {
+        static_assert(I < N, "array index out of bounds");
+        return std::move(elems[I]);
+    }
+
+
     // at() with range check
     constexpr reference at(size_type i)
     {
@@ -313,33 +342,4 @@ struct tuple_element<I, ::sofa::type::fixed_array<T, N> >
 {
     using type = T;
 };
-}
-
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr T& get( ::sofa::type::fixed_array<T, N>& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return a[I];
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr const T& get( const ::sofa::type::fixed_array<T, N>& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return a[I];
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr T&& get( ::sofa::type::fixed_array<T, N>&& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return std::move(a[I]);
-}
-
-template< std::size_t I, class T, std::size_t N >
-[[nodiscard]] constexpr const T&& get( const ::sofa::type::fixed_array<T, N>&& a ) noexcept
-{
-    static_assert(I < N, "array index out of bounds");
-    return std::move(a[I]);
 }

--- a/Sofa/framework/Type/src/sofa/type/fixed_array.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array.h
@@ -141,28 +141,28 @@ public:
     }
 
     template< std::size_t I >
-    [[nodiscard]] constexpr T& get() noexcept
+    [[nodiscard]] constexpr T& get() & noexcept
     {
         static_assert(I < N, "array index out of bounds");
         return elems[I];
     }
 
     template< std::size_t I >
-    [[nodiscard]] constexpr const T& get() noexcept
+    [[nodiscard]] constexpr const T& get() const& noexcept
     {
         static_assert(I < N, "array index out of bounds");
         return elems[I];
     }
 
     template< std::size_t I >
-    [[nodiscard]] constexpr T&& get() noexcept
+    [[nodiscard]] constexpr T&& get() && noexcept
     {
         static_assert(I < N, "array index out of bounds");
         return std::move(elems[I]);
     }
 
     template< std::size_t I >
-    [[nodiscard]] constexpr const T&& get() noexcept
+    [[nodiscard]] constexpr const T&& get() const&& noexcept
     {
         static_assert(I < N, "array index out of bounds");
         return std::move(elems[I]);

--- a/Sofa/framework/Type/test/fixed_array_test.cpp
+++ b/Sofa/framework/Type/test/fixed_array_test.cpp
@@ -33,4 +33,14 @@ TEST(fixed_array, operatorLess)
     EXPECT_GT(edge2, edge1);
 }
 
+
+TEST(fixed_array, structuredBindings)
+{
+    static constexpr sofa::type::fixed_array<std::size_t, 4> sofaArray { 8, -7, 4, -1};
+    const auto& [a, b, c, d] = sofaArray;
+    EXPECT_EQ(a, 8);
+    EXPECT_EQ(b,-7);
+    EXPECT_EQ(c, 4);
+    EXPECT_EQ(d,-1);
+}
 }


### PR DESCRIPTION
It allows to write something like:

```cpp
static constexpr sofa::type::fixed_array<std::size_t, 4> sofaArray { 8, -7, 4, -1};
const auto& [a, b, c, d] = sofaArray;
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
