### PR TITLE
 [SolidMechanics.Spring] CMake: Fix package configuration

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/Sofa.Component.SolidMechanics.SpringConfig.cmake.in
+++ b/Sofa/Component/SolidMechanics/Spring/Sofa.Component.SolidMechanics.SpringConfig.cmake.in
@@ -4,6 +4,10 @@
 @PACKAGE_INIT@
 
 find_package(Sofa.Component.Topology.Container.Grid QUIET REQUIRED)
+find_package(Sofa.Component.Mapping.Linear QUIET REQUIRED)
+find_package(Sofa.Component.StateContainer QUIET REQUIRED)
+find_package(Sofa.Simulation.Graph QUIET REQUIRED)
+find_package(Sofa.Component.Topology.Container.Dynamic QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
The usual :p, adding dependencies introduced in #2777 in the CMakeLists.txt

It will fix the out-of-tree builds based on the current master, especially for SofaPython3



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
