### PR TITLE
[Spring] Rename RestShapeSpringsForceField to a more user-oriented name

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.cpp
@@ -34,11 +34,14 @@ namespace sofa::component::solidmechanics::spring
 using namespace sofa::type;
 using namespace sofa::defaulttype;
 
-int RestShapeSpringsForceFieldClass = core::RegisterObject("Elastic springs generating forces on degrees of freedom between their current and rest shape position")
+int RestShapeSpringsForceFieldClass =
+    core::RegisterObject("Elastic springs generating forces on degrees of freedom between their "
+                         "current position and a reference position. By default, the reference "
+                         "position is the rest position.")
         .add< RestShapeSpringsForceField<Vec3Types> >()
         .add< RestShapeSpringsForceField<Vec1Types> >()
         .add< RestShapeSpringsForceField<Rigid3Types> >()
-
+        .addAlias("SpringConstraint")
         ;
 
 template class SOFA_COMPONENT_SOLIDMECHANICS_SPRING_API RestShapeSpringsForceField<Vec3Types>;


### PR DESCRIPTION
The idea is to ease the understanding of what the **RestShapeSpringsForceField** does. Usually, this component is used to fix points, or follow a path, using elastic forces. That is why, a suggestion of a new name could be **SpringConstraint**. It would be a constraint based on penalties.

Note that this PR requires more work for the renaming. For the moment, it is just a support for a discussion.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
