### PR TITLE
[Components] Add functions to visualization of TetrahedronFemForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -225,11 +225,19 @@ public:
     Data<type::vector<Real> > _vonMisesPerElement; ///< von Mises Stress per element
     Data<type::vector<Real> > _vonMisesPerNode; ///< von Mises Stress per node
     Data<type::vector<type::Vec4f> > _vonMisesStressColors; ///< Vector of colors describing the VonMises stress
-    
+
+    Real _minVMN;
+    Real _maxVMN;
+
+    Data<bool> _showForceField; ///< draw the force field for the current object
+
     Data<std::string> _showStressColorMap; ///< Color map used to show stress values
     Data<float> _showStressAlpha; ///< Alpha for vonMises visualisation
     Data<bool> _showVonMisesStressPerNode; ///< draw points showing vonMises stress interpolated in nodes
+    Data<bool> _showVonMisesStressPerNodeColorMap; ///< draw triangles showing vonMises stress interpolated in nodes
     Data<bool> _showVonMisesStressPerElement; ///< draw triangles showing vonMises stress interpolated in elements
+
+    Data<bool> _showGapBetweenElements; ///< draw gap between elements (when showWireFrame is disabled)
 
     Data<bool>  _updateStiffness; ///< udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -229,15 +229,13 @@ public:
     Real _minVMN;
     Real _maxVMN;
 
-    Data<bool> _showCurrentForceField; ///< draw the force field for the current object
-
     Data<std::string> _showStressColorMap; ///< Color map used to show stress values
     Data<float> _showStressAlpha; ///< Alpha for vonMises visualisation
     Data<bool> _showVonMisesStressPerNode; ///< draw points showing vonMises stress interpolated in nodes
-    Data<bool> _showVonMisesStressPerNodeColorMap; ///< draw triangles showing vonMises stress interpolated in nodes
+    Data<bool> d_showVonMisesStressPerNodeColorMap; ///< draw triangles showing vonMises stress interpolated in nodes
     Data<bool> _showVonMisesStressPerElement; ///< draw triangles showing vonMises stress interpolated in elements
 
-    Data<bool> _showGapBetweenElements; ///< draw gap between elements (when showWireFrame is disabled)
+    Data<float> d_showElementGapScale; ///< draw gap between elements (when showWireFrame is disabled)
 
     Data<bool>  _updateStiffness; ///< udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -226,8 +226,8 @@ public:
     Data<type::vector<Real> > _vonMisesPerNode; ///< von Mises Stress per node
     Data<type::vector<type::Vec4f> > _vonMisesStressColors; ///< Vector of colors describing the VonMises stress
 
-    Real _minVMN;
-    Real _maxVMN;
+    Real m_minVonMisesPerNode;
+    Real m_maxVonMisesPerNode;
 
     Data<std::string> _showStressColorMap; ///< Color map used to show stress values
     Data<float> _showStressAlpha; ///< Alpha for vonMises visualisation
@@ -235,7 +235,7 @@ public:
     Data<bool> d_showVonMisesStressPerNodeColorMap; ///< draw triangles showing vonMises stress interpolated in nodes
     Data<bool> _showVonMisesStressPerElement; ///< draw triangles showing vonMises stress interpolated in elements
 
-    Data<float> d_showElementGapScale; ///< draw gap between elements (when showWireFrame is disabled)
+    Data<Real> d_showElementGapScale; ///< draw gap between elements (when showWireFrame is disabled)
 
     Data<bool>  _updateStiffness; ///< udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -229,7 +229,7 @@ public:
     Real _minVMN;
     Real _maxVMN;
 
-    Data<bool> _showForceField; ///< draw the force field for the current object
+    Data<bool> _showCurrentForceField; ///< draw the force field for the current object
 
     Data<std::string> _showStressColorMap; ///< Color map used to show stress values
     Data<float> _showStressAlpha; ///< Alpha for vonMises visualisation

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -63,7 +63,7 @@ TetrahedronFEMForceField<DataTypes>::TetrahedronFEMForceField()
     , _showVonMisesStressPerNode(initData(&_showVonMisesStressPerNode,false,"showVonMisesStressPerNode","draw points showing vonMises stress interpolated in nodes"))
     , d_showVonMisesStressPerNodeColorMap(initData(&d_showVonMisesStressPerNodeColorMap,false,"showVonMisesStressPerNodeColorMap","draw elements showing vonMises stress interpolated in nodes"))
     , _showVonMisesStressPerElement(initData(&_showVonMisesStressPerElement, false, "showVonMisesStressPerElement", "draw triangles showing vonMises stress interpolated in elements"))
-    , d_showElementGapScale(initData(&d_showElementGapScale, 0.333f, "showElementGapScale", "draw gap between elements (when showWireFrame is disabled) [0,1]: 0: no gap, 1: no element"))
+    , d_showElementGapScale(initData(&d_showElementGapScale, (Real)0.333, "showElementGapScale", "draw gap between elements (when showWireFrame is disabled) [0,1]: 0: no gap, 1: no element"))
     , _updateStiffness(initData(&_updateStiffness,false,"updateStiffness","udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)"))
     , l_topology(initLink("topology", "link to the tetrahedron topology container"))
 {
@@ -1855,7 +1855,7 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
     auto pointsIt = m_renderedPoints.begin() + elementId * 3 * 4;
     auto colorsIt = m_renderedColors.begin() + elementId * 3 * 4;
 
-    float showElementGapScale = d_showElementGapScale.getValue();
+    Real showElementGapScale = d_showElementGapScale.getValue();
 
     for (auto it = range.start; it != range.end; ++it, ++elementId)
     {
@@ -1904,7 +1904,7 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
             else if(d_showVonMisesStressPerNodeColorMap.getValue())
             {
                 helper::ReadAccessor<Data<type::vector<Real> > > vMN =  _vonMisesPerNode;
-                helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(_minVMN, _maxVMN);
+                helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(m_minVonMisesPerNode, m_maxVonMisesPerNode);
                 color[0] = evalColor(vMN[(*it)[0]]);
                 color[1] = evalColor(vMN[(*it)[1]]);
                 color[2] = evalColor(vMN[(*it)[2]]);
@@ -2010,8 +2010,8 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
         maxVM *= _showStressAlpha.getValue();
         maxVMN *= _showStressAlpha.getValue();
 
-        _minVMN = minVMN;
-        _maxVMN = maxVMN;
+        m_minVonMisesPerNode = minVMN;
+        m_maxVonMisesPerNode = maxVMN;
 
         if (_showVonMisesStressPerNode.getValue())
         {

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -1824,6 +1824,8 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
     auto pointsIt = m_renderedPoints.begin() + elementId * 3 * 4;
     auto colorsIt = m_renderedColors.begin() + elementId * 3 * 4;
 
+    float showElementGapScale = d_showElementGapScale.getValue();
+
     for (auto it = range.start; it != range.end; ++it, ++elementId)
     {
         sofa::type::fixed_array<sofa::type::RGBAColor, 4> color;
@@ -1834,16 +1836,16 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
             p[vId] = x[(*it)[vId]];
         }
 
-        if ( !showWireFrame && d_showElementGapScale.getValue() != 0.0 )
+        if ( !showWireFrame && showElementGapScale != 0.0 )
         {
             const Coord center = (p[0] + p[1] + p[2] + p[3]) * 0.25;
 
-            if(d_showElementGapScale.getValue() > 1.0) d_showElementGapScale.setValue(1.0);
-            if(d_showElementGapScale.getValue() < 0.0) d_showElementGapScale.setValue(0.0);
+            if(showElementGapScale > 1.0) d_showElementGapScale.setValue(1.0);
+            if(showElementGapScale < 0.0) d_showElementGapScale.setValue(0.0);
 
             for (auto& pi : p)
             {
-                pi = (pi - center) * Real(1.0 - d_showElementGapScale.getValue()) + center;
+                pi = (pi - center) * Real(1.0 - showElementGapScale) + center;
             }
         }
 


### PR DESCRIPTION
I would like to add some new functions to the visualization in TetrahedronFEMForcefield:

1) In the visualization of Von Mises Stress, the option "_showVonMisesStressPerNode_" shows the stress for each node:
![VisualStress01](https://user-images.githubusercontent.com/56633656/234069177-73cab3bc-9c3a-408d-a0b9-02a2acaa6c1c.png)
while the option "_showVonMisesStressPerElement_" computes the stress in another way:
![VisualStress05](https://user-images.githubusercontent.com/56633656/234069221-f5b8d328-24e1-45c7-9250-c68bcf4422eb.png)
However, my desired color map of the stress is like the following image (using node stress data):
![VisualStress04](https://user-images.githubusercontent.com/56633656/234069253-030154aa-f3c1-4bff-9d92-eccffd3dbc45.png)
Compared to the visualization with "_showVonMisesStressPerElement_", this color map accords more with my intuition of the stress forces (while the feet are pressed).
Therefore, I would like to add a new option "_showVonMisesStressPerNodeColorMap_" to show this color map.

2) I would like to add an option "_showGapBetweenElements_" to activate/deactivate drawing the gap between the elements, in order to show a smooth color map:
![VisualStress07](https://user-images.githubusercontent.com/56633656/234069288-96543e38-47f5-44c7-8c3d-f813fe7557cd.png)

3) I would like to add an option "_showForceField_" to decide if we draw the forcefield of the current object or not. This will be useful when we have several soft tissues and we want to focus on one of the objects:
![VisualStress08](https://user-images.githubusercontent.com/56633656/234069316-194be9c0-1abb-4380-a7e0-cad443d74206.png)
![VisualStress09](https://user-images.githubusercontent.com/56633656/234069330-5e07339a-de8b-4ee0-ae73-df787b64ccbc.png)

Finally I would like to note that the addition of the new functions does not change the visualization with previous settings.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
