### PR TITLE
[test] Fix unit test on RestShapeSpringsForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
@@ -122,7 +122,7 @@ void RestStiffSpringsForceField_test::testDefaultBehavior(sofa::simulation::Node
     auto fixedDofs = dynamic_cast<MechanicalObject<Type>*>(root->getChild("fixedObject")->getObject("dofs"));
     ASSERT_TRUE( fixedDofs != nullptr );
 
-    auto movingDofs = dynamic_cast<MechanicalObject<Type>*>(root->getChild("fixedObject")->getObject("dofs"));
+    auto movingDofs = dynamic_cast<MechanicalObject<Type>*>(root->getChild("movingObject")->getObject("dofs"));
     ASSERT_TRUE( movingDofs != nullptr );
 
     checkDifference(*fixedDofs, true);


### PR DESCRIPTION
I suspect a copy/paste mistake when implementing this unit test in https://github.com/sofa-framework/sofa/pull/942

Note that the unit test succeeded despite the mistake. Perhaps the unit test is not enough strict?


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
