### PR TITLE
[Core] Fix MSVC warning in Link

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Link.h
@@ -299,9 +299,9 @@ public:
     typedef TOwnerType OwnerType;
     typedef TDestType DestType;
     static constexpr unsigned ActiveFlags = TFlags;
-    static constexpr bool IsStrongLink = ActiveFlags & FLAG_STRONGLINK;
-    static constexpr bool IsMultiLink = ActiveFlags & FLAG_MULTILINK;
-    static constexpr bool StorePath = ActiveFlags & FLAG_STOREPATH;
+    static constexpr bool IsStrongLink = (ActiveFlags & FLAG_STRONGLINK) != 0;
+    static constexpr bool IsMultiLink = (ActiveFlags & FLAG_MULTILINK) != 0;
+    static constexpr bool StorePath = (ActiveFlags & FLAG_STOREPATH) != 0;
 
     typedef LinkTraitsDestPtr<DestType, IsStrongLink> TraitsDestPtr;
     typedef typename TraitsDestPtr::T DestPtr;


### PR DESCRIPTION
The following warnings appears everytime a Link is declared:

https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305?view=msvc-170







______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
