### PR TITLE
[StateContainer] Fix bug in dynamic data registration

### DIFF
--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -1660,8 +1660,22 @@ void MechanicalObject<DataTypes>::setVecIdProperties(core::TVecId<vtype, vaccess
 {
     if (!properties.label.empty())
     {
-        vec_d->setName(properties.label + core::VecTypeLabels.at(vtype));
-        vec_d->setHelp("VecId: " + v.getName());
+        std::string newname = properties.label;
+        std::string oldname = properties.label + core::VecTypeLabels.at(vtype);
+        auto base = vec_d->getOwner();
+        if(base && !base->findData(oldname))
+        {
+            base->addAlias(vec_d, oldname.c_str());
+
+            // This allows to find the data field in getData() using its new name eg: constraint_dx
+            if(base->findData(newname))
+                msg_error(base) << "Unable to expose a dynamic data field named '" << newname << "' as that name already exists. Please report this issue to https://github.com/sofa-framework/sofa/issues (for more infos see PR: https://github.com/sofa-framework/sofa/pull/3783)";
+            else
+                base->addAlias(vec_d, newname.c_str());
+
+        }
+        vec_d->setName(newname);
+        vec_d->setHelp("VecId: " + oldname);
     }
     if (!properties.group.empty())
     {

--- a/Sofa/framework/Type/test/MatTypes_test.cpp
+++ b/Sofa/framework/Type/test/MatTypes_test.cpp
@@ -183,7 +183,7 @@ void test_transformInverse(Matrix4 const& M)
 
 TEST(MatTypesTest, transformInverse)
 {
-    test_transformInverse(Matrix4::s_identity);
+    test_transformInverse(Matrix4::Identity());
     test_transformInverse(Matrix4::transformTranslation(Vec3(1.,2.,3.)));
     test_transformInverse(Matrix4::transformScale(Vec3(1.,2.,3.)));
     test_transformInverse(Matrix4::transformRotation(Quat<SReal>::fromEuler(M_PI_4,M_PI_2,M_PI/3.)));
@@ -191,7 +191,7 @@ TEST(MatTypesTest, transformInverse)
 
 TEST(MatTypesTest, setsub_vec)
 {
-    Matrix3 M = Matrix3::s_identity;
+    Matrix3 M = Matrix3::Identity();
     Vec2 v(1.,2.);
     M.setsub(1,2,v);
     double exp[9]={1.,0.,0.,


### PR DESCRIPTION
Dynamic data field added from the mechanical object are not using the "addData" method. The drawback is that they are not registered in the "alias" map which is used in getData/findData to query the data by name. 

In addition the name added there are using a weird naming schema by post-fixing the type of the vector so to the name "constraint_dx" is associated the "constraint_dx(V_DERIV)" datafield which is and conflicting with python syntax. 

I may be an option to fix the bug and deprecate that behavior... but it may be breaking (if two data have conflicting base names  that was not conflicting before due to the postfixing of the typename).
  
This should solve the issue reported in discussion #3779

_____________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
