### PR TITLE
[Core.Visual, Component.Visual] Create VisualState (formerly Vec3State)

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -21,21 +21,21 @@
 ******************************************************************************/
 #include <sofa/component/visual/VisualModelImpl.h>
 
+#include <sofa/type/Quat.h>
+#include <sofa/type/vector.h>
+#include <sofa/type/Material.h>
+#include <sofa/helper/rmath.h>
+#include <sofa/helper/accessor.h>
+#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/io/Mesh.h>
+#include <sofa/helper/system/FileRepository.h>
 #include <sofa/core/topology/TopologyData.inl>
-#include <sofa/component/topology/container/grid/SparseGridTopology.h>
-
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/type/Quat.h>
-#include <sofa/type/vector.h>
-#include <sofa/helper/io/Mesh.h>
-#include <sofa/helper/rmath.h>
-#include <sofa/helper/accessor.h>
-#include <sofa/helper/system/FileRepository.h>
-#include <sofa/type/Material.h>
-#include <sofa/helper/AdvancedTimer.h>
+
+#include <sofa/component/topology/container/grid/SparseGridTopology.h>
 
 #include <sstream>
 #include <map>
@@ -50,72 +50,6 @@ using namespace sofa::type;
 using namespace sofa::defaulttype;
 using namespace sofa::core::topology;
 using type::vector;
-
-Vec3State::Vec3State()
-    : m_positions(initData(&m_positions, "position", "Vertices coordinates"))
-    , m_restPositions(initData(&m_restPositions, "restPosition", "Vertices rest coordinates"))
-    , m_vnormals (initData (&m_vnormals, "normal", "Normals of the model"))
-    , modified(false)
-{
-    m_positions.setGroup("Vector");
-    m_restPositions.setGroup("Vector");
-    m_vnormals.setGroup("Vector");
-}
-
-void Vec3State::resize(Size vsize)
-{
-    helper::WriteOnlyAccessor< Data<VecCoord > > positions = m_positions;
-    if( positions.size() == vsize ) return;
-    helper::WriteOnlyAccessor< Data<VecCoord > > restPositions = m_restPositions;
-    helper::WriteOnlyAccessor< Data<VecDeriv > > normals = m_vnormals;
-
-    positions.resize(vsize);
-    restPositions.resize(vsize); // todo allocate restpos only when it is necessary
-    normals.resize(vsize);
-
-    modified = true;
-}
-
-Size Vec3State::getSize() const { return Size(m_positions.getValue().size()); }
-
-Data<Vec3State::VecCoord>* Vec3State::write(     core::VecCoordId  v )
-{
-    modified = true;
-
-    if( v == core::VecCoordId::position() )
-        return &m_positions;
-    if( v == core::VecCoordId::restPosition() )
-        return &m_restPositions;
-
-    return nullptr;
-}
-
-const Data<Vec3State::VecCoord>* Vec3State::read(core::ConstVecCoordId  v )  const
-{
-    if( v == core::VecCoordId::position() )
-        return &m_positions;
-    if( v == core::VecCoordId::restPosition() )
-        return &m_restPositions;
-
-    return nullptr;
-}
-
-Data<Vec3State::VecDeriv>*	Vec3State::write(core::VecDerivId v )
-{
-    if( v == core::VecDerivId::normal() )
-        return &m_vnormals;
-
-    return nullptr;
-}
-
-const Data<Vec3State::VecDeriv>* Vec3State::read(core::ConstVecDerivId v ) const
-{
-    if( v == core::VecDerivId::normal() )
-        return &m_vnormals;
-
-    return nullptr;
-}
-
 
 void VisualModelImpl::parse(core::objectmodel::BaseObjectDescription* arg)
 {

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
@@ -68,7 +68,7 @@ public:
     typedef type::vector<VisualTriangle> VecVisualTriangle;
     typedef type::vector<VisualQuad> VecVisualQuad;
 
-    typedef Vec3State::DataTypes DataTypes;
+    typedef sofa::core::visual::VisualState<defaulttype::Vec3Types>::DataTypes DataTypes;
     typedef DataTypes::Real Real;
     typedef DataTypes::Coord Coord;
     typedef DataTypes::VecCoord VecCoord;

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
@@ -22,44 +22,20 @@
 #pragma once
 #include <sofa/component/visual/config.h>
 
-#include <sofa/core/State.h>
+#include <sofa/type/Vec.h>
+#include <sofa/helper/io/Mesh.h>
+#include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/visual/VisualModel.h>
+#include <sofa/core/visual/VisualState.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/type/Vec.h>
-#include <sofa/defaulttype/VecTypes.h>
-#include <sofa/defaulttype/RigidTypes.h>
-#include <sofa/helper/io/Mesh.h>
-#include <sofa/core/topology/TopologyData.inl>
+
 #include <string>
 
 namespace sofa::component::visual
 {
 
-using sofa::core::objectmodel::Data ;
-
-class SOFA_COMPONENT_VISUAL_API Vec3State : public core::State< sofa::defaulttype::Vec3Types >
-{
-public:
-    core::topology::PointData< VecCoord > m_positions; ///< Vertices coordinates
-    core::topology::PointData< VecCoord > m_restPositions; ///< Vertices rest coordinates
-    core::topology::PointData< VecDeriv > m_vnormals; ///< Normals of the model
-    bool modified; ///< True if input vertices modified since last rendering
-
-    Vec3State() ;
-
-    virtual void resize(Size vsize) ;
-    virtual Size getSize() const ;
-
-    //State API
-    virtual       Data<VecCoord>* write(core::VecCoordId  v ) ;
-    virtual const Data<VecCoord>* read(core::ConstVecCoordId  v )  const ;
-    virtual Data<VecDeriv>*	write(core::VecDerivId v ) ;
-    virtual const Data<VecDeriv>* read(core::ConstVecDerivId v ) const ;
-
-    virtual       Data<MatrixDeriv>*	write(core::MatrixDerivId /* v */) { return nullptr; }
-    virtual const Data<MatrixDeriv>*	read(core::ConstMatrixDerivId /* v */) const {  return nullptr; }
-};
+using Vec3State = sofa::core::visual::VisualState<defaulttype::Vec3Types>;
 
 /**
  *  \brief Abstract class which implements partially VisualModel.

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
@@ -35,7 +35,9 @@
 namespace sofa::component::visual
 {
 
-using Vec3State = sofa::core::visual::VisualState<defaulttype::Vec3Types>;
+SOFA_ATTRIBUTE_DEPRECATED__VEC3STATE_AS_VISUALSTATE() 
+typedef sofa::core::visual::VisualState<defaulttype::Vec3Types> Vec3State;
+
 
 /**
  *  \brief Abstract class which implements partially VisualModel.
@@ -46,10 +48,10 @@ using Vec3State = sofa::core::visual::VisualState<defaulttype::Vec3Types>;
  *  At the moment, it is only implemented by OglModel for OpenGL systems.
  *
  */
-class SOFA_COMPONENT_VISUAL_API VisualModelImpl : public core::visual::VisualModel, public Vec3State //, public RigidState
+class SOFA_COMPONENT_VISUAL_API VisualModelImpl : public core::visual::VisualModel, public sofa::core::visual::VisualState<defaulttype::Vec3Types>
 {
 public:
-    SOFA_CLASS2(VisualModelImpl, core::visual::VisualModel, Vec3State);
+    SOFA_CLASS2(VisualModelImpl, core::visual::VisualModel, sofa::core::visual::VisualState<defaulttype::Vec3Types>);
 
     typedef sofa::type::Vec<2, float> TexCoord;
     typedef type::vector<TexCoord> VecTexCoord;

--- a/Sofa/Component/Visual/src/sofa/component/visual/config.h.in
+++ b/Sofa/Component/Visual/src/sofa/component/visual/config.h.in
@@ -36,3 +36,12 @@ namespace sofa::component::visual
 	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
 	constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
 } // namespace sofa::component::visual
+
+#ifdef SOFA_BUILD__COMPONENT__VISUAL
+#define SOFA_ATTRIBUTE_DEPRECATED__VEC3STATE_AS_VISUALSTATE()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__VEC3STATE_AS_VISUALSTATE() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v23.06", "v23.12", \
+        "Vec3State is now an alias of sofa::core::visual::VisualState<defaulttype::Vec3Types>.")
+#endif

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.h
@@ -23,18 +23,20 @@
 #include <sofa/gl/component/rendering3d/config.h>
 
 #include <sofa/core/visual/VisualModel.h>
+#include <sofa/core/visual/VisualState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/gl/component/rendering2d/OglColorMap.h>
-#include <sofa/component/visual/VisualModelImpl.h>
 
 #include <sofa/type/RGBAColor.h>
 
 namespace sofa::gl::component::rendering3d
 {
 
-class SOFA_GL_COMPONENT_RENDERING3D_API DataDisplay : public core::visual::VisualModel, public sofa::component::visual::Vec3State
+class SOFA_GL_COMPONENT_RENDERING3D_API DataDisplay : public core::visual::VisualModel, public sofa::core::visual::VisualState<defaulttype::Vec3Types>
 {
 public:
+    using Vec3State = sofa::core::visual::VisualState<defaulttype::Vec3Types>;
+
     SOFA_CLASS2(DataDisplay, core::visual::VisualModel, Vec3State);
 
     typedef core::topology::BaseMeshTopology::Triangle Triangle;

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglCylinderModel.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglCylinderModel.h
@@ -23,7 +23,7 @@
 #include <sofa/gl/component/rendering3d/config.h>
 
 #include <sofa/core/visual/VisualModel.h>
-#include <sofa/component/visual/VisualModelImpl.h>
+#include <sofa/core/visual/VisualState.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/topology/TopologyData.h>
 #include <sofa/core/topology/Topology.h>
@@ -43,10 +43,11 @@ namespace sofa::gl::component::rendering3d
 {
 
 // I have no idea what is Ogl in this component ?...
-class SOFA_GL_COMPONENT_RENDERING3D_API OglCylinderModel : public core::visual::VisualModel, public sofa::component::visual::Vec3State
+class SOFA_GL_COMPONENT_RENDERING3D_API OglCylinderModel : public core::visual::VisualModel, public sofa::core::visual::VisualState<defaulttype::Vec3Types>
 {
 public:
-    SOFA_CLASS2(OglCylinderModel,core::visual::VisualModel, sofa::component::visual::Vec3State);
+    using Vec3State = sofa::core::visual::VisualState<defaulttype::Vec3Types>;
+    SOFA_CLASS2(OglCylinderModel,core::visual::VisualModel, Vec3State);
 
     using Index = sofa::Index;
 protected:

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -175,6 +175,8 @@ set(HEADER_FILES
     ${SRC_ROOT}/visual/VisualManager.h
     ${SRC_ROOT}/visual/VisualModel.h
     ${SRC_ROOT}/visual/VisualParams.h
+    ${SRC_ROOT}/visual/VisualState.h
+    ${SRC_ROOT}/visual/VisualState.inl
 )
 
 set(SOURCE_FILES
@@ -293,6 +295,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/visual/VisualManager.cpp
     ${SRC_ROOT}/visual/VisualModel.cpp
     ${SRC_ROOT}/visual/VisualParams.cpp
+    ${SRC_ROOT}/visual/VisualState.cpp
 )
 
 sofa_find_package(Sofa.Topology REQUIRED)

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.cpp
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.cpp
@@ -1,0 +1,35 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/visual/VisualState.inl>
+
+#include <sofa/defaulttype/VecTypes.h>
+
+#include <sofa/core/topology/TopologyData.inl>
+
+namespace sofa::core::visual
+{
+
+using namespace sofa::defaulttype;
+
+template class SOFA_CORE_API VisualState< Vec3Types >;
+
+} // namespace sofa::core::visual

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.cpp
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.cpp
@@ -23,8 +23,6 @@
 
 #include <sofa/defaulttype/VecTypes.h>
 
-#include <sofa/core/topology/TopologyData.inl>
-
 namespace sofa::core::visual
 {
 

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.cpp
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_CORE_VISUAL_VISUALSTATE_CPP
+
 #include <sofa/core/visual/VisualState.inl>
 
 #include <sofa/defaulttype/VecTypes.h>

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
@@ -33,6 +33,12 @@ template< typename DataTypes >
 class SOFA_CORE_API VisualState : public core::State< DataTypes >
 {
 public:
+    SOFA_CLASS(VisualState, SOFA_TEMPLATE(core::State, defaulttype::Vec3Types));
+
+    using VecCoord = typename DataTypes::VecCoord;
+    using VecDeriv = typename DataTypes::VecCoord;
+    using MatrixDeriv = typename DataTypes::MatrixDeriv;
+
     core::topology::PointData< VecCoord > m_positions; ///< Vertices coordinates
     core::topology::PointData< VecCoord > m_restPositions; ///< Vertices rest coordinates
     core::topology::PointData< VecDeriv > m_vnormals; ///< Normals of the model

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
@@ -24,7 +24,7 @@
 #include <sofa/core/config.h>
 
 #include <sofa/core/State.h>
-#include <sofa/core/topology/TopologyData.h>
+#include <sofa/core/topology/TopologyData.inl>
 
 namespace sofa::core::visual
 {
@@ -46,17 +46,17 @@ public:
 
     VisualState();
 
-    virtual void resize(Size vsize);
-    virtual Size getSize() const { return Size(m_positions.getValue().size()); }
+    virtual void resize(Size vsize) override;
+    virtual Size getSize() const override { return Size(m_positions.getValue().size()); }
 
     //State API
-    virtual       Data<VecCoord>* write(core::VecCoordId  v);
-    virtual const Data<VecCoord>* read(core::ConstVecCoordId  v)  const;
-    virtual Data<VecDeriv>* write(core::VecDerivId v);
-    virtual const Data<VecDeriv>* read(core::ConstVecDerivId v) const;
+    virtual       Data<VecCoord>* write(core::VecCoordId  v) override;
+    virtual const Data<VecCoord>* read(core::ConstVecCoordId  v)  const override;
+    virtual Data<VecDeriv>* write(core::VecDerivId v) override;
+    virtual const Data<VecDeriv>* read(core::ConstVecDerivId v) const override;
 
-    virtual       Data<MatrixDeriv>* write(core::MatrixDerivId /* v */) { return nullptr; }
-    virtual const Data<MatrixDeriv>* read(core::ConstMatrixDerivId /* v */) const { return nullptr; }
+    virtual       Data<MatrixDeriv>* write(core::MatrixDerivId /* v */) override { return nullptr; }
+    virtual const Data<MatrixDeriv>* read(core::ConstMatrixDerivId /* v */) const override { return nullptr; }
 };
 
-}
+} // namespace sofa::core::visual

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/config.h>
+
+#include <sofa/core/State.h>
+#include <sofa/core/topology/TopologyData.h>
+
+namespace sofa::core::visual
+{
+
+template< typename DataTypes >
+class SOFA_CORE_API VisualState : public core::State< DataTypes >
+{
+public:
+    core::topology::PointData< VecCoord > m_positions; ///< Vertices coordinates
+    core::topology::PointData< VecCoord > m_restPositions; ///< Vertices rest coordinates
+    core::topology::PointData< VecDeriv > m_vnormals; ///< Normals of the model
+    bool modified; ///< True if input vertices modified since last rendering
+
+    VisualState();
+
+    virtual void resize(Size vsize);
+    virtual Size getSize() const { return Size(m_positions.getValue().size()); }
+
+    //State API
+    virtual       Data<VecCoord>* write(core::VecCoordId  v);
+    virtual const Data<VecCoord>* read(core::ConstVecCoordId  v)  const;
+    virtual Data<VecDeriv>* write(core::VecDerivId v);
+    virtual const Data<VecDeriv>* read(core::ConstVecDerivId v) const;
+
+    virtual       Data<MatrixDeriv>* write(core::MatrixDerivId /* v */) { return nullptr; }
+    virtual const Data<MatrixDeriv>* read(core::ConstMatrixDerivId /* v */) const { return nullptr; }
+};
+
+}

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
@@ -30,7 +30,7 @@ namespace sofa::core::visual
 {
 
 template< typename DataTypes >
-class SOFA_CORE_API VisualState : public core::State< DataTypes >
+class VisualState : public core::State< DataTypes >
 {
 public:
     SOFA_CLASS(VisualState, SOFA_TEMPLATE(core::State, defaulttype::Vec3Types));

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
@@ -59,4 +59,9 @@ public:
     virtual const Data<MatrixDeriv>* read(core::ConstMatrixDerivId /* v */) const override { return nullptr; }
 };
 
+#if !defined(SOFA_CORE_VISUAL_VISUALSTATE_CPP)
+extern template class SOFA_CORE_API VisualState< defaulttype::Vec3Types >;
+#endif
+
+
 } // namespace sofa::core::visual

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.inl
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.inl
@@ -1,0 +1,97 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/visual/VisualState.h>
+
+namespace sofa::core::visual
+{
+
+template< typename DataTypes >
+VisualState<DataTypes>::VisualState()
+    : m_positions(initData(&m_positions, "position", "Vertices coordinates"))
+    , m_restPositions(initData(&m_restPositions, "restPosition", "Vertices rest coordinates"))
+    , m_vnormals(initData(&m_vnormals, "normal", "Normals of the model"))
+    , modified(false)
+{
+    m_positions.setGroup("Vector");
+    m_restPositions.setGroup("Vector");
+    m_vnormals.setGroup("Vector");
+}
+
+template< typename DataTypes >
+void VisualState<DataTypes>::resize(Size vsize)
+{
+    helper::WriteOnlyAccessor< Data<VecCoord > > positions = m_positions;
+    if (positions.size() == vsize) return;
+    helper::WriteOnlyAccessor< Data<VecCoord > > restPositions = m_restPositions;
+    helper::WriteOnlyAccessor< Data<VecDeriv > > normals = m_vnormals;
+
+    positions.resize(vsize);
+    restPositions.resize(vsize); // todo allocate restpos only when it is necessary
+    normals.resize(vsize);
+
+    modified = true;
+}
+
+template< typename DataTypes >
+auto VisualState<DataTypes>::write(core::VecCoordId  v) -> Data<VisualState::VecCoord>*
+{
+    modified = true;
+
+    if (v == core::VecCoordId::position())
+        return &m_positions;
+    if (v == core::VecCoordId::restPosition())
+        return &m_restPositions;
+
+    return nullptr;
+}
+
+template< typename DataTypes >
+auto VisualState<DataTypes>::read(core::ConstVecCoordId  v)  const -> const Data<VisualState::VecCoord>*
+{
+    if (v == core::VecCoordId::position())
+        return &m_positions;
+    if (v == core::VecCoordId::restPosition())
+        return &m_restPositions;
+
+    return nullptr;
+}
+
+template< typename DataTypes >
+auto VisualState<DataTypes>::write(core::VecDerivId v) -> Data<VisualState::VecDeriv>*
+{
+    if (v == core::VecDerivId::normal())
+        return &m_vnormals;
+
+    return nullptr;
+}
+
+template< typename DataTypes >
+auto VisualState<DataTypes>::read(core::ConstVecDerivId v) const -> const Data<VisualState::VecDeriv>*
+{
+    if (v == core::VecDerivId::normal())
+        return &m_vnormals;
+
+    return nullptr;
+}
+}

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.inl
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.inl
@@ -94,4 +94,5 @@ auto VisualState<DataTypes>::read(core::ConstVecDerivId v) const -> const Data<V
 
     return nullptr;
 }
-}
+
+} // namespace sofa::core::visual


### PR DESCRIPTION
VisualModelImpl inherits from State which allows it to be mapped (with Mappings) .
This State is slightly specialized for Visual thing (contains positions, normals and rest_positions(?) )

It was previously located exclusively in VisualModelImpl.h, this PR renames it and moves it into Sofa.Core.Visual.
Follows the guideline one class -> one (set of) file

Slightly breaking because some includes have been removed.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
