### PR TITLE
[Simulation] Suggest required plugin in the syntax of the scene loader

### DIFF
--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.cpp
@@ -63,6 +63,18 @@ void SceneLoaderXML::getExtensionList(ExtensionList* list)
     list->push_back("scn");
 }
 
+bool SceneLoaderXML::syntaxForAddingRequiredPlugin(const std::string& pluginName,
+                                                   const std::vector<std::string>& listComponents, std::ostream& ss, sofa::simulation::Node* nodeWhereAdded)
+{
+    ss << "<RequiredPlugin name=\"" << pluginName << "\"/> <!-- Needed to use components [";
+    if (!listComponents.empty())
+    {
+        ss << sofa::helper::join(listComponents, ',');
+    }
+    ss << "] -->" << msgendl;
+    return true;
+}
+
 sofa::simulation::Node::SPtr SceneLoaderXML::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
 {
     SOFA_UNUSED(sceneArgs);
@@ -135,18 +147,24 @@ Node::SPtr SceneLoaderXML::processXML(xml::BaseElement* xml, const char *filenam
     return root;
 }
 
-/// Load from a string in memory
-Node::SPtr SceneLoaderXML::loadFromMemory(const char* filename, const char* data)
+NodeSPtr SceneLoaderXML::doLoadFromMemory(const char* filename, const char* data)
 {
-    notifyLoadingSceneBefore();
+    notifyLoadingSceneBefore(this);
 
     xml::BaseElement* xml = xml::loadFromMemory(filename, data);
 
     Node::SPtr root = processXML(xml, filename);
 
     delete xml;
-    notifyLoadingSceneAfter(root);
+    notifyLoadingSceneAfter(root, this);
     return root;
+}
+
+/// Load from a string in memory
+Node::SPtr SceneLoaderXML::loadFromMemory(const char* filename, const char* data)
+{
+    SceneLoaderXML sceneLoader;
+    return sceneLoader.doLoadFromMemory(filename, data);
 }
 
 

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.h
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.h
@@ -47,6 +47,9 @@ public:
     static NodeSPtr processXML(xml::BaseElement* xml, const char *filename);
 
     /// load a scene from memory (typically : an xml into a string)
+    NodeSPtr doLoadFromMemory(const char* filename, const char* data);
+
+    /// load a scene from memory (typically : an xml into a string)
     static NodeSPtr loadFromMemory(const char* filename, const char* data);
 
     SOFA_ATTRIBUTE_DISABLED("v22.12 (PR#)", "v23.06", "loadFromMemory with 3 arguments specifying the size has been deprecated. Use loadFromMemory(const char* filename, const char* data).")
@@ -57,6 +60,9 @@ public:
 
     /// get the list of file extensions
     void getExtensionList(ExtensionList* list) override;
+
+    bool syntaxForAddingRequiredPlugin(const std::string& pluginName,
+                                       const std::vector<std::string>& listComponents, std::ostream& ss, sofa::simulation::Node* nodeWhereAdded) override;
 
     // Test if load succeed
     static bool loadSucceed;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.cpp
@@ -25,7 +25,33 @@ namespace sofa::simulation
 {
 
 SceneCheck::~SceneCheck() = default;
-void SceneCheck::doPrintSummary() {}
-void SceneCheck::doInit(sofa::simulation::Node* node) { SOFA_UNUSED(node); }
+
+void SceneCheck::init(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader)
+{
+    SOFA_UNUSED(sceneLoader);
+    doInit(node);
+}
+
+void SceneCheck::checkOn(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader)
+{
+    SOFA_UNUSED(sceneLoader);
+    doCheckOn(node);
+}
+
+void SceneCheck::printSummary(simulation::SceneLoader* sceneLoader)
+{
+    SOFA_UNUSED(sceneLoader);
+    doPrintSummary();
+}
+
+void SceneCheck::doInit(sofa::simulation::Node* node)
+{
+    SOFA_UNUSED(node);
+}
+
+void SceneCheck::doPrintSummary()
+{}
+
+
 
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheck.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <memory>
+#include <sofa/simulation/SceneLoaderFactory.h>
 
 namespace sofa::simulation
 {
@@ -38,6 +39,11 @@ public:
     typedef std::shared_ptr<SceneCheck> SPtr;
     virtual const std::string getName() = 0;
     virtual const std::string getDesc() = 0;
+
+    virtual void init(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader);
+    virtual void checkOn(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader);
+    virtual void printSummary(simulation::SceneLoader* sceneLoader);
+
     virtual void doInit(sofa::simulation::Node* node);
     virtual void doCheckOn(sofa::simulation::Node* node) = 0;
     virtual void doPrintSummary();

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneLoaderFactory.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneLoaderFactory.h
@@ -72,14 +72,21 @@ public:
     /// get the list of file extensions
     virtual void getExtensionList(ExtensionList* list) = 0;
 
+    /// Write into a ostream the syntax to add a RequiredPlugin component in the scene file. The
+    /// syntax depends on the file format, hence the SceneLoader. The function returns true if the
+    /// derived SceneLoader implements this function, false otherwise.
+    virtual bool syntaxForAddingRequiredPlugin(const std::string& pluginName,
+                                               const std::vector<std::string>& listComponents,
+                                               std::ostream& ss, sofa::simulation::Node* nodeWhereAdded);
+
     /// to be able to inform when a scene is loaded
     struct SOFA_SIMULATION_CORE_API Listener
     {
-        virtual void rightBeforeLoadingScene();  ///< callback called just before loading the scene file
-        virtual void rightAfterLoadingScene(sofa::simulation::NodeSPtr); ///< callback called just after loading the scene file
+        virtual void rightBeforeLoadingScene(SceneLoader* sceneLoader);  ///< callback called just before loading the scene file
+        virtual void rightAfterLoadingScene(sofa::simulation::NodeSPtr, SceneLoader* sceneLoader); ///< callback called just after loading the scene file
 
-        virtual void rightBeforeReloadingScene();  ///< callback called just before reloading the scene file
-        virtual void rightAfterReloadingScene(sofa::simulation::NodeSPtr root); ///< callback called just after reloading the scene file
+        virtual void rightBeforeReloadingScene(SceneLoader* sceneLoader);  ///< callback called just before reloading the scene file
+        virtual void rightAfterReloadingScene(sofa::simulation::NodeSPtr root, SceneLoader* sceneLoader); ///< callback called just after reloading the scene file
     };
 
     /// adding a listener
@@ -92,10 +99,10 @@ protected:
     /// the list of listeners
     typedef std::set<Listener*> Listeners;
     static Listeners s_listeners;
-    static void notifyLoadingSceneBefore();
-    static void notifyReloadingSceneBefore();
-    static void notifyLoadingSceneAfter(sofa::simulation::NodeSPtr node);
-    static void notifyReloadingSceneAfter(sofa::simulation::NodeSPtr node);
+    static void notifyLoadingSceneBefore(SceneLoader* sceneLoader);
+    static void notifyReloadingSceneBefore(SceneLoader* sceneLoader);
+    static void notifyLoadingSceneAfter(sofa::simulation::NodeSPtr node, SceneLoader* sceneLoader);
+    static void notifyReloadingSceneAfter(sofa::simulation::NodeSPtr node, SceneLoader* sceneLoader);
 };
 
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "SceneCheckMissingRequiredPlugin.h"
+#include <SceneChecking/SceneCheckMissingRequiredPlugin.h>
 
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/Visitor.h>
@@ -79,28 +79,58 @@ void SceneCheckMissingRequiredPlugin::doCheckOn(sofa::simulation::Node* node)
     }
 }
 
-void SceneCheckMissingRequiredPlugin::doPrintSummary()
+void SceneCheckMissingRequiredPlugin::printSummary(simulation::SceneLoader* sceneLoader)
 {
     if(!m_requiredPlugins.empty())
     {
         const std::string indent { "  "};
         std::stringstream tmp;
-        for(const auto& kv : m_requiredPlugins)
+        bool hasSyntax = true;
+        for(const auto& [pluginName, listComponents] : m_requiredPlugins)
         {
-            tmp << indent << "<RequiredPlugin name=\""<<kv.first<<"\"/> <!-- Needed to use components [";
-            if (!kv.second.empty())
-            {
-                std::copy(kv.second.begin(), kv.second.end() - 1, std::ostream_iterator<std::string>(tmp, ", "));
-                tmp << kv.second.back();
-            }
-            tmp <<"] -->" << msgendl;
+            tmp << indent;
+            hasSyntax &= formatRequiredPlugin(pluginName, listComponents, sceneLoader, tmp);
+        }
+        if (!hasSyntax)
+        {
+            tmp << "Note that XML syntax is assumed in the suggested lines to add.";
         }
         msg_warning(this->getName())
                 << "This scene is using component defined in plugins but is not importing the required plugins." << msgendl
                 << indent << "Your scene may not work on a sofa environment with different pre-loaded plugins." << msgendl
-                << indent << "To fix your scene and remove this warning you just need to cut & paste the following lines at the beginning of your scene (if it is a .scn): " << msgendl
+                << indent << "To fix your scene and remove this warning you just need to cut & paste the following lines at the beginning of your scene: " << msgendl
                 << tmp.str();
     }
+}
+
+bool SceneCheckMissingRequiredPlugin::formatRequiredPlugin(
+    const std::string& pluginName,
+    const std::vector<std::string>& listComponents,
+    simulation::SceneLoader* sceneLoader,
+    std::ostream& ss) const
+{
+    bool hasSyntax = (sceneLoader != nullptr);
+    if (sceneLoader)
+    {
+        hasSyntax = sceneLoader->syntaxForAddingRequiredPlugin(pluginName, listComponents, ss, m_checkedRootNode);
+    }
+
+    if (!hasSyntax)
+    {
+        formatRequiredPluginInXMLSyntax(pluginName, listComponents, ss);
+    }
+
+    return hasSyntax;
+}
+
+void SceneCheckMissingRequiredPlugin::formatRequiredPluginInXMLSyntax(const std::string& pluginName, const std::vector<std::string>& listComponents, std::ostream& ss)
+{
+    ss << "<RequiredPlugin name=\"" << pluginName << "\"/> <!-- Needed to use components [";
+    if (!listComponents.empty())
+    {
+        ss << sofa::helper::join(listComponents, ',');
+    }
+    ss << "] -->" << msgendl;
 }
 
 void SceneCheckMissingRequiredPlugin::doInit(sofa::simulation::Node* node)
@@ -118,6 +148,8 @@ void SceneCheckMissingRequiredPlugin::doInit(sofa::simulation::Node* node)
             m_loadedPlugins[pluginName] = true;
         }
     }
+
+    m_checkedRootNode = node;
 }
 
 } // namespace sofa::_scenechecking_

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.h
@@ -45,11 +45,21 @@ public:
     virtual const std::string getDesc() override;
     void doInit(sofa::simulation::Node* node) override;
     void doCheckOn(sofa::simulation::Node* node) override;
-    void doPrintSummary() override;
+    void printSummary(simulation::SceneLoader* sceneLoader) override;
 
-private:    
+private:
     std::map<std::string, bool > m_loadedPlugins;
     std::map<std::string, std::vector<std::string> > m_requiredPlugins;
+    sofa::simulation::Node* m_checkedRootNode { nullptr };
+
+    bool formatRequiredPlugin(const std::string& pluginName,
+                              const std::vector<std::string>& listComponents,
+                              simulation::SceneLoader* sceneLoader,
+                              std::ostream& ss) const;
+
+    static void formatRequiredPluginInXMLSyntax(const std::string& pluginName,
+                                                const std::vector<std::string>& listComponents,
+                                                std::ostream& ss);
 };
 
 } // namespace sofa::_scenechecking_

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.cpp
@@ -34,7 +34,7 @@ SceneCheckerListener* SceneCheckerListener::getInstance()
     return &sceneLoaderListener;
 }
 
-void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr node)
+void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr node, simulation::SceneLoader* sceneLoader)
 {
     if(node.get())
     {
@@ -45,7 +45,7 @@ void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr n
             sceneCheckerVisitor.addCheck(sceneCheck);
         }
 
-        sceneCheckerVisitor.validate(node.get());
+        sceneCheckerVisitor.validate(node.get(), sceneLoader);
     }
 }
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.h
@@ -39,11 +39,11 @@ public:
     static SceneCheckerListener* getInstance();
     virtual ~SceneCheckerListener() {}
 
-    virtual void rightAfterLoadingScene(sofa::simulation::NodeSPtr node) override;
+    void rightAfterLoadingScene(sofa::simulation::NodeSPtr node, simulation::SceneLoader* sceneLoader) override;
 
     // Do nothing on reload
-    virtual void rightBeforeReloadingScene() override {}
-    virtual void rightAfterReloadingScene(sofa::simulation::NodeSPtr node) override
+    void rightBeforeReloadingScene(simulation::SceneLoader* sceneLoader) override {}
+    void rightAfterReloadingScene(sofa::simulation::NodeSPtr node, simulation::SceneLoader* sceneLoader) override
     {
         SOFA_UNUSED(node);
     }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.cpp
@@ -51,7 +51,7 @@ void SceneCheckerVisitor::removeCheck(sofa::simulation::SceneCheck::SPtr check)
     m_checkset.erase( std::remove( m_checkset.begin(), m_checkset.end(), check ), m_checkset.end() );
 }
 
-void SceneCheckerVisitor::validate(sofa::simulation::Node* node)
+void SceneCheckerVisitor::validate(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader)
 {
     std::stringstream tmp;
     bool first = true;
@@ -64,14 +64,14 @@ void SceneCheckerVisitor::validate(sofa::simulation::Node* node)
 
     for(sofa::simulation::SceneCheck::SPtr& check : m_checkset)
     {
-        check->doInit(node) ;
+        check->init(node, sceneLoader) ;
     }
 
     execute(node) ;
 
     for(sofa::simulation::SceneCheck::SPtr& check : m_checkset)
     {
-        check->doPrintSummary() ;
+        check->printSummary(sceneLoader) ;
     }
     msg_info("SceneCheckerVisitor") << "Finished validating node \""<< node->getName() << "\".";
 }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerVisitor.h
@@ -24,6 +24,8 @@
 #include <SceneChecking/config.h>
 #include <sofa/simulation/SceneCheck.h>
 #include <sofa/core/ExecParams.h>
+#include <sofa/simulation/SceneLoaderFactory.h>
+
 #include <functional>
 #include <map>
 
@@ -38,7 +40,7 @@ public:
     SceneCheckerVisitor(const sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance()) ;
     ~SceneCheckerVisitor() override;
 
-    void validate(sofa::simulation::Node* node) ;
+    void validate(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader) ;
     Result processNodeTopDown(sofa::simulation::Node* node) override ;
 
     void addCheck(sofa::simulation::SceneCheck::SPtr check) ;

--- a/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
+++ b/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
@@ -92,7 +92,8 @@ struct SceneChecker_test : public BaseSimulationTest
               << "      <EulerExplicitSolver />               \n"
               << "</Node>                                                           \n";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+        SceneLoaderXML sceneLoader;
+        Node::SPtr root = sceneLoader.doLoadFromMemory ("testscene",
                                                           scene.str().c_str());
         EXPECT_MSG_NOEMIT(Error);
 
@@ -105,12 +106,12 @@ struct SceneChecker_test : public BaseSimulationTest
         if(missing)
         {
             EXPECT_MSG_EMIT(Warning); // [SceneCheckMissingRequiredPlugin]
-            checker.validate(root.get());
+            checker.validate(root.get(), &sceneLoader);
         }
         else
         {
             EXPECT_MSG_NOEMIT(Warning);
-            checker.validate(root.get());
+            checker.validate(root.get(), &sceneLoader);
         }
     }
 
@@ -138,7 +139,8 @@ struct SceneChecker_test : public BaseSimulationTest
               << "    </Node>                                                     \n"
               << "</Node>                                                         \n";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+        SceneLoaderXML sceneLoader;
+        Node::SPtr root = sceneLoader.doLoadFromMemory ("testscene",
                                                           scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr);
@@ -153,14 +155,14 @@ struct SceneChecker_test : public BaseSimulationTest
             EXPECT_MSG_NOEMIT(Error);
             EXPECT_MSG_EMIT(Warning);
             ASSERT_NE(root->getChild(nodename), nullptr);
-            checker.validate(root->getChild(nodename));
+            checker.validate(root->getChild(nodename), &sceneLoader);
         }
 
         {
             EXPECT_MSG_NOEMIT(Error);
             EXPECT_MSG_NOEMIT(Warning);
             ASSERT_NE(root->getChild("nothingCheck"), nullptr);
-            checker.validate(root->getChild("nothingCheck"));
+            checker.validate(root->getChild("nothingCheck"), &sceneLoader);
         }
 
     }
@@ -180,7 +182,8 @@ struct SceneChecker_test : public BaseSimulationTest
               << "      <ComponentDeprecated />                                   \n"
               << "</Node>                                                         \n";
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
+        SceneLoaderXML sceneLoader;
+        Node::SPtr root = sceneLoader.doLoadFromMemory("testscene", scene.str().c_str());
 
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
@@ -197,10 +200,10 @@ struct SceneChecker_test : public BaseSimulationTest
         if(shouldWarn){
             /// We check that running a scene set to 17.12 generate a warning on a 17.06 component
             EXPECT_MSG_EMIT(Warning);
-            checker.validate(root.get());
+            checker.validate(root.get(), &sceneLoader);
         }
         else {
-            checker.validate(root.get());
+            checker.validate(root.get(), &sceneLoader);
         }
     }
 
@@ -223,19 +226,20 @@ struct SceneChecker_test : public BaseSimulationTest
         SceneCheckerVisitor checker(sofa::core::execparams::defaultInstance());
         checker.addCheck( SceneCheckUsingAlias::newSPtr() );
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.str().c_str());
+        SceneLoaderXML sceneLoader;
+        Node::SPtr root = sceneLoader.doLoadFromMemory("testscene", scene.str().c_str());
         ASSERT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
         if(sceneWithAlias)
         {
             EXPECT_MSG_EMIT(Warning); // [SceneCheckUsingAlias]
-            checker.validate(root.get());
+            checker.validate(root.get(), &sceneLoader);
         }
         else
         {
             EXPECT_MSG_NOEMIT(Warning);
-            checker.validate(root.get());
+            checker.validate(root.get(), &sceneLoader);
         }
     }
 };


### PR DESCRIPTION
Instead of suggesting to add the required plugins in the XML syntax, the goal is to use the scene loader to adapt the syntax to the type of file. For example, in Python, the message will be:

```
[WARNING] [SceneCheckMissingRequiredPlugin] This scene is using component defined in plugins but is not importing the required plugins.  
  Your scene may not work on a sofa environment with different pre-loaded plugins.  
  To fix your scene and remove this warning you just need to cut & paste the following lines at the beginning of your scene:   
  root.addObject('RequiredPlugin', name='Sofa.Component.AnimationLoop') # Needed to use components [FreeMotionAnimationLoop]  
  root.addObject('RequiredPlugin', name='Sofa.Component.Collision.Detection.Algorithm') # Needed to use components [BVHNarrowPhase,BruteForceBroadPhase,BruteForceDetection,CollisionPipeline]  
  root.addObject('RequiredPlugin', name='Sofa.Component.Collision.Detection.Intersection') # Needed to use components [LocalMinDistance]  
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
