### PR TITLE
[Mass] Replace doUpdateInternal by callback: MeshMatrixMass

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -212,7 +212,7 @@ public:
     void copyVertexMass();
 
 
-    /// Mass APInterface
+    /// Mass API
     void addMDx(const core::MechanicalParams*, DataVecDeriv& f, const DataVecDeriv& dx, SReal factor) override;
 
     void accFromF(const core::MechanicalParams*, DataVecDeriv& a, const DataVecDeriv& f) override; // This function can't be used as it use M^-1

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -91,6 +91,15 @@ public:
     Data< MassType > d_totalMass;
     /// @}
 
+    /// Enumeration specifying which data was used for initialization
+    enum InitMethod {
+        totalMass,
+        massDensity,
+        vertexMass,
+        vertexAndEdgeMass
+    };
+
+    InitMethod m_initMethod = totalMass;
 
     /// Values of the particles masses stored on vertices
     core::topology::PointData<type::vector<MassType> >  d_vertexMass;
@@ -137,6 +146,7 @@ public:
     void reinit() override;
     void init() override;
     void handleEvent(sofa::core::objectmodel::Event *event) override;
+
 
     sofa::geometry::ElementType getMassTopologyType() const
     {
@@ -186,19 +196,23 @@ public:
     virtual void initFromMassDensity();
 
     virtual bool checkTotalMass();
-    virtual void checkTotalMassInit();
     virtual void initFromTotalMass();
 
     bool checkEdgeMass();
     void initFromVertexAndEdgeMass();
     /// @}
 
+    /// Functions updating data
+    sofa::core::objectmodel::ComponentState updateFromTotalMass();
+    sofa::core::objectmodel::ComponentState updateFromMassDensity();
+    sofa::core::objectmodel::ComponentState updateFromVertexAndEdgeMass();
+    sofa::core::objectmodel::ComponentState updateFromVertexMass();
 
     /// Copy the vertex mass scalar (in case of CudaTypes)
     void copyVertexMass();
 
 
-    // -- Mass interface
+    /// Mass APInterface
     void addMDx(const core::MechanicalParams*, DataVecDeriv& f, const DataVecDeriv& dx, SReal factor) override;
 
     void accFromF(const core::MechanicalParams*, DataVecDeriv& a, const DataVecDeriv& f) override; // This function can't be used as it use M^-1

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -137,7 +137,6 @@ public:
     void reinit() override;
     void init() override;
     void handleEvent(sofa::core::objectmodel::Event *event) override;
-    void doUpdateInternal() override;
 
     sofa::geometry::ElementType getMassTopologyType() const
     {

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -131,7 +131,8 @@ protected:
 
     sofa::geometry::ElementType checkTopology();
     void initTopologyHandlers(sofa::geometry::ElementType topologyType);
-    void massInitialization();
+    void massInitializationMethod();
+    void printInitializationOuput();
 
     /// Internal data required for Cuda computation (copy of vertex mass for deviceRead)
     MeshMatrixMassInternalData<DataTypes, MassType, GeometricalTypes> data;

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -94,11 +94,8 @@ public:
     /// Enumeration specifying which data was used for initialization
     enum InitMethod {
         totalMass,
-        massDensity,
-        vertexMass,
-        vertexAndEdgeMass
+        massDensity
     };
-
     InitMethod m_initMethod = totalMass;
 
     /// Values of the particles masses stored on vertices
@@ -143,7 +140,6 @@ protected:
 public:
     virtual void clear();
 
-    void reinit() override;
     void init() override;
     void handleEvent(sofa::core::objectmodel::Event *event) override;
 
@@ -176,7 +172,9 @@ public:
     virtual const sofa::type::vector< MassType > &getMassDensity();
     virtual const Real &getTotalMass();
 
+    SOFA_ATTRIBUTE_DEPRECATED__MESHMATRIXMASS_ONLY_DENSITYANDTOTALMASS()
     virtual void setVertexMass(sofa::type::vector< MassType > vertexMass);
+
     virtual void setMassDensity(sofa::type::vector< MassType > massDensity);
     virtual void setMassDensity(MassType massDensityValue);
     virtual void setTotalMass(MassType totalMass);
@@ -205,12 +203,9 @@ public:
     /// Functions updating data
     sofa::core::objectmodel::ComponentState updateFromTotalMass();
     sofa::core::objectmodel::ComponentState updateFromMassDensity();
-    sofa::core::objectmodel::ComponentState updateFromVertexAndEdgeMass();
-    sofa::core::objectmodel::ComponentState updateFromVertexMass();
 
     /// Copy the vertex mass scalar (in case of CudaTypes)
     void copyVertexMass();
-
 
     /// Mass API
     void addMDx(const core::MechanicalParams*, DataVecDeriv& f, const DataVecDeriv& dx, SReal factor) override;
@@ -411,6 +406,7 @@ protected:
 
     /// Pointer to the topology container. Will be set by link @sa l_topology
     sofa::core::topology::BaseMeshTopology* m_topology;
+
     /// Pointer to the state owning geometrical positions, associated with the topology
     typename sofa::core::behavior::MechanicalState<GeometricalTypes>::SPtr m_geometryState;
 };

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -92,11 +92,12 @@ public:
     /// @}
 
     /// Enumeration specifying which data was used for initialization
-    enum InitMethod {
-        totalMass,
-        massDensity
+    enum class InitMethod
+    {
+        TOTALMASS,
+        MASSDENSITY
     };
-    InitMethod m_initMethod = totalMass;
+    InitMethod m_initMethod = InitMethod::TOTALMASS;
 
     /// Values of the particles masses stored on vertices
     core::topology::PointData<type::vector<MassType> >  d_vertexMass;

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -1554,7 +1554,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::reinit()
 template <class DataTypes, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, GeometricalTypes>::doUpdateInternal()
 {
-    // function empty in #XXXX
+    // function empty in #3928
 }
 
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -1551,13 +1551,6 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::reinit()
 
 
 template <class DataTypes, class GeometricalTypes>
-void MeshMatrixMass<DataTypes, GeometricalTypes>::doUpdateInternal()
-{
-    // function empty in #3928
-}
-
-
-template <class DataTypes, class GeometricalTypes>
 bool MeshMatrixMass<DataTypes, GeometricalTypes>::checkTotalMass()
 {
     //Check for negative or null value, if wrongly set use the default value totalMass = 1.0

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -90,7 +90,6 @@ MeshMatrixMass<DataTypes, GeometricalTypes>::MeshMatrixMass()
             }
         }
 
-        //Info post-init
         msg_info() << "mass information updated";
         printMass();
         return sofa::core::objectmodel::ComponentState::Valid;

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -1083,8 +1083,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::massInitializationMethod()
         {
             if(d_massDensity.isSet())
             {
-                msg_warning(this) << "totalMass value overriding other mass information (massDensity).\n"
-                                  << "To remove this warning you need to define only one single input data for mass initialization";
+                msg_warning() << "totalMass value overriding other mass information (massDensity).\n"
+                              << "To remove this warning you need to define only one single input data for mass initialization";
             }
             m_initMethod = InitMethod::TOTALMASS;
             d_vertexMass.setReadOnly(true);
@@ -1099,11 +1099,20 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::massInitializationMethod()
             d_edgeMass.setReadOnly(true);
             d_totalMass.setReadOnly(true);
         }
+
+        if(d_vertexMass.isSet())
+        {
+            msg_warning() << "vertexMass can not be used for initialization anymore: use either totalMass or massDensity";
+        }
+        if(d_edgeMass.isSet())
+        {
+            msg_warning() << "edgeMass can not be used for initialization anymore: use either totalMass or massDensity";
+        }
     }
     // if no mass information provided
     else
     {
-        msg_error() << "No mass information is given as input, please set totalMass or massDensity";
+        msg_error() << "No mass information is given as input, please set either totalMass or massDensity";
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -65,12 +65,12 @@ MeshMatrixMass<DataTypes, GeometricalTypes>::MeshMatrixMass()
 
     sofa::core::objectmodel::Base::addUpdateCallback("updateFromTotalMass", {&d_totalMass}, [this](const core::DataTracker& )
     {
-        if(m_initMethod == totalMass)
+        if(m_initMethod == InitMethod::TOTALMASS)
         {
             msg_info() << "dataInternalUpdate: data totalMass has changed";
             return updateFromTotalMass();
         }
-        else if(m_initMethod == massDensity)
+        else if(m_initMethod == InitMethod::MASSDENSITY)
         {
             msg_info() << "another mass input data is used at initialization, the callback associated with the totalMass is skipped";
             return updateFromMassDensity();
@@ -79,12 +79,12 @@ MeshMatrixMass<DataTypes, GeometricalTypes>::MeshMatrixMass()
 
     sofa::core::objectmodel::Base::addUpdateCallback("updateFromMassDensity", {&d_massDensity}, [this](const core::DataTracker& )
     {
-        if(m_initMethod == massDensity)
+        if(m_initMethod == InitMethod::MASSDENSITY)
         {
             msg_info() << "dataInternalUpdate: data massDensity has changed";
             return updateFromMassDensity();
         }
-        else if(m_initMethod == totalMass)
+        else if(m_initMethod == InitMethod::TOTALMASS)
         {
             msg_info() << "another mass input data is used at initialization, the callback associated with the massDensity is skipped";
             return updateFromTotalMass();
@@ -1086,7 +1086,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::massInitializationMethod()
                 msg_warning(this) << "totalMass value overriding other mass information (massDensity).\n"
                                   << "To remove this warning you need to define only one single input data for mass initialization";
             }
-            m_initMethod = totalMass;
+            m_initMethod = InitMethod::TOTALMASS;
             d_vertexMass.setReadOnly(true);
             d_edgeMass.setReadOnly(true);
             d_massDensity.setReadOnly(true);
@@ -1094,7 +1094,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::massInitializationMethod()
         //massDensity is subsequently considered
         else if(d_massDensity.isSet())
         {
-            m_initMethod = massDensity;
+            m_initMethod = InitMethod::MASSDENSITY;
             d_vertexMass.setReadOnly(true);
             d_edgeMass.setReadOnly(true);
             d_totalMass.setReadOnly(true);
@@ -1345,9 +1345,9 @@ template <class DataTypes, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, GeometricalTypes>::printInitializationOuput()
 {
     /// Print mass initialization method
-    if(m_initMethod == totalMass)
+    if(m_initMethod == InitMethod::TOTALMASS)
         msg_info() << "totalMass INIT";
-    if(m_initMethod == massDensity)
+    if(m_initMethod == InitMethod::MASSDENSITY)
         msg_info() << "massDensity INIT";
 
     /// Info post-init

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -2007,8 +2007,10 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::clear()
 template <class DataTypes, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, GeometricalTypes>::addMDx(const core::MechanicalParams*, DataVecDeriv& vres, const DataVecDeriv& vdx, SReal factor)
 {
-    if(this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (!this->isComponentStateValid())
+    {
         return;
+    }
 
     const auto &vertexMass= d_vertexMass.getValue();
     const auto &edgeMass= d_edgeMass.getValue();
@@ -2074,8 +2076,10 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addMDx(const core::MechanicalP
 template <class DataTypes, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, GeometricalTypes>::accFromF(const core::MechanicalParams* mparams, DataVecDeriv& a, const DataVecDeriv& f)
 {
-    if(this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (!this->isComponentStateValid())
+    {
         return;
+    }
 
     SOFA_UNUSED(mparams);
     if( !isLumped() )
@@ -2205,8 +2209,10 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addGravityToV(const core::Mech
 template <class DataTypes, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, GeometricalTypes>::addMToMatrix(sofa::linearalgebra::BaseMatrix * mat, SReal mFact, unsigned int &offset)
 {
-    if(this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (!this->isComponentStateValid())
+    {
         return;
+    }
 
     const auto &vertexMass= d_vertexMass.getValue();
     const auto &edgeMass= d_edgeMass.getValue();
@@ -2289,8 +2295,10 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addMToMatrix(sofa::linearalgeb
 template <class DataTypes, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, GeometricalTypes>::buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
 {
-    if(this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (!this->isComponentStateValid())
+    {
         return;
+    }
 
     const MassVector &vertexMass= d_vertexMass.getValue();
     const MassVector &edgeMass= d_edgeMass.getValue();

--- a/Sofa/Component/Mass/src/sofa/component/mass/config.h.in
+++ b/Sofa/Component/Mass/src/sofa/component/mass/config.h.in
@@ -36,3 +36,11 @@ namespace sofa::component::mass
 	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
 	constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
 } // namespace sofa::component::mass
+
+
+#ifdef SOFA_BUILD_SOFA_COMPONENT_MASS
+#define SOFA_ATTRIBUTE_DEPRECATED__MESHMATRIXMASS_ONLY_DENSITYANDTOTALMASS()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__MESHMATRIXMASS_ONLY_DENSITYANDTOTALMASS() \
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Inputs of the MeshMatrixMass are now only the massDensity or the totalMass. Please use associated setters")
+#endif

--- a/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/fake_TopologyScene.h
+++ b/Sofa/Component/Topology/Testing/src/sofa/component/topology/testing/fake_TopologyScene.h
@@ -107,7 +107,7 @@ public:
             createObject(m_root, topoType + "SetGeometryAlgorithms", { { "name", "topoGeo" } });
 
             // Add some mechanical components
-            createObject(m_root, "MeshMatrixMass");
+            createObject(m_root, "MeshMatrixMass", { { "totalMass", "1.0" } });
 
             if (m_topoType == sofa::geometry::ElementType::EDGE) {
                 sofa::simpleapi::importPlugin("Sofa.Component.SolidMechanics.Spring");

--- a/examples/Component/Mass/MeshMatrixMass.scn
+++ b/examples/Component/Mass/MeshMatrixMass.scn
@@ -36,7 +36,7 @@
         <!-- Container for the tetrahedra-->
         <TetrahedronSetTopologyContainer name="TetraTopo" src="@../MeshLoader"/>
         <TetrahedronSetGeometryAlgorithms name="GeomAlgo" />
-        <MeshMatrixMass totalMass="60" name="SparseMass" topology="@TetraTopo" />
+        <MeshMatrixMass totalMass="60" name="SparseMass" topology="@TetraTopo" printLog="1"/>
         <TetrahedralCorotationalFEMForceField template="Vec3" name="FEM" method="large" poissonRatio="0.45" youngModulus="5000" />
         <FixedProjectiveConstraint name="FixedProjectiveConstraint" indices="3 39 64" />
 

--- a/examples/Component/Mass/MeshMatrixMass.scn
+++ b/examples/Component/Mass/MeshMatrixMass.scn
@@ -24,6 +24,8 @@
     <CollisionResponse response="PenalityContactForceField" name="collision response" />
     <DiscreteIntersection />
 
+    <InteractiveCamera position="-2 2.6 17.9" orientation="0 0 0 1" distance="17.9" />
+
     <MeshGmshLoader name="MeshLoader" filename="mesh/liver.msh" />
     <MeshOBJLoader name="LiverSurface" filename="mesh/liver-smooth.obj" />
 

--- a/examples/Component/Mass/MeshMatrixMass.scn
+++ b/examples/Component/Mass/MeshMatrixMass.scn
@@ -36,7 +36,7 @@
         <!-- Container for the tetrahedra-->
         <TetrahedronSetTopologyContainer name="TetraTopo" src="@../MeshLoader"/>
         <TetrahedronSetGeometryAlgorithms name="GeomAlgo" />
-        <MeshMatrixMass totalMass="60" name="SparseMass" topology="@TetraTopo" printLog="1"/>
+        <MeshMatrixMass totalMass="60" name="SparseMass" topology="@TetraTopo" />
         <TetrahedralCorotationalFEMForceField template="Vec3" name="FEM" method="large" poissonRatio="0.45" youngModulus="5000" />
         <FixedProjectiveConstraint name="FixedProjectiveConstraint" indices="3 39 64" />
 

--- a/examples/Component/ODESolver/Forward/EulerExplicitSolver.scn
+++ b/examples/Component/ODESolver/Forward/EulerExplicitSolver.scn
@@ -30,15 +30,16 @@ trivially, it requires a linear solver, here SparseLDLSolver.
         <EulerExplicitSolver name="odeExplicitSolver" symplectic="false"/>
         <SparseLDLSolver />
 
-        <MechanicalObject name="dofs"/>
-
         <RegularGridTopology name="topology" nx="4" ny="4" nz="11" xmin="-1.5" xmax="1.5" ymin="-1.5" ymax="1.5" zmin="0" zmax="10" />
         <HexahedronSetGeometryAlgorithms/>
+
+        <MechanicalObject name="dofs"/>
+
         <MeshMatrixMass totalMass="15"/>
+        <MeshSpringForceField stiffness="3E2"/>
 
         <BoxROI box="-1.5 -1.5 0 1.5 1.5 0.0001" name="box"/>
         <FixedProjectiveConstraint indices="@box.indices" />
-        <MeshSpringForceField stiffness="3E2"/>
 
         <Node name="visual">
             <QuadSetTopologyContainer  name="Container" />


### PR DESCRIPTION
Needs https://github.com/sofa-framework/sofa/pull/4917 to make all tests pass successfully.

In the spirit of #3900 and following #3924, this PR applies the change on the MeshMatrixMass.

To be noted:
- the `componentState` must be added to trigger the callback (done in `addMDx()`, `addMToMatrix`, `accFromF` and `buildMassMatrix`)
- this PR does not solve the problem of circular dependency referred in #2173


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
