### PR TITLE
[Lagrangian.Model] Missing _API keyword

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/StopperConstraint.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/StopperConstraint.cpp
@@ -36,7 +36,7 @@ int StopperConstraintClass = core::RegisterObject("TODO-StopperConstraint")
 
         ;
 
-template class StopperConstraint<Vec1Types>;
+template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API StopperConstraint<Vec1Types>;
 
 
 } //namespace sofa::component::constraint::lagrangian::model

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/StopperConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/StopperConstraint.h
@@ -106,7 +106,7 @@ public:
 };
 
 #if  !defined(SOFA_COMPONENT_CONSTRAINTSET_STOPPERCONSTRAINT_CPP)
-extern template class StopperConstraint<defaulttype::Vec1Types>;
+extern template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API StopperConstraint<defaulttype::Vec1Types>;
 
 #endif
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_UNIFORMCONSTRAINT_CPP
 #include <sofa/component/constraint/lagrangian/model/UniformConstraint.inl>
 
 #include <sofa/core/ObjectFactory.h>
@@ -31,7 +32,7 @@ int UniformConstraintClass = sofa::core::RegisterObject("A constraint equation a
 .add< UniformConstraint<sofa::defaulttype::Vec1Types> >()
 ;
 
-template class UniformConstraint<sofa::defaulttype::Vec1Types>;
+template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API UniformConstraint<sofa::defaulttype::Vec1Types>;
 
 
 } // namespace sofa::component::constraint::lagrangian::model

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.h
@@ -59,4 +59,8 @@ protected:
     UniformConstraint();
 };
 
+#if !defined(SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_UNIFORMCONSTRAINT_CPP)
+    extern template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API UniformConstraint<sofa::defaulttype::Vec1Types>;
+#endif
+
 } // namespace sofa::component::constraint::lagrangian::model


### PR DESCRIPTION
Clean the template instantiations.

I take this opportunity to test a PR from the Regression repo: 
[ci-depends-on https://github.com/sofa-framework/Regression/pull/42]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
