### PR TITLE
[Constraint.Lagrangian.Solver] LCPConstraintSolver: Fix when mu=0 (no friction)

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -783,7 +783,6 @@ void LCPConstraintSolver::computeInitialGuess()
         else
         {
             (*_result)[c] =  0.0;
-            //(*_result)[c+numContact] =  0.0;
         }
     }
     for (const ConstraintBlockInfo& info : constraintBlockInfo)

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -115,7 +115,6 @@ private:
     void keepContactForcesValue();
 
     unsigned int _numConstraints;
-    SReal _mu;
 
     /// Call the method resetConstraint on all the mechanical states and BaseConstraintSet
     void resetConstraints(core::ConstraintParams cparams);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -115,6 +115,7 @@ private:
     void keepContactForcesValue();
 
     unsigned int _numConstraints;
+    SOFA_ATTRIBUTE_DEPRECATED__LCPCONSTRAINTSOLVERMUMEMBER() DeprecatedAndRemoved _mu;
 
     /// Call the method resetConstraint on all the mechanical states and BaseConstraintSet
     void resetConstraints(core::ConstraintParams cparams);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/config.h.in
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/config.h.in
@@ -44,3 +44,12 @@ namespace sofa::component::constraint::lagrangian::solver
     SOFA_ATTRIBUTE_DISABLED( \
         "v22.12", "v23.06", msg)
 #endif // SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER
+
+// deprecate _mu as member
+#ifdef SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER
+#define SOFA_ATTRIBUTE_DEPRECATED__LCPCONSTRAINTSOLVERMUMEMBER()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__LCPCONSTRAINTSOLVERMUMEMBER() \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v23.12", "v24.06", "_mu is not a member anymore. Use the Data \"mu\" to get the friction value.")
+#endif // SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER

--- a/examples/Component/Constraint/Lagrangian/FrictionContact_LCP_with_friction.scn
+++ b/examples/Component/Constraint/Lagrangian/FrictionContact_LCP_with_friction.scn
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<Node name="root" dt="0.03" gravity="0 -9.810 0">
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase,BruteForceBroadPhase,CollisionPipeline] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [LocalMinDistance] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [LineCollisionModel,PointCollisionModel,TriangleCollisionModel] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [UncoupledConstraintCorrection] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Solver"/> <!-- Needed to use components [LCPConstraintSolver] -->
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.NonLinear"/> <!-- Needed to use components [RigidMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+    </Node>
+    <VisualStyle displayFlags="showVisual" />
+
+    <LCPConstraintSolver tolerance="1e-6" maxIt="1000" initial_guess="true" build_lcp="false" mu="0.2"/>
+    <FreeMotionAnimationLoop />
+    <CollisionPipeline depth="15" verbose="0" draw="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <LocalMinDistance name="Proximity" alarmDistance="0.3" contactDistance="0.1" useLMDFilters="0" />
+    <DefaultContactManager name="Response" response="FrictionContactConstraint" responseParams="mu=0.2" />
+    <Node>
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <Node name="CUBE_1_1">
+            <MechanicalObject template="Rigid3" scale="0.3" dx="-2.8" dy="-1.5" dz="0.0" rx="0" />
+            <UniformMass totalMass="100.0" />
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
+            <Node name="Visu">
+                <MeshOBJLoader name="meshLoader_4" filename="mesh/smCube27.obj" scale="0.3" handleSeams="1" />
+                <OglModel name="Visual" src="@meshLoader_4" color="0.0 0.5 0.8 1.0" />
+                <RigidMapping input="@.." output="@Visual" />
+            </Node>
+            <Node name="Surf2">
+                <MeshOBJLoader name="loader" filename="mesh/smCube27.obj" triangulate="true" />
+                <MeshTopology src="@loader"/>
+                <MechanicalObject src="@loader" scale="0.3" />
+                <TriangleCollisionModel />
+                <LineCollisionModel />
+                <PointCollisionModel />
+                <RigidMapping />
+            </Node>
+        </Node>
+        
+        <Node name="BOX">
+            <MeshOBJLoader name="loader" filename="mesh/box_inside.obj" triangulate="true" rotation="5 0 0" />
+            <MeshTopology src="@loader"/>
+            <MechanicalObject src="@loader" />
+            <TriangleCollisionModel simulated="0" moving="0" />
+            <LineCollisionModel simulated="0" moving="0" />
+            <PointCollisionModel simulated="0" moving="0" />
+            <OglModel name="Visual" src="@loader" color="0 0.8 0.3 0.3" />
+        </Node>
+    </Node>
+</Node>
+ 

--- a/examples/Component/Constraint/Lagrangian/FrictionContact_LCP_without_friction.scn
+++ b/examples/Component/Constraint/Lagrangian/FrictionContact_LCP_without_friction.scn
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<Node name="root" dt="0.03" gravity="0 -9.810 0">
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase,BruteForceBroadPhase,CollisionPipeline] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [LocalMinDistance] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [LineCollisionModel,PointCollisionModel,TriangleCollisionModel] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [UncoupledConstraintCorrection] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Solver"/> <!-- Needed to use components [LCPConstraintSolver] -->
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.NonLinear"/> <!-- Needed to use components [RigidMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+    </Node>
+    <VisualStyle displayFlags="showVisual" />
+
+    <LCPConstraintSolver tolerance="1e-6" maxIt="1000" initial_guess="true" build_lcp="false" mu="0.0"/>
+    <FreeMotionAnimationLoop />
+    <CollisionPipeline depth="15" verbose="0" draw="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <LocalMinDistance name="Proximity" alarmDistance="0.3" contactDistance="0.1" useLMDFilters="0" />
+    <DefaultContactManager name="Response" response="FrictionContactConstraint" responseParams="mu=0" />
+    <Node>
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <Node name="CUBE_1_1">
+            <MechanicalObject template="Rigid3" scale="0.3" dx="-2.8" dy="-1.5" dz="0.0" rx="0" />
+            <UniformMass totalMass="100.0" />
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
+            <Node name="Visu">
+                <MeshOBJLoader name="meshLoader_4" filename="mesh/smCube27.obj" scale="0.3" handleSeams="1" />
+                <OglModel name="Visual" src="@meshLoader_4" color="0.0 0.5 0.8 1.0" />
+                <RigidMapping input="@.." output="@Visual" />
+            </Node>
+            <Node name="Surf2">
+                <MeshOBJLoader name="loader" filename="mesh/smCube27.obj" triangulate="true" />
+                <MeshTopology src="@loader"/>
+                <MechanicalObject src="@loader" scale="0.3" />
+                <TriangleCollisionModel />
+                <LineCollisionModel />
+                <PointCollisionModel />
+                <RigidMapping />
+            </Node>
+        </Node>
+        
+        <Node name="BOX">
+            <MeshOBJLoader name="loader" filename="mesh/box_inside.obj" triangulate="true" rotation="5 0 0" />
+            <MeshTopology src="@loader"/>
+            <MechanicalObject src="@loader" />
+            <TriangleCollisionModel simulated="0" moving="0" />
+            <LineCollisionModel simulated="0" moving="0" />
+            <PointCollisionModel simulated="0" moving="0" />
+            <OglModel name="Visual" src="@loader" color="0 0.8 0.3 0.3" />
+        </Node>
+    </Node>
+</Node>
+ 

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -18,6 +18,8 @@ Component/Collision/Response/FrictionContact.scn 100 1e-4 0 1
 Component/Constraint/Lagrangian/BilateralInteractionConstraint_NNCG.scn 100 1e-4 0 1
 Component/Constraint/Lagrangian/BilateralInteractionConstraint_PGS.scn 100 1e-4 0 1
 Component/Constraint/Lagrangian/BilateralInteractionConstraint_UGS.scn 100 1e-4 0 1
+Component/Constraint/Lagrangian/FrictionContact_LCP_with_friction.scn 500 1e-4 0 1
+Component/Constraint/Lagrangian/FrictionContact_LCP_without_friction.scn 500 1e-4 0 1
 Component/Constraint/Projective/FixedConstraint.scn 100 1e-4 0 1
 Component/LinearSolver/Direct/FEMBAR_EigenSimplicialLDLT.scn 100 1e-8 0 1
 Component/LinearSolver/Direct/FEMBAR_EigenSimplicialLLT.scn 100 1e-8 0 1


### PR DESCRIPTION
`lcp_gaussseidel_unbuilt` is called even if there is no constraints, so a test is added.
And the initial guess was writing a 0.0 outside bounds (but I dont know why this line was here)

:warning: WARNING :warning:
one needs to set the responseParams to mu=0.0 also. This is really confusing and would need to refactor somewhere.
If the LCP defines mu to 0.0 but not responseParams, funny things happen (one component expects 1contact = 1 constraint and the other 1contact = 3 constraints)

Moreover:
 - remove (deprecate) usage of the member `_mu` which was confusing with the data `mu`
 - adds two scenes to demonstrate with and without friction, and their regression tests.

[ci-depends-on https://github.com/sofa-framework/Regression/pull/47]

![lcp_friction](https://github.com/sofa-framework/sofa/assets/11028016/eba86b90-3cfc-40f6-850f-6aba720d291d)
![lcp_nofriction](https://github.com/sofa-framework/sofa/assets/11028016/fb015cd7-54c6-4347-a07e-e5c960dc609c)


Benchmarks:
As friction adds two additional constraints in the matrix, then frictionless scenes are faster:
```
caduceus:
w/:   5000 iterations done in 52.071 s ( 96.0227 FPS)
w/o:  5000 iterations done in 44.6895 s ( 111.883 FPS)
```
```
3instruments_collis:
w:    5000 iterations done in 69.8352 s ( 71.5971 FPS)
w/o:  5000 iterations done in 43.0997 s ( 116.01 FPS)
```
Obviously, this change the behavior of the scene...
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
