### PR TITLE
[LinearAlgebra] Implement CompressedRowSparseMatrixConstraint

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.cpp
@@ -38,16 +38,16 @@ SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_CORRECTION_API void PrecomputedConstraintCo
     MatrixDeriv& c = cData.wref();
 
     // On fait tourner les normales (en les ramenant dans le "pseudo" repere initial)
+    auto rowItEnd = c.end();
 
-    MatrixDerivRowIterator rowItEnd = c.end();
-
-    for (MatrixDerivRowIterator rowIt = c.begin(); rowIt != rowItEnd; ++rowIt)
+    for (auto rowIt = c.begin(); rowIt != rowItEnd; ++rowIt)
     {
-        MatrixDerivColIterator colItEnd = rowIt.end();
+        auto rowWrite = c.writeLine(rowIt.index());
+        auto colItEnd = rowIt.end();
 
-        for (MatrixDerivColIterator colIt = rowIt.begin(); colIt != colItEnd; ++colIt)
+        for (auto colIt = rowIt.begin(); colIt != colItEnd; ++colIt)
         {
-            Deriv& n = colIt.val();
+            Deriv n = colIt.val();
             const unsigned int localRowNodeIdx = colIt.index();
 
             sofa::type::Quat<SReal> q;

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -858,21 +858,21 @@ void PrecomputedConstraintCorrection< DataTypes >::rotateConstraints(bool back)
     }
 
     // on fait tourner les normales (en les ramenant dans le "pseudo" repere initial) //
-    MatrixDerivRowIterator rowItEnd = c.end();
-
-    Transformation Ri;
+    auto rowItEnd = c.end();
     const auto& rotations = rotationFinder->getRotations();
-    for (MatrixDerivRowIterator rowIt = c.begin(); rowIt != rowItEnd; ++rowIt)
-    {
-        MatrixDerivColIterator colItEnd = rowIt.end();
 
-        for (MatrixDerivColIterator colIt = rowIt.begin(); colIt != colItEnd; ++colIt)
+    for (auto rowIt = c.begin(); rowIt != rowItEnd; ++rowIt)
+    {
+        auto rowWrite = c.writeLine(rowIt.index());
+        auto colItEnd = rowIt.end();
+
+        for (auto colIt = rowIt.begin(); colIt != colItEnd; ++colIt)
         {
-            Deriv& n = colIt.val();
+            Deriv n = colIt.val();
             const int localRowNodeIdx = colIt.index();
 
             // rotationFinder has been defined
-            Ri = rotations[localRowNodeIdx];
+            auto Ri = rotations[localRowNodeIdx];
 
             if(!back)
                 Ri.transpose();

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.inl
@@ -223,12 +223,12 @@ void UncoupledConstraintCorrection<DataTypes>::getComplianceWithConstraintMerge(
 
     msg_info() << "******\n Constraint before Merge  \n *******" ;
 
-    MatrixDerivRowIterator rowIt = constraints.begin();
-    MatrixDerivRowIterator rowItEnd = constraints.end();
+    auto rowIt = constraints.begin();
+    auto rowItEnd = constraints.end();
 
     while (rowIt != rowItEnd)
     {
-        constraintCopy.writeLine(rowIt.index(), rowIt.row());
+        constraintCopy.setLine(rowIt.index(), rowIt.row());
         ++rowIt;
     }
 
@@ -250,8 +250,8 @@ void UncoupledConstraintCorrection<DataTypes>::getComplianceWithConstraintMerge(
     {
         msg_info() << "constraint[" << group << "] : " ;
 
-        MatrixDerivRowIterator rowCopyIt = constraintCopy.begin();
-        MatrixDerivRowIterator rowCopyItEnd = constraintCopy.end();
+        auto rowCopyIt = constraintCopy.begin();
+        auto rowCopyItEnd = constraintCopy.end();
 
         while (rowCopyIt != rowCopyItEnd)
         {
@@ -277,7 +277,7 @@ void UncoupledConstraintCorrection<DataTypes>::getComplianceWithConstraintMerge(
 
     while (rowIt != rowItEnd)
     {
-        constraints.writeLine(rowIt.index(), rowIt.row());
+        constraints.setLine(rowIt.index(), rowIt.row());
         ++rowIt;
     }
 }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementConstraint.h
@@ -143,8 +143,7 @@ public:
 
 protected:
 
-    template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseImpl(VecDeriv& dx);
 
 private:
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementConstraint.inl
@@ -124,8 +124,7 @@ void AffineMovementConstraint<DataTypes>::init()
 }
 
 template <class DataTypes>
-template <class DataDeriv>
-void AffineMovementConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& dx)
+void AffineMovementConstraint<DataTypes>::projectResponseImpl(VecDeriv& dx)
 {
     const SetIndexArray & indices = m_indices.getValue();
     for (size_t i = 0; i< indices.size(); ++i)
@@ -137,8 +136,9 @@ void AffineMovementConstraint<DataTypes>::projectResponseT(const core::Mechanica
 template <class DataTypes>
 void AffineMovementConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    projectResponseImpl(res.wref());
 }
 
 
@@ -146,8 +146,9 @@ void AffineMovementConstraint<DataTypes>::projectResponse(const core::Mechanical
 template <class DataTypes>
 void AffineMovementConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = vData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    projectResponseImpl(res.wref());
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
@@ -213,29 +213,18 @@ void FixedConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalPar
     SOFA_UNUSED(mparams);
 
     helper::WriteAccessor<DataMatrixDeriv> c (cData );
-    const SetIndexArray & indices = d_indices.getValue();
-
-    MatrixDerivRowIterator rowIt = c->begin();
-    MatrixDerivRowIterator rowItEnd = c->end();
 
     if( d_fixAll.getValue() )
     {
         // fix everything
-        while (rowIt != rowItEnd)
-        {
-            rowIt.row().clear();
-            ++rowIt;
-        }
+        c->clear();
     }
     else
     {
-        while (rowIt != rowItEnd)
+        const SetIndexArray& indices = d_indices.getValue();
+        for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
         {
-            for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
-            {
-                rowIt.row().erase(*it);
-            }
-            ++rowIt;
+            c->clearColBloc(*it);
         }
     }
 }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedConstraint.inl
@@ -224,7 +224,7 @@ void FixedConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalPar
         const SetIndexArray& indices = d_indices.getValue();
         for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
         {
-            c->clearColBloc(*it);
+            c->clearColBlock(*it);
         }
     }
 }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.h
@@ -127,8 +127,9 @@ protected:
     bool isPointInPlane(Coord p) const ;
 
     /// These two are implemented depending on the templates
-    template<class T>
-    void projectResponseImpl(const MechanicalParams* mparams, T& dx) const ;
+    template <class DataDeriv>
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const SetIndexArray&)> project);
 };
 
 #if !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.h
@@ -123,13 +123,7 @@ protected:
     using ProjectiveConstraintSet<DataTypes>::mstate;
     using ProjectiveConstraintSet<DataTypes>::getContext;
 
-    /// These two are implemented depending on the templates
     bool isPointInPlane(Coord p) const ;
-
-    /// These two are implemented depending on the templates
-    template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const SetIndexArray&)> project);
 };
 
 #if !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.h
@@ -123,7 +123,7 @@ protected:
     using ProjectiveConstraintSet<DataTypes>::mstate;
     using ProjectiveConstraintSet<DataTypes>::getContext;
 
-    bool isPointInPlane(Coord p) const ;
+    bool isPointInPlane(const Coord& p) const ;
 };
 
 #if !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.inl
@@ -310,7 +310,7 @@ void FixedPlaneConstraint<DataTypes>::draw(const VisualParams* vparams)
 template<class DataTypes>
 bool FixedPlaneConstraint<DataTypes>::isPointInPlane(Coord p) const
 {
-    Real d = getVec(p) * getVec(d_direction.getValue());
+    const Real d = getVec(p) * getVec(d_direction.getValue());
     if ((d>d_dmin.getValue()) && (d<d_dmax.getValue()))
         return true;
     else

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.inl
@@ -141,7 +141,7 @@ void FixedPlaneConstraint<DataTypes>::removeConstraint(Index index)
 /// This function are there to provide kind of type translation to the vector one so we can
 /// implement the algorithm as is the different objects where of similar type.
 /// this solution is not really satisfactory but for the moment it does the job.
-/// A better solution would that all the used types are following the same iterface which
+/// A better solution would that all the used types are following the same interface which
 /// requires to touch core sofa classes.
 sofa::type::Vec3d& getVec(sofa::defaulttype::Rigid3dTypes::Deriv& i) { return i.getVCenter(); }
 sofa::type::Vec3d& getVec(sofa::defaulttype::Rigid3dTypes::Coord& i) { return i.getCenter(); }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedPlaneConstraint.inl
@@ -308,13 +308,10 @@ void FixedPlaneConstraint<DataTypes>::draw(const VisualParams* vparams)
 }
 
 template<class DataTypes>
-bool FixedPlaneConstraint<DataTypes>::isPointInPlane(Coord p) const
+bool FixedPlaneConstraint<DataTypes>::isPointInPlane(const Coord& p) const
 {
     const Real d = getVec(p) * getVec(d_direction.getValue());
-    if ((d>d_dmin.getValue()) && (d<d_dmax.getValue()))
-        return true;
-    else
-        return false;
+    return d > d_dmin.getValue() && d < d_dmax.getValue();
 }
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.h
@@ -92,7 +92,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear);
+        const std::function<void(DataDeriv&, const unsigned int)>& clear);
 
 };
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.h
@@ -91,8 +91,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear = [](auto& dx, const unsigned int index) {dx[index].clear(); });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear);
 
 };
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.h
@@ -91,7 +91,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear = [](auto& dx, const unsigned int index) {dx[index].clear(); });
 
 };
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
@@ -118,7 +118,7 @@ void FixedTranslationConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
 {
     if (f_fixAll.getValue())
     {
-        for (unsigned int i = 0; i < dx.size(); i++)
+        for (std::size_t i = 0; i < dx.size(); i++)
         {
             clear(dx, i);
         }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
@@ -113,7 +113,7 @@ static inline void clearPos(type::Vec<6,T>& v)
 }
 
 template <class DataTypes> template <class DataDeriv>
-void FixedTranslationConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& dx,
+void FixedTranslationConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
     std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     if (f_fixAll.getValue())
@@ -136,8 +136,9 @@ void FixedTranslationConstraint<DataTypes>::projectResponseT(const core::Mechani
 template <class DataTypes>
 void FixedTranslationConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT(mparams, res.wref());
+    projectResponseT<VecDeriv>(res.wref(), [](auto& dx, const unsigned int index) {dx[index].clear(); });
 }
 
 template <class DataTypes>
@@ -153,10 +154,11 @@ void FixedTranslationConstraint<DataTypes>::projectPosition(const core::Mechanic
 }
 
 template <class DataTypes>
-void FixedTranslationConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataMatrixDeriv& cData)
+void FixedTranslationConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
+    projectResponseT<MatrixDeriv>(c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
@@ -153,7 +153,7 @@ template <class DataTypes>
 void FixedTranslationConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataMatrixDeriv& cData)
 {
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
@@ -114,7 +114,7 @@ static inline void clearPos(type::Vec<6,T>& v)
 
 template <class DataTypes> template <class DataDeriv>
 void FixedTranslationConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
-    std::function<void(DataDeriv&, const unsigned int)> clear)
+    const std::function<void(DataDeriv&, const unsigned int)>& clear)
 {
     if (f_fixAll.getValue())
     {

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedTranslationConstraint.inl
@@ -125,8 +125,11 @@ void FixedTranslationConstraint<DataTypes>::projectResponseT(const core::Mechani
     }
     else
     {
-        for (unsigned int i = 0; i < dx.size(); i++)
-            clear(dx, i);
+        const SetIndexArray & indices = f_indices.getValue();
+        for (const auto index : indices)
+        {
+            clear(dx, index);
+        }
     }
 }
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.h
@@ -116,7 +116,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear = [](auto& dx, const unsigned int index) {dx[index].clear(); });
 
 };
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.h
@@ -116,8 +116,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear = [](auto& dx, const unsigned int index) {dx[index].clear(); });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear);
 
 };
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.h
@@ -117,7 +117,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear);
+        const std::function<void(DataDeriv&, const unsigned int)>& clear);
 
 };
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
@@ -137,7 +137,7 @@ void HermiteSplineConstraint<DataTypes>::computeDerivateHermiteCoefs( const Real
 
 
 template <class DataTypes> template <class DataDeriv>
-void HermiteSplineConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& dx,
+void HermiteSplineConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
     std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     Real t = (Real) this->getContext()->getTime();
@@ -152,8 +152,9 @@ void HermiteSplineConstraint<DataTypes>::projectResponseT(const core::Mechanical
 template <class DataTypes>
 void HermiteSplineConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT(mparams, res.wref());
+    projectResponseT<VecDeriv>(res.wref(), [](auto& dx, const unsigned int index) {dx[index].clear();});
 }
 
 template <class DataTypes>
@@ -207,9 +208,10 @@ void HermiteSplineConstraint<DataTypes>::projectPosition(const core::MechanicalP
 template <class DataTypes>
 void HermiteSplineConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
+    projectResponseT<MatrixDeriv>(c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
@@ -209,7 +209,7 @@ void HermiteSplineConstraint<DataTypes>::projectJacobianMatrix(const core::Mecha
 {
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/HermiteSplineConstraint.inl
@@ -138,7 +138,7 @@ void HermiteSplineConstraint<DataTypes>::computeDerivateHermiteCoefs( const Real
 
 template <class DataTypes> template <class DataDeriv>
 void HermiteSplineConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
-    std::function<void(DataDeriv&, const unsigned int)> clear)
+    const std::function<void(DataDeriv&, const unsigned int)>& clear)
 {
     Real t = (Real) this->getContext()->getTime();
     if ( t >= m_tBegin.getValue() && t <= m_tEnd.getValue())

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.h
@@ -137,7 +137,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear);
+        const std::function<void(DataDeriv&, const unsigned int)>& clear);
 
     template <class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<!std::is_same<MyCoord, defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.h
@@ -136,8 +136,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear = [](auto& dx, const unsigned int index) {dx[index].clear(); });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear);
 
     template <class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<!std::is_same<MyCoord, defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.h
@@ -136,7 +136,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear = [](auto& dx, const unsigned int index) {dx[index].clear(); });
 
     template <class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<!std::is_same<MyCoord, defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
@@ -149,7 +149,7 @@ void LinearMovementConstraint<DataTypes>::reset()
 template <class DataTypes>
 template <class DataDeriv>
 void LinearMovementConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
-    std::function<void(DataDeriv&, const unsigned int)> clear)
+    const std::function<void(DataDeriv&, const unsigned int)>& clear)
 {
     Real cT = static_cast<Real>(this->getContext()->getTime());
     if ((cT != currentTime) || !finished)

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
@@ -148,7 +148,7 @@ void LinearMovementConstraint<DataTypes>::reset()
 
 template <class DataTypes>
 template <class DataDeriv>
-void LinearMovementConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& dx,
+void LinearMovementConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
     std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     Real cT = static_cast<Real>(this->getContext()->getTime());
@@ -172,8 +172,9 @@ void LinearMovementConstraint<DataTypes>::projectResponseT(const core::Mechanica
 template <class DataTypes>
 void LinearMovementConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    projectResponseT<VecDeriv>(res.wref(), [](auto& dx, const unsigned int index) {dx[index].clear(); });
 }
 
 template <class DataTypes>
@@ -287,9 +288,10 @@ void LinearMovementConstraint<DataTypes>::interpolatePosition(Real cT, typename 
 template <class DataTypes>
 void LinearMovementConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
+    projectResponseT<MatrixDeriv>(c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
@@ -289,7 +289,7 @@ void LinearMovementConstraint<DataTypes>::projectJacobianMatrix(const core::Mech
 {
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/LinearMovementConstraint.inl
@@ -148,7 +148,8 @@ void LinearMovementConstraint<DataTypes>::reset()
 
 template <class DataTypes>
 template <class DataDeriv>
-void LinearMovementConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& dx)
+void LinearMovementConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& dx,
+    std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     Real cT = static_cast<Real>(this->getContext()->getTime());
     if ((cT != currentTime) || !finished)
@@ -163,7 +164,7 @@ void LinearMovementConstraint<DataTypes>::projectResponseT(const core::Mechanica
         //set the motion to the Dofs
         for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
         {
-            dx[*it] = Deriv();
+            clear(dx, *it);
         }
     }
 }
@@ -288,14 +289,7 @@ void LinearMovementConstraint<DataTypes>::projectJacobianMatrix(const core::Mech
 {
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    MatrixDerivRowIterator rowIt = c->begin();
-    MatrixDerivRowIterator rowItEnd = c->end();
-
-    while (rowIt != rowItEnd)
-    {
-        projectResponseT<MatrixDerivRowType>(mparams, rowIt.row());
-        ++rowIt;
-    }
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.h
@@ -100,7 +100,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear);
+        const std::function<void(DataDeriv&, const unsigned int)>& clear);
 };
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.h
@@ -99,7 +99,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear = [](VecDeriv& res, const unsigned int index) { res[index].clear(); });
 };
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.h
@@ -99,8 +99,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear = [](VecDeriv& res, const unsigned int index) { res[index].clear(); });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear);
 };
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.inl
@@ -50,7 +50,7 @@ OscillatorConstraint<TDataTypes>*  OscillatorConstraint<TDataTypes>::addConstrai
 
 template <class TDataTypes> template <class DataDeriv>
 void OscillatorConstraint<TDataTypes>::projectResponseT(DataDeriv& res,
-    std::function<void(DataDeriv&, const unsigned int)> clear)
+    const std::function<void(DataDeriv&, const unsigned int)>& clear)
 {
     const auto& oscillators = constraints.getValue();
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.inl
@@ -49,7 +49,7 @@ OscillatorConstraint<TDataTypes>*  OscillatorConstraint<TDataTypes>::addConstrai
 
 
 template <class TDataTypes> template <class DataDeriv>
-void OscillatorConstraint<TDataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& res,
+void OscillatorConstraint<TDataTypes>::projectResponseT(DataDeriv& res,
     std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     const auto& oscillators = constraints.getValue();
@@ -64,8 +64,9 @@ void OscillatorConstraint<TDataTypes>::projectResponseT(const core::MechanicalPa
 template <class TDataTypes>
 void OscillatorConstraint<TDataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT(mparams, res.wref());
+    projectResponseT<VecDeriv>(res.wref(),[](VecDeriv& res, const unsigned int index) { res[index].clear(); });
 }
 
 template <class TDataTypes>
@@ -104,10 +105,11 @@ void OscillatorConstraint<TDataTypes>::projectPosition(const core::MechanicalPar
 }
 
 template <class TDataTypes>
-void OscillatorConstraint<TDataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataMatrixDeriv& cData)
+void OscillatorConstraint<TDataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
+    projectResponseT<MatrixDeriv>(c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class TDataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/OscillatorConstraint.inl
@@ -107,7 +107,7 @@ template <class TDataTypes>
 void OscillatorConstraint<TDataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataMatrixDeriv& cData)
 {
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class TDataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.h
@@ -113,7 +113,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear = [](VecDeriv& dx, const unsigned int index) { dx[index].clear(); });
 };
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.h
@@ -114,7 +114,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear);
+        const std::function<void(DataDeriv&, const unsigned int)>& clear);
 };
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.h
@@ -113,8 +113,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear = [](VecDeriv& dx, const unsigned int index) { dx[index].clear(); });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear);
 };
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
@@ -200,7 +200,7 @@ void ParabolicConstraint<DataTypes>::projectJacobianMatrix(const core::Mechanica
 {
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
@@ -120,7 +120,7 @@ void ParabolicConstraint<DataTypes>::reinit()
 template <class DataTypes>
 template <class DataDeriv>
 void ParabolicConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
-    std::function<void(DataDeriv&, const unsigned int)> clear)
+    const std::function<void(DataDeriv&, const unsigned int)>& clear)
 {
     Real t = (Real) this->getContext()->getTime();
     if ( t >= m_tBegin.getValue() && t <= m_tEnd.getValue())

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
@@ -119,14 +119,15 @@ void ParabolicConstraint<DataTypes>::reinit()
 
 template <class DataTypes>
 template <class DataDeriv>
-void ParabolicConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& dx)
+void ParabolicConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& dx,
+    std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     Real t = (Real) this->getContext()->getTime();
     if ( t >= m_tBegin.getValue() && t <= m_tEnd.getValue())
     {
         const SetIndexArray & indices = m_indices.getValue();
         for(SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
-            dx[*it] = Deriv();
+            clear(dx, *it);
     }
 }
 
@@ -199,14 +200,7 @@ void ParabolicConstraint<DataTypes>::projectJacobianMatrix(const core::Mechanica
 {
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    MatrixDerivRowIterator rowIt = c->begin();
-    MatrixDerivRowIterator rowItEnd = c->end();
-
-    while (rowIt != rowItEnd)
-    {
-        projectResponseT<MatrixDerivRowType>(mparams, rowIt.row());
-        ++rowIt;
-    }
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
 }
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ParabolicConstraint.inl
@@ -119,7 +119,7 @@ void ParabolicConstraint<DataTypes>::reinit()
 
 template <class DataTypes>
 template <class DataDeriv>
-void ParabolicConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& dx,
+void ParabolicConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
     std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     Real t = (Real) this->getContext()->getTime();
@@ -134,8 +134,9 @@ void ParabolicConstraint<DataTypes>::projectResponseT(const core::MechanicalPara
 template <class DataTypes>
 void ParabolicConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT(mparams, res.wref());
+    projectResponseT<VecDeriv>(res.wref(),[](VecDeriv& dx, const unsigned int index) { dx[index].clear(); });
 }
 
 template <class DataTypes>
@@ -198,9 +199,10 @@ void ParabolicConstraint<DataTypes>::projectPosition(const core::MechanicalParam
 template <class DataTypes>
 void ParabolicConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
+    projectResponseT<MatrixDeriv>(c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.h
@@ -89,10 +89,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear =
-        [](VecDeriv& dx, const unsigned int index, const VecBool& b)
-        { for (unsigned j = 0; j < b.size(); j++) if (b[j]) dx[index][j] = 0.0; });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear);
 };
 
 #if  !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_PARTIALFIXEDCONSTRAINT_CPP)

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.h
@@ -89,7 +89,10 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear =
+        [](VecDeriv& dx, const unsigned int index, const VecBool& b)
+        { for (unsigned j = 0; j < b.size(); j++) if (b[j]) dx[index][j] = 0.0; });
 };
 
 #if  !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_PARTIALFIXEDCONSTRAINT_CPP)

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.h
@@ -90,7 +90,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear);
+        const std::function<void(DataDeriv&, const unsigned int, const VecBool&)>& clear);
 };
 
 #if  !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_PARTIALFIXEDCONSTRAINT_CPP)

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.inl
@@ -67,7 +67,7 @@ void PartialFixedConstraint<DataTypes>::projectResponseT(DataDeriv& res,
     if (this->d_fixAll.getValue() == true)
     {
         // fix everything
-        for( unsigned i=0; i<res.size(); i++ )
+        for( std::size_t i=0; i<res.size(); i++ )
         {
             clear(res, i, blockedDirection);
         }
@@ -87,8 +87,12 @@ void PartialFixedConstraint<DataTypes>::projectResponse(const core::MechanicalPa
 {
     SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT<VecDeriv>(res.wref(), [](VecDeriv& dx, const unsigned int index, const VecBool& b)
-    { for (unsigned j = 0; j < b.size(); j++) if (b[j]) dx[index][j] = 0.0; });
+    projectResponseT<VecDeriv>(res.wref(), 
+        [](VecDeriv& dx, const unsigned int index, const VecBool& b)
+        { 
+            for (std::size_t j = 0; j < b.size(); j++) if (b[j]) dx[index][j] = 0.0; 
+        }
+    );
 }
 
 // projectVelocity applies the same changes on velocity vector as projectResponse on position vector :

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialFixedConstraint.inl
@@ -60,7 +60,7 @@ void PartialFixedConstraint<DataTypes>::reinit()
 template <class DataTypes>
 template <class DataDeriv>
 void PartialFixedConstraint<DataTypes>::projectResponseT(DataDeriv& res,
-    std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear)
+    const std::function<void(DataDeriv&, const unsigned int, const VecBool&)>& clear)
 {
     const VecBool& blockedDirection = d_fixedDirections.getValue();
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.h
@@ -145,7 +145,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear);
+        const std::function<void(DataDeriv&, const unsigned int, const VecBool&)>& clear);
 
     template <class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<!std::is_same<MyCoord, sofa::defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.h
@@ -144,10 +144,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear =
-        [](VecDeriv& dx, const unsigned int index, const VecBool& b)
-        { for (unsigned j = 0; j < b.size(); j++) if (b[j]) dx[index][j] = 0.0; });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear);
 
     template <class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<!std::is_same<MyCoord, sofa::defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.h
@@ -144,7 +144,10 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear =
+        [](VecDeriv& dx, const unsigned int index, const VecBool& b)
+        { for (unsigned j = 0; j < b.size(); j++) if (b[j]) dx[index][j] = 0.0; });
 
     template <class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<!std::is_same<MyCoord, sofa::defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.inl
@@ -164,7 +164,7 @@ void PartialLinearMovementConstraint<DataTypes>::reset()
 template <class DataTypes>
 template <class DataDeriv>
 void PartialLinearMovementConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
-    std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear)
+    const std::function<void(DataDeriv&, const unsigned int, const VecBool&)>& clear)
 {
     Real cT = (Real) this->getContext()->getTime();
     VecBool movedDirection = movedDirections.getValue();

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PartialLinearMovementConstraint.inl
@@ -163,7 +163,7 @@ void PartialLinearMovementConstraint<DataTypes>::reset()
 
 template <class DataTypes>
 template <class DataDeriv>
-void PartialLinearMovementConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& dx,
+void PartialLinearMovementConstraint<DataTypes>::projectResponseT(DataDeriv& dx,
     std::function<void(DataDeriv&, const unsigned int, const VecBool&)> clear)
 {
     Real cT = (Real) this->getContext()->getTime();
@@ -188,8 +188,10 @@ void PartialLinearMovementConstraint<DataTypes>::projectResponseT(const core::Me
 template <class DataTypes>
 void PartialLinearMovementConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    projectResponseT<VecDeriv>(res.wref(), [](VecDeriv& dx, const unsigned int index, const VecBool& b)
+                               { for (unsigned j = 0; j < b.size(); j++) if (b[j]) dx[index][j] = 0.0; });
 }
 
 template <class DataTypes>
@@ -349,8 +351,9 @@ void PartialLinearMovementConstraint<DataTypes>::interpolatePosition(Real cT, ty
 template <class DataTypes>
 void PartialLinearMovementConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(),
+    projectResponseT<MatrixDeriv>(c.wref(),
         [](MatrixDeriv& res, const unsigned int index, const VecBool& btype)
         {
             auto itRow = res.begin();

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PatchTestMovementConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PatchTestMovementConstraint.h
@@ -137,9 +137,8 @@ public:
      void draw(const core::visual::VisualParams* vparams) override;
 
 protected:
-    
-    template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+
+    void projectResponseImpl(VecDeriv& dx);
 
 private:
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PatchTestMovementConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/PatchTestMovementConstraint.inl
@@ -219,8 +219,7 @@ void PatchTestMovementConstraint<DataTypes>::findCornerPoints()
 }
 
 template <class DataTypes>
-template <class DataDeriv>
-void PatchTestMovementConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& dx)
+void PatchTestMovementConstraint<DataTypes>::projectResponseImpl(VecDeriv& dx)
 {
     const SetIndexArray & indices = d_indices.getValue();
     for (size_t i = 0; i< indices.size(); ++i)
@@ -232,17 +231,17 @@ void PatchTestMovementConstraint<DataTypes>::projectResponseT(const core::Mechan
 template <class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    projectResponseImpl(res.wref());
 }
-
-
 
 template <class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataVecDeriv> res = vData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    projectResponseImpl(res.wref());
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPointConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPointConstraint.inl
@@ -174,31 +174,20 @@ void ProjectToPointConstraint<DataTypes>::projectJacobianMatrix(const core::Mech
     SOFA_UNUSED(mparams);
 
     helper::WriteAccessor<DataMatrixDeriv> c ( cData );
-    const SetIndexArray & indices = f_indices.getValue();
-
-    MatrixDerivRowIterator rowIt = c->begin();
-    MatrixDerivRowIterator rowItEnd = c->end();
 
     if( f_fixAll.getValue() )
     {
         // fix everything
-        while (rowIt != rowItEnd)
-        {
-            rowIt.row().clear();
-            ++rowIt;
-        }
+        c->clear();
     }
     else
     {
-        while (rowIt != rowItEnd)
-        {
-            for (SetIndexArray::const_iterator it = indices.begin();
+        const SetIndexArray& indices = f_indices.getValue();
+        for (SetIndexArray::const_iterator it = indices.begin();
                     it != indices.end();
                     ++it)
-            {
-                rowIt.row().erase(*it);
-            }
-            ++rowIt;
+        {
+            c->clearColBloc(*it);
         }
     }
 }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPointConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/ProjectToPointConstraint.inl
@@ -187,7 +187,7 @@ void ProjectToPointConstraint<DataTypes>::projectJacobianMatrix(const core::Mech
                     it != indices.end();
                     ++it)
         {
-            c->clearColBloc(*it);
+            c->clearColBlock(*it);
         }
     }
 }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.h
@@ -95,8 +95,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear = [](VecDeriv& res, const unsigned int index) { res[index].clear(); });
+    void projectResponseT(DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear);
 
     template<class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<std::is_same<MyCoord, defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.h
@@ -95,7 +95,8 @@ public:
 
 protected:
     template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
+    void projectResponseT(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataDeriv& dx,
+        std::function<void(DataDeriv&, const unsigned int)> clear = [](VecDeriv& res, const unsigned int index) { res[index].clear(); });
 
     template<class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<std::is_same<MyCoord, defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.h
@@ -96,7 +96,7 @@ public:
 protected:
     template <class DataDeriv>
     void projectResponseT(DataDeriv& dx,
-        std::function<void(DataDeriv&, const unsigned int)> clear);
+        const std::function<void(DataDeriv&, const unsigned int)>& clear);
 
     template<class MyCoord>
     void interpolatePosition(Real cT, typename std::enable_if<std::is_same<MyCoord, defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x);

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
@@ -241,7 +241,7 @@ void SkeletalMotionConstraint<DataTypes>::projectJacobianMatrix(const core::Mech
 
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
@@ -109,7 +109,7 @@ void SkeletalMotionConstraint<DataTypes>::findKeyTimes(Real ct)
 }
 
 template <class TDataTypes> template <class DataDeriv>
-void SkeletalMotionConstraint<TDataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& res,
+void SkeletalMotionConstraint<TDataTypes>::projectResponseT(DataDeriv& res,
     std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     if( !active.getValue() ) return;
@@ -121,10 +121,11 @@ void SkeletalMotionConstraint<TDataTypes>::projectResponseT(const core::Mechanic
 template <class DataTypes>
 void SkeletalMotionConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
     if( !active.getValue() ) return;
 
     helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    projectResponseT<VecDeriv>(res.wref(), [](VecDeriv& res, const unsigned int index) { res[index].clear(); });
 }
 
 template <class DataTypes>
@@ -237,11 +238,12 @@ void SkeletalMotionConstraint<DataTypes>::interpolatePosition(Real cT, typename 
 template <class DataTypes>
 void SkeletalMotionConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     if( !active.getValue() ) return;
 
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
+    projectResponseT<MatrixDeriv>(c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBlock(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
@@ -108,27 +108,14 @@ void SkeletalMotionConstraint<DataTypes>::findKeyTimes(Real ct)
     }
 }
 
-template <class DataTypes>
-template <class DataDeriv>
-void SkeletalMotionConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& dx)
+template <class TDataTypes> template <class DataDeriv>
+void SkeletalMotionConstraint<TDataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/ /* PARAMS FIRST */, DataDeriv& res,
+    std::function<void(DataDeriv&, const unsigned int)> clear)
 {
     if( !active.getValue() ) return;
 
-    for(unsigned int i = 0; i < dx.size(); ++i)
-        dx[i] = Deriv();
-    /*Real cT = (Real) this->getContext()->getTime() * animationSpeed.getValue();
-
-    if(0.0 != cT)
-    {
-        findKeyTimes();
-
-        if(finished && nextT != prevT)
-        {
-            //set the motion to the Dofs
-            for(unsigned int i = 0; i < dx.size(); ++i)
-                dx[i] = Deriv();
-        }
-    }*/
+    for (unsigned int i = 0; i < res.size(); ++i)
+        clear(res, i);
 }
 
 template <class DataTypes>
@@ -254,14 +241,7 @@ void SkeletalMotionConstraint<DataTypes>::projectJacobianMatrix(const core::Mech
 
     helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
-    MatrixDerivRowIterator rowIt = c->begin();
-    MatrixDerivRowIterator rowItEnd = c->end();
-
-    while(rowIt != rowItEnd)
-    {
-        projectResponseT<MatrixDerivRowType>(mparams, rowIt.row());
-        ++rowIt;
-    }
+    projectResponseT<MatrixDeriv>(mparams /* PARAMS FIRST */, c.wref(), [](MatrixDeriv& res, const unsigned int index) { res.clearColBloc(index); });
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/SkeletalMotionConstraint.inl
@@ -110,7 +110,7 @@ void SkeletalMotionConstraint<DataTypes>::findKeyTimes(Real ct)
 
 template <class TDataTypes> template <class DataDeriv>
 void SkeletalMotionConstraint<TDataTypes>::projectResponseT(DataDeriv& res,
-    std::function<void(DataDeriv&, const unsigned int)> clear)
+    const std::function<void(DataDeriv&, const unsigned int)>& clear)
 {
     if( !active.getValue() ) return;
 

--- a/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.inl
+++ b/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.inl
@@ -382,6 +382,9 @@ void LCPForceFeedback<DataTypes>::handleEvent(sofa::core::objectmodel::Event *ev
         constraints.addLine(rowIt.index(), rowIt.row());
     }
 
+    // make sure the MatrixDeriv has been compressed
+    constraints.compress();
+
     // valid buffer
 
     {

--- a/Sofa/Component/Haptics/tests/scenes/ToolvsFloorCollision_test.scn
+++ b/Sofa/Component/Haptics/tests/scenes/ToolvsFloorCollision_test.scn
@@ -42,7 +42,7 @@
 
     <Node name="Instrument" >
         <EulerImplicitSolver name="ODE solver" rayleighStiffness="0.01" rayleighMass="0.01" />
-        <SparseLDLSolver />
+        <SparseLDLSolver template="CompressedRowSparseMatrixd" />
         
         <MechanicalObject name="instrumentState" template="Rigid3" />
         <UniformMass name="mass" totalMass="0.5" />
@@ -60,8 +60,8 @@
             <MeshOBJLoader filename="Demos/Dentistry/data/mesh/dental_instrument_centerline.obj"  name="loader"/>
             <MeshTopology src="@loader" name="InstrumentCollisionModel" />
             <MechanicalObject src="@loader" name="instrumentCollisionState"  ry="-180" rz="-90" dz="3.5" dx="-0.3" />
-            <LineCollisionModel contactStiffness="100"/>            
-            <PointCollisionModel contactStiffness="100"/>
+            <LineCollisionModel />
+            <PointCollisionModel />
             <RigidMapping name="MM->CM mapping" input="@instrumentState" output="@instrumentCollisionState" />        
         </Node>       
     </Node> 

--- a/Sofa/Component/Haptics/tests/scenes/ToolvsFloorCollision_test.scn
+++ b/Sofa/Component/Haptics/tests/scenes/ToolvsFloorCollision_test.scn
@@ -42,7 +42,7 @@
 
     <Node name="Instrument" >
         <EulerImplicitSolver name="ODE solver" rayleighStiffness="0.01" rayleighMass="0.01" />
-        <SparseLDLSolver template="CompressedRowSparseMatrixd" />
+        <SparseLDLSolver template="CompressedRowSparseMatrix" />
         
         <MechanicalObject name="instrumentState" template="Rigid3" />
         <UniformMass name="mass" totalMass="0.5" />

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceFromTargetMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceFromTargetMapping.inl
@@ -27,7 +27,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/type/RGBAColor.h>
-#include <sofa/defaulttype/MapMapSparseMatrixEigenUtils.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h>
 #include <iostream>
 
 namespace sofa::component::mapping::nonlinear

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
@@ -29,7 +29,7 @@
 #include <sofa/core/ConstraintParams.h>
 #include <iostream>
 #include <sofa/simulation/Node.h>
-#include <sofa/defaulttype/CompressedRowSparseMatrixConstraintEigenUtils.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h>
 #include <sofa/core/behavior/BaseForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/component/mapping/nonlinear/DistanceMultiMapping.inl>

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
@@ -29,7 +29,7 @@
 #include <sofa/core/ConstraintParams.h>
 #include <iostream>
 #include <sofa/simulation/Node.h>
-#include <sofa/defaulttype/MapMapSparseMatrixEigenUtils.h>
+#include <sofa/defaulttype/CompressedRowSparseMatrixConstraintEigenUtils.h>
 #include <sofa/core/behavior/BaseForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/component/mapping/nonlinear/DistanceMultiMapping.inl>

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
@@ -29,7 +29,7 @@
 #include <sofa/simulation/Node.h>
 #include <sofa/core/behavior/BaseForceField.h>
 #include <sofa/core/behavior/MechanicalState.inl>
-#include <sofa/defaulttype/MapMapSparseMatrixEigenUtils.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h>
 
 namespace sofa::component::mapping::nonlinear
 {

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
@@ -27,7 +27,7 @@
 #include <sofa/core/MechanicalParams.h>
 #include <iostream>
 #include <sofa/simulation/Node.h>
-#include <sofa/defaulttype/MapMapSparseMatrixEigenUtils.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h>
 
 namespace sofa::component::mapping::nonlinear
 {

--- a/Sofa/framework/DefaultType/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC_ROOT "src/sofa/defaulttype")
 
 set(HEADER_FILES
     ${SRC_ROOT}/AbstractTypeInfo.h
+    ${SRC_ROOT}/CompressedRowSparseMatrixConstraint.h
     ${SRC_ROOT}/DataTypeInfo.h
     ${SRC_ROOT}/DataTypeOperations.h
     ${SRC_ROOT}/MapMapSparseMatrix.h
@@ -59,6 +60,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     ${SRC_ROOT}/AbstractTypeInfo.cpp
+    ${SRC_ROOT}/CompressedRowSparseMatrixConstraint.cpp
     ${SRC_ROOT}/MatrixExporter.cpp
     ${SRC_ROOT}/SolidTypes.cpp
     ${SRC_ROOT}/TemplatesAliases.cpp

--- a/Sofa/framework/DefaultType/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/CMakeLists.txt
@@ -5,8 +5,6 @@ set(SRC_ROOT "src/sofa/defaulttype")
 
 set(HEADER_FILES
     ${SRC_ROOT}/AbstractTypeInfo.h
-    ${SRC_ROOT}/CompressedRowSparseMatrixConstraint.h
-    ${SRC_ROOT}/CompressedRowSparseMatrixConstraintEigenUtils.h
     ${SRC_ROOT}/DataTypeInfo.h
     ${SRC_ROOT}/DataTypeOperations.h
     ${SRC_ROOT}/MapMapSparseMatrix.h
@@ -61,7 +59,6 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     ${SRC_ROOT}/AbstractTypeInfo.cpp
-    ${SRC_ROOT}/CompressedRowSparseMatrixConstraint.cpp
     ${SRC_ROOT}/MatrixExporter.cpp
     ${SRC_ROOT}/SolidTypes.cpp
     ${SRC_ROOT}/TemplatesAliases.cpp

--- a/Sofa/framework/DefaultType/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC_ROOT "src/sofa/defaulttype")
 set(HEADER_FILES
     ${SRC_ROOT}/AbstractTypeInfo.h
     ${SRC_ROOT}/CompressedRowSparseMatrixConstraint.h
+    ${SRC_ROOT}/CompressedRowSparseMatrixConstraintEigenUtils.h
     ${SRC_ROOT}/DataTypeInfo.h
     ${SRC_ROOT}/DataTypeOperations.h
     ${SRC_ROOT}/MapMapSparseMatrix.h

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.cpp
@@ -1,0 +1,43 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, version 1.0 RC 1        *
+*            (c) 2006-2021 MGH, INRIA, USTL, UJF, CNRS, InSimo                *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                               SOFA :: Modules                               *
+*                                                                             *
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFA_DEFAULTTYPE_COMPRESSEDROWSPARSEMATRIXCONSTRAINT_CPP
+#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
+#include <sofa/type/Vec.h>
+
+namespace sofa::defaulttype
+{
+
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1f>;
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2f>;
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3f>;
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6f>;
+
+
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1d>;
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2d>;
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3d>;
+template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6d>;
+
+} // namespace sofa::defaulttype

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.h
@@ -363,29 +363,29 @@ public:
     /// Get the iterator corresponding to the beginning of the rows of blocks
     RowConstIterator begin() const
     {
-        SOFA_IF_CONSTEXPR (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        if constexpr (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
         return RowConstIterator(this, 0);
     }
 
     /// Get the iterator corresponding to the end of the rows of blocks
     RowConstIterator end() const
     {
-        SOFA_IF_CONSTEXPR (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
-        return RowConstIterator(this, this->rowIndex.size());
+        if constexpr (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        return RowConstIterator(this, Index(this->rowIndex.size()));
     }
 
     /// Get the iterator corresponding to the beginning of the rows of blocks
     RowConstIterator cbegin() const
     {
-        SOFA_IF_CONSTEXPR(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        if constexpr(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
         return RowConstIterator(this, 0);
     }
 
     /// Get the iterator corresponding to the end of the rows of blocks
     RowConstIterator cend() const
     {
-        SOFA_IF_CONSTEXPR(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
-        return RowConstIterator(this, this->rowIndex.size());
+        if constexpr(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        return RowConstIterator(this, Index(this->rowIndex.size()));
     }
 
     class RowWriteAccessor
@@ -405,14 +405,14 @@ public:
 
         void addCol(Index id, const Block& value)
         {
-            SOFA_IF_CONSTEXPR (Policy::LogTrace) m_matrix->logCall(FnEnum::addCol, m_rowIndex, id, value);
+            if constexpr (Policy::LogTrace) m_matrix->logCall(linearalgebra::FnEnum::addCol, m_rowIndex, id, value);
             *m_matrix->wbloc(m_rowIndex, id, true) += value;
         }
 
         // TODO: this is wrong in case the returned bloc is within the uncompressed triplets
         void setCol(Index id, const Block& value)
         {
-            SOFA_IF_CONSTEXPR (Policy::LogTrace) m_matrix->logCall(FnEnum::setCol, m_rowIndex, id, value);
+            if constexpr (Policy::LogTrace) m_matrix->logCall(linearalgebra::FnEnum::setCol, m_rowIndex, id, value);
             *m_matrix->wbloc(m_rowIndex, id, true) = value;
         }
 
@@ -430,8 +430,6 @@ public:
         int m_rowIndex;
         CompressedRowSparseMatrixConstraint* m_matrix;
     };
-
-    typedef RowWriteAccessor RowIterator; /// Definition for MapMapSparseMatrix and CompressedRowSparseMatrixConstraint compatibility
 
     class RowType : public std::pair<ColConstIterator, ColConstIterator>
     {
@@ -465,7 +463,7 @@ public:
     /// Get the number of constraint
     size_t size() const
     {
-        SOFA_IF_CONSTEXPR(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        if constexpr(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
         return this->getRowIndex().size();
     }
 
@@ -474,7 +472,7 @@ public:
     /// If lIndex row doesn't exist, returns end iterator
     RowConstIterator readLine(Index lIndex) const
     {
-        SOFA_IF_CONSTEXPR (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        if constexpr (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
         Index rowId = (this->nBlocRow == 0) ? 0 : lIndex * this->rowIndex.size() / this->nBlocRow;
         if (this->sortedFind(this->rowIndex, lIndex, rowId))
         {
@@ -577,7 +575,7 @@ public:
             in >> c_id;
             in >> c_number;
 
-            RowIterator c_it = sc.writeLine(c_id);
+            auto c_it = sc.writeLine(c_id);
 
             for (unsigned int i = 0; i < c_number; i++)
             {
@@ -596,6 +594,10 @@ public:
         static std::string name = std::string("CompressedRowSparseMatrixConstraint") + std::string(traits::Name());
         return name.c_str();
     }
+
+    /// Definition for MapMapSparseMatrix and CompressedRowSparseMatrixConstraint compatibility
+    using ColIterator = ColConstIterator;
+    using RowIterator = RowWriteAccessor;
 };
 
 /// As it is no longer thread-safe to write to different pre-created rows in CompressedRowSparseMatrixConstraint,

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.h
@@ -1,0 +1,690 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/defaulttype/config.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+
+
+namespace sofa::defaulttype
+{
+
+template<class RowType, class VecDeriv, typename Real = typename VecDeriv::value_type::Real>
+Real CompressedRowSparseMatrixVecDerivMult(const RowType row, const VecDeriv& vec)
+{
+    Real r = 0;
+    for (typename RowType::first_type it = row.first, itend = row.second; it != itend; ++it)
+        r += it.val() * vec[it.index()];
+    return r;
+}
+
+template<class RowType, class VecDeriv>
+void convertCompressedRowSparseMatrixRowToVecDeriv(const RowType row, VecDeriv& out)
+{
+    for (typename RowType::first_type it = row.first, itend = row.second; it != itend; ++it)
+    {
+        out[it.index()] += it.val();
+    }
+}
+
+/// Constraint policy type, showing the types and flags to give to CompressedRowSparseMatrix
+/// for its second template type. The default values correspond to the original implementation.
+class CRSConstraintPolicy : public linearalgebra::CRSDefaultPolicy
+{
+public:
+    static constexpr bool AutoSize = true;
+    static constexpr bool AutoCompress = true;
+    static constexpr bool CompressZeros = false;
+    static constexpr bool ClearByZeros = false;
+    static constexpr bool OrderedInsertion = false;
+
+    static constexpr int  matrixType = 2;
+};
+
+template<typename TBloc, typename TPolicy = CRSConstraintPolicy >
+class CompressedRowSparseMatrixConstraint : public sofa::linearalgebra::CompressedRowSparseMatrix<TBloc, TPolicy>
+{
+public:
+    typedef CompressedRowSparseMatrixConstraint<TBloc, TPolicy> Matrix;
+    typedef linearalgebra::CompressedRowSparseMatrix<TBloc, TPolicy> CRSMatrix;
+    typedef typename CRSMatrix::Policy Policy;
+
+    using Block     = TBloc;
+    using VecBloc  = typename linearalgebra::CRSBlocTraits<Block>::VecBloc;
+    using VecIndex = typename linearalgebra::CRSBlocTraits<Block>::VecIndex;
+    using VecFlag  = typename linearalgebra::CRSBlocTraits<Block>::VecFlag;
+    using Index    = typename VecIndex::value_type;
+
+    typedef typename CRSMatrix::Block Data;
+    typedef typename CRSMatrix::Range Range;
+    typedef typename CRSMatrix::traits traits;
+    typedef typename CRSMatrix::Real Real;
+    typedef typename CRSMatrix::Index KeyType;
+    typedef typename CRSMatrix::IndexedBlock IndexedBlock;
+
+public:
+    CompressedRowSparseMatrixConstraint()
+        : CRSMatrix()
+    {
+    }
+
+    CompressedRowSparseMatrixConstraint(Index nbRow, Index nbCol)
+        : CRSMatrix(nbRow, nbCol)
+    {
+    }
+
+    bool empty() const
+    {
+        return this->rowIndex.empty();
+    }
+
+    class RowType;
+    class RowConstIterator;
+    /// Row Sparse Matrix columns constant Iterator to match with constraint matrix manipulation
+    class ColConstIterator : std::iterator<std::bidirectional_iterator_tag, Index>
+    {
+    public:
+        friend class RowConstIterator;
+        friend class RowType;
+    protected:
+
+        ColConstIterator(const Index _rowIt, int _internal, const CompressedRowSparseMatrixConstraint* _matrix)
+            : m_rowIt(_rowIt)
+            , m_internal(_internal)
+            , m_matrix(_matrix)
+        {}
+
+    public:
+
+        ColConstIterator(const ColConstIterator& it2)
+            : m_rowIt(it2.m_rowIt)
+            , m_internal(it2.m_internal)
+            , m_matrix(it2.m_matrix)
+        {}
+
+        ColConstIterator& operator=(const ColConstIterator& other)
+        {
+            if (this != &other)
+            {
+                m_rowIt = other.m_rowIt;
+                m_internal = other.m_internal;
+                m_matrix = other.m_matrix;
+            }
+            return *this;
+        }
+
+        Index row() const
+        {
+            return m_matrix->rowIndex[m_rowIt];
+        }
+
+        /// @return the constraint value
+        const TBloc &val() const
+        {
+            return m_matrix->colsValue[m_internal];
+        }
+
+        /// @return the DOF index the constraint is applied on
+        Index index() const
+        {
+            return m_matrix->colsIndex[m_internal];
+        }
+
+        const Index getInternal() const
+        {
+            return m_internal;
+        }
+
+        void operator++() // prefix
+        {
+            m_internal++;
+        }
+
+        void operator++(int) // postfix
+        {
+            m_internal++;
+        }
+
+        void operator--() // prefix
+        {
+            m_internal--;
+        }
+
+        void operator--(int) // postfix
+        {
+            m_internal--;
+        }
+
+        void operator+=(int i)
+        {
+            m_internal += i;
+        }
+
+        void operator-=(int i)
+        {
+            m_internal -= i;
+        }
+
+        bool operator==(const ColConstIterator& it2) const
+        {
+            return (m_internal == it2.m_internal);
+        }
+
+        bool operator!=(const ColConstIterator& it2) const
+        {
+            return (m_internal != it2.m_internal);
+        }
+
+        bool operator<(const ColConstIterator& it2) const
+        {
+            return m_internal < it2.m_internal;
+        }
+
+        bool operator>(const ColConstIterator& it2) const
+        {
+            return m_internal > it2.m_internal;
+        }
+
+    private :
+
+        Index m_rowIt;
+        Index m_internal;
+        const CompressedRowSparseMatrixConstraint* m_matrix;
+    };
+
+    class RowConstIterator : public std::iterator<std::bidirectional_iterator_tag, Index>
+    {
+    public:
+
+        friend class CompressedRowSparseMatrixConstraint;
+
+    protected:
+
+        RowConstIterator(const CompressedRowSparseMatrixConstraint* _matrix, int _m_internal)
+            : m_internal(_m_internal)
+            , m_matrix(_matrix)
+        {}
+
+    public:
+
+        RowConstIterator(const RowConstIterator& it2)
+            : m_internal(it2.m_internal)
+            , m_matrix(it2.m_matrix)
+        {}
+
+        RowConstIterator()
+        {}
+
+        RowConstIterator&  operator=(const RowConstIterator& other)
+        {
+            if (this != &other)
+            {
+                m_matrix = other.m_matrix;
+                m_internal = other.m_internal;
+            }
+            return *this;
+        }
+
+        Index index() const
+        {
+            return m_matrix->rowIndex[m_internal];
+        }
+
+        Index getInternal() const
+        {
+            return m_internal;
+        }
+
+        ColConstIterator begin() const
+        {
+            Range r = m_matrix->getRowRange(m_internal);
+            return ColConstIterator(m_internal, r.begin(), m_matrix);
+        }
+
+        ColConstIterator end() const
+        {
+            Range r = m_matrix->getRowRange(m_internal);
+            return ColConstIterator(m_internal, r.end(), m_matrix);
+        }
+
+        RowType row() const
+        {
+            Range r = m_matrix->getRowRange(m_internal);
+            return RowType(ColConstIterator(m_internal, r.begin(), m_matrix),
+                           ColConstIterator(m_internal, r.end(), m_matrix));
+        }
+
+        bool empty() const
+        {
+            Range r = m_matrix->getRowRange(m_internal);
+            return r.empty();
+        }
+
+        void operator++() // prefix
+        {
+            m_internal++;
+        }
+
+        void operator++(int) // postfix
+        {
+            m_internal++;
+        }
+
+        void operator--() // prefix
+        {
+            m_internal--;
+        }
+
+        void operator--(int) // postfix
+        {
+            m_internal--;
+        }
+
+        void operator+=(int i)
+        {
+            m_internal += i;
+        }
+
+        void operator-=(int i)
+        {
+            m_internal -= i;
+        }
+
+        int operator-(const RowConstIterator& it2) const
+        {
+            return m_internal - it2.m_internal;
+        }
+
+        RowConstIterator operator+(int i) const
+        {
+            RowConstIterator res = *this;
+            res += i;
+            return res;
+        }
+
+        RowConstIterator operator-(int i) const
+        {
+            RowConstIterator res = *this;
+            res -= i;
+            return res;
+        }
+
+        bool operator==(const RowConstIterator& it2) const
+        {
+            return m_internal == it2.m_internal;
+        }
+
+        bool operator!=(const RowConstIterator& it2) const
+        {
+            return !(m_internal == it2.m_internal);
+        }
+
+        bool operator<(const RowConstIterator& it2) const
+        {
+            return m_internal < it2.m_internal;
+        }
+
+        bool operator>(const RowConstIterator& it2) const
+        {
+            return m_internal > it2.m_internal;
+        }
+
+        template <class VecDeriv, typename Real>
+        Real operator*(const VecDeriv& v) const
+        {
+            return CompressedRowSparseMatrixVecDerivMult(row(), v);
+        }
+
+    private:
+
+        Index m_internal;
+        const CompressedRowSparseMatrixConstraint* m_matrix;
+    };
+
+    /// Get the iterator corresponding to the beginning of the rows of blocks
+    RowConstIterator begin() const
+    {
+        SOFA_IF_CONSTEXPR (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        return RowConstIterator(this, 0);
+    }
+
+    /// Get the iterator corresponding to the end of the rows of blocks
+    RowConstIterator end() const
+    {
+        SOFA_IF_CONSTEXPR (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        return RowConstIterator(this, this->rowIndex.size());
+    }
+
+    /// Get the iterator corresponding to the beginning of the rows of blocks
+    RowConstIterator cbegin() const
+    {
+        SOFA_IF_CONSTEXPR(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        return RowConstIterator(this, 0);
+    }
+
+    /// Get the iterator corresponding to the end of the rows of blocks
+    RowConstIterator cend() const
+    {
+        SOFA_IF_CONSTEXPR(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        return RowConstIterator(this, this->rowIndex.size());
+    }
+
+    class RowWriteAccessor
+    {
+    public:
+
+        friend class CompressedRowSparseMatrixConstraint;
+
+    protected:
+
+        RowWriteAccessor(CompressedRowSparseMatrixConstraint* _matrix, int _rowIndex)
+            : m_rowIndex(_rowIndex)
+            , m_matrix(_matrix)
+        {}
+
+    public:
+
+        void addCol(Index id, const Block& value)
+        {
+            SOFA_IF_CONSTEXPR (Policy::LogTrace) m_matrix->logCall(FnEnum::addCol, m_rowIndex, id, value);
+            *m_matrix->wbloc(m_rowIndex, id, true) += value;
+        }
+
+        // TODO: this is wrong in case the returned bloc is within the uncompressed triplets
+        void setCol(Index id, const Block& value)
+        {
+            SOFA_IF_CONSTEXPR (Policy::LogTrace) m_matrix->logCall(FnEnum::setCol, m_rowIndex, id, value);
+            *m_matrix->wbloc(m_rowIndex, id, true) = value;
+        }
+
+        bool operator==(const RowWriteAccessor& it2) const
+        {
+            return m_rowIndex == it2.m_rowIndex;
+        }
+
+        bool operator!=(const RowWriteAccessor& it2) const
+        {
+            return !(m_rowIndex == it2.m_rowIndex);
+        }
+
+    private:
+        int m_rowIndex;
+        CompressedRowSparseMatrixConstraint* m_matrix;
+    };
+
+    typedef RowWriteAccessor RowIterator; /// Definition for MapMapSparseMatrix and CompressedRowSparseMatrixConstraint compatibility
+
+    class RowType : public std::pair<ColConstIterator, ColConstIterator>
+    {
+        typedef std::pair<ColConstIterator, ColConstIterator> Inherit;
+    public:
+        RowType(ColConstIterator begin, ColConstIterator end) : Inherit(begin,end) {}
+        ColConstIterator begin() const { return this->first; }
+        ColConstIterator end() const { return this->second; }
+        ColConstIterator cbegin() const { return this->first; }
+        ColConstIterator cend() const { return this->second; }
+        void setBegin(ColConstIterator i) { this->first = i; }
+        void setEnd(ColConstIterator i) { this->second = i; }
+        bool empty() const { return begin() == end(); }
+        Index size() const { return end().getInternal() - begin().getInternal(); }
+        void operator++() { ++this->first; }
+        void operator++(int) { ++this->first; }
+        ColConstIterator find(Index col) const
+        {
+            const CompressedRowSparseMatrixConstraint* matrix = this->first.m_matrix;
+            Range r(this->first.m_internal, this->second.m_internal);
+            Index index = 0;
+            if (!matrix->sortedFind(matrix->colsIndex, r, col, index))
+            {
+                index = r.end(); // not found -> return end
+            }
+            return ColConstIterator(this->first.m_rowIt, index, matrix);
+        }
+
+    };
+
+    /// Get the number of constraint
+    size_t size() const
+    {
+        SOFA_IF_CONSTEXPR(Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        return this->getRowIndex().size();
+    }
+
+    /// @return Constant Iterator on specified row
+    /// @param lIndex row index
+    /// If lIndex row doesn't exist, returns end iterator
+    RowConstIterator readLine(Index lIndex) const
+    {
+        SOFA_IF_CONSTEXPR (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
+        Index rowId = (this->nBlocRow == 0) ? 0 : lIndex * this->rowIndex.size() / this->nBlocRow;
+        if (this->sortedFind(this->rowIndex, lIndex, rowId))
+        {
+            return RowConstIterator(this, rowId);
+        }
+        else
+        {
+            return RowConstIterator(this, this->rowIndex.size());
+        }
+    }
+
+    /// @return Iterator on specified row
+    /// @param lIndex row index
+    RowWriteAccessor writeLine(Index lIndex)
+    {
+        return RowWriteAccessor(this, lIndex);
+    }
+
+    /// @param lIndex row Index
+    /// @param row constraint itself
+    /// If lindex already exists, overwrite existing constraint
+    void setLine(Index lIndex, RowType row)
+    {
+        if (readLine(lIndex) != this->end()) this->clearRowBloc(lIndex);
+
+        RowWriteAccessor it(this, lIndex);
+        ColConstIterator colIt = row.first;
+        ColConstIterator colItEnd = row.second;
+
+        while (colIt != colItEnd)
+        {
+            it.setCol(colIt.index(), colIt.val());
+            ++colIt;
+        }
+    }
+
+    /// @param lIndex row Index
+    /// @param row constraint itself
+    /// If lindex doesn't exists, creates the row
+    void addLine(Index lIndex, RowType row)
+    {
+        RowWriteAccessor it(this, lIndex);
+
+        ColConstIterator colIt = row.first;
+        ColConstIterator colItEnd = row.second;
+
+        while (colIt != colItEnd)
+        {
+            it.addCol(colIt.index(), colIt.val());
+            ++colIt;
+        }
+    }
+
+    template< class VecDeriv>
+    void multTransposeBaseVector(VecDeriv& res, const sofa::linearalgebra::BaseVector* lambda ) const
+    {
+        typedef typename VecDeriv::value_type Deriv;
+
+        static_assert(std::is_same<Deriv, TBloc>::value, "res must be contain same type as CompressedRowSparseMatrix type");
+
+        for (auto rowIt = begin(), rowItEnd = end(); rowIt != rowItEnd; ++rowIt)
+        {
+            const SReal f = lambda->element(rowIt.index());
+            for (auto colIt = rowIt.begin(), colItEnd = rowIt.end(); colIt != colItEnd; ++colIt)
+            {
+                res[colIt.index()] += colIt.val() * f;
+            }
+        }
+    }
+
+    /// write to an output stream
+    inline friend std::ostream& operator << ( std::ostream& out, const CompressedRowSparseMatrixConstraint<TBloc, Policy>& sc)
+    {
+        for (RowConstIterator rowIt = sc.begin(); rowIt !=  sc.end(); ++rowIt)
+        {
+            out << "Constraint ID : ";
+            out << rowIt.index();
+            for (ColConstIterator colIt = rowIt.begin(); colIt !=  rowIt.end(); ++colIt)
+            {
+                out << "  dof ID : " << colIt.index() << "  value : " << colIt.val() << "  ";
+            }
+            out << "\n";
+        }
+
+        return out;
+    }
+
+    /// read from an input stream
+    inline friend std::istream& operator >> ( std::istream& in, CompressedRowSparseMatrixConstraint<TBloc, Policy>& sc)
+    {
+        sc.clear();
+
+        unsigned int c_id;
+        unsigned int c_number;
+        unsigned int c_dofIndex;
+        TBloc c_value;
+
+        while (!(in.rdstate() & std::istream::eofbit))
+        {
+            in >> c_id;
+            in >> c_number;
+
+            RowIterator c_it = sc.writeLine(c_id);
+
+            for (unsigned int i = 0; i < c_number; i++)
+            {
+                in >> c_dofIndex;
+                in >> c_value;
+                c_it.addCol(c_dofIndex, c_value);
+            }
+        }
+
+        sc.compress();
+        return in;
+    }
+
+    static const char* Name()
+    {
+        static std::string name = std::string("CompressedRowSparseMatrixConstraint") + std::string(traits::Name());
+        return name.c_str();
+    }
+};
+
+/// As it is no longer thread-safe to write to different pre-created rows in CompressedRowSparseMatrixConstraint,
+/// this helper class allows to create a per-row buffer vector that can be filled in parallel and then copied sequentially
+/// to the output matrix.
+///
+/// Usage (processing values from inMatrix to outMatrix):
+///    CompressedRowSparseMatrixConstraintRowsBuffer outRows;
+///    outRows.initRows(inMatrix.begin(),inMatrix.end());
+///    for_each(inMatrix.begin(), inMatrix.end(), [auto rowIt] { my_compute_fn(rowIt, outRows.writeLine(rowIt))}); // parallelized loop
+///    outRows.addToMatrix(outMatrix); // sequential copy to output matrix
+template <class TBloc>
+class SparseMatrixRowsBuffer
+{
+    using Index = int;
+    using Block = TBloc;
+    using VecBloc  = typename linearalgebra::CRSBlocTraits<Block>::VecBloc;
+    using VecIndex = typename linearalgebra::CRSBlocTraits<Block>::VecIndex;
+public:
+    class RowBuffer
+    {
+    public:
+        void init(Index row)
+        {
+            m_row = row;
+            m_cols.clear();
+            m_values.clear();
+        }
+        void addCol(Index col, const TBloc& val)
+        {
+            m_cols.push_back(col);
+            m_values.push_back(val);
+        }
+        template <class OutMatrix>
+        void addToMatrix(OutMatrix& out)
+        {
+            if (!m_cols.empty())
+            {
+                auto rowOut = out.writeLine(m_row);
+                for (std::size_t i = 0; i < m_cols.size(); ++i)
+                {
+                    rowOut.addCol(m_cols[i], m_values[i]);
+                }
+            }
+        }
+    protected:
+        Index m_row;
+        VecIndex m_cols;
+        VecBloc m_values;
+    };
+    template<class RowConstIterator>
+    void initRows(const RowConstIterator& rowBegin, const RowConstIterator& rowEnd)
+    {
+        m_rows.resize(rowEnd-rowBegin);
+        for (RowConstIterator rowIt = rowBegin; rowIt != rowEnd; ++rowIt)
+        {
+            m_rows[std::distance(rowBegin, rowIt)].init(rowIt.index());
+        }
+    }
+    template <class RowConstIterator>
+    RowBuffer& writeLine(const RowConstIterator& rowIt)
+    {
+        return m_rows[rowIt.getInternal()];
+    }
+    template <class OutMatrix>
+    void addToMatrix(OutMatrix& out)
+    {
+        for (auto& row : m_rows)
+        {
+            row.addToMatrix(out);
+        }
+    }
+protected:
+    type::vector<RowBuffer> m_rows;
+};
+
+#if !defined(SOFA_DEFAULTTYPE_COMPRESSEDROWSPARSEMATRIXCONSTRAINT_CPP) 
+
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1f>;
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2f>;
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3f>;
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6f>;
+
+
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1d>;
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2d>;
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3d>;
+extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6d>;
+
+#endif
+
+} // namespace sofa::defaulttype

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraint.h
@@ -100,9 +100,15 @@ public:
     class RowType;
     class RowConstIterator;
     /// Row Sparse Matrix columns constant Iterator to match with constraint matrix manipulation
-    class ColConstIterator : std::iterator<std::bidirectional_iterator_tag, Index>
+    class ColConstIterator
     {
     public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = Index;
+        using difference_type = Index;
+        using pointer = Index*;
+        using reference = Index&;
+
         friend class RowConstIterator;
         friend class RowType;
     protected:
@@ -211,9 +217,14 @@ public:
         const CompressedRowSparseMatrixConstraint* m_matrix;
     };
 
-    class RowConstIterator : public std::iterator<std::bidirectional_iterator_tag, Index>
+    class RowConstIterator
     {
     public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = Index;
+        using difference_type = Index;
+        using pointer = Index*;
+        using reference = Index&;
 
         friend class CompressedRowSparseMatrixConstraint;
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -30,7 +30,7 @@
 namespace sofa::defaulttype
 {
 
-template< class TBloc >
+template< class TBlock >
 struct CompressedRowSparseMatrixToEigenSparse
 {
 
@@ -89,7 +89,7 @@ class CompressedRowSparseMatrixToEigenSparse< sofa::defaulttype::RigidDeriv<N, R
 };
 
 
-template< class TBloc >
+template< class TBlock >
 struct EigenSparseToCompressedRowSparseMatrix
 {
 
@@ -131,9 +131,9 @@ struct EigenSparseToCompressedRowSparseMatrixVec
                 while (i != rowNonZeros)
                 {
                     TVec val;
-                    int currentBlockIndex = blockIndex;
+                    int currenTBlockkIndex = blockIndex;
                     //int currentCol   = *colPtr;
-                    while (currentBlockIndex == blockIndex && i != rowNonZeros)
+                    while (currenTBlockkIndex == blockIndex && i != rowNonZeros)
                     {
                         val[blockOffset] = *valuePtr; // TODO: valPtr ?
                         ++i;
@@ -143,7 +143,7 @@ struct EigenSparseToCompressedRowSparseMatrixVec
                         blockOffset = *colPtr - (blockIndex * TVec::size());
                     }
 
-                    rowIterator.addCol(currentBlockIndex, val);
+                    rowIterator.addCol(currenTBlockkIndex, val);
                 }
             }
         }

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -1,0 +1,254 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
+#include <Eigen/Sparse>
+#include <sofa/type/Vec.h>
+#include <sofa/defaulttype/RigidTypes.h>
+#include <cassert>
+#include <type_traits>
+#include <cstdlib>
+
+namespace sofa::defaulttype
+{
+
+template< class TBloc >
+struct CompressedRowSparseMatrixToEigenSparse
+{
+
+};
+
+template <typename TVec>
+struct CompressedRowSparseMatrixToEigenSparseVec
+{
+    typedef typename TVec::Real Real;
+    typedef CompressedRowSparseMatrixConstraint< TVec > TCompressedRowSparseMatrix;
+    typedef Eigen::SparseMatrix<Real, Eigen::RowMajor> EigenSparseMatrix;
+
+
+    EigenSparseMatrix operator() (const TCompressedRowSparseMatrix& mat, std::size_t size)
+    {
+        std::size_t eigenMatSize = size * TVec::size();
+        EigenSparseMatrix eigenMat(eigenMatSize, eigenMatSize);
+
+        std::vector<Eigen::Triplet<Real> > triplets;
+
+        for (auto row = mat.begin(); row != mat.end(); ++row)
+        {
+            for (auto col = row.begin(), colend = row.end(); col !=colend; ++col)
+            {
+                const TVec& vec = col.val();
+                int   colIndex  = col.index() * TVec::size();
+
+                for (std::size_t i = 0; i < TVec::size(); ++i)
+                {
+                    triplets.emplace_back(Eigen::Triplet<Real>( row.index(), colIndex + i, vec[i]) );
+                }
+
+            }
+        }
+
+        eigenMat.setFromTriplets(triplets.begin(), triplets.end());;
+        eigenMat.makeCompressed();
+
+        return eigenMat;
+    }
+
+};
+
+template< int N, typename Real >
+class CompressedRowSparseMatrixToEigenSparse< sofa::type::Vec<N,Real> >
+    : public  CompressedRowSparseMatrixToEigenSparseVec< sofa::type::Vec<N, Real> >
+{
+
+};
+
+template< int N, typename Real >
+class CompressedRowSparseMatrixToEigenSparse< sofa::defaulttype::RigidDeriv<N, Real > >
+    : public CompressedRowSparseMatrixToEigenSparseVec<sofa::defaulttype::RigidDeriv<N, Real>>
+{
+
+};
+
+
+template< class TBloc >
+struct EigenSparseToCompressedRowSparseMatrix
+{
+
+};
+
+
+template <typename TVec>
+struct EigenSparseToCompressedRowSparseMatrixVec
+{
+    typedef typename TVec::Real Real;
+    typedef CompressedRowSparseMatrixConstraint< TVec > TCompressedRowSparseMatrix;
+    typedef Eigen::SparseMatrix<double, Eigen::RowMajor> EigenSparseMatrix;
+
+
+    TCompressedRowSparseMatrix operator() (const EigenSparseMatrix& eigenMat)
+    {
+        TCompressedRowSparseMatrix mat;
+
+        const int* outerIndexPtr  = eigenMat.outerIndexPtr();
+        const int* innerIndexPtr  = eigenMat.innerIndexPtr();
+        const double* valuePtr      = eigenMat.valuePtr();
+
+        for (int rowIndex = 0; rowIndex < eigenMat.outerSize(); ++rowIndex)
+        {
+            int offset      = *(outerIndexPtr + rowIndex);
+            int rowNonZeros = *(outerIndexPtr + rowIndex + 1) - *(outerIndexPtr + rowIndex);
+
+            if (rowNonZeros != 0)
+            {
+                auto rowIterator = mat.writeLine(rowIndex);
+
+                int i = 0;
+                const int*  colPtr = innerIndexPtr + offset;
+                //const Real* valPtr = valuePtr + offset;
+                int   blockIndex   = *colPtr / TVec::size();
+                int   blockOffset  = *colPtr - (blockIndex * TVec::size());
+
+
+                while (i != rowNonZeros)
+                {
+                    TVec val;
+                    int currentBlockIndex = blockIndex;
+                    //int currentCol   = *colPtr;
+                    while (currentBlockIndex == blockIndex && i != rowNonZeros)
+                    {
+                        val[blockOffset] = *valuePtr; // TODO: valPtr ?
+                        ++i;
+                        ++colPtr;
+                        ++valuePtr; // TODO: valPtr ?
+                        blockIndex = *colPtr / TVec::size();
+                        blockOffset = *colPtr - (blockIndex * TVec::size());
+                    }
+
+                    rowIterator.addCol(currentBlockIndex, val);
+                }
+            }
+        }
+
+        return mat;
+    }
+};
+
+template< int N, typename Real>
+class EigenSparseToCompressedRowSparseMatrix< sofa::type::Vec<N, Real> > :
+    public EigenSparseToCompressedRowSparseMatrixVec<sofa::type::Vec<N, Real> >
+{
+
+};
+
+template< int N, typename Real>
+class EigenSparseToCompressedRowSparseMatrix< sofa::defaulttype::RigidDeriv<N, Real> > :
+    public EigenSparseToCompressedRowSparseMatrixVec<sofa::defaulttype::RigidDeriv<N, Real> >
+{
+
+};
+
+
+
+/// Computes lhs += jacobian^T * rhs
+template< typename LhsMatrixDeriv, typename RhsMatrixDeriv, typename Real >
+void addMultTransposeEigen(LhsMatrixDeriv& lhs, const Eigen::SparseMatrix<Real, Eigen::RowMajor>& jacobian, const RhsMatrixDeriv& rhs)
+{
+    auto rhsRowIt    = rhs.begin();
+    auto rhsRowItEnd = rhs.end();
+
+    typedef typename LhsMatrixDeriv::Data LhsDeriv;
+    typedef typename RhsMatrixDeriv::Data RhsDeriv;
+    typedef Eigen::SparseMatrix<Real, Eigen::RowMajor> EigenSparseMatrix;
+    const EigenSparseMatrix jacobianT = jacobian.transpose();
+
+    typedef Eigen::Matrix<typename RhsDeriv::value_type, RhsDeriv::total_size, 1> EigenRhsVector;
+    typedef Eigen::Matrix<typename LhsDeriv::value_type, LhsDeriv::total_size, 1> EigenLhsVector;
+
+    // must be passed a valid iterator
+    auto isEigenSparseIteratorInsideBlock = [](const typename EigenSparseMatrix::InnerIterator& it,
+                                               int bBegin, int bEnd) -> bool
+    {
+        assert(it);
+        return (it.col() >= bBegin && it.col() < bEnd);
+    };
+
+
+    while (rhsRowIt != rhsRowItEnd)
+    {
+        auto rhsColIt = rhsRowIt.begin();
+        auto rhsColItEnd = rhsRowIt.end();
+
+        if (rhsColIt != rhsColItEnd)
+        {
+            auto lhsRowIt = lhs.writeLine(rhsRowIt.index());
+            while (rhsColIt != rhsColItEnd)
+            {
+                const int bColBegin = rhsColIt.index() * RhsDeriv::total_size;
+                const int bColEnd   = bColBegin + RhsDeriv::total_size;
+
+                // read jacobianT rows, block by block
+                for (int k = 0; k < jacobianT.outerSize(); k+= LhsDeriv::total_size)
+                {
+                    // check the next LhsDeriv::total_size rows for potential non zero values
+                    // inside the block [k, bCol, k+LhsDeriv::total_size, bCol+RhsDeriv::total_size]
+                    bool blockEmpty = true;
+                    for (int j = 0; j < LhsDeriv::total_size; ++j)
+                    {
+                        typename EigenSparseMatrix::InnerIterator it(jacobianT, k+j);
+                        // advance until we are either invalid or inside the block
+                        while (it && 
+                               !isEigenSparseIteratorInsideBlock(it,bColBegin, bColEnd) )
+                        {
+                            ++it;
+                        }
+
+                        if (it)
+                        {
+                            blockEmpty = false;
+                            break;
+                        }
+                    }
+
+                    if(!blockEmpty)
+                    {
+                        auto b = jacobianT.block(k, bColBegin, LhsDeriv::total_size, RhsDeriv::total_size);
+
+                        LhsDeriv lhsToInsert;
+                        Eigen::Map< EigenLhsVector >       lhs(lhsToInsert.ptr());
+                        Eigen::Map<const EigenRhsVector >  rhs(rhsColIt.val().ptr());
+                        lhs = b * rhs;
+
+                        lhsRowIt.addCol( k / LhsDeriv::total_size, lhsToInsert);
+                        
+                    }
+
+                }
+
+                ++rhsColIt;
+            }
+        }
+
+        ++rhsRowIt;
+    }
+}
+
+} // namespace sofa::defaulttype

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
@@ -32,7 +32,7 @@ namespace sofa::defaulttype
 {
 
 
-template< class TBloc >
+template< class TBlock >
 class MapMapSparseMatrixToEigenSparse
 {
 
@@ -91,7 +91,7 @@ class MapMapSparseMatrixToEigenSparse< sofa::defaulttype::RigidDeriv<N, Real > >
 };
 
 
-template< class TBloc >
+template< class TBlock >
 class EigenSparseToMapMapSparseMatrix
 {
 
@@ -131,8 +131,8 @@ struct EigenSparseToMapMapSparseMatrixVec
                 while (i != rowNonZeros)
                 {
                     TVec val;
-                    int currentBlockIndex = blockIndex;
-                    while (currentBlockIndex == blockIndex && i != rowNonZeros)
+                    int currenTBlockkIndex = blockIndex;
+                    while (currenTBlockkIndex == blockIndex && i != rowNonZeros)
                     {
                         val[blockOffset] = *valuePtr;
                         ++i;
@@ -142,7 +142,7 @@ struct EigenSparseToMapMapSparseMatrixVec
                         blockOffset = *colPtr - (blockIndex * TVec::size());
                     }
 
-                    rowIterator.addCol(currentBlockIndex, val);
+                    rowIterator.addCol(currenTBlockkIndex, val);
                 }
             }
         }

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
@@ -27,9 +27,9 @@
 #include <sofa/type/Vec.h>
 #include <sofa/type/Quat.h>
 #include <sofa/type/vector.h>
+#include <sofa/linearalgebra/matrix_bloc_traits.h>
 #include <sofa/helper/rmath.h>
 #include <cmath>
-
 
 namespace sofa::defaulttype
 {
@@ -573,3 +573,38 @@ constexpr RigidDeriv<2,T> velocityAtRotatedPoint(const RigidDeriv<2,T>& v, const
 }
 
 } // namespace sofa::defaulttype
+
+
+namespace sofa::linearalgebra
+{
+    template <int N, class T, typename IndexType>
+    class matrix_bloc_traits < defaulttype::RigidDeriv<N, T>, IndexType >
+    {
+    public:
+        typedef defaulttype::RigidDeriv<N, T> Block;
+        typedef T Real;
+        typedef Block BlockTranspose;
+
+        enum { NL = 1 };
+        enum { NC = defaulttype::RigidDeriv<N, T>::total_size };
+
+        static const Real& v(const Block& b, int /*row*/, int col) { return b[col]; }
+        static Real& v(Block& b, int /*row*/, int col) { return b[col]; }
+        static void vset(Block& b, int /*row*/, int col, Real v) { b[col] = v; }
+        static void vadd(Block& b, int /*row*/, int col, Real v) { b[col] += v; }
+        static void clear(Block& b) { b.clear(); }
+        static bool empty(const Block& b)
+        {
+            for (int i = 0; i < NC; ++i)
+                if (b[i] != 0) return false;
+            return true;
+        }
+
+        static BlockTranspose transposed(const Block& b) { return b; }
+
+        static void transpose(BlockTranspose& res, const Block& b) { res = b; }
+
+        static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return matrix_bloc_traits<Real>::getElementType(); }
+        static const char* Name() { return defaulttype::DataTypeName<defaulttype::RigidDeriv<N, T>>::name(); }
+    };
+}

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
@@ -31,6 +31,8 @@
 #include <sofa/helper/rmath.h>
 #include <cmath>
 
+#include <sofa/defaulttype/DataTypeInfo.h>
+
 namespace sofa::defaulttype
 {
 
@@ -577,7 +579,7 @@ constexpr RigidDeriv<2,T> velocityAtRotatedPoint(const RigidDeriv<2,T>& v, const
 
 namespace sofa::linearalgebra
 {
-    template <int N, class T, typename IndexType>
+    template <Size N, class T, typename IndexType>
     class matrix_bloc_traits < defaulttype::RigidDeriv<N, T>, IndexType >
     {
     public:
@@ -604,7 +606,7 @@ namespace sofa::linearalgebra
 
         static void transpose(BlockTranspose& res, const Block& b) { res = b; }
 
-        static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return matrix_bloc_traits<Real>::getElementType(); }
+        static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return matrix_bloc_traits<Real,IndexType>::getElementType(); }
         static const char* Name() { return defaulttype::DataTypeName<defaulttype::RigidDeriv<N, T>>::name(); }
     };
 }

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -25,7 +25,6 @@
 #include <sofa/defaulttype/RigidCoord.h>
 #include <sofa/defaulttype/RigidDeriv.h>
 #include <sofa/defaulttype/RigidMass.h>
-#include <sofa/defaulttype/MapMapSparseMatrix.h>
 #include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 
 #include <sofa/type/Vec.h>
@@ -74,7 +73,6 @@ public:
     static constexpr const DRot& getDRot(const Deriv& d) { return getVOrientation(d); }
     static constexpr void setDRot(Deriv& d, const DRot& v) { getVOrientation(d) = v; }
 
-    //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
     typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     typedef type::vector<Coord> VecCoord;
@@ -292,7 +290,6 @@ public:
     typedef type::vector<Deriv> VecDeriv;
     typedef type::vector<Real> VecReal;
 
-    //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
     typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     template<typename T>

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -26,6 +26,7 @@
 #include <sofa/defaulttype/RigidDeriv.h>
 #include <sofa/defaulttype/RigidMass.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
+#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
 
 #include <sofa/type/Vec.h>
 #include <sofa/type/Quat.h>
@@ -73,7 +74,8 @@ public:
     static constexpr const DRot& getDRot(const Deriv& d) { return getVOrientation(d); }
     static constexpr void setDRot(Deriv& d, const DRot& v) { getVOrientation(d) = v; }
 
-    typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
+    //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
+    typedef CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     typedef type::vector<Coord> VecCoord;
     typedef type::vector<Deriv> VecDeriv;
@@ -290,7 +292,8 @@ public:
     typedef type::vector<Deriv> VecDeriv;
     typedef type::vector<Real> VecReal;
 
-    typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
+    //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
+    typedef CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     template<typename T>
     static constexpr void set(Coord& c, T x, T y, T)

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -26,7 +26,7 @@
 #include <sofa/defaulttype/RigidDeriv.h>
 #include <sofa/defaulttype/RigidMass.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
-#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 
 #include <sofa/type/Vec.h>
 #include <sofa/type/Quat.h>
@@ -75,7 +75,7 @@ public:
     static constexpr void setDRot(Deriv& d, const DRot& v) { getVOrientation(d) = v; }
 
     //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
-    typedef CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
+    typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     typedef type::vector<Coord> VecCoord;
     typedef type::vector<Deriv> VecDeriv;
@@ -293,7 +293,7 @@ public:
     typedef type::vector<Real> VecReal;
 
     //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
-    typedef CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
+    typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     template<typename T>
     static constexpr void set(Coord& c, T x, T y, T)

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
@@ -25,7 +25,6 @@
 #include <sofa/type/Vec.h>
 #include <sofa/type/vector.h>
 #include <sofa/helper/random.h>
-#include <sofa/defaulttype/MapMapSparseMatrix.h>
 #include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 #include <istream>
 #include <ostream>
@@ -59,7 +58,6 @@ public:
     static constexpr const DPos& getDPos(const Deriv& d) { return d; }
     static constexpr void setDPos(Deriv& d, const DPos& v) { d = v; }
 
-    //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
     typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
@@ -26,6 +26,7 @@
 #include <sofa/type/vector.h>
 #include <sofa/helper/random.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
+#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
 #include <istream>
 #include <ostream>
 #include <algorithm>
@@ -58,7 +59,8 @@ public:
     static constexpr const DPos& getDPos(const Deriv& d) { return d; }
     static constexpr void setDPos(Deriv& d, const DPos& v) { d = v; }
 
-    typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
+    //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
+    typedef CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
 
 protected:

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/VecTypes.h
@@ -26,7 +26,7 @@
 #include <sofa/type/vector.h>
 #include <sofa/helper/random.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
-#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 #include <istream>
 #include <ostream>
 #include <algorithm>
@@ -60,7 +60,7 @@ public:
     static constexpr void setDPos(Deriv& d, const DPos& v) { d = v; }
 
     //typedef MapMapSparseMatrix<Deriv> MatrixDeriv;
-    typedef CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
+    typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
 
 protected:

--- a/Sofa/framework/LinearAlgebra/CMakeLists.txt
+++ b/Sofa/framework/LinearAlgebra/CMakeLists.txt
@@ -20,6 +20,8 @@ set(HEADER_FILES
     ${SOFALINEARALGEBRASRC_ROOT}/BlockVector.h
     ${SOFALINEARALGEBRASRC_ROOT}/BlockVector.inl
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrix.h
+    ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixConstraint.h
+    ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixConstraintEigenUtils.h
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixGeneric.h
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixMechanical.h
     ${SOFALINEARALGEBRASRC_ROOT}/DiagonalMatrix.h
@@ -48,6 +50,7 @@ set(SOURCE_FILES
     ${SOFALINEARALGEBRASRC_ROOT}/BlockFullMatrix.cpp
     ${SOFALINEARALGEBRASRC_ROOT}/BlockVector.cpp
     ${SOFALINEARALGEBRASRC_ROOT}/BTDMatrix.cpp
+    ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixConstraint.cpp
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixGeneric.cpp
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixMechanical.cpp
     ${SOFALINEARALGEBRASRC_ROOT}/EigenVector.cpp

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.cpp
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.cpp
@@ -22,22 +22,23 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_DEFAULTTYPE_COMPRESSEDROWSPARSEMATRIXCONSTRAINT_CPP
-#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
+#define SOFA_LINEARALGEBRA_COMPRESSEDROWSPARSEMATRIXCONSTRAINT_CPP
+
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 #include <sofa/type/Vec.h>
 
-namespace sofa::defaulttype
+namespace sofa::linearalgebra
 {
 
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1f>;
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2f>;
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3f>;
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6f>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec1f>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec2f>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec3f>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec6f>;
 
 
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1d>;
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2d>;
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3d>;
-template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6d>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec1d>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec2d>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec3d>;
+template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec6d>;
 
-} // namespace sofa::defaulttype
+} // namespace sofa::linearalgebra

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
@@ -21,11 +21,11 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/defaulttype/config.h>
-#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <sofa/linearalgebra/config.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h>
 
 
-namespace sofa::defaulttype
+namespace sofa::linearalgebra
 {
 
 template<class RowType, class VecDeriv, typename Real = typename VecDeriv::value_type::Real>
@@ -61,11 +61,11 @@ public:
 };
 
 template<typename TBlock, typename TPolicy = CRSConstraintPolicy >
-class CompressedRowSparseMatrixConstraint : public sofa::linearalgebra::CompressedRowSparseMatrix<TBlock, TPolicy>
+class CompressedRowSparseMatrixConstraint : public sofa::linearalgebra::CompressedRowSparseMatrixGeneric<TBlock, TPolicy>
 {
 public:
     typedef CompressedRowSparseMatrixConstraint<TBlock, TPolicy> Matrix;
-    typedef linearalgebra::CompressedRowSparseMatrix<TBlock, TPolicy> CRSMatrix;
+    typedef linearalgebra::CompressedRowSparseMatrixGeneric<TBlock, TPolicy> CRSMatrix;
     typedef typename CRSMatrix::Policy Policy;
 
     using Block     = TBlock;
@@ -685,19 +685,19 @@ protected:
     type::vector<RowBuffer> m_rows;
 };
 
-#if !defined(SOFA_DEFAULTTYPE_COMPRESSEDROWSPARSEMATRIXCONSTRAINT_CPP) 
+#if !defined(SOFA_LINEARALGEBRA_COMPRESSEDROWSPARSEMATRIXCONSTRAINT_CPP) 
 
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1f>;
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2f>;
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3f>;
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6f>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec1f>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec2f>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec3f>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec6f>;
 
 
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec1d>;
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec2d>;
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec3d>;
-extern template class SOFA_DEFAULTTYPE_API CompressedRowSparseMatrixConstraint<type::Vec6d>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec1d>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec2d>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec3d>;
+extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixConstraint<type::Vec6d>;
 
 #endif
 
-} // namespace sofa::defaulttype
+} // namespace sofa::linearalgebra

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
@@ -416,14 +416,12 @@ public:
 
         void addCol(Index id, const Block& value)
         {
-            if constexpr (Policy::LogTrace) m_matrix->logCall(linearalgebra::FnEnum::addCol, m_rowIndex, id, value);
             *m_matrix->wblock(m_rowIndex, id, true) += value;
         }
 
         // TODO: this is wrong in case the returned block is within the uncompressed triplets
         void setCol(Index id, const Block& value)
         {
-            if constexpr (Policy::LogTrace) m_matrix->logCall(linearalgebra::FnEnum::setCol, m_rowIndex, id, value);
             *m_matrix->wblock(m_rowIndex, id, true) = value;
         }
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -67,7 +67,6 @@ struct CompressedRowSparseMatrixToEigenSparseVec
         }
 
         eigenMat.setFromTriplets(triplets.begin(), triplets.end());;
-        eigenMat.makeCompressed();
 
         return eigenMat;
     }

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -81,12 +81,6 @@ class CompressedRowSparseMatrixToEigenSparse< sofa::type::Vec<N,Real> >
 
 };
 
-//template< int N, typename Real >
-//class CompressedRowSparseMatrixToEigenSparse< sofa::defaulttype::RigidDeriv<N, Real > >
-//    : public CompressedRowSparseMatrixToEigenSparseVec<sofa::defaulttype::RigidDeriv<N, Real>>
-//{
-//
-//};
 
 
 template< class TBlock >

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -46,21 +46,21 @@ struct CompressedRowSparseMatrixToEigenSparseVec
 
     EigenSparseMatrix operator() (const TCompressedRowSparseMatrix& mat, std::size_t size)
     {
-        std::size_t eigenMatSize = size * TVec::size();
+        const std::size_t eigenMatSize = size * TVec::size();
         EigenSparseMatrix eigenMat(eigenMatSize, eigenMatSize);
 
-        std::vector<Eigen::Triplet<Real> > triplets;
+        sofa::type::vector<Eigen::Triplet<Real> > triplets;
 
         for (auto row = mat.begin(); row != mat.end(); ++row)
         {
             for (auto col = row.begin(), colend = row.end(); col !=colend; ++col)
             {
                 const TVec& vec = col.val();
-                int   colIndex  = col.index() * TVec::size();
+                const int   colIndex  = col.index() * TVec::size();
 
                 for (std::size_t i = 0; i < TVec::size(); ++i)
                 {
-                    triplets.emplace_back(Eigen::Triplet<Real>( row.index(), colIndex + i, vec[i]) );
+                    triplets.emplace_back(row.index(), colIndex + i, vec[i]);
                 }
 
             }
@@ -108,8 +108,8 @@ struct EigenSparseToCompressedRowSparseMatrixVec
 
         for (int rowIndex = 0; rowIndex < eigenMat.outerSize(); ++rowIndex)
         {
-            int offset      = *(outerIndexPtr + rowIndex);
-            int rowNonZeros = *(outerIndexPtr + rowIndex + 1) - *(outerIndexPtr + rowIndex);
+            const int offset      = *(outerIndexPtr + rowIndex);
+            const int rowNonZeros = *(outerIndexPtr + rowIndex + 1) - *(outerIndexPtr + rowIndex);
 
             if (rowNonZeros != 0)
             {
@@ -126,7 +126,6 @@ struct EigenSparseToCompressedRowSparseMatrixVec
                 {
                     TVec val;
                     int currenTBlockkIndex = blockIndex;
-                    //int currentCol   = *colPtr;
                     while (currenTBlockkIndex == blockIndex && i != rowNonZeros)
                     {
                         val[blockOffset] = *valuePtr; // TODO: valPtr ?

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -19,15 +19,15 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/defaulttype/CompressedRowSparseMatrixConstraint.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 #include <Eigen/Sparse>
 #include <sofa/type/Vec.h>
-#include <sofa/defaulttype/RigidTypes.h>
+//#include <sofa/defaulttype/RigidTypes.h>
 #include <cassert>
 #include <type_traits>
 #include <cstdlib>
 
-namespace sofa::defaulttype
+namespace sofa::linearalgebra
 {
 
 template< class TBlock >
@@ -81,12 +81,12 @@ class CompressedRowSparseMatrixToEigenSparse< sofa::type::Vec<N,Real> >
 
 };
 
-template< int N, typename Real >
-class CompressedRowSparseMatrixToEigenSparse< sofa::defaulttype::RigidDeriv<N, Real > >
-    : public CompressedRowSparseMatrixToEigenSparseVec<sofa::defaulttype::RigidDeriv<N, Real>>
-{
-
-};
+//template< int N, typename Real >
+//class CompressedRowSparseMatrixToEigenSparse< sofa::defaulttype::RigidDeriv<N, Real > >
+//    : public CompressedRowSparseMatrixToEigenSparseVec<sofa::defaulttype::RigidDeriv<N, Real>>
+//{
+//
+//};
 
 
 template< class TBlock >

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -95,7 +95,7 @@ struct EigenSparseToCompressedRowSparseMatrixVec
 {
     typedef typename TVec::Real Real;
     typedef CompressedRowSparseMatrixConstraint< TVec > TCompressedRowSparseMatrix;
-    typedef Eigen::SparseMatrix<double, Eigen::RowMajor> EigenSparseMatrix;
+    typedef Eigen::SparseMatrix<Real, Eigen::RowMajor> EigenSparseMatrix;
 
 
     TCompressedRowSparseMatrix operator() (const EigenSparseMatrix& eigenMat)
@@ -104,7 +104,7 @@ struct EigenSparseToCompressedRowSparseMatrixVec
 
         const int* outerIndexPtr  = eigenMat.outerIndexPtr();
         const int* innerIndexPtr  = eigenMat.innerIndexPtr();
-        const double* valuePtr      = eigenMat.valuePtr();
+        const Real* valuePtr      = eigenMat.valuePtr();
 
         for (int rowIndex = 0; rowIndex < eigenMat.outerSize(); ++rowIndex)
         {
@@ -117,7 +117,7 @@ struct EigenSparseToCompressedRowSparseMatrixVec
 
                 int i = 0;
                 const int*  colPtr = innerIndexPtr + offset;
-                //const Real* valPtr = valuePtr + offset;
+
                 int   blockIndex   = *colPtr / TVec::size();
                 int   blockOffset  = *colPtr - (blockIndex * TVec::size());
 
@@ -128,10 +128,10 @@ struct EigenSparseToCompressedRowSparseMatrixVec
                     int currenTBlockkIndex = blockIndex;
                     while (currenTBlockkIndex == blockIndex && i != rowNonZeros)
                     {
-                        val[blockOffset] = *valuePtr; // TODO: valPtr ?
+                        val[blockOffset] = *valuePtr;
                         ++i;
                         ++colPtr;
-                        ++valuePtr; // TODO: valPtr ?
+                        ++valuePtr;
                         blockIndex = *colPtr / TVec::size();
                         blockOffset = *colPtr - (blockIndex * TVec::size());
                     }

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
@@ -34,6 +34,30 @@
 #include <sofa/linearalgebra/matrix_bloc_traits.h>
 #include <algorithm>
 
+namespace // anonymous
+{
+    // Boiler-plate code to test if a type implements a method
+    // explanation https://stackoverflow.com/a/30848101
+
+    template <typename...>
+    using void_t = void;
+
+    // Primary template handles all types not supporting the operation.
+    template <typename, template <typename> class, typename = void_t<>>
+    struct detectMatrix : std::false_type {};
+
+    // Specialization recognizes/validates only types supporting the archetype.
+    template <typename T, template <typename> class Op>
+    struct detectMatrix<T, Op, void_t<Op<T>>> : std::true_type {};
+
+    // Actual test if T implements transposed() (hence is a type::Mat)
+    template <typename T>
+    using isMatrix_t = decltype(std::declval<T>().transposed());
+
+    template <typename T>
+    using isMatrix = detectMatrix<T, isMatrix_t>;
+} // anonymous
+
 namespace sofa::linearalgebra
 {
 
@@ -1370,13 +1394,13 @@ public:
 
     static auto blockMultTranspose(const TBlock& blockA, const TBlock& blockB)
     {
-        if constexpr (std::is_scalar_v<TBlock>)
+        if constexpr (isMatrix<Block>())
         {
-            return blockA * blockB;
+            return blockA.multTranspose(blockB);
         }
         else
         {
-            return blockA.multTranspose(blockB);
+            return blockA * blockB;
         }
     }
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
@@ -1125,7 +1125,6 @@ public:
             nBlockRow = 0;
             nBlockCol = 0;
             skipCompressZero = true;
-            if constexpr (Policy::StoreTouchFlags) touchedBlock.clear();
         }
 
         btemp.clear();

--- a/applications/plugins/ArticulatedSystemPlugin/src/ArticulatedSystemPlugin/ArticulatedSystemMapping.inl
+++ b/applications/plugins/ArticulatedSystemPlugin/src/ArticulatedSystemPlugin/ArticulatedSystemMapping.inl
@@ -489,17 +489,6 @@ void ArticulatedSystemMapping<TIn, TInRoot, TOut>::applyJT( InMatrixDeriv& out, 
         {
             typename InMatrixDeriv::RowIterator o = out.writeLine(rowIt.index());
 
-            //Hack to get a RowIterator, withtout default constructor
-            InRootMatrixDeriv temp;
-            typename InRootMatrixDeriv::RowIterator rootRowIt = temp.end();
-            typename InRootMatrixDeriv::RowIterator rootRowItEnd = temp.end();
-
-            if(m_fromRootModel && outRoot)
-            {
-                rootRowIt = outRoot->end();
-                rootRowItEnd = outRoot->end();
-            }
-
             while (colIt != colItEnd)
             {
                 int childIndex = colIt.index();
@@ -553,10 +542,7 @@ void ArticulatedSystemMapping<TIn, TInRoot, TOut>::applyJT( InMatrixDeriv& out, 
                     getVCenter(T) = getVCenter(valueConst);
                     getVOrientation(T) = getVOrientation(valueConst) + cross(C - posRoot, getVCenter(valueConst));
 
-                    if (rootRowIt == rootRowItEnd)
-                        rootRowIt = (*outRoot).writeLine(rowIt.index());
-
-                    rootRowIt.addCol(d_indexFromRoot.getValue(), T);
+                    (*outRoot).writeLine(rowIt.index()).addCol(d_indexFromRoot.getValue(), T);
                 }
 
                 ++colIt;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -29,7 +29,7 @@
 #include <sofa/type/Vec.h>
 #include <sofa/type/vector.h>
 #include <sofa/type/vector_device.h>
-#include <sofa/defaulttype/MapMapSparseMatrix.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/accessor.h>
 #include <sofa/core/behavior/ForceField.h>
@@ -91,7 +91,7 @@ public:
     typedef CudaVector<Coord> VecCoord;
     typedef CudaVector<Deriv> VecDeriv;
     typedef CudaVector<Real> VecReal;
-    typedef defaulttype::MapMapSparseMatrix<Deriv> MatrixDeriv;
+    typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     static constexpr sofa::Size spatial_dimensions = Coord::spatial_dimensions;
     static constexpr sofa::Size coord_total_size = Coord::total_size;
@@ -493,7 +493,7 @@ public:
     typedef CudaVector<Coord> VecCoord;
     typedef CudaVector<Deriv> VecDeriv;
     typedef CudaVector<Real> VecReal;
-    typedef defaulttype::MapMapSparseMatrix<Deriv> MatrixDeriv;
+    typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
     typedef Vec3 AngularVector;
 
     static constexpr sofa::Size spatial_dimensions = Coord::spatial_dimensions;
@@ -677,7 +677,7 @@ public:
     typedef CudaVector<Deriv> VecDeriv;
     typedef CudaVector<Real> VecReal;
 
-    typedef defaulttype::MapMapSparseMatrix<Deriv> MatrixDeriv;
+    typedef linearalgebra::CompressedRowSparseMatrixConstraint<Deriv> MatrixDeriv;
 
     template<typename T>
     static void set(Coord& c, T x, T y, T)
@@ -1046,5 +1046,20 @@ namespace sofa::component::mass
 
 } // namespace sofa::component::mass
 
+
+// define block traits for Vec3r1 (see matrix_bloc_traits.h)
+// mainly used with CompressedRowSparseMatrix
+namespace sofa::linearalgebra
+{
+
+template <class T, typename IndexType >
+class matrix_bloc_traits < sofa::gpu::cuda::Vec3r1<T>, IndexType > : public matrix_bloc_traits<sofa::type::Vec<3, T>, IndexType>
+{
+public:
+    typedef sofa::gpu::cuda::Vec3r1<T> Block;
+
+};
+
+} // namespace sofa::linearalgebra
 
 #endif


### PR DESCRIPTION
 and replace MapMapSparseMatrix

Continuation of #3515 

Breaking because one or two functions have been deleted (for perf reasons), especially the batch clear function.

Some benchs, where constraints are supposedly the bottleneck

caduceus.scn
```
before: 5000 iterations done in 48.2532 s ( 103.62 FPS).
after:  5000 iterations done in 22.042 s ( 226.839 FPS).
```

TorusFall.scn
```
before: 5000 iterations done in 47.5045 s ( 105.253 FPS).
after:  5000 iterations done in 37.8749 s ( 132.014 FPS).
```

3instruments_collis.scn
```
before: 5000 iterations done in 63.3632 s ( 78.9101 FPS).
after:  5000 iterations done in 53.7899 s ( 92.9542 FPS).
```


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
