### PR TITLE
[examples] Introduce example and tests for SquareMapping

### DIFF
--- a/Sofa/Component/Mapping/NonLinear/tests/SquareDistanceMapping_test.cpp
+++ b/Sofa/Component/Mapping/NonLinear/tests/SquareDistanceMapping_test.cpp
@@ -24,6 +24,7 @@
 
 #include <sofa/component/mapping/testing/MappingTestCreation.h>
 #include <sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.h>
+#include <sofa/simulation/graph/SimpleApi.h>
 
 namespace sofa {
 namespace {
@@ -128,4 +129,144 @@ TYPED_TEST( SquareDistanceMappingTest , test )
 
 
 } // namespace
+
+/**
+ * This test checks two different methods to simulate a triple pendulum using quadratic springs:
+ * 1) A SquaredDistanceMapping is used to transform the DOFs from the 3d space to a 1d space
+ * (representing the squared distances between the DOFs). Then a spring acts in the 1d space
+ * 2) A combination of two mappings: DistanceMapping and SquareMapping. It also transforms the 3d
+ * space to a 1d space where a spring is added.
+ *
+ * Two methods are supposed to lead to the same result. This test checks that both mechanical
+ * objects are at the same position, velocity and force.
+ * However, this test can fail easily with different parameters (number of strings, number of time
+ * steps etc).
+ */
+struct SquareDistanceMappingCompare_test : NumericTest<SReal>
+{
+    simulation::Node::SPtr root;
+    simulation::Node::SPtr oneMapping;
+    simulation::Node::SPtr twoMappings;
+
+    void onSetUp() override
+    {
+        if (!simulation::getSimulation()) {
+            simulation::setSimulation(new simulation::graph::DAGSimulation()) ;
+        }
+
+        root = simulation::getSimulation()->createNewNode("root");
+
+        simpleapi::createObject(root, "RequiredPlugin", {{"pluginName", "Sofa.Component"}});
+        simpleapi::createObject(root, "DefaultAnimationLoop");
+        simpleapi::createObject(root, "StringMeshCreator", {{"name", "loader"}, {"resolution", "3"}});
+
+        oneMapping = simpleapi::createChild(root, "oneMapping");
+        twoMappings = simpleapi::createChild(root, "twoMappings");
+
+        for (const auto& node : {oneMapping, twoMappings})
+        {
+            simpleapi::createObject(node, "EulerImplicitSolver", {{"rayleighStiffness", "0.1"}, {"rayleighMass","0.1"}});
+            simpleapi::createObject(node, "EdgeSetTopologyContainer",
+                {{"position", "@../loader.position"}, {"edges", "@../loader.edges"}, {"name", "topology"}});
+            simpleapi::createObject(node, "MechanicalObject", {{"name", "defoDOF"}, {"template", "Vec3"}});
+            simpleapi::createObject(node, "EdgeSetGeometryAlgorithms");
+            simpleapi::createObject(node, "FixedConstraint", {{"indices", "0"}});
+            simpleapi::createObject(node, "DiagonalMass", {{"totalMass", "1e-2"}});
+        }
+
+        auto oneMappingExtension = simpleapi::createChild(oneMapping, "extensionsNode");
+        auto twoMappingsExtension = simpleapi::createChild(twoMappings, "extensionsNode");
+
+        simpleapi::createObject(oneMappingExtension, "MechanicalObject", {{"name", "extensionsDOF"}, {"template", "Vec1"}});
+        simpleapi::createObject(twoMappingsExtension, "MechanicalObject", {{"name", "extensionsDOF"}, {"template", "Vec1"}});
+
+        simpleapi::createObject(oneMappingExtension, "SquareDistanceMapping",
+                                {{"topology", "@../topology"}, {"input", "@../defoDOF"},
+                                 {"output", "@extensionsDOF"}, {"geometricStiffness", "1"},
+                                 {"applyRestPosition", "true"}});
+        simpleapi::createObject(oneMappingExtension, "RestShapeSpringsForceField", {{"template", "Vec1"}, {"stiffness", "10000"}});
+
+
+
+
+        simpleapi::createObject(twoMappingsExtension, "DistanceMapping",
+                                {{"topology", "@../topology"}, {"input", "@../defoDOF"},
+                                 {"output", "@extensionsDOF"}, {"geometricStiffness", "1"},
+                                 {"applyRestPosition", "true"}, {"computeDistance", "true"}});
+        auto distanceMappingNode = simpleapi::createChild(twoMappingsExtension, "square");
+        simpleapi::createObject(distanceMappingNode, "MechanicalObject", {{"name", "squaredDOF"}, {"template", "Vec1"}});
+        simpleapi::createObject(distanceMappingNode, "SquareMapping",
+                                        {{"input", "@../extensionsDOF"},
+                                         {"output", "@squaredDOF"}, {"geometricStiffness", "1"},
+                                         {"applyRestPosition", "true"}});
+        simpleapi::createObject(distanceMappingNode, "RestShapeSpringsForceField", {{"template", "Vec1"}, {"stiffness", "10000"}});
+
+    }
+
+    void compareMechanicalObjects(unsigned int timeStepCount)
+    {
+        const auto epsilon = 1e-7_sreal;
+
+        core::behavior::BaseMechanicalState* mstate0 = oneMapping->getMechanicalState();
+        ASSERT_NE(mstate0, nullptr);
+
+        core::behavior::BaseMechanicalState* mstate1 = twoMappings->getMechanicalState();
+        ASSERT_NE(mstate1, nullptr);
+
+        //position
+        {
+            sofa::type::vector<SReal> mstatex0(mstate0->getMatrixSize());
+            mstate0->copyToBuffer(mstatex0.data(), core::ConstVecCoordId::position(), mstate0->getMatrixSize());
+
+            sofa::type::vector<SReal> mstatex1(mstate1->getMatrixSize());
+            mstate1->copyToBuffer(mstatex1.data(), core::ConstVecCoordId::position(), mstate1->getMatrixSize());
+
+            EXPECT_LT(this->vectorMaxDiff(mstatex0, mstatex1), epsilon) << "Time step " << timeStepCount
+                << "\n" << mstatex0 << "\n" << mstatex1;
+        }
+
+        //velocity
+        {
+            sofa::type::vector<SReal> mstatev0(mstate0->getMatrixSize());
+            mstate0->copyToBuffer(mstatev0.data(), core::ConstVecDerivId::velocity(), mstate0->getMatrixSize());
+
+            sofa::type::vector<SReal> mstatev1(mstate1->getMatrixSize());
+            mstate1->copyToBuffer(mstatev1.data(), core::ConstVecDerivId::velocity(), mstate1->getMatrixSize());
+
+            EXPECT_LT(this->vectorMaxDiff(mstatev0, mstatev1), epsilon) << "Time step " << timeStepCount
+                << "\n" << mstatev0 << "\n" << mstatev1;
+        }
+
+        //force
+        {
+            sofa::type::vector<SReal> mstatef0(mstate0->getMatrixSize());
+            mstate0->copyToBuffer(mstatef0.data(), core::ConstVecDerivId::force(), mstate0->getMatrixSize());
+
+            sofa::type::vector<SReal> mstatef1(mstate1->getMatrixSize());
+            mstate1->copyToBuffer(mstatef1.data(), core::ConstVecDerivId::force(), mstate1->getMatrixSize());
+
+            EXPECT_LT(this->vectorMaxDiff(mstatef0, mstatef1), epsilon) << "Time step " << timeStepCount
+                << "\n" << mstatef0 << "\n" << mstatef1;
+        }
+    }
+};
+
+TEST_F(SquareDistanceMappingCompare_test, compareToDistanceMappingAndSquareMapping)
+{
+    for (const auto& node : {oneMapping, twoMappings})
+    {
+        simpleapi::createObject(node, "CGLinearSolver", {{"iterations", "1e4"}, {"tolerance", "1.0e-9"}, {"threshold", "1.0e-9"}});
+    }
+
+    simulation::getSimulation()->init(root.get());
+
+    for (unsigned int i = 0 ; i < 100; ++i)
+    {
+        simulation::getSimulation()->animate(root.get(), 0.01_sreal);
+
+        compareMechanicalObjects(i);
+    }
+}
+
+
 } // namespace sofa

--- a/examples/Component/Mapping/NonLinear/SquareMapping.scn
+++ b/examples/Component/Mapping/NonLinear/SquareMapping.scn
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0"?>
+<Node name="Root" gravity="0 -10 0" time="0" animate="0"  dt="0.01">
+
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [StringMeshCreator] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.NonLinear"/> <!-- Needed to use components [DistanceMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.Spring"/> <!-- Needed to use components [RestShapeSpringsForceField] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [EdgeSetGeometryAlgorithms, EdgeSetTopologyContainer] -->
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+    </Node>
+
+    <DefaultVisualManagerLoop/>
+    <VisualStyle displayFlags="showVisualModels showBehaviorModels showMappings showForceFields showMechanicalMappings" />
+
+    <DefaultAnimationLoop/>
+    <StringMeshCreator name="loader" resolution="3" />
+
+    <Node name="twoMappings">
+
+        <EulerImplicitSolver name="solverTwoMappings" rayleighStiffness="0.1" rayleighMass="0.1"/>
+        <CGLinearSolver iterations="1e4" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <EdgeSetTopologyContainer name="topology" position="@../loader.position" edges="@../loader.edges" />
+        <MechanicalObject name="defoDOF" template="Vec3" />
+        <EdgeSetGeometryAlgorithms drawEdges="true" />
+        <FixedConstraint indices="0" />
+        <DiagonalMass  name="mass" totalMass="1e-2"/>
+        <Node name="extensionsNode" >
+            <MechanicalObject template="Vec1" name="extensionsDOF" />
+            <DistanceMapping name="distanceMapping" topology="@../topology" input="@../defoDOF" output="@extensionsDOF" geometricStiffness="1" applyRestPosition="true" computeDistance="true"/>
+            <Node name="square">
+                <MechanicalObject template="Vec1" name="squaredDOF" />
+                <SquareMapping input="@../extensionsDOF" output="@squaredDOF" geometricStiffness="1" applyRestPosition="true"/>
+                <RestShapeSpringsForceField template="Vec1" stiffness="10000"/>
+            </Node>
+        </Node>
+    </Node>
+
+    <Node name="oneMapping">
+        <TransformEngine name="transform" template="Vec3" translation="0 0 0" input_position="@../loader.position" />
+
+        <EulerImplicitSolver name="solverOneMapping" rayleighStiffness="0.1" rayleighMass="0.1"/>
+        <CGLinearSolver iterations="1e4" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <EdgeSetTopologyContainer name="topology" position="@transform.output_position" edges="@../loader.edges" />
+        <MechanicalObject name="defoDOF" template="Vec3" />
+        <EdgeSetGeometryAlgorithms drawEdges="true" />
+        <FixedConstraint indices="0" />
+        <DiagonalMass  name="mass" totalMass="1e-2"/>
+        <Node name="extensionsNode" >
+            <MechanicalObject template="Vec1" name="extensionsDOF" />
+            <SquareDistanceMapping name="distanceMapping" topology="@../topology" input="@../defoDOF" output="@extensionsDOF" geometricStiffness="1" applyRestPosition="true"/>
+            <RestShapeSpringsForceField template="Vec1" stiffness="10000"/>
+        </Node>
+    </Node>
+
+</Node>


### PR DESCRIPTION
An example is introduced for SquareMapping. In this scene, the goal was to verify that two methods are equivalent:
1) A SquaredDistanceMapping is used to transform the DOFs from the 3d space to a 1d space (representing the squared distances between the DOFs). Then a spring acts in the 1d space
2) A combination of two mappings: DistanceMapping and SquareMapping. It also transforms the 3d space to a 1d space where a spring is added.

A unit test is added to check both methods are equivalent. However, we can observe that if the simulation runs long enough, both objects diverge. It will be a challenge to find the reasons.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
