### PR TITLE
[FEM.Elastic] Implement buildStiffnessMatrix for FastTetrahedralCorotationalForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.h
@@ -156,6 +156,8 @@ public:
 
     void addKToMatrix(sofa::linearalgebra::BaseMatrix *m, SReal kFactor, unsigned int &offset) override;
     void addKToMatrix(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/ ) override;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
+    void buildDampingMatrix(core::behavior::DampingMatrix* matrix) override;
 
     void updateTopologyInformation();
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -584,6 +584,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::buildDampingMatrix(
     core::behavior::DampingMatrix* matrix)
 {
     //no damping in this force field
+    SOFA_UNUSED(matrix);
 }
 
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -201,7 +201,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::init()
         m_decompositionMethod = QR_DECOMPOSITION;
     else if (method == "polar2")
         m_decompositionMethod = POLAR_DECOMPOSITION_MODIFIED;
-     else if ((method == "none") || (method == "linear"))
+     else if ((method == "none") || (method == "linear") || (method == "small"))
         m_decompositionMethod = LINEAR_ELASTIC;
     else
     {
@@ -489,6 +489,101 @@ void FastTetrahedralCorotationalForceField<DataTypes>::addKToMatrix(const core::
         addKToMatrix(r.matrix, sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue()), r.offset);
     else
         msg_error() << "addKToMatrix found no valid matrix accessor.";
+}
+
+template <class DataTypes>
+void FastTetrahedralCorotationalForceField<DataTypes>::buildStiffnessMatrix(
+    core::behavior::StiffnessMatrix* matrix)
+{
+    const sofa::Size nbEdges = m_topology->getNbEdges();
+    const sofa::Size nbPoints = m_topology->getNbPoints();
+    const sofa::Size nbTetrahedra = m_topology->getNbTetrahedra();
+
+    helper::WriteOnlyAccessor< Data< VecTetrahedronRestInformation > > tetrahedronInf = tetrahedronInfo;
+    helper::WriteOnlyAccessor< Data< VecMat3x3 > > edgeDfDx = edgeInfo;
+    helper::WriteOnlyAccessor< Data< VecMat3x3 > > pointDfDx = pointInfo;
+
+    auto dfdx = matrix->getForceDerivativeIn(this->mstate)
+                       .withRespectToPositionsIn(this->mstate);
+
+    Mat3x3NoInit tmp;
+    if (updateMatrix)
+    {
+        /// if not done in addDForce: update off-diagonal blocks ("edges") of each element matrix
+        updateMatrix = false;
+        // reset all edge matrices
+        for (auto& e : edgeDfDx)
+        {
+            e.clear();
+        }
+
+        for(sofa::Size i=0; i < nbTetrahedra; i++ )
+        {
+            TetrahedronRestInformation& tetinfo = tetrahedronInf[i];
+            const core::topology::BaseMeshTopology::EdgesInTetrahedron &tea = m_topology->getEdgesInTetrahedron(i);
+
+            for (sofa::Size j=0; j < EdgesInTetrahedron::size(); ++j)
+            {
+                unsigned int edgeID = tea[j];
+
+                // test if the tetrahedron edge has the same orientation as the global edge
+                tmp = tetinfo.linearDfDx[j]*tetinfo.rotation;
+
+                if (tetinfo.edgeOrientation[j]==1)
+                {
+                    // store the two edge matrices since the stiffness sub-matrix is not symmetric
+                    edgeDfDx[edgeID] += tetinfo.rotation.transposed()*tmp;
+                }
+                else
+                {
+                    edgeDfDx[edgeID] += tmp.transposed()*tetinfo.rotation;
+                }
+
+            }
+        }
+    }
+
+    /// must update point data since these are not computed in addDForce
+    for (auto& p : pointDfDx)
+    {
+        p.clear();
+    }
+
+    for(sofa::Size i = 0; i < nbTetrahedra; ++i)
+    {
+        const TetrahedronRestInformation& tetinfo = tetrahedronInf[i];
+        const core::topology::BaseMeshTopology::Tetrahedron& t = m_topology->getTetrahedron(i);
+
+        for (sofa::Size j = 0; j < Tetrahedron::size(); ++j)
+        {
+            const unsigned int Id = t[j];
+
+            tmp = tetinfo.rotation.transposed() * tetinfo.linearDfDxDiag[j] * tetinfo.rotation;
+            pointDfDx[Id] += tmp;
+        }
+    }
+
+    /// construct the diagonal blocks from point data
+    for (sofa::Size i=0; i<nbPoints; ++i)
+    {
+        dfdx(3 * i, 3 * i) += -pointDfDx[i];
+    }
+
+    /// construct the off-diagonal blocks from edge data
+    const auto& edges = m_topology->getEdges();
+    for(sofa::Size i=0; i < nbEdges; ++i )
+    {
+        const auto& edge = edges[i];
+        dfdx(3 * edge[0], 3 * edge[1]) += -edgeDfDx[i];
+        dfdx(3 * edge[1], 3 * edge[0]) += -edgeDfDx[i];
+    }
+}
+
+template <class DataTypes>
+void FastTetrahedralCorotationalForceField<DataTypes>::buildDampingMatrix(
+    core::behavior::DampingMatrix* matrix)
+{
+    //no damping in this force field
 }
 
 

--- a/examples/Component/SolidMechanics/FEM/FastTetrahedralCorotationalForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/FastTetrahedralCorotationalForceField.scn
@@ -1,50 +1,95 @@
-<?xml version="1.0" ?>
-<Node name="root" dt="0.05" showBoundingTree="0" gravity="0 0 0">
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [DiscreteIntersection] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
-    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint FixedPlaneConstraint] -->
-    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->
-    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
-    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+<?xml version="1.0"?>
+<Node name="root" dt="0.01" gravity="0 -9 0">
+    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
+    <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+    <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [EigenSimplicialLDLT] -->
     <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->
-    <RequiredPlugin name="Sofa.Component.MechanicalLoad"/> <!-- Needed to use components [TrianglePressureForceField] -->
     <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
     <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [FastTetrahedralCorotationalForceField] -->
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms TetrahedronSetTopologyContainer TetrahedronSetTopologyModifier TriangleSetGeometryAlgorithms TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Tetra2TriangleTopologicalMapping] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms TetrahedronSetTopologyContainer TetrahedronSetTopologyModifier] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
-    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
-    <VisualStyle displayFlags="showBehaviorModels showForceFields showCollisionModels showVisual" />
-    <CollisionPipeline verbose="0" name="CollisionPipeline" />
-    <BruteForceBroadPhase/>
-    <BVHNarrowPhase/>
-    <CollisionResponse response="PenalityContactForceField" name="collision response" />
-    <DiscreteIntersection />
-    <DefaultAnimationLoop/>
 
-    <Node name="TT_FAST">
+    <DefaultAnimationLoop/>
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <Node name="BeamFEM_SMALL">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshGmshLoader name="loader" filename="mesh/cylinder_8x30x6.msh" />
-        <MechanicalObject src="@loader" name="Volume" translation="1 0 0"/>
-        <include href="Objects/TetrahedronSetTopology.xml" src="@loader" tags=" " />
-        <DiagonalMass massDensity="0.5" />
-        <FixedPlaneConstraint direction="0 0 1" dmin="-0.1" dmax="0.1" />
-        <FixedConstraint indices="0" />
-        <FastTetrahedralCorotationalForceField poissonRatio="0.3" youngModulus="3600" method="large" /> 
-        
-        <Node name="T_FAST">
-            <include href="Objects/TriangleSetTopology.xml" src="@../loader" tags=" " />
-            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
-            <TrianglePressureForceField normal="0 0 1" dmin="0.9" dmax="1.1" pressure="0.4 0 0" />
-            <TriangleCollisionModel />
-            <Node name="Visu">
-                <OglModel name="Visual" color="blue" />
-                <IdentityMapping input="@../../Volume" output="@Visual" />
-            </Node>
-        </Node>
+        <EigenSimplicialLDLT template="CompressedRowSparseMatrixMat3x3"/>
+
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3" />
+
+        <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+
+        <DiagonalMass massDensity="0.2" />
+        <FastTetrahedralCorotationalForceField name="FEM" youngModulus="1000" poissonRatio="0.4" method="small"/>
+
+        <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3" indices="@box_roi.indices" />
     </Node>
+
+
+    <Node name="BeamFEM_LARGE">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <EigenSimplicialLDLT template="CompressedRowSparseMatrixMat3x3"/>
+
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3" translation="11 0 0"/>
+
+        <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+
+        <DiagonalMass massDensity="0.2" />
+        <FastTetrahedralCorotationalForceField name="FEM" youngModulus="1000" poissonRatio="0.4" method="large"/>
+
+        <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3" indices="@box_roi.indices" />
+    </Node>
+
+    <Node name="BeamFEM_POLAR">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <EigenSimplicialLDLT template="CompressedRowSparseMatrixMat3x3"/>
+
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3" translation="22 0 0"/>
+
+        <TetrahedronSetTopologyContainer name="Tetra_topo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+
+        <DiagonalMass massDensity="0.2" />
+        <FastTetrahedralCorotationalForceField name="FEM" youngModulus="1000" poissonRatio="0.4" method="polar"/>
+
+        <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3" indices="@box_roi.indices" />
+    </Node>
+
+    <Node name="BeamFEM_polar2">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <EigenSimplicialLDLT template="CompressedRowSparseMatrixMat3x3"/>
+
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3" translation="33 0 0"/>
+
+        <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+
+        <DiagonalMass massDensity="0.2" />
+        <FastTetrahedralCorotationalForceField name="FEM" youngModulus="1000" poissonRatio="0.4" method="polar2"/>
+
+        <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3" indices="@box_roi.indices" />
+    </Node>
+
 </Node>


### PR DESCRIPTION
Following #2777, `buildStiffnessMatrix` and `buildDampingMatrix` are implemented for `FastTetrahedralCorotationalForceField`.

I took the opportunity to simplify the code and clean it compared to `addKToMatrix`.

I also changed the example scene, as it was not really functional. Now, the scene is the same than `TetrahedronFEMForceField`.

I also added the possibility to define the method as `small`, for consistency with `TetrahedronFEMForceField`. At some point, this should be refactored with an OptionGroup.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
