### PR TITLE
[LinearAlgebra] Restore insertion operator for BaseVector

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseVector.cpp
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseVector.cpp
@@ -20,8 +20,19 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/linearalgebra/BaseVector.h>
+#include <ostream>
 
 namespace sofa::linearalgebra
 {
+
+std::ostream& operator << (std::ostream& out, const BaseVector& v )
+{
+    const BaseVector::Index ny = v.size();
+    for (BaseVector::Index y=0; y<ny; ++y)
+    {
+        out << " " << v.element(y);
+    }
+    return out;
+}
 
 } // namespace sofa::linearalgebra

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseVector.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseVector.h
@@ -166,7 +166,7 @@ public:
     friend SOFA_LINEARALGEBRA_API std::ostream& operator << (std::ostream& out, const BaseVector& v );
 };
 
-/// Declare that the operator >> exists but is defined in a BaseMatrix.cpp
+/// Declare that the operator << exists but is defined in BaseVector.cpp
 SOFA_LINEARALGEBRA_API std::ostream& operator<<(std::ostream& out, const  BaseVector& v );
 
 } // namespace sofa::linearalgebra


### PR DESCRIPTION
It has somehow been forgotten during a refactoring



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
