### PR TITLE
[Helper] Improve text message for users in ComponentChange

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
@@ -58,10 +58,10 @@ public:
         output << "This component has been DEPRECATED since SOFA " << sinceVersion << " "
                   "and will be removed in SOFA " << untilVersion << ". "
                << instruction <<
-                  " Please consider updating your scene as using "
+                  "\nPlease consider updating your scene as using "
                   "deprecated component may result in poor performance and undefined behavior. "
-                  "If this component is crucial to you please report that to sofa-dev@ so we can "
-                  "reconsider this component for future re-integration.";
+                  "If this component is crucial to you please report in a GitHub issue "
+                  "in order to reconsider this component for future re-integration.";
         m_message = output.str();
         m_changeVersion = untilVersion;
     }
@@ -89,9 +89,9 @@ public:
         std::stringstream output;
         output << "This component has been REMOVED since SOFA " << atVersion << " "
                   "(deprecated since " << sinceVersion << "). "
-                  "Please consider updating your scene. "
-                  "If this component is crucial to you please report that to sofa-dev@ so that we can "
-                  "reconsider this component for future re-integration.";
+                  "\nPlease consider updating your scene. "
+                  "If this component is crucial to you please report in a GitHub issue "
+                  "in order to reconsider this component for future re-integration.";
         m_message = output.str();
         m_changeVersion = atVersion;
     }


### PR DESCRIPTION
Improve the message when a component is deprecated and removed, in order to mention GitHub issues :love_letter: 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
