### PR TITLE
[SofaCUDA] Deprecated CudaTexture.h

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTexture.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTexture.h
@@ -22,6 +22,9 @@
 #ifndef CUDATEXTURE_H
 #define CUDATEXTURE_H
 
+#include <sofa/config.h>
+SOFA_DEPRECATED_HEADER_NOT_REPLACED("v23.06", "v23.12")
+
 #include "CudaMath.h"
 
 /// Accesss to a vector in global memory using either direct access or linear texture

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.cu
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
-#include "CudaTexture.h"
 #include "cuda.h"
 
 #if defined(__cplusplus) && CUDA_VERSION < 2000

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.cu
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
-#include <sofa/gpu/cuda/CudaTexture.h>
 #include <cuda.h>
 #include <stdio.h>
 

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.cu
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
-#include <sofa/gpu/cuda/CudaTexture.h>
 #include "cuda.h"
 #include <sofa/gpu/cuda/mycuda.h>
 #include <stdio.h>

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/spring/CudaSpringForceField.cu
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/spring/CudaSpringForceField.cu
@@ -22,7 +22,6 @@
 #include <sofa/gpu/cuda/CudaCommon.h>
 #include <sofa/gpu/cuda/CudaMath.h>
 #include "cuda.h"
-#include <sofa/gpu/cuda/CudaTexture.h>
 
 #if defined(__cplusplus) && CUDA_VERSION < 2000
 namespace sofa


### PR DESCRIPTION
It is not used, and its content is deprecated in Cuda 12






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
