### PR TITLE
[Rendering3D] OglModel: Use glMapBufferRange to update buffers

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -1005,15 +1005,8 @@ void VisualModelImpl::computeNormals()
     }
     else
     {
-        vector<Coord> normals;
-        std::size_t nbn = 0;
-        for (std::size_t i = 0; i < vertNormIdx.size(); i++)
-        {
-            if (vertNormIdx[i] >= nbn)
-                nbn = vertNormIdx[i]+1;
-        }
-
-        normals.resize(nbn); // resize() will call the default ctor, which initializes with zeros
+        const std::size_t nbn = static_cast<std::size_t>(*std::max_element(vertNormIdx.begin(), vertNormIdx.end())) + 1;
+        sofa::type::vector<Coord> normals(nbn); // will call the default ctor, which initializes with zeros
 
         for (const auto& triangle : triangles)
         {

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -26,7 +26,7 @@
 #include <sofa/type/Material.h>
 #include <sofa/helper/rmath.h>
 #include <sofa/helper/accessor.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/helper/io/Mesh.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/core/topology/TopologyData.inl>
@@ -1316,28 +1316,30 @@ void VisualModelImpl::updateVisual()
             }
         }
 
-        sofa::helper::AdvancedTimer::stepBegin("VisualModelImpl::computePositions");
-        computePositions();
-        sofa::helper::AdvancedTimer::stepEnd("VisualModelImpl::computePositions");
-
-        sofa::helper::AdvancedTimer::stepBegin("VisualModelImpl::updateBuffers");
-        updateBuffers();
-        sofa::helper::AdvancedTimer::stepEnd("VisualModelImpl::updateBuffers");
-
-        sofa::helper::AdvancedTimer::stepBegin("VisualModelImpl::computeNormals");
-        computeNormals();
-        sofa::helper::AdvancedTimer::stepEnd("VisualModelImpl::computeNormals");
-
+        {
+            sofa::helper::ScopedAdvancedTimer t("VisualModelImpl::computePositions");
+            computePositions();
+        }
+        {
+            sofa::helper::ScopedAdvancedTimer t("VisualModelImpl::computeNormals");
+            computeNormals();
+        }
         if (m_updateTangents.getValue())
         {
-            sofa::helper::AdvancedTimer::stepBegin("VisualModelImpl::computeTangents");
+            sofa::helper::ScopedAdvancedTimer t("VisualModelImpl::computeTangents");
             computeTangents();
-            sofa::helper::AdvancedTimer::stepEnd("VisualModelImpl::computeTangents");
         }
-        modified = false;
-
         if (m_vtexcoords.getValue().size() == 0)
+        {
+            sofa::helper::ScopedAdvancedTimer t("VisualModelImpl::computeUVSphereProjection");
             computeUVSphereProjection();
+        }
+        {
+            sofa::helper::ScopedAdvancedTimer t("VisualModelImpl::updateBuffers");
+            updateBuffers();
+        }
+
+        modified = false;
 
     }
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -954,7 +954,7 @@ void VisualModelImpl::initFromTopology()
 void VisualModelImpl::computeNormals()
 {
     const VecCoord& vertices = getVertices();
-    //const VecCoord& vertices = m_vertices2.getValue();
+
     if (vertices.empty() || (!m_updateNormals.getValue() && (m_vnormals.getValue()).size() == (vertices).size())) return;
 
     const VecVisualTriangle& triangles = m_triangles.getValue();
@@ -963,38 +963,34 @@ void VisualModelImpl::computeNormals()
 
     if (vertNormIdx.empty())
     {
-        std::size_t nbn = vertices.size();
-
-        VecDeriv& normals = *(m_vnormals.beginEdit());
+        const std::size_t nbn = vertices.size();
+        auto normals = sofa::helper::getWriteOnlyAccessor(m_vnormals);
 
         normals.resize(nbn);
-        for (std::size_t i = 0; i < nbn; i++)
-            normals[i].clear();
+        std::memset(&normals[0], 0, sizeof(normals[0]) * nbn); // bulk reset with zeros
 
-        for (std::size_t i = 0; i < triangles.size(); i++)
+        for (const auto& triangle : triangles)
         {
-            const VisualTriangle& triangle = triangles[i];
             const Coord& v1 = vertices[ triangle[0] ];
             const Coord& v2 = vertices[ triangle[1] ];
             const Coord& v3 = vertices[ triangle[2] ];
-            Coord n = cross(v2-v1, v3-v1);
+            const Coord n = cross(v2-v1, v3-v1);
 
             normals[ triangle[0] ] += n;
             normals[ triangle[1] ] += n;
             normals[ triangle[2] ] += n;
         }
 
-        for (std::size_t i = 0; i < quads.size(); i++)
+        for (const auto& quad : quads)
         {
-            const VisualQuad& quad = quads[i];
             const Coord & v1 = vertices[ quad[0] ];
             const Coord & v2 = vertices[ quad[1] ];
             const Coord & v3 = vertices[ quad[2] ];
             const Coord & v4 = vertices[ quad[3] ];
-            Coord n1 = cross(v2-v1, v4-v1);
-            Coord n2 = cross(v3-v2, v1-v2);
-            Coord n3 = cross(v4-v3, v2-v3);
-            Coord n4 = cross(v1-v4, v3-v4);
+            const Coord n1 = cross(v2-v1, v4-v1);
+            const Coord n2 = cross(v3-v2, v1-v2);
+            const Coord n3 = cross(v4-v3, v2-v3);
+            const Coord n4 = cross(v1-v4, v3-v4);
 
             normals[ quad[0] ] += n1;
             normals[ quad[1] ] += n2;
@@ -1002,10 +998,10 @@ void VisualModelImpl::computeNormals()
             normals[ quad[3] ] += n4;
         }
 
-        for (std::size_t i = 0; i < normals.size(); i++)
-            normals[i].normalize();
-
-        m_vnormals.endEdit();
+        for (auto& normal : normals)
+        {
+            normal.normalize();
+        }
     }
     else
     {
@@ -1017,34 +1013,30 @@ void VisualModelImpl::computeNormals()
                 nbn = vertNormIdx[i]+1;
         }
 
-        normals.resize(nbn);
-        for (std::size_t i = 0; i < nbn; i++)
-            normals[i].clear();
+        normals.resize(nbn); // resize() will call the default ctor, which initializes with zeros
 
-        for (std::size_t i = 0; i < triangles.size() ; i++)
+        for (const auto& triangle : triangles)
         {
-            const VisualTriangle& triangle = triangles[i];
             const Coord & v1 = vertices[ triangle[0] ];
             const Coord & v2 = vertices[ triangle[1] ];
             const Coord & v3 = vertices[ triangle[2] ];
-            Coord n = cross(v2-v1, v3-v1);
+            const Coord n = cross(v2-v1, v3-v1);
 
             normals[vertNormIdx[ triangle[0] ]] += n;
             normals[vertNormIdx[ triangle[1] ]] += n;
             normals[vertNormIdx[ triangle[2] ]] += n;
         }
 
-        for (std::size_t i = 0; i < quads.size() ; i++)
+        for (const auto& quad : quads)
         {
-            const VisualQuad& quad = quads[i];
             const Coord & v1 = vertices[ quad[0] ];
             const Coord & v2 = vertices[ quad[1] ];
             const Coord & v3 = vertices[ quad[2] ];
             const Coord & v4 = vertices[ quad[3] ];
-            Coord n1 = cross(v2-v1, v4-v1);
-            Coord n2 = cross(v3-v2, v1-v2);
-            Coord n3 = cross(v4-v3, v2-v3);
-            Coord n4 = cross(v1-v4, v3-v4);
+            const Coord n1 = cross(v2-v1, v4-v1);
+            const Coord n2 = cross(v3-v2, v1-v2);
+            const Coord n3 = cross(v4-v3, v2-v3);
+            const Coord n4 = cross(v1-v4, v3-v4);
 
             normals[vertNormIdx[ quad[0] ]] += n1;
             normals[vertNormIdx[ quad[1] ]] += n2;
@@ -1052,18 +1044,17 @@ void VisualModelImpl::computeNormals()
             normals[vertNormIdx[ quad[3] ]] += n4;
         }
 
-        for (std::size_t i = 0; i < normals.size(); i++)
+        for (auto& normal : normals)
         {
-            normals[i].normalize();
+            normal.normalize();
         }
 
-        VecDeriv& vnormals = *(m_vnormals.beginEdit());
+        auto vnormals = sofa::helper::getWriteOnlyAccessor(m_vnormals);
         vnormals.resize(vertices.size());
         for (std::size_t i = 0; i < vertices.size(); i++)
         {
             vnormals[i] = normals[vertNormIdx[i]];
         }
-        m_vnormals.endEdit();
     }
 }
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -863,65 +863,41 @@ void OglModel::updateVertexBuffer()
         }
     }
 
+    std::size_t vboBufferSizeInBytes = positionsBufferSize + normalsBufferSize 
+        + textureCoordsBufferSize + tangentsBufferSize + bitangentsBufferSize;
+
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
 
     float* vertex_vbo_ptr = (float*)glMapBufferRange(
         GL_ARRAY_BUFFER,
         0,
-        positionsBufferSize,
+        vboBufferSizeInBytes,
         GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT
     );
     assert(vertex_vbo_ptr);
+
     memcpy(vertex_vbo_ptr, positionBuffer, positionsBufferSize);
 
-    glUnmapBuffer(GL_ARRAY_BUFFER);
-
-    float* normal_vbo_ptr = (float*)glMapBufferRange(
-        GL_ARRAY_BUFFER,
-        positionsBufferSize,
-        normalsBufferSize,
-        GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT
-    );
-    assert(normal_vbo_ptr);
+    float* normal_vbo_ptr = vertex_vbo_ptr + vertices.size() * 3;
     memcpy(normal_vbo_ptr, normalBuffer, normalsBufferSize);
-    glUnmapBuffer(GL_ARRAY_BUFFER);
 
     ////Texture coords
     if(tex || putOnlyTexCoords.getValue() ||!textures.empty())
     {
-        float* tex_vbo_ptr = (float*)glMapBufferRange(
-            GL_ARRAY_BUFFER,
-            positionsBufferSize + normalsBufferSize,
-            textureCoordsBufferSize,
-            GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT
-        );
-        assert(tex_vbo_ptr);
-        memcpy(tex_vbo_ptr, vtexcoords.data(), textureCoordsBufferSize);
-        glUnmapBuffer(GL_ARRAY_BUFFER);
+        float* texcoords_vbo_ptr = normal_vbo_ptr + vnormals.size() * 3;
+        memcpy(texcoords_vbo_ptr, vtexcoords.data(), textureCoordsBufferSize);
 
         if (hasTangents)
         {
-            float* tan_vbo_ptr = (float*)glMapBufferRange(
-                GL_ARRAY_BUFFER,
-                positionsBufferSize + normalsBufferSize + textureCoordsBufferSize,
-                tangentsBufferSize,
-                GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT
-            );
-            assert(tan_vbo_ptr);
+            float* tan_vbo_ptr = texcoords_vbo_ptr + vtexcoords.size() * 2;
             memcpy(tan_vbo_ptr, vtangents.data(), tangentsBufferSize);
-            glUnmapBuffer(GL_ARRAY_BUFFER);
 
-            float* bitan_vbo_ptr = (float*)glMapBufferRange(
-                GL_ARRAY_BUFFER,
-                positionsBufferSize + normalsBufferSize + textureCoordsBufferSize + tangentsBufferSize,
-                bitangentsBufferSize,
-                GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT
-            );
-            assert(bitan_vbo_ptr);
+            float* bitan_vbo_ptr = tan_vbo_ptr + vtangents.size() * 3;
             memcpy(bitan_vbo_ptr, vbitangents.data(), bitangentsBufferSize);
-            glUnmapBuffer(GL_ARRAY_BUFFER);
         }
     }
+
+    glUnmapBuffer(GL_ARRAY_BUFFER);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -840,17 +840,21 @@ void OglModel::updateVertexBuffer()
     const void* positionBuffer = vertices.data();
     const void* normalBuffer = vnormals.data();
 
+    // use only temporary float buffers if vertices/normals are using double
+    if constexpr(std::is_same_v<Coord, sofa::type::Vec3d>)
+    {
+        verticesTmpBuffer.resize( vertices.size() );
+        normalsTmpBuffer.resize( vnormals.size() );
 
-    verticesTmpBuffer.resize( vertices.size() );
-    normalsTmpBuffer.resize( vnormals.size() );
+        copyVector(vertices, verticesTmpBuffer);
+        copyVector(vnormals, normalsTmpBuffer);
 
-    copyVector(vertices, verticesTmpBuffer);
-    copyVector(vnormals, normalsTmpBuffer);
+        positionBuffer = verticesTmpBuffer.data();
+        normalBuffer = normalsTmpBuffer.data();
+    }
 
     positionsBufferSize = (vertices.size()*sizeof(Vec3f));
     normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
-    positionBuffer = verticesTmpBuffer.data();
-    normalBuffer = normalsTmpBuffer.data();
 
     if (tex || putOnlyTexCoords.getValue() || !textures.empty())
     {

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
@@ -77,6 +77,7 @@ protected:
     GLuint vbo, iboEdges, iboTriangles, iboQuads;
     bool VBOGenDone, initDone, useEdges, useTriangles, useQuads, canUsePatches;
     size_t oldVerticesSize, oldNormalsSize, oldTexCoordsSize, oldTangentsSize, oldBitangentsSize, oldEdgesSize, oldTrianglesSize, oldQuadsSize;
+    int edgesRevision, trianglesRevision, quadsRevision;
 
     /// These two buffers are used to convert the data field to float type before being sent to
     /// opengl


### PR DESCRIPTION
Based on #3815 and #3805 

... instead of glBufferSubData() as it is a faster method to upload stuff on the GPU directly

Also:
 - dont update indices (lines, triangles, quads) if there are not modified
 - dont copy to temporary float if already in float

(same mesh as #3805)
Before:
`1000 iterations done in 14.075 s ( 71.048 FPS)` 

After:
`1000 iterations done in 9.597 s ( 104.199 FPS)`

After (float)
` 1000 iterations done in 7.618 s ( 131.268 FPS)`

Based on :
 - #3815 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
