### PR TITLE
[Config] Remove suspicious Eigen macro preventing vectorization

### DIFF
--- a/Sofa/framework/Config/src/sofa/config.h.in
+++ b/Sofa/framework/Config/src/sofa/config.h.in
@@ -41,10 +41,6 @@
 
 #cmakedefine SOFA_WITH_DEVTOOLS
 
-#ifdef _MSC_VER
-#define EIGEN_DONT_ALIGN
-#endif // _MSC_VER
-
 #ifdef WIN32
 #define UNICODE
 #endif // WIN32


### PR DESCRIPTION
It is also deprecated, and replaced by `EIGEN_MAX_ALIGN_BYTES` with value 0. See https://eigen.tuxfamily.org/dox/TopicPreprocessorDirectives.html

It has been introduced in https://github.com/sofa-framework/sofa/commit/a08e0d505cb68d0de73bf7126a1ff1c6f5cd68f0

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
