### PR TITLE
[Logging] Suggestion to better highlight warnings in console

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/logging/MessageFormatter.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/MessageFormatter.cpp
@@ -57,7 +57,7 @@ std::ostream & MessageFormatter::setColor(std::ostream &os, unsigned int type) c
         case Message::Advice     : return os << console::Foreground::Bright::Green;
         case Message::Info       : return os << console::Foreground::Bright::Green;
         case Message::Deprecated : return os << console::Foreground::Bright::Yellow;
-        case Message::Warning    : return os << console::Foreground::Bright::Cyan;
+        case Message::Warning    : return os << console::Foreground::Bright::Yellow;
         case Message::Error      : return os << console::Foreground::Bright::Red;
         case Message::Fatal      : return os << console::Foreground::Bright::Magenta;
 

--- a/Sofa/framework/Helper/src/sofa/helper/logging/MessageFormatter.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/MessageFormatter.cpp
@@ -56,8 +56,8 @@ std::ostream & MessageFormatter::setColor(std::ostream &os, unsigned int type) c
     switch (type) {
         case Message::Advice     : return os << console::Foreground::Bright::Green;
         case Message::Info       : return os << console::Foreground::Bright::Green;
-        case Message::Deprecated : return os << console::Foreground::Bright::Yellow;
         case Message::Warning    : return os << console::Foreground::Bright::Yellow;
+        case Message::Deprecated : return os << console::Foreground::Normal::Yellow;
         case Message::Error      : return os << console::Foreground::Bright::Red;
         case Message::Fatal      : return os << console::Foreground::Bright::Magenta;
 


### PR DESCRIPTION
IMO it's pain to see and consider WARNINGS when they do not burn my retina from the console :eyeglasses: 
Yellow color for warning messages (as for deprecation) will help me sleeping at night 

![Screenshot_2023-06-02_15-39-17](https://github.com/sofa-framework/sofa/assets/17544719/81ad75c4-a272-4378-a2c5-a6012d19ef99)

______________________________________________________



By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
