### PR TITLE
add functions to visualization in FEMForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -56,7 +56,7 @@ class TetrahedronFEMForceField;
 template<class DataTypes>
 class TetrahedronFEMForceFieldInternalData
 {
-public:
+   public:
     typedef TetrahedronFEMForceField<DataTypes> Main;
     void initPtrData(Main * m)
     {
@@ -71,11 +71,11 @@ public:
 
 /** Compute Finite Element forces based on tetrahedral elements.
 *   Corotational methods are based on a rotation from world-space to material-space.
-*/
+ */
 template<class DataTypes>
 class TetrahedronFEMForceField : public core::behavior::ForceField<DataTypes>, public sofa::core::behavior::RotationFinder<DataTypes>
 {
-public:
+   public:
     SOFA_CLASS2(SOFA_TEMPLATE(TetrahedronFEMForceField, DataTypes), SOFA_TEMPLATE(core::behavior::ForceField, DataTypes), SOFA_TEMPLATE(core::behavior::RotationFinder, DataTypes));
 
     typedef typename core::behavior::ForceField<DataTypes> InheritForceField;
@@ -96,12 +96,12 @@ public:
     using TetrahedronID = core::topology::BaseMeshTopology::TetrahedronID;
 
     enum { SMALL = 0,   ///< Symbol of small displacements tetrahedron solver
-           LARGE = 1,   ///< Symbol of corotational large displacements tetrahedron solver based on a QR decomposition    -> Nesme et al 2005 "Efficient, Physically Plausible Finite Elements"
-           POLAR = 2,   ///< Symbol of corotational large displacements tetrahedron solver based on a polar decomposition -> Muller et al 2004 "Interactive Virtual Materials"
-           SVD = 3      ///< Symbol of corotational large displacements tetrahedron solver based on a SVD decomposition   -> inspired from Irving et al 2004 "Invertible Finite Element for Robust Simulation of Large Deformation"
-         };
+        LARGE = 1,   ///< Symbol of corotational large displacements tetrahedron solver based on a QR decomposition    -> Nesme et al 2005 "Efficient, Physically Plausible Finite Elements"
+        POLAR = 2,   ///< Symbol of corotational large displacements tetrahedron solver based on a polar decomposition -> Muller et al 2004 "Interactive Virtual Materials"
+        SVD = 3      ///< Symbol of corotational large displacements tetrahedron solver based on a SVD decomposition   -> inspired from Irving et al 2004 "Invertible Finite Element for Robust Simulation of Large Deformation"
+    };
 
-protected:
+   protected:
 
     /// @name Per element (tetrahedron) data
     /// @{
@@ -173,14 +173,14 @@ protected:
     std::vector< sofa::type::Vec3 > m_renderedPoints;
     std::vector< sofa::type::RGBAColor > m_renderedColors;
 
-public:
+   public:
     // get the volume of the mesh
     Real getRestVolume() {return m_restVolume;}
 
     //For a faster contact handling with simplified compliance
     void getRotation(Mat33& R, Index nodeIdx);
     void getRotations(VecReal& vecR) ;
-    
+
     // BaseRotationFinder API
     void getRotations(linearalgebra::BaseMatrix * rotations,int offset = 0) override;
     // RotationFinder<T> API
@@ -225,26 +225,35 @@ public:
     Data<type::vector<Real> > _vonMisesPerElement; ///< von Mises Stress per element
     Data<type::vector<Real> > _vonMisesPerNode; ///< von Mises Stress per node
     Data<type::vector<type::Vec4f> > _vonMisesStressColors; ///< Vector of colors describing the VonMises stress
-    
+
+    Real _minVMN;
+    Real _maxVMN;
+
+
+    Data<bool> _showForceField; ///< draw the force field for the current object
+
     Data<std::string> _showStressColorMap; ///< Color map used to show stress values
     Data<float> _showStressAlpha; ///< Alpha for vonMises visualisation
     Data<bool> _showVonMisesStressPerNode; ///< draw points showing vonMises stress interpolated in nodes
+    Data<bool> _showVonMisesStressPerNodeColorMap; ///< draw triangles showing vonMises stress interpolated in nodes
     Data<bool> _showVonMisesStressPerElement; ///< draw triangles showing vonMises stress interpolated in elements
+
+    Data<bool> _showGapBetweenElements; ///< draw gap between elements (when showWireFrame is disabled)
 
     Data<bool>  _updateStiffness; ///< udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)
 
-    /// Link to be set to the topology container in the component graph. 
+    /// Link to be set to the topology container in the component graph.
     SingleLink<TetrahedronFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_topology;
 
     type::vector<type::Vec<6,Real> > elemDisplacements;
 
     bool updateVonMisesStress;
 
-protected:
+   protected:
     TetrahedronFEMForceField() ;
     ~TetrahedronFEMForceField() override;
 
-public:
+   public:
     void setPoissonRatio(Real val) { this->_poissonRatio.setValue(val); }
     void setYoungModulus(Real val) ;
     void setComputeGlobalMatrix(bool val) { this->_assembling.setValue(val); }
@@ -290,7 +299,7 @@ public:
     void getElementStiffnessMatrix(Real* stiffness, Tetrahedron& te);
     virtual void computeMaterialStiffness(MaterialStiffness& materialMatrix, Index&a, Index&b, Index&c, Index&d);
 
-protected:
+   protected:
     void computeStrainDisplacement( StrainDisplacement &J, Coord a, Coord b, Coord c, Coord d );
     Real peudo_determinant_for_coef ( const type::Mat<2, 3, Real>&  M );
 
@@ -333,18 +342,18 @@ protected:
     bool isComputeVonMisesStressMethodSet();
     void computeMinMaxFromYoungsModulus();
     virtual void drawTrianglesFromTetrahedra(const core::visual::VisualParams* vparams,
-                                     bool showVonMisesStressPerElement,
-                                     bool drawVonMisesStress, const VecCoord& x,
-                                     const VecReal& youngModulus,
-                                     bool heterogeneous, Real minVM, Real maxVM,
-                                     helper::ReadAccessor<Data<type::vector<Real>>> vM);
+                                             bool showVonMisesStressPerElement,
+                                             bool drawVonMisesStress, const VecCoord& x,
+                                             const VecReal& youngModulus,
+                                             bool heterogeneous, Real minVM, Real maxVM,
+                                             helper::ReadAccessor<Data<type::vector<Real>>> vM);
     virtual void drawTrianglesFromRangeOfTetrahedra(const simulation::Range<VecElement::const_iterator>& range,
-                                 const core::visual::VisualParams* vparams,
-                                 bool showVonMisesStressPerElement,
-                                 bool drawVonMisesStress, bool showWireFrame, const VecCoord& x,
-                                 const VecReal& youngModulus,
-                                 bool heterogeneous, Real minVM, Real maxVM,
-                                 helper::ReadAccessor<Data<type::vector<Real>>> vM);
+                                                    const core::visual::VisualParams* vparams,
+                                                    bool showVonMisesStressPerElement,
+                                                    bool drawVonMisesStress, bool showWireFrame, const VecCoord& x,
+                                                    const VecReal& youngModulus,
+                                                    bool heterogeneous, Real minVM, Real maxVM,
+                                                    helper::ReadAccessor<Data<type::vector<Real>>> vM);
     void handleEvent(core::objectmodel::Event *event) override;
 };
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -38,32 +38,35 @@ using sofa::core::objectmodel::ComponentState ;
 template<class DataTypes>
 TetrahedronFEMForceField<DataTypes>::TetrahedronFEMForceField()
     : m_topology(nullptr)
-    , _indexedElements(nullptr)
-    , needUpdateTopology(false)
-    , m_VonMisesColorMap(nullptr)
-    , _initialPoints(initData(&_initialPoints, "initialPoints", "Initial Position"))
-    , f_method(initData(&f_method,std::string("large"),"method","\"small\", \"large\" (by QR), \"polar\" or \"svd\" displacements"))
-    , _poissonRatio(initData(&_poissonRatio,(Real)0.45,"poissonRatio","FEM Poisson Ratio in Hooke's law [0,0.5["))
-    , _youngModulus(initData(&_youngModulus,"youngModulus","FEM Young's Modulus in Hooke's law"))
-    , _localStiffnessFactor(initData(&_localStiffnessFactor, "localStiffnessFactor","Allow specification of different stiffness per element. If there are N element and M values are specified, the youngModulus factor for element i would be localStiffnessFactor[i*M/N]"))
-    , _updateStiffnessMatrix(initData(&_updateStiffnessMatrix,false,"updateStiffnessMatrix",""))
-    , _assembling(initData(&_assembling,false,"computeGlobalMatrix",""))
-    , _plasticMaxThreshold(initData(&_plasticMaxThreshold,(Real)0.f,"plasticMaxThreshold","Plastic Max Threshold (2-norm of the strain)"))
-    , _plasticYieldThreshold(initData(&_plasticYieldThreshold,(Real)0.0001f,"plasticYieldThreshold","Plastic Yield Threshold (2-norm of the strain)"))
-    , _plasticCreep(initData(&_plasticCreep,(Real)0.9f,"plasticCreep","Plastic Creep Factor * dt [0,1]. Warning this factor depends on dt."))
-    , _gatherPt(initData(&_gatherPt,"gatherPt","number of dof accumulated per threads during the gather operation (Only use in GPU version)"))
-    , _gatherBsize(initData(&_gatherBsize,"gatherBsize","number of dof accumulated per threads during the gather operation (Only use in GPU version)"))
-    , drawHeterogeneousTetra(initData(&drawHeterogeneousTetra,false,"drawHeterogeneousTetra","Draw Heterogeneous Tetra in different color"))
-    , _computeVonMisesStress(initData(&_computeVonMisesStress,0,"computeVonMisesStress","compute and display von Mises stress: 0: no computations, 1: using corotational strain, 2: using full Green strain. Set listening=1"))
-    , _vonMisesPerElement(initData(&_vonMisesPerElement, "vonMisesPerElement", "von Mises Stress per element"))
-    , _vonMisesPerNode(initData(&_vonMisesPerNode, "vonMisesPerNode", "von Mises Stress per node"))
-    , _vonMisesStressColors(initData(&_vonMisesStressColors, "vonMisesStressColors", "Vector of colors describing the VonMises stress"))
-    , _showStressColorMap(initData(&_showStressColorMap, std::string("Blue to Red"),"showStressColorMap", "Color map used to show stress values"))
-    , _showStressAlpha(initData(&_showStressAlpha, 1.0f, "showStressAlpha", "Alpha for vonMises visualisation"))
-    , _showVonMisesStressPerNode(initData(&_showVonMisesStressPerNode,false,"showVonMisesStressPerNode","draw points showing vonMises stress interpolated in nodes"))
-    , _showVonMisesStressPerElement(initData(&_showVonMisesStressPerElement, false, "showVonMisesStressPerElement", "draw triangles showing vonMises stress interpolated in elements"))
-    , _updateStiffness(initData(&_updateStiffness,false,"updateStiffness","udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)"))
-    , l_topology(initLink("topology", "link to the tetrahedron topology container"))
+      , _indexedElements(nullptr)
+      , needUpdateTopology(false)
+      , m_VonMisesColorMap(nullptr)
+      , _initialPoints(initData(&_initialPoints, "initialPoints", "Initial Position"))
+      , f_method(initData(&f_method,std::string("large"),"method","\"small\", \"large\" (by QR), \"polar\" or \"svd\" displacements"))
+      , _poissonRatio(initData(&_poissonRatio,(Real)0.45,"poissonRatio","FEM Poisson Ratio in Hooke's law [0,0.5["))
+      , _youngModulus(initData(&_youngModulus,"youngModulus","FEM Young's Modulus in Hooke's law"))
+      , _localStiffnessFactor(initData(&_localStiffnessFactor, "localStiffnessFactor","Allow specification of different stiffness per element. If there are N element and M values are specified, the youngModulus factor for element i would be localStiffnessFactor[i*M/N]"))
+      , _updateStiffnessMatrix(initData(&_updateStiffnessMatrix,false,"updateStiffnessMatrix",""))
+      , _assembling(initData(&_assembling,false,"computeGlobalMatrix",""))
+      , _plasticMaxThreshold(initData(&_plasticMaxThreshold,(Real)0.f,"plasticMaxThreshold","Plastic Max Threshold (2-norm of the strain)"))
+      , _plasticYieldThreshold(initData(&_plasticYieldThreshold,(Real)0.0001f,"plasticYieldThreshold","Plastic Yield Threshold (2-norm of the strain)"))
+      , _plasticCreep(initData(&_plasticCreep,(Real)0.9f,"plasticCreep","Plastic Creep Factor * dt [0,1]. Warning this factor depends on dt."))
+      , _gatherPt(initData(&_gatherPt,"gatherPt","number of dof accumulated per threads during the gather operation (Only use in GPU version)"))
+      , _gatherBsize(initData(&_gatherBsize,"gatherBsize","number of dof accumulated per threads during the gather operation (Only use in GPU version)"))
+      , drawHeterogeneousTetra(initData(&drawHeterogeneousTetra,false,"drawHeterogeneousTetra","Draw Heterogeneous Tetra in different color"))
+      , _computeVonMisesStress(initData(&_computeVonMisesStress,0,"computeVonMisesStress","compute and display von Mises stress: 0: no computations, 1: using corotational strain, 2: using full Green strain. Set listening=1"))
+      , _vonMisesPerElement(initData(&_vonMisesPerElement, "vonMisesPerElement", "von Mises Stress per element"))
+      , _vonMisesPerNode(initData(&_vonMisesPerNode, "vonMisesPerNode", "von Mises Stress per node"))
+      , _vonMisesStressColors(initData(&_vonMisesStressColors, "vonMisesStressColors", "Vector of colors describing the VonMises stress"))
+      , _showForceField(initData(&_showForceField, true, "showForceField", "draw the force field for the current object"))
+      , _showGapBetweenElements(initData(&_showGapBetweenElements, true, "showGapBetweenElements", "draw gap between elements (when showWireFrame is disabled)"))
+      , _showStressColorMap(initData(&_showStressColorMap, std::string("Blue to Red"),"showStressColorMap", "Color map used to show stress values"))
+      , _showStressAlpha(initData(&_showStressAlpha, 1.0f, "showStressAlpha", "Alpha for vonMises visualisation"))
+      , _showVonMisesStressPerNode(initData(&_showVonMisesStressPerNode,false,"showVonMisesStressPerNode","draw points showing vonMises stress interpolated in nodes"))
+      , _showVonMisesStressPerNodeColorMap(initData(&_showVonMisesStressPerNodeColorMap,false,"showVonMisesStressPerNodeColorMap","draw elements showing vonMises stress interpolated in nodes"))
+      , _showVonMisesStressPerElement(initData(&_showVonMisesStressPerElement, false, "showVonMisesStressPerElement", "draw triangles showing vonMises stress interpolated in elements"))
+      , _updateStiffness(initData(&_updateStiffness,false,"updateStiffness","udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)"))
+      , l_topology(initLink("topology", "link to the tetrahedron topology container"))
 {
     _poissonRatio.setRequired(true);
     _youngModulus.setRequired(true);
@@ -77,27 +80,27 @@ TetrahedronFEMForceField<DataTypes>::TetrahedronFEMForceField()
     maxYoung = 0.0;
 
     this->addUpdateCallback("updateComputeVonMisesStress", {&_computeVonMisesStress}, [this](const core::DataTracker& )
-    {
-        if(_computeVonMisesStress.getValue() == 0 || _computeVonMisesStress.getValue() == 1 || _computeVonMisesStress.getValue() == 2)
-        {
-            if (_computeVonMisesStress.getValue() == 1 && f_method.getValue() == "small")
-            {
-                msg_warning() << "VonMisesStress can only be computed with full Green strain when the method is SMALL.";
-                return sofa::core::objectmodel::ComponentState::Invalid;
-            }
-            else
-            {
-                msg_info() << "Correct update of " << _computeVonMisesStress.getName();
-            }
-        }
-        else
-        {
-            msg_warning() << "Value of " << _computeVonMisesStress.getName() << " is invalid (must be 0, 1 or 2). ";
-            return sofa::core::objectmodel::ComponentState::Invalid;
-        }
+                            {
+                                if(_computeVonMisesStress.getValue() == 0 || _computeVonMisesStress.getValue() == 1 || _computeVonMisesStress.getValue() == 2)
+                                {
+                                    if (_computeVonMisesStress.getValue() == 1 && f_method.getValue() == "small")
+                                    {
+                                        msg_warning() << "VonMisesStress can only be computed with full Green strain when the method is SMALL.";
+                                        return sofa::core::objectmodel::ComponentState::Invalid;
+                                    }
+                                    else
+                                    {
+                                        msg_info() << "Correct update of " << _computeVonMisesStress.getName();
+                                    }
+                                }
+                                else
+                                {
+                                    msg_warning() << "Value of " << _computeVonMisesStress.getName() << " is invalid (must be 0, 1 or 2). ";
+                                    return sofa::core::objectmodel::ComponentState::Invalid;
+                                }
 
-        return sofa::core::objectmodel::ComponentState::Valid;
-    }, {});
+                                return sofa::core::objectmodel::ComponentState::Valid;
+                            }, {});
 }
 
 
@@ -295,7 +298,7 @@ void TetrahedronFEMForceField<DataTypes>::computeMaterialStiffness(Index i, Inde
 
     materialsStiffnesses[i][0][0] = materialsStiffnesses[i][1][1] = materialsStiffnesses[i][2][2] = 1;
     materialsStiffnesses[i][0][1] = materialsStiffnesses[i][0][2] = materialsStiffnesses[i][1][0]
-            = materialsStiffnesses[i][1][2] = materialsStiffnesses[i][2][0] =
+        = materialsStiffnesses[i][1][2] = materialsStiffnesses[i][2][0] =
             materialsStiffnesses[i][2][1] = poissonRatio/(1-poissonRatio);
     materialsStiffnesses[i][0][3] = materialsStiffnesses[i][0][4] = materialsStiffnesses[i][0][5] = 0;
     materialsStiffnesses[i][1][3] = materialsStiffnesses[i][1][4] = materialsStiffnesses[i][1][5] = 0;
@@ -404,29 +407,29 @@ inline void TetrahedronFEMForceField<DataTypes>::computeForce( Displacement &F, 
 
     VoigtTensor JtD;
     JtD[0] =   J[ 0][0]*Depl[ 0]+/*J[ 1][0]*Depl[ 1]+  J[ 2][0]*Depl[ 2]+*/
-            J[ 3][0]*Depl[ 3]+/*J[ 4][0]*Depl[ 4]+  J[ 5][0]*Depl[ 5]+*/
-            J[ 6][0]*Depl[ 6]+/*J[ 7][0]*Depl[ 7]+  J[ 8][0]*Depl[ 8]+*/
-            J[ 9][0]*Depl[ 9] /*J[10][0]*Depl[10]+  J[11][0]*Depl[11]*/;
+             J[ 3][0]*Depl[ 3]+/*J[ 4][0]*Depl[ 4]+  J[ 5][0]*Depl[ 5]+*/
+             J[ 6][0]*Depl[ 6]+/*J[ 7][0]*Depl[ 7]+  J[ 8][0]*Depl[ 8]+*/
+             J[ 9][0]*Depl[ 9] /*J[10][0]*Depl[10]+  J[11][0]*Depl[11]*/;
     JtD[1] = /*J[ 0][1]*Depl[ 0]+*/J[ 1][1]*Depl[ 1]+/*J[ 2][1]*Depl[ 2]+*/
-            /*J[ 3][1]*Depl[ 3]+*/J[ 4][1]*Depl[ 4]+/*J[ 5][1]*Depl[ 5]+*/
-            /*J[ 6][1]*Depl[ 6]+*/J[ 7][1]*Depl[ 7]+/*J[ 8][1]*Depl[ 8]+*/
-            /*J[ 9][1]*Depl[ 9]+*/J[10][1]*Depl[10] /*J[11][1]*Depl[11]*/;
+             /*J[ 3][1]*Depl[ 3]+*/J[ 4][1]*Depl[ 4]+/*J[ 5][1]*Depl[ 5]+*/
+             /*J[ 6][1]*Depl[ 6]+*/J[ 7][1]*Depl[ 7]+/*J[ 8][1]*Depl[ 8]+*/
+             /*J[ 9][1]*Depl[ 9]+*/J[10][1]*Depl[10] /*J[11][1]*Depl[11]*/;
     JtD[2] = /*J[ 0][2]*Depl[ 0]+  J[ 1][2]*Depl[ 1]+*/J[ 2][2]*Depl[ 2]+
-            /*J[ 3][2]*Depl[ 3]+  J[ 4][2]*Depl[ 4]+*/J[ 5][2]*Depl[ 5]+
-            /*J[ 6][2]*Depl[ 6]+  J[ 7][2]*Depl[ 7]+*/J[ 8][2]*Depl[ 8]+
-            /*J[ 9][2]*Depl[ 9]+  J[10][2]*Depl[10]+*/J[11][2]*Depl[11]  ;
+             /*J[ 3][2]*Depl[ 3]+  J[ 4][2]*Depl[ 4]+*/J[ 5][2]*Depl[ 5]+
+             /*J[ 6][2]*Depl[ 6]+  J[ 7][2]*Depl[ 7]+*/J[ 8][2]*Depl[ 8]+
+             /*J[ 9][2]*Depl[ 9]+  J[10][2]*Depl[10]+*/J[11][2]*Depl[11]  ;
     JtD[3] =   J[ 0][3]*Depl[ 0]+  J[ 1][3]*Depl[ 1]+/*J[ 2][3]*Depl[ 2]+*/
-            J[ 3][3]*Depl[ 3]+  J[ 4][3]*Depl[ 4]+/*J[ 5][3]*Depl[ 5]+*/
-            J[ 6][3]*Depl[ 6]+  J[ 7][3]*Depl[ 7]+/*J[ 8][3]*Depl[ 8]+*/
-            J[ 9][3]*Depl[ 9]+  J[10][3]*Depl[10] /*J[11][3]*Depl[11]*/;
+             J[ 3][3]*Depl[ 3]+  J[ 4][3]*Depl[ 4]+/*J[ 5][3]*Depl[ 5]+*/
+             J[ 6][3]*Depl[ 6]+  J[ 7][3]*Depl[ 7]+/*J[ 8][3]*Depl[ 8]+*/
+             J[ 9][3]*Depl[ 9]+  J[10][3]*Depl[10] /*J[11][3]*Depl[11]*/;
     JtD[4] = /*J[ 0][4]*Depl[ 0]+*/J[ 1][4]*Depl[ 1]+  J[ 2][4]*Depl[ 2]+
-            /*J[ 3][4]*Depl[ 3]+*/J[ 4][4]*Depl[ 4]+  J[ 5][4]*Depl[ 5]+
-            /*J[ 6][4]*Depl[ 6]+*/J[ 7][4]*Depl[ 7]+  J[ 8][4]*Depl[ 8]+
-            /*J[ 9][4]*Depl[ 9]+*/J[10][4]*Depl[10]+  J[11][4]*Depl[11]  ;
+             /*J[ 3][4]*Depl[ 3]+*/J[ 4][4]*Depl[ 4]+  J[ 5][4]*Depl[ 5]+
+             /*J[ 6][4]*Depl[ 6]+*/J[ 7][4]*Depl[ 7]+  J[ 8][4]*Depl[ 8]+
+             /*J[ 9][4]*Depl[ 9]+*/J[10][4]*Depl[10]+  J[11][4]*Depl[11]  ;
     JtD[5] =   J[ 0][5]*Depl[ 0]+/*J[ 1][5]*Depl[ 1]*/ J[ 2][5]*Depl[ 2]+
-            J[ 3][5]*Depl[ 3]+/*J[ 4][5]*Depl[ 4]*/ J[ 5][5]*Depl[ 5]+
-            J[ 6][5]*Depl[ 6]+/*J[ 7][5]*Depl[ 7]*/ J[ 8][5]*Depl[ 8]+
-            J[ 9][5]*Depl[ 9]+/*J[10][5]*Depl[10]*/ J[11][5]*Depl[11];
+             J[ 3][5]*Depl[ 3]+/*J[ 4][5]*Depl[ 4]*/ J[ 5][5]*Depl[ 5]+
+             J[ 6][5]*Depl[ 6]+/*J[ 7][5]*Depl[ 7]*/ J[ 8][5]*Depl[ 8]+
+             J[ 9][5]*Depl[ 9]+/*J[10][5]*Depl[10]*/ J[11][5]*Depl[11];
 
     // eventually remove a part of the strain to simulate plasticity
     if( _plasticMaxThreshold.getValue() > 0 )
@@ -449,38 +452,38 @@ inline void TetrahedronFEMForceField<DataTypes>::computeForce( Displacement &F, 
 
     VoigtTensor KJtD;
     KJtD[0] =   K[0][0]*JtD[0]+  K[0][1]*JtD[1]+  K[0][2]*JtD[2]
-            /*K[0][3]*JtD[3]+  K[0][4]*JtD[4]+  K[0][5]*JtD[5]*/;
+        /*K[0][3]*JtD[3]+  K[0][4]*JtD[4]+  K[0][5]*JtD[5]*/;
     KJtD[1] =   K[1][0]*JtD[0]+  K[1][1]*JtD[1]+  K[1][2]*JtD[2]
-            /*K[1][3]*JtD[3]+  K[1][4]*JtD[4]+  K[1][5]*JtD[5]*/;
+        /*K[1][3]*JtD[3]+  K[1][4]*JtD[4]+  K[1][5]*JtD[5]*/;
     KJtD[2] =   K[2][0]*JtD[0]+  K[2][1]*JtD[1]+  K[2][2]*JtD[2]
-            /*K[2][3]*JtD[3]+  K[2][4]*JtD[4]+  K[2][5]*JtD[5]*/;
+        /*K[2][3]*JtD[3]+  K[2][4]*JtD[4]+  K[2][5]*JtD[5]*/;
     KJtD[3] = /*K[3][0]*JtD[0]+  K[3][1]*JtD[1]+  K[3][2]*JtD[2]+*/
-            K[3][3]*JtD[3] /*K[3][4]*JtD[4]+  K[3][5]*JtD[5]*/;
+        K[3][3]*JtD[3] /*K[3][4]*JtD[4]+  K[3][5]*JtD[5]*/;
     KJtD[4] = /*K[4][0]*JtD[0]+  K[4][1]*JtD[1]+  K[4][2]*JtD[2]+*/
-            /*K[4][3]*JtD[3]+*/K[4][4]*JtD[4] /*K[4][5]*JtD[5]*/;
+        /*K[4][3]*JtD[3]+*/K[4][4]*JtD[4] /*K[4][5]*JtD[5]*/;
     KJtD[5] = /*K[5][0]*JtD[0]+  K[5][1]*JtD[1]+  K[5][2]*JtD[2]+*/
-            /*K[5][3]*JtD[3]+  K[5][4]*JtD[4]+*/K[5][5]*JtD[5]  ;
+        /*K[5][3]*JtD[3]+  K[5][4]*JtD[4]+*/K[5][5]*JtD[5]  ;
 
     F[ 0] =   J[ 0][0]*KJtD[0]+/*J[ 0][1]*KJtD[1]+  J[ 0][2]*KJtD[2]+*/
-            J[ 0][3]*KJtD[3]+/*J[ 0][4]*KJtD[4]+*/J[ 0][5]*KJtD[5]  ;
+           J[ 0][3]*KJtD[3]+/*J[ 0][4]*KJtD[4]+*/J[ 0][5]*KJtD[5]  ;
     F[ 1] = /*J[ 1][0]*KJtD[0]+*/J[ 1][1]*KJtD[1]+/*J[ 1][2]*KJtD[2]+*/
-            J[ 1][3]*KJtD[3]+  J[ 1][4]*KJtD[4] /*J[ 1][5]*KJtD[5]*/;
+           J[ 1][3]*KJtD[3]+  J[ 1][4]*KJtD[4] /*J[ 1][5]*KJtD[5]*/;
     F[ 2] = /*J[ 2][0]*KJtD[0]+  J[ 2][1]*KJtD[1]+*/J[ 2][2]*KJtD[2]+
-            /*J[ 2][3]*KJtD[3]+*/J[ 2][4]*KJtD[4]+  J[ 2][5]*KJtD[5]  ;
+           /*J[ 2][3]*KJtD[3]+*/J[ 2][4]*KJtD[4]+  J[ 2][5]*KJtD[5]  ;
     F[ 3] =   J[ 3][0]*KJtD[0]+/*J[ 3][1]*KJtD[1]+  J[ 3][2]*KJtD[2]+*/
-            J[ 3][3]*KJtD[3]+/*J[ 3][4]*KJtD[4]+*/J[ 3][5]*KJtD[5]  ;
+           J[ 3][3]*KJtD[3]+/*J[ 3][4]*KJtD[4]+*/J[ 3][5]*KJtD[5]  ;
     F[ 4] = /*J[ 4][0]*KJtD[0]+*/J[ 4][1]*KJtD[1]+/*J[ 4][2]*KJtD[2]+*/
-            J[ 4][3]*KJtD[3]+  J[ 4][4]*KJtD[4] /*J[ 4][5]*KJtD[5]*/;
+           J[ 4][3]*KJtD[3]+  J[ 4][4]*KJtD[4] /*J[ 4][5]*KJtD[5]*/;
     F[ 5] = /*J[ 5][0]*KJtD[0]+  J[ 5][1]*KJtD[1]+*/J[ 5][2]*KJtD[2]+
-            /*J[ 5][3]*KJtD[3]+*/J[ 5][4]*KJtD[4]+  J[ 5][5]*KJtD[5]  ;
+           /*J[ 5][3]*KJtD[3]+*/J[ 5][4]*KJtD[4]+  J[ 5][5]*KJtD[5]  ;
     F[ 6] =   J[ 6][0]*KJtD[0]+/*J[ 6][1]*KJtD[1]+  J[ 6][2]*KJtD[2]+*/
-            J[ 6][3]*KJtD[3]+/*J[ 6][4]*KJtD[4]+*/J[ 6][5]*KJtD[5]  ;
+           J[ 6][3]*KJtD[3]+/*J[ 6][4]*KJtD[4]+*/J[ 6][5]*KJtD[5]  ;
     F[ 7] = /*J[ 7][0]*KJtD[0]+*/J[ 7][1]*KJtD[1]+/*J[ 7][2]*KJtD[2]+*/
-            J[ 7][3]*KJtD[3]+  J[ 7][4]*KJtD[4] /*J[ 7][5]*KJtD[5]*/;
+           J[ 7][3]*KJtD[3]+  J[ 7][4]*KJtD[4] /*J[ 7][5]*KJtD[5]*/;
     F[ 8] = /*J[ 8][0]*KJtD[0]+  J[ 8][1]*KJtD[1]+*/J[ 8][2]*KJtD[2]+
-            /*J[ 8][3]*KJtD[3]+*/J[ 8][4]*KJtD[4]+  J[ 8][5]*KJtD[5]  ;
+           /*J[ 8][3]*KJtD[3]+*/J[ 8][4]*KJtD[4]+  J[ 8][5]*KJtD[5]  ;
     F[ 9] =   J[ 9][0]*KJtD[0]+/*J[ 9][1]*KJtD[1]+  J[ 9][2]*KJtD[2]+*/
-            J[ 9][3]*KJtD[3]+/*J[ 9][4]*KJtD[4]+*/J[ 9][5]*KJtD[5]  ;
+           J[ 9][3]*KJtD[3]+/*J[ 9][4]*KJtD[4]+*/J[ 9][5]*KJtD[5]  ;
     F[10] = /*J[10][0]*KJtD[0]+*/J[10][1]*KJtD[1]+/*J[10][2]*KJtD[2]+*/
             J[10][3]*KJtD[3]+  J[10][4]*KJtD[4] /*J[10][5]*KJtD[5]*/;
     F[11] = /*J[11][0]*KJtD[0]+  J[11][1]*KJtD[1]+*/J[11][2]*KJtD[2]+
@@ -528,66 +531,66 @@ inline void TetrahedronFEMForceField<DataTypes>::computeForce( Displacement &F, 
 
     type::VecNoInit<6,Real> JtD;
     JtD[0] =   J[ 0][0]*Depl[ 0]+/*J[ 1][0]*Depl[ 1]+  J[ 2][0]*Depl[ 2]+*/
-            J[ 3][0]*Depl[ 3]+/*J[ 4][0]*Depl[ 4]+  J[ 5][0]*Depl[ 5]+*/
-            J[ 6][0]*Depl[ 6]+/*J[ 7][0]*Depl[ 7]+  J[ 8][0]*Depl[ 8]+*/
-            J[ 9][0]*Depl[ 9] /*J[10][0]*Depl[10]+  J[11][0]*Depl[11]*/;
+             J[ 3][0]*Depl[ 3]+/*J[ 4][0]*Depl[ 4]+  J[ 5][0]*Depl[ 5]+*/
+             J[ 6][0]*Depl[ 6]+/*J[ 7][0]*Depl[ 7]+  J[ 8][0]*Depl[ 8]+*/
+             J[ 9][0]*Depl[ 9] /*J[10][0]*Depl[10]+  J[11][0]*Depl[11]*/;
     JtD[1] = /*J[ 0][1]*Depl[ 0]+*/J[ 1][1]*Depl[ 1]+/*J[ 2][1]*Depl[ 2]+*/
-            /*J[ 3][1]*Depl[ 3]+*/J[ 4][1]*Depl[ 4]+/*J[ 5][1]*Depl[ 5]+*/
-            /*J[ 6][1]*Depl[ 6]+*/J[ 7][1]*Depl[ 7]+/*J[ 8][1]*Depl[ 8]+*/
-            /*J[ 9][1]*Depl[ 9]+*/J[10][1]*Depl[10] /*J[11][1]*Depl[11]*/;
+             /*J[ 3][1]*Depl[ 3]+*/J[ 4][1]*Depl[ 4]+/*J[ 5][1]*Depl[ 5]+*/
+             /*J[ 6][1]*Depl[ 6]+*/J[ 7][1]*Depl[ 7]+/*J[ 8][1]*Depl[ 8]+*/
+             /*J[ 9][1]*Depl[ 9]+*/J[10][1]*Depl[10] /*J[11][1]*Depl[11]*/;
     JtD[2] = /*J[ 0][2]*Depl[ 0]+  J[ 1][2]*Depl[ 1]+*/J[ 2][2]*Depl[ 2]+
-            /*J[ 3][2]*Depl[ 3]+  J[ 4][2]*Depl[ 4]+*/J[ 5][2]*Depl[ 5]+
-            /*J[ 6][2]*Depl[ 6]+  J[ 7][2]*Depl[ 7]+*/J[ 8][2]*Depl[ 8]+
-            /*J[ 9][2]*Depl[ 9]+  J[10][2]*Depl[10]+*/J[11][2]*Depl[11]  ;
+             /*J[ 3][2]*Depl[ 3]+  J[ 4][2]*Depl[ 4]+*/J[ 5][2]*Depl[ 5]+
+             /*J[ 6][2]*Depl[ 6]+  J[ 7][2]*Depl[ 7]+*/J[ 8][2]*Depl[ 8]+
+             /*J[ 9][2]*Depl[ 9]+  J[10][2]*Depl[10]+*/J[11][2]*Depl[11]  ;
     JtD[3] =   J[ 0][3]*Depl[ 0]+  J[ 1][3]*Depl[ 1]+/*J[ 2][3]*Depl[ 2]+*/
-            J[ 3][3]*Depl[ 3]+  J[ 4][3]*Depl[ 4]+/*J[ 5][3]*Depl[ 5]+*/
-            J[ 6][3]*Depl[ 6]+  J[ 7][3]*Depl[ 7]+/*J[ 8][3]*Depl[ 8]+*/
-            J[ 9][3]*Depl[ 9]+  J[10][3]*Depl[10] /*J[11][3]*Depl[11]*/;
+             J[ 3][3]*Depl[ 3]+  J[ 4][3]*Depl[ 4]+/*J[ 5][3]*Depl[ 5]+*/
+             J[ 6][3]*Depl[ 6]+  J[ 7][3]*Depl[ 7]+/*J[ 8][3]*Depl[ 8]+*/
+             J[ 9][3]*Depl[ 9]+  J[10][3]*Depl[10] /*J[11][3]*Depl[11]*/;
     JtD[4] = /*J[ 0][4]*Depl[ 0]+*/J[ 1][4]*Depl[ 1]+  J[ 2][4]*Depl[ 2]+
-            /*J[ 3][4]*Depl[ 3]+*/J[ 4][4]*Depl[ 4]+  J[ 5][4]*Depl[ 5]+
-            /*J[ 6][4]*Depl[ 6]+*/J[ 7][4]*Depl[ 7]+  J[ 8][4]*Depl[ 8]+
-            /*J[ 9][4]*Depl[ 9]+*/J[10][4]*Depl[10]+  J[11][4]*Depl[11]  ;
+             /*J[ 3][4]*Depl[ 3]+*/J[ 4][4]*Depl[ 4]+  J[ 5][4]*Depl[ 5]+
+             /*J[ 6][4]*Depl[ 6]+*/J[ 7][4]*Depl[ 7]+  J[ 8][4]*Depl[ 8]+
+             /*J[ 9][4]*Depl[ 9]+*/J[10][4]*Depl[10]+  J[11][4]*Depl[11]  ;
     JtD[5] =   J[ 0][5]*Depl[ 0]+/*J[ 1][5]*Depl[ 1]*/ J[ 2][5]*Depl[ 2]+
-            J[ 3][5]*Depl[ 3]+/*J[ 4][5]*Depl[ 4]*/ J[ 5][5]*Depl[ 5]+
-            J[ 6][5]*Depl[ 6]+/*J[ 7][5]*Depl[ 7]*/ J[ 8][5]*Depl[ 8]+
-            J[ 9][5]*Depl[ 9]+/*J[10][5]*Depl[10]*/ J[11][5]*Depl[11];
+             J[ 3][5]*Depl[ 3]+/*J[ 4][5]*Depl[ 4]*/ J[ 5][5]*Depl[ 5]+
+             J[ 6][5]*Depl[ 6]+/*J[ 7][5]*Depl[ 7]*/ J[ 8][5]*Depl[ 8]+
+             J[ 9][5]*Depl[ 9]+/*J[10][5]*Depl[10]*/ J[11][5]*Depl[11];
 
     type::VecNoInit<6,Real> KJtD;
     KJtD[0] =   K[0][0]*JtD[0]+  K[0][1]*JtD[1]+  K[0][2]*JtD[2]
-            /*K[0][3]*JtD[3]+  K[0][4]*JtD[4]+  K[0][5]*JtD[5]*/;
+        /*K[0][3]*JtD[3]+  K[0][4]*JtD[4]+  K[0][5]*JtD[5]*/;
     KJtD[1] =   K[1][0]*JtD[0]+  K[1][1]*JtD[1]+  K[1][2]*JtD[2]
-            /*K[1][3]*JtD[3]+  K[1][4]*JtD[4]+  K[1][5]*JtD[5]*/;
+        /*K[1][3]*JtD[3]+  K[1][4]*JtD[4]+  K[1][5]*JtD[5]*/;
     KJtD[2] =   K[2][0]*JtD[0]+  K[2][1]*JtD[1]+  K[2][2]*JtD[2]
-            /*K[2][3]*JtD[3]+  K[2][4]*JtD[4]+  K[2][5]*JtD[5]*/;
+        /*K[2][3]*JtD[3]+  K[2][4]*JtD[4]+  K[2][5]*JtD[5]*/;
     KJtD[3] = /*K[3][0]*JtD[0]+  K[3][1]*JtD[1]+  K[3][2]*JtD[2]+*/
-            K[3][3]*JtD[3] /*K[3][4]*JtD[4]+  K[3][5]*JtD[5]*/;
+        K[3][3]*JtD[3] /*K[3][4]*JtD[4]+  K[3][5]*JtD[5]*/;
     KJtD[4] = /*K[4][0]*JtD[0]+  K[4][1]*JtD[1]+  K[4][2]*JtD[2]+*/
-            /*K[4][3]*JtD[3]+*/K[4][4]*JtD[4] /*K[4][5]*JtD[5]*/;
+        /*K[4][3]*JtD[3]+*/K[4][4]*JtD[4] /*K[4][5]*JtD[5]*/;
     KJtD[5] = /*K[5][0]*JtD[0]+  K[5][1]*JtD[1]+  K[5][2]*JtD[2]+*/
-            /*K[5][3]*JtD[3]+  K[5][4]*JtD[4]+*/K[5][5]*JtD[5]  ;
+        /*K[5][3]*JtD[3]+  K[5][4]*JtD[4]+*/K[5][5]*JtD[5]  ;
 
     KJtD *= fact;
 
     F[ 0] =   J[ 0][0]*KJtD[0]+/*J[ 0][1]*KJtD[1]+  J[ 0][2]*KJtD[2]+*/
-            J[ 0][3]*KJtD[3]+/*J[ 0][4]*KJtD[4]+*/J[ 0][5]*KJtD[5]  ;
+           J[ 0][3]*KJtD[3]+/*J[ 0][4]*KJtD[4]+*/J[ 0][5]*KJtD[5]  ;
     F[ 1] = /*J[ 1][0]*KJtD[0]+*/J[ 1][1]*KJtD[1]+/*J[ 1][2]*KJtD[2]+*/
-            J[ 1][3]*KJtD[3]+  J[ 1][4]*KJtD[4] /*J[ 1][5]*KJtD[5]*/;
+           J[ 1][3]*KJtD[3]+  J[ 1][4]*KJtD[4] /*J[ 1][5]*KJtD[5]*/;
     F[ 2] = /*J[ 2][0]*KJtD[0]+  J[ 2][1]*KJtD[1]+*/J[ 2][2]*KJtD[2]+
-            /*J[ 2][3]*KJtD[3]+*/J[ 2][4]*KJtD[4]+  J[ 2][5]*KJtD[5]  ;
+           /*J[ 2][3]*KJtD[3]+*/J[ 2][4]*KJtD[4]+  J[ 2][5]*KJtD[5]  ;
     F[ 3] =   J[ 3][0]*KJtD[0]+/*J[ 3][1]*KJtD[1]+  J[ 3][2]*KJtD[2]+*/
-            J[ 3][3]*KJtD[3]+/*J[ 3][4]*KJtD[4]+*/J[ 3][5]*KJtD[5]  ;
+           J[ 3][3]*KJtD[3]+/*J[ 3][4]*KJtD[4]+*/J[ 3][5]*KJtD[5]  ;
     F[ 4] = /*J[ 4][0]*KJtD[0]+*/J[ 4][1]*KJtD[1]+/*J[ 4][2]*KJtD[2]+*/
-            J[ 4][3]*KJtD[3]+  J[ 4][4]*KJtD[4] /*J[ 4][5]*KJtD[5]*/;
+           J[ 4][3]*KJtD[3]+  J[ 4][4]*KJtD[4] /*J[ 4][5]*KJtD[5]*/;
     F[ 5] = /*J[ 5][0]*KJtD[0]+  J[ 5][1]*KJtD[1]+*/J[ 5][2]*KJtD[2]+
-            /*J[ 5][3]*KJtD[3]+*/J[ 5][4]*KJtD[4]+  J[ 5][5]*KJtD[5]  ;
+           /*J[ 5][3]*KJtD[3]+*/J[ 5][4]*KJtD[4]+  J[ 5][5]*KJtD[5]  ;
     F[ 6] =   J[ 6][0]*KJtD[0]+/*J[ 6][1]*KJtD[1]+  J[ 6][2]*KJtD[2]+*/
-            J[ 6][3]*KJtD[3]+/*J[ 6][4]*KJtD[4]+*/J[ 6][5]*KJtD[5]  ;
+           J[ 6][3]*KJtD[3]+/*J[ 6][4]*KJtD[4]+*/J[ 6][5]*KJtD[5]  ;
     F[ 7] = /*J[ 7][0]*KJtD[0]+*/J[ 7][1]*KJtD[1]+/*J[ 7][2]*KJtD[2]+*/
-            J[ 7][3]*KJtD[3]+  J[ 7][4]*KJtD[4] /*J[ 7][5]*KJtD[5]*/;
+           J[ 7][3]*KJtD[3]+  J[ 7][4]*KJtD[4] /*J[ 7][5]*KJtD[5]*/;
     F[ 8] = /*J[ 8][0]*KJtD[0]+  J[ 8][1]*KJtD[1]+*/J[ 8][2]*KJtD[2]+
-            /*J[ 8][3]*KJtD[3]+*/J[ 8][4]*KJtD[4]+  J[ 8][5]*KJtD[5]  ;
+           /*J[ 8][3]*KJtD[3]+*/J[ 8][4]*KJtD[4]+  J[ 8][5]*KJtD[5]  ;
     F[ 9] =   J[ 9][0]*KJtD[0]+/*J[ 9][1]*KJtD[1]+  J[ 9][2]*KJtD[2]+*/
-            J[ 9][3]*KJtD[3]+/*J[ 9][4]*KJtD[4]+*/J[ 9][5]*KJtD[5]  ;
+           J[ 9][3]*KJtD[3]+/*J[ 9][4]*KJtD[4]+*/J[ 9][5]*KJtD[5]  ;
     F[10] = /*J[10][0]*KJtD[0]+*/J[10][1]*KJtD[1]+/*J[10][2]*KJtD[2]+*/
             J[10][3]*KJtD[3]+  J[10][4]*KJtD[4] /*J[10][5]*KJtD[5]*/;
     F[11] = /*J[11][0]*KJtD[0]+  J[11][1]*KJtD[1]+*/J[11][2]*KJtD[2]+
@@ -636,8 +639,8 @@ inline void TetrahedronFEMForceField<DataTypes>::accumulateForceSmall( Vector& f
     if(!_assembling.getValue())
     {
         computeForce( F, D, _plasticStrains[elementIndex],
-                      materialsStiffnesses[elementIndex],
-                      strainDisplacements[elementIndex] );
+                     materialsStiffnesses[elementIndex],
+                     strainDisplacements[elementIndex] );
     }
     else if( _plasticMaxThreshold.getValue() <= 0 )
     {
@@ -712,88 +715,88 @@ inline SReal TetrahedronFEMForceField<DataTypes>::getPotentialEnergy(const core:
 
     switch(method)
     {
-    case SMALL :
-    {
-
-        for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+        case SMALL :
         {
-            Element index = *it;
-            Index a = index[0];
-            Index b = index[1];
-            Index c = index[2];
-            Index d = index[3];
 
-            // displacements
-            Displacement D;
-            D[0] = 0;
-            D[1] = 0;
-            D[2] = 0;
-            D[3] =  initialPoints[b][0] - initialPoints[a][0] - p[b][0]+p[a][0];
-            D[4] =  initialPoints[b][1] - initialPoints[a][1] - p[b][1]+p[a][1];
-            D[5] =  initialPoints[b][2] - initialPoints[a][2] - p[b][2]+p[a][2];
-            D[6] =  initialPoints[c][0] - initialPoints[a][0] - p[c][0]+p[a][0];
-            D[7] =  initialPoints[c][1] - initialPoints[a][1] - p[c][1]+p[a][1];
-            D[8] =  initialPoints[c][2] - initialPoints[a][2] - p[c][2]+p[a][2];
-            D[9] =  initialPoints[d][0] - initialPoints[a][0] - p[d][0]+p[a][0];
-            D[10] = initialPoints[d][1] - initialPoints[a][1] - p[d][1]+p[a][1];
-            D[11] = initialPoints[d][2] - initialPoints[a][2] - p[d][2]+p[a][2];
-
-            if(!_assembling.getValue())
+            for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
             {
+                Element index = *it;
+                Index a = index[0];
+                Index b = index[1];
+                Index c = index[2];
+                Index d = index[3];
 
-                // compute force on element
-                Displacement F;
+                // displacements
+                Displacement D;
+                D[0] = 0;
+                D[1] = 0;
+                D[2] = 0;
+                D[3] =  initialPoints[b][0] - initialPoints[a][0] - p[b][0]+p[a][0];
+                D[4] =  initialPoints[b][1] - initialPoints[a][1] - p[b][1]+p[a][1];
+                D[5] =  initialPoints[b][2] - initialPoints[a][2] - p[b][2]+p[a][2];
+                D[6] =  initialPoints[c][0] - initialPoints[a][0] - p[c][0]+p[a][0];
+                D[7] =  initialPoints[c][1] - initialPoints[a][1] - p[c][1]+p[a][1];
+                D[8] =  initialPoints[c][2] - initialPoints[a][2] - p[c][2]+p[a][2];
+                D[9] =  initialPoints[d][0] - initialPoints[a][0] - p[d][0]+p[a][0];
+                D[10] = initialPoints[d][1] - initialPoints[a][1] - p[d][1]+p[a][1];
+                D[11] = initialPoints[d][2] - initialPoints[a][2] - p[d][2]+p[a][2];
 
-                // ComputeForce without the case of  plasticity simulation when  _plasticMaxThreshold.getValue() > 0
-                // This case actually modifies  the member plasticStrain and getPotentialEnergy is a const fonction.
-                MaterialStiffness K = materialsStiffnesses[i];
-                StrainDisplacement J = strainDisplacements[i];
+                if(!_assembling.getValue())
+                {
 
-                /// The following may be doing F = J*(K*(J.multTranspose(D))) ?
-                VoigtTensor JtD;
-                JtD[0] = J[ 0][0]*D[ 0]+ J[ 3][0]*D[ 3]+ J[ 6][0]*D[ 6]+ J[ 9][0]*D[ 9];
-                JtD[1] = J[ 1][1]*D[ 1]+ J[ 4][1]*D[ 4]+ J[ 7][1]*D[ 7]+ J[10][1]*D[10];
-                JtD[2] = J[ 2][2]*D[ 2]+ J[ 5][2]*D[ 5]+ J[ 8][2]*D[ 8]+ J[11][2]*D[11];
-                JtD[3] = J[ 0][3]*D[ 0]+ J[ 1][3]*D[ 1]+ J[ 3][3]*D[ 3]+ J[ 4][3]*D[ 4]+
-                        J[ 6][3]*D[ 6]+ J[ 7][3]*D[ 7]+ J[ 9][3]*D[ 9]+ J[10][3]*D[10];
-                JtD[4] = J[ 1][4]*D[ 1]+ J[ 2][4]*D[ 2]+ J[ 4][4]*D[ 4]+ J[ 5][4]*D[ 5]+
-                        J[ 7][4]*D[ 7]+ J[ 8][4]*D[ 8]+ J[10][4]*D[10]+ J[11][4]*D[11];
-                JtD[5] = J[ 0][5]*D[ 0]+ J[ 2][5]*D[ 2]+ J[ 3][5]*D[ 3]+ J[ 5][5]*D[ 5]+
-                        J[ 6][5]*D[ 6]+ J[ 8][5]*D[ 8]+ J[ 9][5]*D[ 9]+ J[11][5]*D[11];
+                    // compute force on element
+                    Displacement F;
+
+                    // ComputeForce without the case of  plasticity simulation when  _plasticMaxThreshold.getValue() > 0
+                    // This case actually modifies  the member plasticStrain and getPotentialEnergy is a const fonction.
+                    MaterialStiffness K = materialsStiffnesses[i];
+                    StrainDisplacement J = strainDisplacements[i];
+
+                    /// The following may be doing F = J*(K*(J.multTranspose(D))) ?
+                    VoigtTensor JtD;
+                    JtD[0] = J[ 0][0]*D[ 0]+ J[ 3][0]*D[ 3]+ J[ 6][0]*D[ 6]+ J[ 9][0]*D[ 9];
+                    JtD[1] = J[ 1][1]*D[ 1]+ J[ 4][1]*D[ 4]+ J[ 7][1]*D[ 7]+ J[10][1]*D[10];
+                    JtD[2] = J[ 2][2]*D[ 2]+ J[ 5][2]*D[ 5]+ J[ 8][2]*D[ 8]+ J[11][2]*D[11];
+                    JtD[3] = J[ 0][3]*D[ 0]+ J[ 1][3]*D[ 1]+ J[ 3][3]*D[ 3]+ J[ 4][3]*D[ 4]+
+                             J[ 6][3]*D[ 6]+ J[ 7][3]*D[ 7]+ J[ 9][3]*D[ 9]+ J[10][3]*D[10];
+                    JtD[4] = J[ 1][4]*D[ 1]+ J[ 2][4]*D[ 2]+ J[ 4][4]*D[ 4]+ J[ 5][4]*D[ 5]+
+                             J[ 7][4]*D[ 7]+ J[ 8][4]*D[ 8]+ J[10][4]*D[10]+ J[11][4]*D[11];
+                    JtD[5] = J[ 0][5]*D[ 0]+ J[ 2][5]*D[ 2]+ J[ 3][5]*D[ 3]+ J[ 5][5]*D[ 5]+
+                             J[ 6][5]*D[ 6]+ J[ 8][5]*D[ 8]+ J[ 9][5]*D[ 9]+ J[11][5]*D[11];
 
 
-                VoigtTensor KJtD;
-                KJtD[0] = K[0][0]*JtD[0]+  K[0][1]*JtD[1]+  K[0][2]*JtD[2];
-                KJtD[1] = K[1][0]*JtD[0]+  K[1][1]*JtD[1]+  K[1][2]*JtD[2];
-                KJtD[2] = K[2][0]*JtD[0]+  K[2][1]*JtD[1]+  K[2][2]*JtD[2];
-                KJtD[3] = K[3][3]*JtD[3] ;
-                KJtD[4] = K[4][4]*JtD[4];
-                KJtD[5] = K[5][5]*JtD[5]  ;
+                    VoigtTensor KJtD;
+                    KJtD[0] = K[0][0]*JtD[0]+  K[0][1]*JtD[1]+  K[0][2]*JtD[2];
+                    KJtD[1] = K[1][0]*JtD[0]+  K[1][1]*JtD[1]+  K[1][2]*JtD[2];
+                    KJtD[2] = K[2][0]*JtD[0]+  K[2][1]*JtD[1]+  K[2][2]*JtD[2];
+                    KJtD[3] = K[3][3]*JtD[3] ;
+                    KJtD[4] = K[4][4]*JtD[4];
+                    KJtD[5] = K[5][5]*JtD[5]  ;
 
-                F[ 0] = J[ 0][0]*KJtD[0]+ J[ 0][3]*KJtD[3]+ J[ 0][5]*KJtD[5];
-                F[ 1] = J[ 1][1]*KJtD[1]+ J[ 1][3]*KJtD[3]+ J[ 1][4]*KJtD[4];
-                F[ 2] = J[ 2][2]*KJtD[2]+ J[ 2][4]*KJtD[4]+ J[ 2][5]*KJtD[5];
-                F[ 3] = J[ 3][0]*KJtD[0]+ J[ 3][3]*KJtD[3]+ J[ 3][5]*KJtD[5];
-                F[ 4] = J[ 4][1]*KJtD[1]+ J[ 4][3]*KJtD[3]+ J[ 4][
-                        4]*KJtD[4];
-                F[ 5] = J[ 5][2]*KJtD[2]+ J[ 5][4]*KJtD[4]+ J[ 5][5]*KJtD[5];
-                F[ 6] = J[ 6][0]*KJtD[0]+ J[ 6][3]*KJtD[3]+ J[ 6][5]*KJtD[5];
-                F[ 7] = J[ 7][1]*KJtD[1]+ J[ 7][3]*KJtD[3]+ J[ 7][4]*KJtD[4];
-                F[ 8] = J[ 8][2]*KJtD[2]+ J[ 8][4]*KJtD[4]+ J[ 8][5]*KJtD[5];
-                F[ 9] = J[ 9][0]*KJtD[0]+ J[ 9][3]*KJtD[3]+ J[ 9][5]*KJtD[5];
-                F[10] = J[10][1]*KJtD[1]+ J[10][3]*KJtD[3]+ J[10][4]*KJtD[4];
-                F[11] = J[11][2]*KJtD[2]+ J[11][4]*KJtD[4]+ J[11][5]*KJtD[5];
+                    F[ 0] = J[ 0][0]*KJtD[0]+ J[ 0][3]*KJtD[3]+ J[ 0][5]*KJtD[5];
+                    F[ 1] = J[ 1][1]*KJtD[1]+ J[ 1][3]*KJtD[3]+ J[ 1][4]*KJtD[4];
+                    F[ 2] = J[ 2][2]*KJtD[2]+ J[ 2][4]*KJtD[4]+ J[ 2][5]*KJtD[5];
+                    F[ 3] = J[ 3][0]*KJtD[0]+ J[ 3][3]*KJtD[3]+ J[ 3][5]*KJtD[5];
+                    F[ 4] = J[ 4][1]*KJtD[1]+ J[ 4][3]*KJtD[3]+ J[ 4][
+                                                                       4]*KJtD[4];
+                    F[ 5] = J[ 5][2]*KJtD[2]+ J[ 5][4]*KJtD[4]+ J[ 5][5]*KJtD[5];
+                    F[ 6] = J[ 6][0]*KJtD[0]+ J[ 6][3]*KJtD[3]+ J[ 6][5]*KJtD[5];
+                    F[ 7] = J[ 7][1]*KJtD[1]+ J[ 7][3]*KJtD[3]+ J[ 7][4]*KJtD[4];
+                    F[ 8] = J[ 8][2]*KJtD[2]+ J[ 8][4]*KJtD[4]+ J[ 8][5]*KJtD[5];
+                    F[ 9] = J[ 9][0]*KJtD[0]+ J[ 9][3]*KJtD[3]+ J[ 9][5]*KJtD[5];
+                    F[10] = J[10][1]*KJtD[1]+ J[10][3]*KJtD[3]+ J[10][4]*KJtD[4];
+                    F[11] = J[11][2]*KJtD[2]+ J[11][4]*KJtD[4]+ J[11][5]*KJtD[5];
 
-                // Compute potentialEnergy
-                energyPotential += dot(Deriv( F[0], F[1], F[2] ) ,-Deriv( D[0], D[1], D[2]));
-                energyPotential += dot(Deriv( F[3], F[4], F[5] ) ,-Deriv( D[3], D[4], D[5] ));
-                energyPotential += dot(Deriv( F[6], F[7], F[8] ) ,-Deriv( D[6], D[7], D[8] ));
-                energyPotential += dot(Deriv( F[9], F[10], F[11]),-Deriv( D[9], D[10], D[11] ));
+                    // Compute potentialEnergy
+                    energyPotential += dot(Deriv( F[0], F[1], F[2] ) ,-Deriv( D[0], D[1], D[2]));
+                    energyPotential += dot(Deriv( F[3], F[4], F[5] ) ,-Deriv( D[3], D[4], D[5] ));
+                    energyPotential += dot(Deriv( F[6], F[7], F[8] ) ,-Deriv( D[6], D[7], D[8] ));
+                    energyPotential += dot(Deriv( F[9], F[10], F[11]),-Deriv( D[9], D[10], D[11] ));
+                }
             }
+            energyPotential/=-2.0;
+            break;
         }
-        energyPotential/=-2.0;
-        break;
-    }
     }
 
     return energyPotential;
@@ -841,9 +844,9 @@ inline void TetrahedronFEMForceField<DataTypes>::computeRotationLarge( Transform
     // third vector orthogonal to first and second
 
     const Coord edgex = (p[b]-p[a]).normalized();
-          Coord edgey = p[c]-p[a];
+    Coord edgey = p[c]-p[a];
     const Coord edgez = cross( edgex, edgey ).normalized();
-                edgey = cross( edgez, edgex ); //edgey is unit vector because edgez and edgex are orthogonal unit vectors
+    edgey = cross( edgez, edgex ); //edgey is unit vector because edgez and edgex are orthogonal unit vectors
 
     r[0][0] = edgex[0];
     r[0][1] = edgex[1];
@@ -861,7 +864,7 @@ inline void TetrahedronFEMForceField<DataTypes>::computeRotationLarge( Transform
 //HACK get rotation for fast contact handling with simplified compliance
 template<class DataTypes>
 inline void TetrahedronFEMForceField<DataTypes>::getRotation(Mat33& R, unsigned int nodeIdx)
-{ 
+{
     if(method == SMALL)
     {
         R[0][0] = 1.0 ; R[1][1] = 1.0 ; R[2][2] = 1.0 ;
@@ -944,13 +947,13 @@ void TetrahedronFEMForceField<DataTypes>::initLarge(Index i, Index&a, Index&b, I
     _rotatedInitialElements[i][0] = Coord(0,0,0);
 
     computeStrainDisplacement(strainDisplacements[i],_rotatedInitialElements[i][0],
-            _rotatedInitialElements[i][1],_rotatedInitialElements[i][2],
-            _rotatedInitialElements[i][3] );
+                              _rotatedInitialElements[i][1],_rotatedInitialElements[i][2],
+                              _rotatedInitialElements[i][3] );
 }
 
 template<class DataTypes>
 inline void TetrahedronFEMForceField<DataTypes>::accumulateForceLarge( Vector& f, const Vector & p,
-                                                                       typename VecElement::const_iterator elementIt, Index elementIndex )
+                                                                      typename VecElement::const_iterator elementIt, Index elementIndex )
 {
     Element index = *elementIt;
 
@@ -1099,7 +1102,7 @@ void TetrahedronFEMForceField<DataTypes>::initPolar(Index i, Index& a, Index&b, 
     _rotatedInitialElements[i][3] = R_0_1*initialPoints[d];
 
     computeStrainDisplacement( strainDisplacements[i],_rotatedInitialElements[i][0],
-                                _rotatedInitialElements[i][1],_rotatedInitialElements[i][2],_rotatedInitialElements[i][3] );
+                              _rotatedInitialElements[i][1],_rotatedInitialElements[i][2],_rotatedInitialElements[i][3] );
 
 }
 
@@ -1381,7 +1384,7 @@ void TetrahedronFEMForceField<DataTypes>::init()
     if (m_topology == nullptr)
     {
         msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name << " object must have a mesh topology. The component is inactivated.  "
-            "To remove this error message please add a topology component to your scene.";
+                                                                                                                                                            "To remove this error message please add a topology component to your scene.";
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
 
         // Need to affect a vector to the pointer even if it is empty.
@@ -1391,11 +1394,11 @@ void TetrahedronFEMForceField<DataTypes>::init()
         return;
     }
 
-    
+
     if (m_topology->getNbTetrahedra()<=0 && m_topology->getNbHexahedra()<=0)
     {
         msg_error()     << " object must have a tetrahedric topology. The component is inactivated.  "
-                           "To remove this error message please add a tetrahedric topology component to your scene.";
+                       "To remove this error message please add a tetrahedric topology component to your scene.";
 
         // Need to affect a vector to the pointer even if it is empty.
         if (_indexedElements == nullptr)
@@ -1464,7 +1467,7 @@ void TetrahedronFEMForceField<DataTypes>::init()
             tetrahedra->push_back(Tetra(c[6],c[7],c[0],c[5]));
             tetrahedra->push_back(Tetra(c[7],c[5],c[4],c[0]));
         }
-       _indexedElements = tetrahedra;
+        _indexedElements = tetrahedra;
     }
 
     this->d_componentState.setValue(ComponentState::Valid) ;
@@ -1548,75 +1551,75 @@ inline void TetrahedronFEMForceField<DataTypes>::reinit()
     typename VecElement::const_iterator it;
     switch(method)
     {
-    case SMALL :
-    {
-        for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+        case SMALL :
         {
-            Index a = (*it)[0];
-            Index b = (*it)[1];
-            Index c = (*it)[2];
-            Index d = (*it)[3];
-            this->computeMaterialStiffness(i,a,b,c,d);
-            this->initSmall(i,a,b,c,d);
+            for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+            {
+                Index a = (*it)[0];
+                Index b = (*it)[1];
+                Index c = (*it)[2];
+                Index d = (*it)[3];
+                this->computeMaterialStiffness(i,a,b,c,d);
+                this->initSmall(i,a,b,c,d);
+            }
+            break;
         }
-        break;
-    }
-    case LARGE :
-    {
-        rotations.resize( _indexedElements->size() );
-        _initialRotations.resize( _indexedElements->size() );
-        _rotationIdx.resize(m_topology->getNbPoints());
-        _rotatedInitialElements.resize(_indexedElements->size());
-        for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+        case LARGE :
         {
-            Index a = (*it)[0];
-            Index b = (*it)[1];
-            Index c = (*it)[2];
-            Index d = (*it)[3];
-            computeMaterialStiffness(i,a,b,c,d);
-            initLarge(i,a,b,c,d);
+            rotations.resize( _indexedElements->size() );
+            _initialRotations.resize( _indexedElements->size() );
+            _rotationIdx.resize(m_topology->getNbPoints());
+            _rotatedInitialElements.resize(_indexedElements->size());
+            for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+            {
+                Index a = (*it)[0];
+                Index b = (*it)[1];
+                Index c = (*it)[2];
+                Index d = (*it)[3];
+                computeMaterialStiffness(i,a,b,c,d);
+                initLarge(i,a,b,c,d);
+            }
+            break;
         }
-        break;
-    }
-    case POLAR :
-    {
-        rotations.resize( _indexedElements->size() );
-        _initialRotations.resize( _indexedElements->size() );
-        _rotationIdx.resize(m_topology->getNbPoints());
-        _rotatedInitialElements.resize(_indexedElements->size());
-        unsigned int i=0;
-        typename VecElement::const_iterator it;
-        for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+        case POLAR :
         {
-            Index a = (*it)[0];
-            Index b = (*it)[1];
-            Index c = (*it)[2];
-            Index d = (*it)[3];
-            computeMaterialStiffness(i,a,b,c,d);
-            initPolar(i,a,b,c,d);
+            rotations.resize( _indexedElements->size() );
+            _initialRotations.resize( _indexedElements->size() );
+            _rotationIdx.resize(m_topology->getNbPoints());
+            _rotatedInitialElements.resize(_indexedElements->size());
+            unsigned int i=0;
+            typename VecElement::const_iterator it;
+            for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+            {
+                Index a = (*it)[0];
+                Index b = (*it)[1];
+                Index c = (*it)[2];
+                Index d = (*it)[3];
+                computeMaterialStiffness(i,a,b,c,d);
+                initPolar(i,a,b,c,d);
+            }
+            break;
         }
-        break;
-    }
-    case SVD :
-    {
-        rotations.resize( _indexedElements->size() );
-        _initialRotations.resize( _indexedElements->size() );
-        _rotationIdx.resize(m_topology->getNbPoints());
-        _rotatedInitialElements.resize(_indexedElements->size());
-        _initialTransformation.resize(_indexedElements->size());
-        unsigned int i=0;
-        typename VecElement::const_iterator it;
-        for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+        case SVD :
         {
-            Index a = (*it)[0];
-            Index b = (*it)[1];
-            Index c = (*it)[2];
-            Index d = (*it)[3];
-            computeMaterialStiffness(i,a,b,c,d);
-            initSVD(i,a,b,c,d);
+            rotations.resize( _indexedElements->size() );
+            _initialRotations.resize( _indexedElements->size() );
+            _rotationIdx.resize(m_topology->getNbPoints());
+            _rotatedInitialElements.resize(_indexedElements->size());
+            _initialTransformation.resize(_indexedElements->size());
+            unsigned int i=0;
+            typename VecElement::const_iterator it;
+            for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+            {
+                Index a = (*it)[0];
+                Index b = (*it)[1];
+                Index c = (*it)[2];
+                Index d = (*it)[3];
+                computeMaterialStiffness(i,a,b,c,d);
+                initSVD(i,a,b,c,d);
+            }
+            break;
         }
-        break;
-    }
     }
 
     if ( isComputeVonMisesStressMethodSet() )
@@ -1665,39 +1668,39 @@ inline void TetrahedronFEMForceField<DataTypes>::addForce (const core::Mechanica
     typename VecElement::const_iterator it;
     switch(method)
     {
-    case SMALL :
-    {
-        for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+        case SMALL :
         {
-            accumulateForceSmall( f, p, it, i );
+            for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+            {
+                accumulateForceSmall( f, p, it, i );
+            }
+            break;
         }
-        break;
-    }
-    case LARGE :
-    {
-        for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+        case LARGE :
         {
+            for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+            {
 
-            accumulateForceLarge( f, p, it, i );
+                accumulateForceLarge( f, p, it, i );
+            }
+            break;
         }
-        break;
-    }
-    case POLAR :
-    {
-        for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+        case POLAR :
         {
-            accumulateForcePolar( f, p, it, i );
+            for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+            {
+                accumulateForcePolar( f, p, it, i );
+            }
+            break;
         }
-        break;
-    }
-    case SVD :
-    {
-        for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+        case SVD :
         {
-            accumulateForceSVD( f, p, it, i );
+            for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
+            {
+                accumulateForceSVD( f, p, it, i );
+            }
+            break;
         }
-        break;
-    }
     }
     d_f.endEdit();
 
@@ -1801,12 +1804,13 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromTetrahedra(
     const auto showWireFrame = vparams->displayFlags().getShowWireFrame();
 
     sofa::simulation::forEachRange(this->_indexedElements->begin(), this->_indexedElements->end(),
-        [&](const sofa::simulation::Range<VecElement::const_iterator>& range)
-        {
-            this->drawTrianglesFromRangeOfTetrahedra(range, vparams, showVonMisesStressPerElement, drawVonMisesStress, showWireFrame, x, youngModulus, heterogeneous, minVM, maxVM, vM);
-        });
+                                   [&](const sofa::simulation::Range<VecElement::const_iterator>& range)
+                                   {
+                                       this->drawTrianglesFromRangeOfTetrahedra(range, vparams, showVonMisesStressPerElement, drawVonMisesStress, showWireFrame, x, youngModulus, heterogeneous, minVM, maxVM, vM);
+                                   });
 
     vparams->drawTool()->drawTriangles(m_renderedPoints, m_renderedColors);
+
 }
 
 template <class DataTypes>
@@ -1834,7 +1838,7 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
 
         const Coord center = (p[0] + p[1] + p[2] + p[3]) * 0.125;
 
-        if ( !showWireFrame )
+        if ( !showWireFrame && _showGapBetweenElements.getValue() )
         {
             for (auto& pi : p)
             {
@@ -1865,6 +1869,15 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
                 color[3] = col;
             }
         }
+        else if(drawVonMisesStress && _showVonMisesStressPerNodeColorMap.getValue())
+        {
+            helper::ReadAccessor<Data<type::vector<Real> > > vMN =  _vonMisesPerNode;
+            helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(_minVMN, _maxVMN);
+            color[0] = evalColor(vMN[(*it)[0]]);
+            color[1] = evalColor(vMN[(*it)[1]]);
+            color[2] = evalColor(vMN[(*it)[2]]);
+            color[3] = evalColor(vMN[(*it)[3]]);
+        }
         else if (!drawVonMisesStress)
         {
             color[0] = sofa::type::RGBAColor(0.0, 0.0, 1.0, 1.0);
@@ -1878,10 +1891,19 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
         *pointsIt++ = p[2];  *pointsIt++ = p[3];  *pointsIt++ = p[0];
         *pointsIt++ = p[3];  *pointsIt++ = p[0];  *pointsIt++ = p[1];
 
-        *colorsIt++ = color[0];  *colorsIt++ = color[0];  *colorsIt++ = color[0];
-        *colorsIt++ = color[1];  *colorsIt++ = color[1];  *colorsIt++ = color[1];
-        *colorsIt++ = color[2];  *colorsIt++ = color[2];  *colorsIt++ = color[2];
-        *colorsIt++ = color[3];  *colorsIt++ = color[3];  *colorsIt++ = color[3];
+
+        if(!_showVonMisesStressPerNodeColorMap.getValue()){
+            *colorsIt++ = color[0];  *colorsIt++ = color[0];  *colorsIt++ = color[0];
+            *colorsIt++ = color[1];  *colorsIt++ = color[1];  *colorsIt++ = color[1];
+            *colorsIt++ = color[2];  *colorsIt++ = color[2];  *colorsIt++ = color[2];
+            *colorsIt++ = color[3];  *colorsIt++ = color[3];  *colorsIt++ = color[3];
+        }
+        else{
+            *colorsIt++ = color[0];  *colorsIt++ = color[1];  *colorsIt++ = color[2];
+            *colorsIt++ = color[1];  *colorsIt++ = color[2];  *colorsIt++ = color[3];
+            *colorsIt++ = color[2];  *colorsIt++ = color[3];  *colorsIt++ = color[0];
+            *colorsIt++ = color[3];  *colorsIt++ = color[0];  *colorsIt++ = color[1];
+        }
 
         ++elementId;
     }
@@ -1890,6 +1912,8 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
 template<class DataTypes>
 void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
+    if(!_showForceField.getValue()) return;
+
     if(this->d_componentState.getValue() == ComponentState::Invalid)
         return ;
 
@@ -1904,7 +1928,7 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
 
     const bool showVonMisesStressPerElement = _showVonMisesStressPerElement.getValue();
 
-    const bool drawVonMisesStress = (_showVonMisesStressPerNode.getValue() || showVonMisesStressPerElement) && isComputeVonMisesStressMethodSet();
+    const bool drawVonMisesStress = (_showVonMisesStressPerNode.getValue() || showVonMisesStressPerElement || _showVonMisesStressPerNodeColorMap.getValue()) && isComputeVonMisesStressMethodSet();
 
     const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
@@ -1954,6 +1978,8 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
         maxVM *= _showStressAlpha.getValue();
         maxVMN *= _showStressAlpha.getValue();
 
+        _minVMN = minVMN;
+        _maxVMN = maxVMN;
 
         if (_showVonMisesStressPerNode.getValue())
         {
@@ -2185,18 +2211,18 @@ const typename TetrahedronFEMForceField<DataTypes>::Transformation& TetrahedronF
         return rotations[index];
 
     msg_warning() << "Method getActualTetraRotation called with element index: " << index
-        << " which is out of bounds: [0, " << rotations.size() << "]. Returning default empty array of coordinates.";
+                  << " which is out of bounds: [0, " << rotations.size() << "]. Returning default empty array of coordinates.";
     return InvalidTransform;
 }
 
 template<class DataTypes>
 const typename TetrahedronFEMForceField<DataTypes>::Transformation& TetrahedronFEMForceField<DataTypes>::getInitialTetraRotation(unsigned int index)
-{ 
+{
     if (index < _initialRotations.size())
         return _initialRotations[index];
 
     msg_warning() << "Method getInitialTetraRotation called with element index: " << index
-        << " which is out of bounds: [0, " << _initialRotations.size() << "]. Returning default empty array of coordinates.";
+                  << " which is out of bounds: [0, " << _initialRotations.size() << "]. Returning default empty array of coordinates.";
     return InvalidTransform;
 }
 
@@ -2207,7 +2233,7 @@ const typename TetrahedronFEMForceField<DataTypes>::MaterialStiffness& Tetrahedr
         return materialsStiffnesses[tetraId];
 
     msg_warning() << "Method getMaterialStiffness called with element index: " << tetraId
-        << " which is out of bounds: [0, " << materialsStiffnesses.size() << "]. Returning default empty array of coordinates.";
+                  << " which is out of bounds: [0, " << materialsStiffnesses.size() << "]. Returning default empty array of coordinates.";
     return InvalidMaterialStiffness;
 }
 
@@ -2218,7 +2244,7 @@ const typename TetrahedronFEMForceField<DataTypes>::StrainDisplacement& Tetrahed
         return strainDisplacements[tetraId];
 
     msg_warning() << "Method getStrainDisplacement called with element index: " << tetraId
-        << " which is out of bounds: [0, " << strainDisplacements.size() << "]. Returning default empty array of coordinates.";
+                  << " which is out of bounds: [0, " << strainDisplacements.size() << "]. Returning default empty array of coordinates.";
     return InvalidStrainDisplacement;
 }
 
@@ -2230,7 +2256,7 @@ const type::fixed_array<typename TetrahedronFEMForceField<DataTypes>::Coord, 4>&
         return _rotatedInitialElements[tetraId];
 
     msg_warning() << "Method getRotatedInitialElements called with element index: " << tetraId
-        << " which is out of bounds: [0, " << _rotatedInitialElements.size() << "]. Returning default empty array of coordinates.";
+                  << " which is out of bounds: [0, " << _rotatedInitialElements.size() << "]. Returning default empty array of coordinates.";
     return InvalidCoords;
 }
 
@@ -2255,10 +2281,10 @@ void TetrahedronFEMForceField<DataTypes>::setMethod(int val)
     method = val;
     switch(val)
     {
-    case SMALL: f_method.setValue("small"); break;
-    case POLAR: f_method.setValue("polar"); break;
-    case SVD:   f_method.setValue("svd"); break;
-    default   : f_method.setValue("large");
+        case SMALL: f_method.setValue("small"); break;
+        case POLAR: f_method.setValue("polar"); break;
+        case SVD:   f_method.setValue("svd"); break;
+        default   : f_method.setValue("large");
     }
 }
 


### PR DESCRIPTION
Hello,

I would like to add some new functions to the visualization in **TetrahedronFEMForcefield**:

1) In the visualization of Von Mises Stress, the option "_showVonMisesStressPerNode_" shows the stress for each node:
![VisualStress01](https://user-images.githubusercontent.com/56633656/234046047-3264cd75-896e-465a-8421-d2bf29b304cb.png)
while the option "_showVonMisesStressPerElement_" computes the stress in another way:
![VisualStress05](https://user-images.githubusercontent.com/56633656/234046608-193dee0f-9771-4526-be96-6987aa0b87d1.png)

However, my desired color map of the stress is like the following image (using node stress data):
![VisualStress04](https://user-images.githubusercontent.com/56633656/234047053-0d382e09-243c-470b-8f49-ebbc6b756482.png)
Compared to the visualization with "_showVonMisesStressPerElement_", this color map accords more with my intuition of the stress forces (while the feet are pressed).
Therefore, I would like to add a new option "_showVonMisesStressPerNodeColorMap_" to show this color map.

2) I would like to add an option "_showGapBetweenElements_" to activate/deactivate drawing the gap between the elements, in order to  show a smooth color map:
![VisualStress07](https://user-images.githubusercontent.com/56633656/234049502-781340eb-e323-402d-8aeb-fc4f14c0e722.png)

3) I would like to add an option "_showForceField_" to decide if we draw the forcefield of the current object or not. This will be useful when we have several soft tissues and we want to focus on one of the objects:
![VisualStress08](https://user-images.githubusercontent.com/56633656/234050359-c2c27e3b-ba45-48b9-98dc-337757e25b6d.png)
![VisualStress09](https://user-images.githubusercontent.com/56633656/234050426-38c84e34-49f8-4c2c-bcea-b8d4e2acef59.png)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
