### PR TITLE
[Config] Fix cross-compilation for embedded external libs

### DIFF
--- a/Sofa/framework/Config/cmake/Modules/FindDiffLib.cmake
+++ b/Sofa/framework/Config/cmake/Modules/FindDiffLib.cmake
@@ -1,5 +1,10 @@
 find_path(DIFFLIB_INCLUDE_DIR difflib.h
 		  HINTS ${DIFFLIB_ROOT}
+		  # If cross-compiling and typically use CMAKE_FIND_ROOT_PATH variable,
+		  # each of its directory entry will be prepended to PATHS locations, and
+		  # DIFFLIB_ROOT is set as an absolute path. So we have to disable this behavior
+		  # for such external libs
+		  NO_CMAKE_FIND_ROOT_PATH
 	)
 
 include(FindPackageHandleStandardArgs)

--- a/Sofa/framework/Config/cmake/Modules/FindJson.cmake
+++ b/Sofa/framework/Config/cmake/Modules/FindJson.cmake
@@ -67,6 +67,11 @@ else()
         PATH_SUFFIXES
             nlohmann
             include/nlohmann
+        # If cross-compiling and typically use CMAKE_FIND_ROOT_PATH variable,
+        # each of its directory entry will be prepended to PATHS locations, and
+        # JSON_ROOT is set as an absolute path. So we have to disable this behavior
+        # for such external libs
+        NO_CMAKE_FIND_ROOT_PATH
         )
         
     if(JSON_INCLUDE_DIR)

--- a/Sofa/framework/Config/cmake/Modules/FindSTB.cmake
+++ b/Sofa/framework/Config/cmake/Modules/FindSTB.cmake
@@ -1,5 +1,10 @@
 find_path(STB_INCLUDE_DIR stb_image.h
 		  HINTS ${STB_ROOT}
+		  # If cross-compiling and typically use CMAKE_FIND_ROOT_PATH variable,
+		  # each of its directory entry will be prepended to PATHS locations, and
+		  # STB_ROOT is set as an absolute path. So we have to disable this behavior
+		  # for such external libs
+		  NO_CMAKE_FIND_ROOT_PATH
 	)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Embedded external libs (DiffLib, Json and STB) rely on cmake variables (resp. DIFFLIB_ROOT, JSON_ROOT and STB_ROOT) as HINTS / PATHS for find_path() in their respectives cmake find modules (FindDiffLib.cmake, FindJson.cmake and FindSTB.cmake). 
If CMAKE_FIND_ROOT_PATH is set (typically the case when cross-compiling and for my concerns when building a Conda package for Sofa), default behavior is to prepend all contained paths to the search performed by the find_path() calls. But as the *_ROOT variables are set with absolute paths, the search for these embedded libs will typically fail. 
This PR disables the use of CMAKE_FIND_ROOT_PATH for these libs.




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
