### PR TITLE
[Mapping.NonLinear] Warns when non-symmetric matrix is produced

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSparseLU.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSparseLU.h
@@ -47,6 +47,7 @@ public:
 
     SOFA_CLASS(SOFA_TEMPLATE(EigenSparseLU, TBlockType), SOFA_TEMPLATE2(EigenDirectSparseSolver, TBlockType, SparseLUTraits<Real>));
 
+    bool supportNonSymmetricSystem() const override { return true; }
 };
 
 #ifndef SOFA_COMPONENT_LINEARSOLVER_DIRECT_EIGENSPARSELU_CPP

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSparseQR.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSparseQR.h
@@ -47,6 +47,7 @@ public:
 
     SOFA_CLASS(SOFA_TEMPLATE(EigenSparseQR, TBlockType), SOFA_TEMPLATE2(EigenDirectSparseSolver, TBlockType, SparseQRTraits<Real>));
 
+    bool supportNonSymmetricSystem() const override { return true; }
 };
 
 #ifndef SOFA_COMPONENT_LINEARSOLVER_DIRECT_EIGENSPARSEQR_CPP

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SVDLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SVDLinearSolver.h
@@ -57,6 +57,7 @@ public:
     void solve (Matrix& M, Vector& x, Vector& b) override;
     Data<Real> f_conditionNumber; ///< Condition number of the matrix: ratio between the largest and smallest singular values. Computed in method solve.
 
+    bool supportNonSymmetricSystem() const override { return true; }
 };
 
 #if !defined(SOFA_COMPONENT_LINEARSOLVER_DIRECT_SVDLINEARSOLVER_CPP)

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLUSolver.h
@@ -79,6 +79,8 @@ public:
 
     SparseLUSolver();
 
+    bool supportNonSymmetricSystem() const override { return true; }
+
 protected :
 
     Data<sofa::helper::OptionsGroup> d_typePermutation;

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
@@ -656,14 +656,17 @@ void MatrixLinearSystem<TMatrix, TVector>::associateLocalMatrixTo(
             if constexpr (c == Contribution::STIFFNESS)
             {
                 m_stiffness[component].setMatrixAccumulator(mat, mstate0, mstate1);
+                m_stiffness[component].setMechanicalParams(mparams);
             }
             else if constexpr (c == Contribution::DAMPING)
             {
                 m_damping[component].setMatrixAccumulator(mat, mstate0, mstate1);
+                m_damping[component].setMechanicalParams(mparams);
             }
             else if constexpr (c == Contribution::GEOMETRIC_STIFFNESS)
             {
                 m_geometricStiffness[component].setMatrixAccumulator(mat, mstate0, mstate1);
+                m_geometricStiffness[component].setMechanicalParams(mparams);
             }
             else if constexpr (c == Contribution::MASS)
             {

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
@@ -382,9 +382,6 @@ void RigidMapping<TIn, TOut>::applyDJT(const core::MechanicalParams* mparams, co
         }
         else
         {
-            // This method corresponds to a non-symmetric matrix, due to the non-commutativity of the group of rotations.
-            assert( !mparams->symmetricMatrix() );
-
             helper::ReadAccessor<Data<OutVecDeriv> > childForces (*mparams->readF(this->toModel.get()));
             helper::WriteAccessor<Data<InVecDeriv> > parentForces (*parentForceChangeId[this->fromModel.get()].write());
             helper::ReadAccessor<Data<InVecDeriv> > parentDisplacements (*mparams->readDx(this->fromModel.get()));
@@ -656,6 +653,12 @@ void RigidMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
     }
     else
     {
+        if (geomStiff == 1)
+        {
+            // This method corresponds to a non-symmetric matrix, due to the non-commutativity of the group of rotations.
+            checkLinearSolverSymmetry(matrices->getMechanicalParams());
+        }
+
         const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 
         const auto childForces = this->toModel->readForces();

--- a/Sofa/Component/Mapping/NonLinear/tests/RigidMapping_test.cpp
+++ b/Sofa/Component/Mapping/NonLinear/tests/RigidMapping_test.cpp
@@ -87,7 +87,7 @@ struct RigidMappingTest : public sofa::mapping_test::Mapping_test<_RigidMapping>
 
         rigidMapping = static_cast<RigidMapping*>( this->mapping );
 
-        if( InDataTypes::spatial_dimensions != 3 )
+        if constexpr ( InDataTypes::spatial_dimensions != 3 )
         {
             // RigidMapping::getK is not yet implemented for 2D rigids
             this->flags &= ~Inherit::TEST_getK;

--- a/Sofa/framework/Core/src/sofa/core/MechanicalStatesMatrixAccumulators.h
+++ b/Sofa/framework/Core/src/sofa/core/MechanicalStatesMatrixAccumulators.h
@@ -40,6 +40,10 @@ public:
     void setMatrixAccumulator(MatrixAccumulator* matrixAccumulator,
                               BaseState* mstate1);
 
+    void setMechanicalParams(const core::MechanicalParams* mparams) { m_mparams = mparams; }
+
+    const core::MechanicalParams* getMechanicalParams() const { return m_mparams; }
+
 // protected:
 
     std::map<std::pair<BaseState*, BaseState*>,
@@ -51,6 +55,10 @@ public:
     virtual ~MechanicalStatesMatrixAccumulators() = default;
     MechanicalStatesMatrixAccumulators(const MechanicalStatesMatrixAccumulators&) = delete;
     void operator=(const MechanicalStatesMatrixAccumulators&) = delete;
+
+private:
+
+    const core::MechanicalParams* m_mparams { nullptr };
 };
 
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
@@ -57,6 +57,9 @@ public:
     /// Indicate if the solver update the system in parallel
     virtual bool isAsyncSolver() { return false; }
 
+    /// Returns true if the solver supports non-symmetric systems
+    virtual bool supportNonSymmetricSystem() const { return false; }
+
     /// Indicate if the solver updated the system after the last call of setSystemMBKMatrix (should return true if isParallelSolver return false)
     virtual bool hasUpdatedMatrix() { return true; }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
@@ -451,6 +451,7 @@ void MechanicalOperations::m_setSystemMBKMatrix(SReal mFact, SReal bFact, SReal 
     mparams.setMFactor(mFact);
     mparams.setBFactor(bFact);
     mparams.setKFactor(kFact);
+    mparams.setSymmetricMatrix(!s->supportNonSymmetricSystem());
     s->setSystemMBKMatrix(&mparams);
 }
 


### PR DESCRIPTION
Warns the user when a non-symmetric matrix is produced by a non-linear mapping while a symmetric linear solver is used. The message looks like:
```
[ERROR]   [RigidMapping(RigidMapping1)] The geometric stiffness of this mapping is a non-symmetric matrix. It means a linear solver supporting non-symmetric matrices must be used, but it is not the case here. To fix your scene, you have two options: 1) Use a linear solver supporting non-symmetric matrices, 2) stabilize the geometric stiffness with the Data 'geometricStiffness' set to 'Stabilized'
```

Note that the detection was already considered in the past through a `bool` in the `MechanicalParams`, but not used at all.

Note that even if a linear system supporting non-symmetric matrices is used, the exact geometric stiffness computed in `RigidMapping` leads to large stability issues in `examples/Component/LinearSystem/MatrixLinearSystem.scn`


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
