### PR TITLE
[plugins] ADD external collisions plugins

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -53,6 +53,9 @@ sofa_add_subdirectory(plugin SofaAssimp SofaAssimp) # ColladaSceneLoader Depends
 sofa_add_subdirectory(plugin SofaMatrix SofaMatrix ON) # Depends on image, CImgPlugin
 sofa_add_subdirectory(plugin OpenCTMPlugin OpenCTMPlugin EXTERNAL)
 sofa_add_subdirectory(plugin BeamAdapter BeamAdapter EXTERNAL)
+sofa_add_subdirectory(plugin CollisionAlgorithm CollisionAlgorithm EXTERNAL)
+sofa_add_subdirectory(plugin ConstraintGeometry ConstraintGeometry EXTERNAL)
+
 
 sofa_add_subdirectory(plugin PSL PSL EXPERIMENTAL)
 

--- a/applications/plugins/CollisionAlgorithm/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/CollisionAlgorithm/ExternalProjectConfig.cmake.in
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.11)
+
+include(ExternalProject)
+ExternalProject_Add(CollisionAlgorithm
+    GIT_REPOSITORY https://github.com/courtecuisse/CollisionAlgorithm.git
+    GIT_TAG origin/master
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/CollisionAlgorithm"
+    BINARY_DIR ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+    GIT_CONFIG "remote.origin.fetch=+refs/pull/*:refs/remotes/origin/pr/*"
+)

--- a/applications/plugins/ConstraintGeometry/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/ConstraintGeometry/ExternalProjectConfig.cmake.in
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.11)
+
+include(ExternalProject)
+ExternalProject_Add(ConstraintGeometry
+    GIT_REPOSITORY https://github.com/courtecuisse/ConstraintGeometry.git
+    GIT_TAG origin/master
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/ConstraintGeometry"
+    BINARY_DIR ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+    GIT_CONFIG "remote.origin.fetch=+refs/pull/*:refs/remotes/origin/pr/*"
+)


### PR DESCRIPTION
ADD Hadrien's collisionAlgorithm and ContraintGeometry to external plugins






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
