### PR TITLE
[Spring] Remove variable redefinitions

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
@@ -417,9 +417,6 @@ void RestShapeSpringsForceField<DataTypes>::addForce(const MechanicalParams*  mp
         }
         else // non-rigid implementation
         {
-            const sofa::Index index = m_indices[i];
-            const sofa::Index ext_index = m_ext_indices[i];
-
             Deriv dx = p1[index] - p0[ext_index];
             f1[index] -= dx * stiffness;
         }


### PR DESCRIPTION
`index` and `ext_index` were already defined, and I think they referred to the same thing. The difference is only on the condition with `useRestMState`. 
It follows changes from https://github.com/sofa-framework/sofa/pull/3175. Strangely, we can see that the condition on `useRestMState` was implemented only for rigids. Now it is also for vecs.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
