### PR TITLE
[LinearSolver.Iterative] CMake: Fix package configuration

### DIFF
--- a/Sofa/Component/LinearSolver/Iterative/Sofa.Component.LinearSolver.IterativeConfig.cmake.in
+++ b/Sofa/Component/LinearSolver/Iterative/Sofa.Component.LinearSolver.IterativeConfig.cmake.in
@@ -4,6 +4,7 @@
 @PACKAGE_INIT@
 
 find_package(Sofa.Simulation.Core QUIET REQUIRED)
+find_package(Sofa.Component.LinearSystem QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Reflect change in CMake which added a dependency on LinearSystem in #2777

It will fix out-of-tree builds based on the current master.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
