### PR TITLE
[SceneChecking] Add check when setting contactStiffness uselessly

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/CollisionModel.h
+++ b/Sofa/framework/Core/src/sofa/core/CollisionModel.h
@@ -325,6 +325,8 @@ public:
     [[nodiscard]] SReal getContactStiffness(Index /*index*/) const { return contactStiffness.getValue(); }
     /// Set contact stiffness
     void setContactStiffness(SReal stiffness) { contactStiffness.setValue(stiffness); }
+    /// Get contact stiffness
+    [[nodiscard]] bool isContactStiffnessSet() const { return contactStiffness.isSet(); }
 
     /// Get contact friction (damping) coefficient
     [[nodiscard]] SReal getContactFriction(Index /*index*/) const { return contactFriction.getValue(); }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
@@ -96,6 +96,20 @@ void SceneCheckCollisionResponse::doCheckOn(Node* node)
                 {
                     m_message <<"A FreeMotionAnimationLoop must be in the scene to solve FrictionContactConstraint" << msgendl;
                 }
+                else
+                {
+                    type::vector<core::CollisionModel*> colModels;
+                    root->get<core::CollisionModel>(&colModels, core::objectmodel::BaseContext::SearchDown);
+                    for (auto model : colModels)
+                    {
+                        if(model->isContactStiffnessSet())
+                        {
+                            m_message <<"The data \"contactStiffness\" is set in the component " << model->getClassName() <<" named " << model->getName() << msgendl;
+                            m_message <<"This data is not used when using a FrictionContactConstraint collision response." << msgendl;
+                            m_message <<"Remove the data \"contactStiffness\" to remove this warning" << msgendl;
+                        }
+                    }
+                }
             }
         }
     }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
@@ -98,19 +98,24 @@ void SceneCheckCollisionResponse::doCheckOn(Node* node)
                 }
                 else
                 {
-                    type::vector<core::CollisionModel*> colModels;
-                    root->get<core::CollisionModel>(&colModels, core::objectmodel::BaseContext::SearchDown);
-                    for (auto model : colModels)
-                    {
-                        if(model->isContactStiffnessSet())
-                        {
-                            m_message <<"The data \"contactStiffness\" is set in the component " << model->getClassName() <<" named " << model->getName() << msgendl;
-                            m_message <<"This data is not used when using a FrictionContactConstraint collision response." << msgendl;
-                            m_message <<"Remove the data \"contactStiffness\" to remove this warning" << msgendl;
-                        }
-                    }
+                    checkIfContactStiffnessIsSet(root);
                 }
             }
+        }
+    }
+}
+
+void SceneCheckCollisionResponse::checkIfContactStiffnessIsSet(const sofa::core::objectmodel::BaseContext* root)
+{
+    type::vector<core::CollisionModel*> colModels;
+    root->get<core::CollisionModel>(&colModels, core::objectmodel::BaseContext::SearchDown);
+    for (auto model : colModels)
+    {
+        if(model->isContactStiffnessSet())
+        {
+            m_message <<"The data \"contactStiffness\" is set in the component " << model->getClassName() <<" named " << model->getName() << msgendl;
+            m_message <<"This data is not used when using a FrictionContactConstraint collision response." << msgendl;
+            m_message <<"Remove the data \"contactStiffness\" to remove this warning" << msgendl;
         }
     }
 }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
@@ -45,6 +45,8 @@ public:
 private:
     bool m_checkDone = false;
     std::stringstream m_message;
+
+    void checkIfContactStiffnessIsSet(const core::objectmodel::BaseContext *root);
 };
 
 } // namespace sofa::_scenechecking_


### PR DESCRIPTION
Warns the user when setting the `contactStiffness` data while using a Lagrange-based constraint resolution! Because it's **useless** :godmode: 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
