### PR TITLE
[SofaDefaultType] Extend TypeInfo to handle containers that are not flat array.

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/AbstractTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/AbstractTypeInfo.h
@@ -113,6 +113,10 @@ public:
     /// That is, if it can contain several values. In particular, strings are
     /// not considered containers.
     virtual bool Container() const = 0;
+    virtual bool UniqueKeyContainer() const = 0;
+
+    /// clear the container
+    virtual void clear(void* data) const = 0;
 
     /// The size of this type, in number of elements.
     /// For example, the size of a `fixed_array<fixed_array<int, 2>, 3>` is 6,
@@ -156,6 +160,15 @@ public:
     virtual void setScalarValue (void* data, Index index, double value) const = 0;
     /// Set the value at \a index of \a data from a string value.
     virtual void setTextValue(void* data, Index index, const std::string& value) const = 0;
+
+    /// Insert a value from an integer value.
+    virtual void insertIntegerValue(void* data, long long value) const = 0;
+
+    /// Insert a value from an scalar value.
+    virtual void insertScalarValue (void* data, double value) const = 0;
+
+    /// Insert a value from a string value.
+    virtual void insertTextValue(void* data, const std::string& value) const = 0;
 
     /// Get a read pointer to the underlying memory
     /// Relevant only if this type is SimpleLayout

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfo.h
@@ -84,9 +84,8 @@ struct DefaultDataTypeInfo
     typedef DataTypeInfo<BaseType> BaseTypeInfo;
     /// TypeInfo for ValueType
     typedef DataTypeInfo<ValueType> ValueTypeInfo;
-    /**
-       \{
-     */
+
+    ///   \{
     enum { ValidInfo       = 0 /**< 1 if this type has valid infos*/ };
     enum { FixedSize       = 0 /**< 1 if this type has a fixed size*/ };
     enum { ZeroConstructor = 0 /**< 1 if the constructor is equivalent to setting memory to 0*/ };
@@ -97,34 +96,27 @@ struct DefaultDataTypeInfo
     enum { Text            = 0 /**< 1 if this type uses text values*/ };
     enum { CopyOnWrite     = 0 /**< 1 if this type uses copy-on-write. The memory is shared with its source Data while only the source is changing (and the source modifications are then visible in the current Data). As soon as modifications are applied to the current Data, it will allocate its own value, and no longer shares memory with the source.*/ };
     enum { Container       = 0 /**< 1 if this type is a container*/ };
+    enum { UniqueKeyContainer = 0 /**< 1 if this type is a container*/ };
     enum { Size            = 1 /**< largest known fixed size for this type, as returned by size() */ };
-
-    // \}
+    /// \}
 
     static sofa::Size size() { return 1; }
     static sofa::Size byteSize() { return 1; }
 
+    /// Container API
     static sofa::Size size(const DataType& /*data*/) { return 1; }
+    static void clear(const DataType &) {}
 
-    template <typename T>
-    static void getValue(const DataType& /*data*/, Index /*index*/, T& /*value*/)
-    {
-    }
+    template <typename T> static void insertValue(DataType &, T& ) {}
 
+    /// FixedSize API
     static bool setSize(DataType& /*data*/, sofa::Size /*size*/) { return false; }
 
-    template<typename T>
-    static void setValue(DataType& /*data*/, Index /*index*/, const T& /*value*/)
-    {
-    }
-
-    static void getValueString(const DataType& /*data*/, Index /*index*/, std::string& /*value*/)
-    {
-    }
-
-    static void setValueString(DataType& /*data*/, Index /*index*/, const std::string& /*value*/)
-    {
-    }
+    /// IndexableContainer API
+    template <typename T> static void getValue(const DataType& /*data*/, Index /*index*/, T& /*value*/) {}
+    template<typename T> static void setValue(DataType& /*data*/, Index /*index*/, const T& /*value*/) {}
+    static void getValueString(const DataType& /*data*/, Index /*index*/, std::string& /*value*/) {}
+    static void setValueString(DataType& /*data*/, Index /*index*/, const std::string& /*value*/) {}
 
     static const void* getValuePtr(const DataType& /*type*/)
     {

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NameOnlyTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NameOnlyTypeInfo.h
@@ -73,6 +73,11 @@ public:
     /// not considered containers.
     bool Container() const override {return false;}
 
+    /// True iff this type is a container fullfilling the "unique key requirement" eg: map, set, unordered_set
+    bool UniqueKeyContainer() const override {return false;}
+
+    void clear(void*) const override {}
+
     /// The size of this type, in number of elements.
     /// For example, the size of a `fixed_array<fixed_array<int, 2>, 3>` is 6,
     /// and those six elements are conceptually numbered from 0 to 5.  This is
@@ -115,6 +120,13 @@ public:
     void setScalarValue (void* /*data*/, Index /*index*/, double /*value*/) const override {}
     /// Set the value at \a index of \a data from a string value.
     void setTextValue(void* /*data*/, Index /*index*/, const std::string& /*value*/) const override {}
+
+    /// Insert a value from an integer value.
+    void insertIntegerValue(void*, long long) const override {}
+    /// Insert a value from an scalar value.
+    void insertScalarValue (void*, double) const override {}
+    /// Insert a value from a string value.
+    void insertTextValue(void*, const std::string&) const override {}
 
     /// Get a read pointer to the underlying memory
     /// Relevant only if this type is SimpleLayout

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
@@ -1,24 +1,24 @@
 /******************************************************************************
-*                 SOFA, Simulation Open-Framework Architecture                *
-*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
-*                                                                             *
-* This program is free software; you can redistribute it and/or modify it     *
-* under the terms of the GNU Lesser General Public License as published by    *
-* the Free Software Foundation; either version 2.1 of the License, or (at     *
-* your option) any later version.                                             *
-*                                                                             *
-* This program is distributed in the hope that it will be useful, but WITHOUT *
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
-* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
-* for more details.                                                           *
-*                                                                             *
-* You should have received a copy of the GNU Lesser General Public License    *
-* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
-*******************************************************************************
-* Authors: The SOFA Team and external contributors (see Authors.txt)          *
-*                                                                             *
-* Contact information: contact@sofa-framework.org                             *
-******************************************************************************/
+ *                 SOFA, Simulation Open-Framework Architecture                *
+ *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+ *                                                                             *
+ * This program is free software; you can redistribute it and/or modify it     *
+ * under the terms of the GNU Lesser General Public License as published by    *
+ * the Free Software Foundation; either version 2.1 of the License, or (at     *
+ * your option) any later version.                                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful, but WITHOUT *
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+ * for more details.                                                           *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+ *******************************************************************************
+ * Authors: The SOFA Team and external contributors (see Authors.txt)          *
+ *                                                                             *
+ * Contact information: contact@sofa-framework.org                             *
+ ******************************************************************************/
 #pragma once
 #include <sofa/defaulttype/AbstractTypeInfo.h>
 #include <sofa/defaulttype/TypeInfoID.h>
@@ -28,7 +28,7 @@ namespace sofa::defaulttype
 
 class SOFA_DEFAULTTYPE_API NoTypeInfo : public AbstractTypeInfo
 {
-public:
+   public:
     NoTypeInfo(){ setCompilationTarget("SofaDefaultType"); }
 
     const AbstractTypeInfo* BaseType() const override { return Get(); }
@@ -36,18 +36,19 @@ public:
 
     static AbstractTypeInfo* Get(){ static NoTypeInfo t; return &t; }
 
-    /// \brief Returns the name of this type.
+            /// \brief Returns the name of this type.
     std::string name() const override {return "NoTypeInfo"; }
     std::string getTypeName() const override {return "NoTypeInfo"; }
 
-    /// True iff the TypeInfo for this type contains valid information.
-    /// A Type is considered "Valid" if there's at least one specialization of the ValueType
+            /// True iff the TypeInfo for this type contains valid information.
+            /// A Type is considered "Valid" if there's at least one specialization of the ValueType
     bool ValidInfo() const override { return false; }
 
-    /// True iff this type has a fixed size.
-    ///  (It cannot be resized)
+            /// True iff this type has a fixed size.
+            ///  (It cannot be resized)
     bool FixedSize() const override {return false;}
-    /// True iff the default constructor of this type is equivalent to setting the memory to 0.
+
+            /// True iff the default constructor of this type is equivalent to setting the memory to 0.
     bool ZeroConstructor() const override {return false;}
     /// True iff copying the data can be done with a memcpy().
     bool SimpleCopy() const override {return false;}
@@ -68,62 +69,72 @@ public:
     /// That is, if it can contain several values. In particular, strings are
     /// not considered containers.
     bool Container() const override {return false;}
+    bool UniqueKeyContainer() const override { return false; }
 
-    /// The size of this type, in number of elements.
-    /// For example, the size of a `fixed_array<fixed_array<int, 2>, 3>` is 6,
-    /// and those six elements are conceptually numbered from 0 to 5.  This is
-    /// relevant only if FixedSize() is true. I FixedSize() is false,
-    /// the return value will be equivalent to the one of byteSize()
+    void clear(void*) const override {}
+
+            /// The size of this type, in number of elements.
+            /// For example, the size of a `fixed_array<fixed_array<int, 2>, 3>` is 6,
+            /// and those six elements are conceptually numbered from 0 to 5.  This is
+            /// relevant only if FixedSize() is true. I FixedSize() is false,
+            /// the return value will be equivalent to the one of byteSize()
     sofa::Size size() const override {return -1;}
     /// The size in bytes of the ValueType
     /// For example, the size of a fixed_array<fixed_array<int, 2>, 3>` is 4 on most systems,
     /// as it is the byte size of the smallest dimension in the array (int -> 32bit)
     sofa::Size byteSize() const override {return -1;}
 
-    /// The size of \a data, in number of iterable elements
-    /// (For containers, that'll be the number of elements in the 1st dimension).
-    /// For example, with type == `
+            /// The size of \a data, in number of iterable elements
+            /// (For containers, that'll be the number of elements in the 1st dimension).
+            /// For example, with type == `
     sofa::Size size(const void* /*data*/) const override {return -1;}
     /// Resize \a data to \a size elements, if relevant.
 
-    /// But resizing is not always relevant, for example:
-    /// - nothing happens if FixedSize() is true;
-    /// - sets can't be resized; they are cleared instead;
-    /// - nothing happens for vectors containing resizable values (i.e. when
-    ///   BaseType()::FixedSize() is false), because of the "single index"
-    ///   abstraction;
-    ///
-    /// Returns true iff the data was resizable
+            /// But resizing is not always relevant, for example:
+            /// - nothing happens if FixedSize() is true;
+            /// - sets can't be resized; they are cleared instead;
+            /// - nothing happens for vectors containing resizable values (i.e. when
+            ///   BaseType()::FixedSize() is false), because of the "single index"
+            ///   abstraction;
+            ///
+            /// Returns true iff the data was resizable
     bool setSize(void*, sofa::Size) const override { return false; };
 
-    /// Get the value at \a index of \a data as an integer.
-    /// Relevant only if this type can be casted to `long long`.
-     long long   getIntegerValue(const void*, Index) const override {return 0;}
+            /// Get the value at \a index of \a data as an integer.
+            /// Relevant only if this type can be casted to `long long`.
+    long long   getIntegerValue(const void*, Index) const override {return 0;}
     /// Get the value at \a index of \a data as a scalar.
     /// Relevant only if this type can be casted to `double`.
     double      getScalarValue (const void*, Index) const override {return 0;}
     /// Get the value at \a index of \a data as a string.
     std::string getTextValue   (const void*, Index) const override {return 0;}
 
-    /// Set the value at \a index of \a data from an integer value.
+            /// Set the value at \a index of \a data from an integer value.
     void setIntegerValue(void*, Index, long long ) const override {return;}
     /// Set the value at \a index of \a data from a scalar value.
     void setScalarValue (void*, Index, double ) const override {return;}
     /// Set the value at \a index of \a data from a string value.
     void setTextValue(void*, Index, const std::string&) const override {return;}
 
-    /// Get a read pointer to the underlying memory
-    /// Relevant only if this type is SimpleLayout
+    /// Insert a value from an integer value.
+    void insertIntegerValue(void*, long long) const override {}
+    /// Insert a value from an scalar value.
+    void insertScalarValue (void*, double) const override {}
+    /// Insert a value from a string value.
+    void insertTextValue(void*, const std::string&) const override {}
+
+            /// Get a read pointer to the underlying memory
+            /// Relevant only if this type is SimpleLayout
     const void* getValuePtr(const void*) const override {return 0;}
 
-    /// Get a write pointer to the underlying memory
-    /// Relevant only if this type is SimpleLayout
+            /// Get a write pointer to the underlying memory
+            /// Relevant only if this type is SimpleLayout
     void* getValuePtr(void*) const override {return 0;}
 
-    /// Get the type_info for this type.
+            /// Get the type_info for this type.
     const std::type_info* type_info() const override {return &typeid(this); }
 
-protected:
+   protected:
     const TypeInfoId& getBaseTypeId() const override { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
     const TypeInfoId& getValueTypeId() const override { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_BoundingBox.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_BoundingBox.h
@@ -36,6 +36,7 @@ struct BoundingBoxTypeInfo
     typedef type::Vec3 BaseType;
     typedef DataTypeInfo<type::Vec3d> BaseTypeInfo;
     typedef SReal ValueType;
+    typedef SReal ValueTypeInfo;
 
     enum
     {
@@ -79,6 +80,10 @@ struct BoundingBoxTypeInfo
     {
         Container = 1
     };  ///< 1 if this type is a container
+    enum
+    {
+        UniqueKeyContainer = 0
+    };  ///< 1 if this type is a container with key uniqueness
 
     enum
     {

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/BoolTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/BoolTypeInfo.h
@@ -48,14 +48,28 @@ struct SOFA_DEFAULTTYPE_API BoolTypeInfo
     enum { Text            = 0 };
     enum { CopyOnWrite     = 0 };
     enum { Container       = 0 };
+    enum { UniqueKeyContainer = 0 };
 
     enum { Size = 1 };
+
+    static void clear(const DataType&) {}
+
     static sofa::Size size() { return 1; }
     static sofa::Size byteSize() { return sizeof(DataType); }
 
     static sofa::Size size(const DataType& /*data*/) { return 1; }
 
     static bool setSize(DataType& /*data*/, sofa::Size /*size*/) { return false; }
+
+    template <typename T> static void insertValue(DataType &, T&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
+
+    static void insertValueString(DataType&, const std::string&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
 
     template <typename T>
     static void getValue(const DataType &data, sofa::Size index, T& value)

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/FixedArrayTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/FixedArrayTypeInfo.h
@@ -47,6 +47,9 @@ struct FixedArrayTypeInfo
     enum { Text            = BaseTypeInfo::Text            };
     enum { CopyOnWrite     = 1                             };
     enum { Container       = 1                             };
+    enum { UniqueKeyContainer = 0                          };
+
+    static void clear(const DataType&) {}
 
     enum { Size = static_size * BaseTypeInfo::Size };
     static sofa::Size size()
@@ -82,6 +85,16 @@ struct FixedArrayTypeInfo
             return true;
         }
         return false;
+    }
+
+    template <typename T> static void insertValue(DataType &, T&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
+
+    static void insertValueString(DataType&, const std::string&)
+    {
+        throw std::runtime_error("Invalid operation");
     }
 
     template <typename T>

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/IncompleteTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/IncompleteTypeInfo.h
@@ -23,6 +23,7 @@
 
 #include <sofa/defaulttype/config.h>
 #include <sofa/defaulttype/typeinfo/DataTypeInfo.h>
+#include <stdexcept>
 
 namespace sofa::defaulttype
 {
@@ -51,20 +52,29 @@ struct IncompleteTypeInfo
     enum { Text            = 0 /**< 1 if this type uses text values*/ };
     enum { CopyOnWrite     = 0 /**< 1 if this type uses copy-on-write. The memory is shared with its source Data while only the source is changing (and the source modifications are then visible in the current Data). As soon as modifications are applied to the current Data, it will allocate its own value, and no longer shares memory with the source.*/ };
     enum { Container       = 0 /**< 1 if this type is a container*/ };
+    enum { UniqueKeyContainer = 0 /**< 1 if this type is a container*/ };
     enum { Size = 0 /**< largest known fixed size for this type, as returned by size() */ };
 
+    static void clear(const DataType&) {}
     static sofa::Size size() { return 0; }
     static sofa::Size byteSize() { return 0; }
     static sofa::Size size(const DataType& /*data*/) { return 1; }
 
-    template <typename T>
-    static void getValue(const DataType& /*data*/, sofa::Size /*index*/, T& /*value*/)
-    {}
+    template <typename T> static void insertValue(DataType &, T&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
+
+    static void insertValueString(DataType&, const std::string&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
+
+    template <typename T> static void getValue(const DataType& /*data*/, sofa::Size /*index*/, T& /*value*/){}
 
     static bool setSize(DataType& /*data*/, sofa::Size /*size*/) { return false; }
 
-    template<typename T>
-    static void setValue(DataType& /*data*/, sofa::Size /*index*/, const T& /*value*/){}
+    template<typename T> static void setValue(DataType& /*data*/, sofa::Size /*index*/, const T& /*value*/){}
 
     static void getValueString(const DataType& /*data*/, sofa::Size /*index*/, std::string& /*value*/){}
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/IntegerTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/IntegerTypeInfo.h
@@ -47,14 +47,23 @@ struct IntegerTypeInfo
     enum { Text            = 0 };
     enum { CopyOnWrite     = 0 };
     enum { Container       = 0 };
+    enum { UniqueKeyContainer = 0};
 
     enum { Size = 1 };
+
+    static void clear(const DataType&) {}
+
     static sofa::Size size() { return 1; }
     static sofa::Size byteSize() { return sizeof(DataType); }
 
     static sofa::Size size(const DataType& /*data*/) { return 1; }
 
     static bool setSize(DataType& /*data*/, sofa::Size /*size*/) { return false; }
+
+    template <typename T> static void insertValue(DataType &, T&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
 
     template <typename T>
     static void getValue(const DataType &data, sofa::Size index, T& value)

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/ScalarTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/ScalarTypeInfo.h
@@ -47,14 +47,22 @@ struct ScalarTypeInfo
     enum { Text            = 0 };
     enum { CopyOnWrite     = 0 };
     enum { Container       = 0 };
+    enum { UniqueKeyContainer = 0 };
 
     enum { Size = 1 };
     static sofa::Size size() { return 1; }
     static sofa::Size byteSize() { return sizeof(DataType); }
 
+    static void clear(const DataType&) {}
+
     static sofa::Size size(const DataType& /*data*/) { return 1; }
 
     static bool setSize(DataType& /*data*/, sofa::Size /*size*/) { return false; }
+
+    template <typename T> static void insertValue(DataType &, T&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
 
     template <typename T>
     static void getValue(const DataType &data, sofa::Size index, T& value)

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
@@ -33,6 +33,7 @@ struct SetTypeInfo
     typedef TDataType DataType;
     typedef typename DataType::value_type BaseType;
     typedef DataTypeInfo<BaseType> BaseTypeInfo;
+
     typedef typename BaseTypeInfo::ValueType ValueType;
     typedef DataTypeInfo<ValueType> ValueTypeInfo;
 
@@ -46,6 +47,10 @@ struct SetTypeInfo
     enum { Text            = BaseTypeInfo::Text            };
     enum { CopyOnWrite     = 1                             };
     enum { Container       = 1                             };
+    enum { UniqueKeyContainer = 1                          };
+
+    static std::string name() { std::ostringstream o; o << "set<" << DataTypeInfo<BaseType>::name() << ">"; return o.str(); }
+    static std::string GetTypeName() { std::ostringstream o; o << "set<" << DataTypeInfo<BaseType>::GetTypeName() << ">"; return o.str(); }
 
     enum { Size = BaseTypeInfo::Size };
     static sofa::Size size()
@@ -69,6 +74,17 @@ struct SetTypeInfo
                 s+= BaseTypeInfo::size(*it);
             return s;
         }
+    }
+
+    static void clear(DataType &data)
+    {
+        data.clear();
+    }
+
+    template <typename T>
+    static void insertValue(DataType &data, T& value)
+    {
+        data.insert(value);
     }
 
     static bool setSize(DataType& data, sofa::Size /*size*/)

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/TextTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/TextTypeInfo.h
@@ -47,12 +47,21 @@ struct TextTypeInfo
     enum { Text            = 1 };
     enum { CopyOnWrite     = 1 };
     enum { Container       = 0 };
+    enum { UniqueKeyContainer = 0 };
 
     enum { Size = 1 };
+
+    static void clear(const DataType&) {}
+
     static sofa::Size size() { return 1; }
     static sofa::Size byteSize() { return 1; }
 
     static sofa::Size size(const DataType& /*data*/) { return 1; }
+
+    template <typename T> static void insertValue(DataType &, T&)
+    {
+        throw std::runtime_error("Invalid operation");
+    }
 
     static bool setSize(DataType& /*data*/, sofa::Size /*size*/) { return false; }
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
@@ -47,9 +47,13 @@ struct VectorTypeInfo
     enum { Text            = BaseTypeInfo::Text            };
     enum { CopyOnWrite     = 1                             };
     enum { Container       = 1                             };
+    enum { UniqueKeyContainer = 0 };
+
     enum { Size = BaseTypeInfo::Size };
     static std::string name() { std::ostringstream o; o << "vector<" << DataTypeInfo<BaseType>::name() << ">"; return o.str(); }
     static std::string GetTypeName() { std::ostringstream o; o << "vector<" << DataTypeInfo<BaseType>::GetTypeName() << ">"; return o.str(); }
+
+    static void clear(const DataType& data) { data.clear(); }
 
     static sofa::Size size()
     {
@@ -83,6 +87,12 @@ struct VectorTypeInfo
             return true;
         }
         return false;
+    }
+
+    template <typename T>
+    static void insertValue(DataType &data, T& value)
+    {
+        data.push_back(value);
     }
 
     template <typename T>

--- a/Sofa/framework/Type/test/MatTypes_test.cpp
+++ b/Sofa/framework/Type/test/MatTypes_test.cpp
@@ -183,7 +183,7 @@ void test_transformInverse(Matrix4 const& M)
 
 TEST(MatTypesTest, transformInverse)
 {
-    test_transformInverse(Matrix4::s_identity);
+    test_transformInverse(Matrix4::Identity());
     test_transformInverse(Matrix4::transformTranslation(Vec3(1.,2.,3.)));
     test_transformInverse(Matrix4::transformScale(Vec3(1.,2.,3.)));
     test_transformInverse(Matrix4::transformRotation(Quat<SReal>::fromEuler(M_PI_4,M_PI_2,M_PI/3.)));
@@ -191,7 +191,7 @@ TEST(MatTypesTest, transformInverse)
 
 TEST(MatTypesTest, setsub_vec)
 {
-    Matrix3 M = Matrix3::s_identity;
+    Matrix3 M = Matrix3::Identity();
     Vec2 v(1.,2.);
     M.setsub(1,2,v);
     double exp[9]={1.,0.,0.,


### PR DESCRIPTION
Quick test on what could be a direction to fix issue:  https://github.com/sofa-framework/SofaPython3/issues/346

I'm now wonder:
- how to generalize that find more comprehensible names for all that. 
- is there room for small refactoring in TypeInfo related to the exisitng containers. 

If some of you have suggestion, it is more than welcome. 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
