### PR TITLE
[Core] Access cumulative sum of VecIds through proxy class

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -196,6 +196,14 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
         MechanicalVInitVisitor< core::V_DERIV >(params, core::VecDerivId::freeVelocity(), core::ConstVecDerivId::velocity(), true).execute(gnode);
     }
 
+    // This animation loop works with lagrangian constraints. Forces derive from the constraints.
+    // Therefore we notice the States that they have to consider them in the total accumulation of
+    // forces.
+    for (auto* state : this->getContext()->getObjects<sofa::core::BaseState>(sofa::core::objectmodel::BaseContext::SearchDirection::SearchDown))
+    {
+        state->addToTotalForces(cparams.lambda().getId(state));
+    }
+
 
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printNode("Step");

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
@@ -355,12 +355,14 @@ void DistanceMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
     const SeqEdges& links = l_topology->getEdges();
     const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 
-    for(size_t i=0; i<links.size(); i++)
+    for(sofa::Size i=0; i<links.size(); i++)
     {
+        const OutDeriv force_i = childForce[i];
+
         // force in compression (>0) can lead to negative eigen values in geometric stiffness
         // this results in a undefinite implicit matrix that causes instabilies
         // if stabilized GS (geometricStiffness==2) -> keep only force in extension
-        if( childForce[i][0] < 0 || geometricStiffness==1 )
+        if( force_i[0] < 0 || geometricStiffness==1 )
         {
             const sofa::topology::Edge link = links[i];
             const Direction& dir = directions[i];
@@ -373,7 +375,7 @@ void DistanceMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
                     b[j][k] = static_cast<Real>(1) * ( j==k ) - dir[j] * dir[k];
                 }
             }
-            b *= childForce[i][0] * invlengths[i];  // (I - uu^T)*f/l
+            b *= force_i[0] * invlengths[i];  // (I - uu^T)*f/l
 
             dJdx(link[0] * Nin, link[0] * Nin) += b;
             dJdx(link[0] * Nin, link[1] * Nin) += -b;

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
@@ -351,7 +351,7 @@ void DistanceMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
         return;
     }
 
-    const auto childForce = this->toModel->readForces();
+    const auto childForce = this->toModel->readTotalForces();
     const SeqEdges& links = l_topology->getEdges();
     const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.inl
@@ -416,7 +416,7 @@ void DistanceMultiMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
     const unsigned& geometricStiffness = d_geometricStiffness.getValue().getSelectedId();
     if( !geometricStiffness ) { return; }
 
-    const auto childForce = this->getToModels()[0]->readForces();
+    const auto childForce = this->getToModels()[0]->readTotalForces();
     const SeqEdges& links = l_topology->getEdges();
     const type::vector<type::Vec2i>& pairs = d_indexPairs.getValue();
 

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.inl
@@ -420,12 +420,14 @@ void DistanceMultiMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
     const SeqEdges& links = l_topology->getEdges();
     const type::vector<type::Vec2i>& pairs = d_indexPairs.getValue();
 
-    for(size_t i=0; i<links.size(); i++)
+    for(sofa::Size i=0; i<links.size(); i++)
     {
+        const OutDeriv force_i = childForce[i];
+
         // force in compression (>0) can lead to negative eigen values in geometric stiffness
         // this results in a undefinite implicit matrix that causes instabilies
         // if stabilized GS (geometricStiffness==2) -> keep only force in extension
-        if( childForce[i][0] < 0 || geometricStiffness==1 )
+        if( force_i[0] < 0 || geometricStiffness==1 )
         {
             type::Mat<Nin,Nin,Real> b;  // = (I - uu^T)
             for(unsigned j=0; j<In::spatial_dimensions; j++)
@@ -435,7 +437,7 @@ void DistanceMultiMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
                     b[j][k] = static_cast<Real>(1) * ( j==k ) - directions[j] * directions[k];
                 }
             }
-            b *= childForce[i][0] * invlengths[i];  // (I - uu^T)*f/l
+            b *= force_i[0] * invlengths[i];  // (I - uu^T)*f/l
 
             const type::Vec2i& pair0 = pairs[ links[i][0] ];
             const type::Vec2i& pair1 = pairs[ links[i][1] ];

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
@@ -661,7 +661,7 @@ void RigidMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
 
         const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 
-        const auto childForces = this->toModel->readForces();
+        const auto childForces = this->toModel->readTotalForces();
 
         std::map<unsigned, sofa::type::vector<unsigned> > in_out;
         for(sofa::Index i = 0; i < m_rotatedPoints.size(); ++i)

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
@@ -283,15 +283,17 @@ void SquareDistanceMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
     const SeqEdges& links = l_topology->getEdges();
     const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 
-    for(size_t i=0; i<links.size(); i++)
+    for(sofa::Size i=0; i<links.size(); i++)
     {
+        const OutDeriv force_i = childForce[i];
+
         const sofa::topology::Edge link = links[i];
         // force in compression (>0) can lead to negative eigen values in geometric stiffness
         // this results in a undefinite implicit matrix that causes instabilies
         // if stabilized GS (geometricStiffness==2) -> keep only force in extension
-        if( childForce[i][0] < 0 || geometricStiffness==1 )
+        if( force_i[0] < 0 || geometricStiffness==1 )
         {
-            SReal tmp = 2*childForce[i][0];
+            const Real tmp = 2 * force_i[0];
 
             for(unsigned k=0; k<In::spatial_dimensions; k++)
             {

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
@@ -279,7 +279,7 @@ void SquareDistanceMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
         return;
     }
 
-    const auto childForce = this->toModel->readForces();
+    const auto childForce = this->toModel->readTotalForces();
     const SeqEdges& links = l_topology->getEdges();
     const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
@@ -191,7 +191,7 @@ void SquareMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
         return;
     }
 
-    const auto childForce = this->toModel->readForces();
+    const auto childForce = this->toModel->readTotalForces();
     unsigned int size = this->fromModel->getSize();
     const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareMapping.inl
@@ -192,10 +192,10 @@ void SquareMapping<TIn, TOut>::buildGeometricStiffnessMatrix(
     }
 
     const auto childForce = this->toModel->readTotalForces();
-    unsigned int size = this->fromModel->getSize();
+    const unsigned int size = this->fromModel->getSize();
     const auto dJdx = matrices->getMappingDerivativeIn(this->fromModel).withRespectToPositionsIn(this->fromModel);
 
-    for( size_t i=0 ; i<size ; ++i )
+    for( sofa::Size i=0 ; i<size ; ++i )
     {
         dJdx(i, i) += 2*childForce[i][0];
     }

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -5,6 +5,8 @@ set(SRC_ROOT "src/sofa/core")
 
 set(HEADER_FILES
     ${SRC_ROOT}/config.h.in
+    ${SRC_ROOT}/AccumulationVecId.h
+    ${SRC_ROOT}/AccumulationVecId.inl
     ${SRC_ROOT}/BaseMatrixAccumulatorComponent.h
     ${SRC_ROOT}/BaseLocalMappingMatrix.h
     ${SRC_ROOT}/BaseMapping.h
@@ -190,6 +192,7 @@ set(HEADER_FILES
 )
 
 set(SOURCE_FILES
+    ${SRC_ROOT}/AccumulationVecId.cpp
     ${SRC_ROOT}/BaseMatrixAccumulatorComponent.cpp
     ${SRC_ROOT}/BaseMapping.cpp
     ${SRC_ROOT}/BaseState.cpp

--- a/Sofa/framework/Core/src/sofa/core/AccumulationVecId.cpp
+++ b/Sofa/framework/Core/src/sofa/core/AccumulationVecId.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,35 +19,19 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/BaseState.h>
-#include <sofa/core/objectmodel/BaseNode.h>
+#define SOFA_CORE_ACCUMULATIONVECID_CPP
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/defaulttype/RigidTypes.h>
+
+#include <sofa/core/AccumulationVecId.inl>
 
 namespace sofa::core
 {
-
-
-bool BaseState::insertInNode( objectmodel::BaseNode* node )
-{
-    node->addState(this);
-    Inherit1::insertInNode(node);
-    return true;
+template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec3dTypes, V_DERIV, V_READ>;
+template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec2Types, V_DERIV, V_READ>;
+template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec1Types, V_DERIV, V_READ>;
+template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec6Types, V_DERIV, V_READ>;
+template struct SOFA_CORE_API AccumulationVecId<defaulttype::Rigid3Types, V_DERIV, V_READ>;
+template struct SOFA_CORE_API AccumulationVecId<defaulttype::Rigid2Types, V_DERIV, V_READ>;
+template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec3fTypes, V_DERIV, V_READ>;
 }
-
-bool BaseState::removeInNode( objectmodel::BaseNode* node )
-{
-    node->removeState(this);
-    Inherit1::removeInNode(node);
-    return true;
-}
-
-void BaseState::addToTotalForces(core::ConstVecDerivId forceId)
-{
-    SOFA_UNUSED(forceId);
-}
-
-void BaseState::removeFromTotalForces(core::ConstVecDerivId forceId)
-{
-    SOFA_UNUSED(forceId);
-}
-} // namespace sofa::core
-

--- a/Sofa/framework/Core/src/sofa/core/AccumulationVecId.h
+++ b/Sofa/framework/Core/src/sofa/core/AccumulationVecId.h
@@ -1,0 +1,76 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/core/VecId.h>
+#include <sofa/type/vector.h>
+
+namespace sofa::core
+{
+template<class TDataTypes>
+class State;
+
+/**
+ * \brief Proxy class for accessing elements within an imaginary container that represents the
+ * cumulative sum of multiple other containers. Each individual container is represented by a
+ * VecId. The class maintains a list of VecIdDeriv objects, which defines the containers
+ * contributing to the final cumulative sum.
+ * This class provides a simplified interface for accessing elements within the cumulative
+ * container. It allows retrieving specific elements using the overloaded subscript operator
+ * (operator[]). When accessing an element at a particular index, the class delegates the retrieval
+ * to the appropriate container represented by the associated VecIdDeriv.
+ * In addition to element retrieval, the class supports dynamic management of the contributing
+ * containers. It offers functions to add and remove VecId objects from the list of containers
+ * that contribute to the cumulative sum.
+ * \tparam TDataTypes Type of DOFs stored in the State
+ */
+template<class TDataTypes, VecType vtype, VecAccess vaccess>
+struct AccumulationVecId
+{
+private:
+    type::vector<TVecId<vtype, vaccess> > m_contributingVecIds{};
+    const State<TDataTypes>& m_state;
+
+public:
+    using DataTypes = TDataTypes;
+    using Deriv = typename DataTypes::Deriv;
+    Deriv operator[](Size i) const;
+
+    /// The provided VecDerivId container will contribute in the cumulative sum
+    void addToContributingVecIds(core::ConstVecDerivId vecDerivId);
+
+    void removeFromContributingVecIds(core::ConstVecDerivId vecDerivId);
+
+    explicit AccumulationVecId(const State<TDataTypes>& state) : m_state(state) {}
+    AccumulationVecId() = delete;
+};
+
+#if !defined(SOFA_CORE_ACCUMULATIONVECID_CPP)
+extern template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec3dTypes, V_DERIV, V_READ>;
+extern template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec2Types, V_DERIV, V_READ>;
+extern template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec1Types, V_DERIV, V_READ>;
+extern template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec6Types, V_DERIV, V_READ>;
+extern template struct SOFA_CORE_API AccumulationVecId<defaulttype::Rigid3Types, V_DERIV, V_READ>;
+extern template struct SOFA_CORE_API AccumulationVecId<defaulttype::Rigid2Types, V_DERIV, V_READ>;
+extern template struct SOFA_CORE_API AccumulationVecId<defaulttype::Vec3fTypes, V_DERIV, V_READ>;
+#endif
+
+}

--- a/Sofa/framework/Core/src/sofa/core/BaseState.h
+++ b/Sofa/framework/Core/src/sofa/core/BaseState.h
@@ -64,6 +64,12 @@ public:
     bool insertInNode( objectmodel::BaseNode* node ) override;
     bool removeInNode( objectmodel::BaseNode* node ) override;
 
+    /// The given VecDerivId is appended to a list representing all the forces containers
+    /// It is useful to be able to compute the accumulation of all forces (for example the ones
+    /// coming from force fields and the ones coming from lagrangian constraints).
+    virtual void addToTotalForces(core::ConstVecDerivId forceId);
+
+    virtual void removeFromTotalForces(core::ConstVecDerivId forceId);
 };
 
 } // namespace sofa::core

--- a/Sofa/framework/Core/src/sofa/core/State.h
+++ b/Sofa/framework/Core/src/sofa/core/State.h
@@ -113,7 +113,7 @@ public:
     AccumulationVecId<TDataTypes, V_DERIV, V_READ> accumulatedForces;
 
     /// Returns a proxy objects offering simplified access to elements of the cumulative sum of all force containers
-    AccumulationVecId<TDataTypes, V_DERIV, V_READ> readTotalForces() const { return accumulatedForces;}
+    const AccumulationVecId<TDataTypes, V_DERIV, V_READ>& readTotalForces() const { return accumulatedForces;}
     //@}
 
     /// The provided VecDerivId will contribute to the sum of all force containers

--- a/Sofa/framework/Core/src/sofa/core/State.h
+++ b/Sofa/framework/Core/src/sofa/core/State.h
@@ -25,6 +25,7 @@
 #include <sofa/core/BaseState.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
+#include <sofa/core/AccumulationVecId.h>
 
 namespace sofa::core
 {
@@ -107,11 +108,22 @@ public:
     WriteVecDeriv writeDx()                 { return WriteVecDeriv(*this->write(core::VecDerivId::dx())); }
     WriteOnlyVecDeriv writeOnlyDx()         { return WriteOnlyVecDeriv(*this->write(core::VecDerivId::dx())); }
     ReadVecDeriv  readNormals() const       { return ReadVecDeriv (*this->read (core::ConstVecDerivId::normal())); }
+
+    /// Stores all the VecDerivId corresponding to a force. They can then be accumulated
+    AccumulationVecId<TDataTypes, V_DERIV, V_READ> accumulatedForces;
+
+    /// Returns a proxy objects offering simplified access to elements of the cumulative sum of all force containers
+    AccumulationVecId<TDataTypes, V_DERIV, V_READ> readTotalForces() const { return accumulatedForces;}
     //@}
 
+    /// The provided VecDerivId will contribute to the sum of all force containers
+    void addToTotalForces(core::ConstVecDerivId forceId) override;
+
+    void removeFromTotalForces(core::ConstVecDerivId forceId) override;
 
 protected:
-    State() {}
+    State();
+
     ~State() override { }
 	
 private:

--- a/Sofa/framework/Core/src/sofa/core/State.inl
+++ b/Sofa/framework/Core/src/sofa/core/State.inl
@@ -22,9 +22,28 @@
 #pragma once
 
 #include <sofa/core/State.h>
+#include <sofa/core/AccumulationVecId.inl>
 
 namespace sofa::core
 {
+template <class TDataTypes>
+void State<TDataTypes>::addToTotalForces(core::ConstVecDerivId forceId)
+{
+    accumulatedForces.addToContributingVecIds(forceId);
+}
+
+template <class TDataTypes>
+void State<TDataTypes>::removeFromTotalForces(core::ConstVecDerivId forceId)
+{
+    accumulatedForces.removeFromContributingVecIds(forceId);
+}
+
+template <class TDataTypes>
+State<TDataTypes>::State()
+    : accumulatedForces(*this)
+{
+    State::addToTotalForces(core::ConstVecDerivId::force());
+}
 
 template<class DataTypes>
 objectmodel::BaseData* State<DataTypes>::baseWrite(VecId v)

--- a/Sofa/framework/Core/src/sofa/core/behavior/MechanicalState.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/MechanicalState.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/State.inl>
 
 namespace sofa::core::behavior
 {

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/statecontainer/CudaMechanicalObject.cpp
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/statecontainer/CudaMechanicalObject.cpp
@@ -27,6 +27,26 @@
 #include <sofa/component/statecontainer/MappedObject.inl>
 #include <sofa/core/State.inl>
 
+namespace sofa::core
+{
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec1fTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec2fTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec3fTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec3f1Types, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec6fTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaRigid3fTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaRigid2fTypes, V_DERIV, V_READ>;
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec1dTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec2dTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec3dTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec3d1Types, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaVec6dTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaRigid3dTypes, V_DERIV, V_READ>;
+template struct SOFA_GPU_CUDA_API AccumulationVecId<sofa::gpu::cuda::CudaRigid2dTypes, V_DERIV, V_READ>;
+#endif // SOFA_GPU_CUDA_DOUBLE
+}
+
 namespace sofa::component::statecontainer
 {
 // template specialization must be in the same namespace as original namespace for GCC 4.1


### PR DESCRIPTION
This is to take into account the geometric stiffness in non-linear mappings. It has to take into account the sum of all forces applied on a MechanicalObject. Therefore, a list of VecIds is maintained and accessed later.

It fixes some of the existing scenes that were broken due to #2777.




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
