### PR TITLE
[LinearAlgebra] Fix matrix unit test

### DIFF
--- a/Sofa/framework/LinearAlgebra/test/Matrix_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/Matrix_test.cpp
@@ -429,7 +429,7 @@ using TestSparseMatricesImplementations = ::testing::Types<
     TestSparseMatricesTraits<SReal, 4, 8, 4, 2>,
     TestSparseMatricesTraits<SReal, 4, 8, 1, 8>,
     TestSparseMatricesTraits<SReal, 4, 8, 2, 8>,
-    TestSparseMatricesTraits<SReal, 4, 8, 2, 3>,
+    TestSparseMatricesTraits<SReal, 4, 8, 2, 4>,
     TestSparseMatricesTraits<SReal, 24, 24, 3, 3>
 >;
 


### PR DESCRIPTION
The block size (2x3) did not make sense with regards to the matrix size (4x8). I changed the block size to 2x4



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
