### PR TITLE
[LinearAlgebra] Change access specifier for the method set

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenBaseSparseMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenBaseSparseMatrix.h
@@ -59,17 +59,6 @@ class EigenBaseSparseMatrix : public linearalgebra::BaseMatrix
 
 public:
 
-    void set(Index i, Index j, double v) override
-    {
-        for (typename CompressedMatrix::InnerIterator it(compressedMatrix,i); it; ++it)
-        {
-            if(Index(it.index()) == j) // diagonal entry
-                it.valueRef()=0.0;
-        }
-
-        incoming.push_back( Triplet(i,j,(Real)v) );
-    }
-
 
     typedef TReal Real;
     typedef Eigen::SparseMatrix<Real,Eigen::RowMajor> CompressedMatrix;
@@ -77,15 +66,8 @@ public:
     typedef EigenBaseSparseMatrix<TReal> ThisMatrix;
     typedef Eigen::Triplet<Real> Triplet;
 
-private:
-
-    type::vector<Triplet> incoming;             ///< Scheduled additions
-
 
 public:
-
-    CompressedMatrix compressedMatrix;    ///< the compressed matrix
-
 
     EigenBaseSparseMatrix(Index nbRow=0, Index nbCol=0)
     {
@@ -105,6 +87,18 @@ public:
         compressedMatrix = m.compressedMatrix;
     }
 
+
+    void set(Index i, Index j, double v) override
+    {
+        for (typename CompressedMatrix::InnerIterator it(compressedMatrix,i); it; ++it)
+        {
+            if(Index(it.index()) == j) // diagonal entry
+                it.valueRef()=0.0;
+        }
+
+        incoming.push_back( Triplet(i,j,(Real)v) );
+    }
+
     void setIdentity()
     {
         clear();
@@ -115,6 +109,8 @@ public:
         }
         compress();
     }
+
+
 
     /// Schedule the addition of the value at the given place. Scheduled additions must be finalized using function compress().
     void add( Index row, Index col, double value ) override{
@@ -321,10 +317,6 @@ public:
     static const char* Name();
 
     // sparse solver support
-protected:
-    typedef Eigen::SimplicialCholesky<Eigen::SparseMatrix<Real> >  SimplicialCholesky;
-    SimplicialCholesky cholesky; ///< used to factorize the matrix and solve systems using Cholesky method, for symmetric positive definite matrices only.
-public:
     /// Try to compute the LDLT decomposition, and return true if success. The matrix is unchanged.
     bool choleskyDecompose()
     {
@@ -356,8 +348,6 @@ public:
             }
     }
 
-
-public:
 
     /// EigenBaseSparseMatrix multiplication
     /// res can be the same variable as this or rhs
@@ -400,6 +390,15 @@ public:
 #endif
     }
 
+public:
+	CompressedMatrix compressedMatrix;    ///< the compressed matrix
+
+protected:
+    typedef Eigen::SimplicialCholesky<Eigen::SparseMatrix<Real> >  SimplicialCholesky;
+    SimplicialCholesky cholesky; ///< used to factorize the matrix and solve systems using Cholesky method, for symmetric positive definite matrices only.
+
+private:
+    type::vector<Triplet> incoming;             ///< Scheduled additions
 
 };
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenBaseSparseMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenBaseSparseMatrix.h
@@ -56,6 +56,9 @@ Rows, columns, or the full matrix can be set to zero using the clear* methods.
 template<class TReal>
 class EigenBaseSparseMatrix : public linearalgebra::BaseMatrix
 {
+
+public:
+
     void set(Index i, Index j, double v) override
     {
         for (typename CompressedMatrix::InnerIterator it(compressedMatrix,i); it; ++it)
@@ -67,8 +70,6 @@ class EigenBaseSparseMatrix : public linearalgebra::BaseMatrix
         incoming.push_back( Triplet(i,j,(Real)v) );
     }
 
-
-public:
 
     typedef TReal Real;
     typedef Eigen::SparseMatrix<Real,Eigen::RowMajor> CompressedMatrix;


### PR DESCRIPTION
Change access specifier for the method set. A public access is needed in SofaCUDASolver plugin. 

Moreover, regardless of the reasons of this modification, the fact that this method is at the beginning of the class declaration without any access specifier before is not wanted. Even if it is a class which makes its access private by default, it lacks of readability.  






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
