### PR TITLE
[Mapping.NonLinear] Fix SquareMapping applyDJT

### DIFF
--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.h
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.h
@@ -87,6 +87,8 @@ public:
     void updateK( const core::MechanicalParams* mparams, core::ConstMultiVecDerivId childForce ) override;
     const linearalgebra::BaseMatrix* getK() override;
 
+    Data < bool > d_useGeometricStiffnessMatrix; ///< If available (cached), the geometric stiffness matrix is used in order to compute the product with the parent displacement. Otherwise, the product is computed directly using the available vectors (matrix-free method).
+
 protected:
     SquareMapping();
     ~SquareMapping() override;
@@ -94,7 +96,6 @@ protected:
     SparseMatrixEigen jacobian;                             ///< Jacobian of the mapping
     type::vector<linearalgebra::BaseMatrix*> baseMatrices;  ///< Jacobian of the mapping, in a vector
     SparseKMatrixEigen K;                                   ///< Assembled geometric stiffness matrix
-
 };
 
 

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
@@ -33,6 +33,10 @@ namespace sofa::component::mapping::nonlinear
 template <class TIn, class TOut>
 SquareMapping<TIn, TOut>::SquareMapping()
     : Inherit()
+    , d_useGeometricStiffnessMatrix(initData(&d_useGeometricStiffnessMatrix, true, "useGeometricStiffnessMatrix",
+        "If available (cached), the geometric stiffness matrix is used in order to compute the "
+        "product with the parent displacement. Otherwise, the product is computed directly using "
+        "the available vectors (matrix-free method)."))
 {
 }
 
@@ -109,7 +113,7 @@ void SquareMapping<TIn, TOut>::applyDJT(const core::MechanicalParams* mparams, c
     SReal kfactor = mparams->kFactor();
     helper::ReadAccessor<Data<OutVecDeriv> > childForce (*mparams->readF(this->toModel.get()));
 
-    if( K.compressedMatrix.nonZeros() )
+    if(d_useGeometricStiffnessMatrix.getValue() && K.compressedMatrix.nonZeros() )
     {
         K.addMult( parentForce.wref(), parentDisplacement.ref(), (typename In::Real)kfactor );
     }
@@ -120,7 +124,7 @@ void SquareMapping<TIn, TOut>::applyDJT(const core::MechanicalParams* mparams, c
 
         for(unsigned i=0; i<size; i++ )
         {
-            parentForce[i][0] += childForce[i][0]*kfactor;
+            parentForce[i][0] += parentDisplacement[i][0] * childForce[i][0]*kfactor;
         }
     }
 }

--- a/Sofa/Component/Mapping/NonLinear/tests/SquareMapping_test.cpp
+++ b/Sofa/Component/Mapping/NonLinear/tests/SquareMapping_test.cpp
@@ -84,6 +84,14 @@ TYPED_TEST( SquareMappingTest , test )
     ASSERT_TRUE(this->test());
 }
 
+TYPED_TEST( SquareMappingTest , testNoGeometricStiffnessMatrix )
+{
+    TypeParam* map = static_cast<TypeParam*>( this->mapping );
+    map->d_useGeometricStiffnessMatrix.setValue(false);
+
+    ASSERT_TRUE(this->test());
+}
+
 
 
 } // namespace


### PR DESCRIPTION
In `applyDJT`, the following product is computed:

$$
b \mathrel{{+}{=}} h^2 \frac{\partial \mathbf{J}}{\partial x_{\text{out}}} f_{\text{out}} v_\text{in}
$$

with `b` being the right side of the main equation, `h` the time step size ($h^2$ is the `kFactor`), `x` the position, `v` the velocity and `f` the force. Subscript `in` refers to the parent of the mapping, and `out` to the child. $J$ is the jacobian matrix of the mapping.

The method in `SquareMapping` had two ways to compute this product:

1) Using K which has been computed previsously. And multiply it by $v_\text{in}$
2) Using $f_{\text{out}}$ and $v_\text{in}$ only, without using a cached matrix

Only the first method was tested in unit tests. I forced the second method in a unit test by introducing a Data `useGeometricStiffnessMatrix`. It could be observed that the second method failed. It needed a fix. The product with $v_\text{in}$ was forgotten. It is now added in this pull request.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
