### PR TITLE
[SolidMechanics] Use accessors & make geometrical data required in BFF

### DIFF
--- a/examples/Component/SolidMechanics/FEM/BeamFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/BeamFEMForceField.scn
@@ -34,7 +34,7 @@
 
         <FixedConstraint name="FixedConstraint" indices="0" />
         <UniformMass vertexMass="1 1 0.01 0 0 0 0.1 0 0 0 0.1" printLog="false" />
-        <BeamFEMForceField name="FEM" radius="0.1" youngModulus="20000000" poissonRatio="0.49"/>
+        <BeamFEMForceField name="FEM" radius="0.1" radiusInner="0" youngModulus="20000000" poissonRatio="0.49"/>
 
 
         <Node name="Collision">
@@ -51,7 +51,7 @@
         <MeshTopology name="lines" lines="0 1 1 2 2 3 3 4 4 5 5 6 6 7" />
         <FixedConstraint name="FixedConstraint" indices="0" />
         <UniformMass vertexMass="1 1 0.01 0 0 0 0.1 0 0 0 0.1" printLog="false" />
-        <BeamFEMForceField name="FEM" radius="0.1" youngModulus="20000000" poissonRatio="0.49"/>
+        <BeamFEMForceField name="FEM" radius="0.1" radiusInner="0" youngModulus="20000000" poissonRatio="0.49"/>
 
         <Node name="Collision">
             <CubeTopology nx="15" ny="2" nz="2" min="0 -0.1 -0.1" max="7 0.1 0.1" />
@@ -72,7 +72,7 @@
         <MeshTopology name="lines" lines="0 1 1 2 2 3" />
         <FixedConstraint name="FixedConstraint" indices="0" />
         <UniformMass totalMass="4" />
-        <BeamFEMForceField name="FEM" radius="0.05" youngModulus="20000000" poissonRatio="0.49"/>
+        <BeamFEMForceField name="FEM" radius="0.05" radiusInner="0" youngModulus="20000000" poissonRatio="0.49"/>
 
         <Node name="Collision">
             <MechanicalObject />


### PR DESCRIPTION
Small cleanings for the BeamFEMForceField :
- Use read and write accessors
- Make the data `youngModulus`, `radius` and `radiusInner` required to explicit the fact that BFFF only focuses on circular sections



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
