### PR TITLE
[MechanicalLoad] Restore addKToMatrix and test SurfacePressureForceField

### DIFF
--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.cpp
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.cpp
@@ -33,7 +33,7 @@ void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::
                                                                     DataVecDeriv& d_df, const DataVecDeriv& d_dx)
 {
     const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
-    auto df = sofa::helper::getWriteOnlyAccessor(df);
+    auto df = sofa::helper::getWriteOnlyAccessor(d_df);
     const VecDeriv& dx = d_dx.getValue();
 
 

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.cpp
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.cpp
@@ -24,16 +24,207 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
+
 namespace sofa::component::mechanicalload
 {
+
+template <>
+void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::MechanicalParams* mparams,
+                                                                    DataVecDeriv& d_df, const DataVecDeriv& d_dx)
+{
+    const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
+    VecDeriv& df = *(d_df.beginEdit());
+    const VecDeriv& dx = d_dx.getValue();
+
+
+    for (unsigned int i = 0; i < derivTriNormalIndices.size(); i++)
+    {
+        for (unsigned int j = 0; j < derivTriNormalIndices[i].size(); j++)
+        {
+            const unsigned int v = derivTriNormalIndices[i][j];
+            df[i].getVCenter() += (derivTriNormalValues[i][j] * dx[v].getVCenter()) * kFactor;
+        }
+    }
+
+    d_df.endEdit();
+}
+
+template <>
+SurfacePressureForceField<defaulttype::Rigid3Types>::Real SurfacePressureForceField<defaulttype::Rigid3Types>::computeMeshVolume(const VecDeriv& /*f*/, const VecCoord& x)
+{
+    typedef core::topology::BaseMeshTopology::Triangle Triangle;
+    typedef core::topology::BaseMeshTopology::Quad Quad;
+
+    Real volume = 0;
+
+    unsigned int nTriangles = 0;
+    const VecIndex& triangleIndices = m_triangleIndices.getValue();
+    if (!triangleIndices.empty())
+    {
+        nTriangles = triangleIndices.size();
+    }
+    else
+    {
+        nTriangles = m_topology->getNbTriangles();
+    }
+
+    unsigned int triangleIdx = 0;
+    for (unsigned int i = 0; i < nTriangles; i++)
+    {
+        if (!triangleIndices.empty())
+        {
+            triangleIdx = triangleIndices[i];
+        }
+        else
+        {
+            triangleIdx = i;
+        }
+        Triangle t = m_topology->getTriangle(triangleIdx);
+        const defaulttype::Rigid3Types::CPos a = x[t[0]].getCenter();
+        const defaulttype::Rigid3Types::CPos b = x[t[1]].getCenter();
+        const defaulttype::Rigid3Types::CPos c = x[t[2]].getCenter();
+        volume += dot(cross(a, b), c);
+    }
+
+    unsigned int nQuads = 0;
+    const VecIndex& quadIndices = m_quadIndices.getValue();
+    if (!quadIndices.empty())
+    {
+        nQuads = quadIndices.size();
+    }
+    else
+    {
+        nQuads = m_topology->getNbQuads();
+    }
+
+    unsigned int quadIdx = 0;
+    for (unsigned int i = 0; i < nQuads; i++)
+    {
+        if (!quadIndices.empty())
+        {
+            quadIdx = quadIndices[i];
+        }
+        else
+        {
+            quadIdx = i;
+        }
+        Quad q = m_topology->getQuad(quadIdx);
+        const defaulttype::Rigid3Types::CPos a = x[q[0]].getCenter();
+        const defaulttype::Rigid3Types::CPos b = x[q[1]].getCenter();
+        const defaulttype::Rigid3Types::CPos c = x[q[2]].getCenter();
+        const defaulttype::Rigid3Types::CPos d = x[q[3]].getCenter();
+        volume += dot(cross(a, b), c);
+        volume += dot(cross(a, c), d);
+    }
+
+    // Divide by 6 when computing tetrahedron volume
+    return volume / 6.0;
+}
+
+template <>
+void SurfacePressureForceField<defaulttype::Rigid3Types>::addTriangleSurfacePressure(unsigned int triId, VecDeriv& f, const VecCoord& x, const VecDeriv& /*v*/, const Real& pressure, bool computeDerivatives)
+{
+    Triangle t = m_topology->getTriangle(triId);
+
+    defaulttype::Rigid3Types::CPos ab = x[t[1]].getCenter() - x[t[0]].getCenter();
+    defaulttype::Rigid3Types::CPos ac = x[t[2]].getCenter() - x[t[0]].getCenter();
+    defaulttype::Rigid3Types::CPos bc = x[t[2]].getCenter() - x[t[1]].getCenter();
+
+    defaulttype::Rigid3Types::CPos p = (ab.cross(ac)) * (pressure / static_cast<Real>(6.0));
+
+
+    if (computeDerivatives)
+    {
+        Mat33 DcrossDA;
+        DcrossDA[0][0] = 0;
+        DcrossDA[0][1] = -bc[2];
+        DcrossDA[0][2] = bc[1];
+        DcrossDA[1][0] = bc[2];
+        DcrossDA[1][1] = 0;
+        DcrossDA[1][2] = -bc[0];
+        DcrossDA[2][0] = -bc[1];
+        DcrossDA[2][1] = bc[0];
+        DcrossDA[2][2] = 0;
+
+        Mat33 DcrossDB;
+        DcrossDB[0][0] = 0;
+        DcrossDB[0][1] = ac[2];
+        DcrossDB[0][2] = -ac[1];
+        DcrossDB[1][0] = -ac[2];
+        DcrossDB[1][1] = 0;
+        DcrossDB[1][2] = ac[0];
+        DcrossDB[2][0] = ac[1];
+        DcrossDB[2][1] = -ac[0];
+        DcrossDB[2][2] = 0;
+
+
+        Mat33 DcrossDC;
+        DcrossDC[0][0] = 0;
+        DcrossDC[0][1] = -ab[2];
+        DcrossDC[0][2] = ab[1];
+        DcrossDC[1][0] = ab[2];
+        DcrossDC[1][1] = 0;
+        DcrossDC[1][2] = -ab[0];
+        DcrossDC[2][0] = -ab[1];
+        DcrossDC[2][1] = ab[0];
+        DcrossDC[2][2] = 0;
+
+        for (unsigned int j = 0; j < 3; j++)
+        {
+            derivTriNormalValues[t[j]].push_back(DcrossDA * (pressure / static_cast<Real>(6.0)));
+            derivTriNormalValues[t[j]].push_back(DcrossDB * (pressure / static_cast<Real>(6.0)));
+            derivTriNormalValues[t[j]].push_back(DcrossDC * (pressure / static_cast<Real>(6.0)));
+
+            derivTriNormalIndices[t[j]].push_back(t[0]);
+            derivTriNormalIndices[t[j]].push_back(t[1]);
+            derivTriNormalIndices[t[j]].push_back(t[2]);
+        }
+    }
+
+
+    if (m_mainDirection.getValue().getVCenter() != defaulttype::Rigid3Types::CPos())
+    {
+        defaulttype::Rigid3Types::CPos n = ab.cross(ac);
+        n.normalize();
+        const Real scal = n * m_mainDirection.getValue().getVCenter();
+        p *= fabs(scal);
+    }
+
+    f[t[0]].getVCenter() += p;
+    f[t[1]].getVCenter() += p;
+    f[t[2]].getVCenter() += p;
+}
+
+template <>
+void SurfacePressureForceField<defaulttype::Rigid3Types>::addQuadSurfacePressure(unsigned int quadId, VecDeriv& f, const VecCoord& x, const VecDeriv& /*v*/, const Real& pressure)
+{
+    Quad q = m_topology->getQuad(quadId);
+
+    const defaulttype::Rigid3Types::CPos ab = x[q[1]].getCenter() - x[q[0]].getCenter();
+    const defaulttype::Rigid3Types::CPos ac = x[q[2]].getCenter() - x[q[0]].getCenter();
+    const defaulttype::Rigid3Types::CPos ad = x[q[3]].getCenter() - x[q[0]].getCenter();
+
+    const defaulttype::Rigid3Types::CPos p1 = (ab.cross(ac)) * (pressure / static_cast<Real>(6.0));
+    const defaulttype::Rigid3Types::CPos p2 = (ac.cross(ad)) * (pressure / static_cast<Real>(6.0));
+
+    const defaulttype::Rigid3Types::CPos p = p1 + p2;
+
+    f[q[0]].getVCenter() += p;
+    f[q[1]].getVCenter() += p1;
+    f[q[2]].getVCenter() += p;
+    f[q[3]].getVCenter() += p2;
+}
+
+template <>
+void SurfacePressureForceField<defaulttype::Rigid3Types>::verifyDerivative(VecDeriv& /*v_plus*/, VecDeriv& /*v*/, VecVec3DerivValues& /*DVval*/, VecVec3DerivIndices& /*DVind*/, const VecDeriv& /*Din*/)
+{}
+
 
 using namespace sofa::defaulttype;
 
 int SurfacePressureForceFieldClass = core::RegisterObject("SurfacePressure")
-        .add< SurfacePressureForceField<Vec3Types> >()
-		.add< SurfacePressureForceField<Rigid3Types> >()
-
-        ;
+                                     .add<SurfacePressureForceField<Vec3Types> >()
+                                     .add<SurfacePressureForceField<Rigid3Types> >();
 
 template class SOFA_COMPONENT_MECHANICALLOAD_API SurfacePressureForceField<Vec3Types>;
 template class SOFA_COMPONENT_MECHANICALLOAD_API SurfacePressureForceField<Rigid3Types>;

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.cpp
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.cpp
@@ -33,7 +33,7 @@ void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::
                                                                     DataVecDeriv& d_df, const DataVecDeriv& d_dx)
 {
     const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
-    VecDeriv& df = *(d_df.beginEdit());
+    auto df = sofa::helper::getWriteOnlyAccessor(df);
     const VecDeriv& dx = d_dx.getValue();
 
 
@@ -46,7 +46,6 @@ void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::
         }
     }
 
-    d_df.endEdit();
 }
 
 template <>

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.h
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.h
@@ -25,9 +25,10 @@
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 
+
 namespace sofa::core::topology
 {
-    class BaseMeshTopology;
+class BaseMeshTopology;
 } // namespace sofa::core::topology
 
 
@@ -40,7 +41,7 @@ namespace sofa::component::mechanicalload
  * Implements a pressure force applied on a triangle or quad surface.
  * Each surfel receives a pressure in the direction of its normal.
  */
-template<class DataTypes>
+template <class DataTypes>
 class SurfacePressureForceField : public core::behavior::ForceField<DataTypes>
 {
 public:
@@ -48,14 +49,14 @@ public:
 
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
-    typedef typename DataTypes::Coord    Coord   ;
-    typedef typename DataTypes::Deriv    Deriv   ;
-    typedef typename Coord::value_type   Real    ;
-    typedef type::Mat<3,3,Real> Mat33;
-    typedef type::vector< Mat33 > Vec3DerivValues;
-    typedef type::vector< unsigned int > Vec3DerivIndices;
-    typedef type::vector< Vec3DerivValues> VecVec3DerivValues;
-    typedef type::vector< Vec3DerivIndices > VecVec3DerivIndices;
+    typedef typename DataTypes::Coord Coord;
+    typedef typename DataTypes::Deriv Deriv;
+    typedef typename Coord::value_type Real;
+    typedef type::Mat<3, 3, Real> Mat33;
+    typedef type::vector<Mat33> Vec3DerivValues;
+    typedef type::vector<unsigned int> Vec3DerivIndices;
+    typedef type::vector<Vec3DerivValues> VecVec3DerivValues;
+    typedef type::vector<Vec3DerivIndices> VecVec3DerivIndices;
 
     typedef core::objectmodel::Data<VecCoord> DataVecCoord;
     typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
@@ -63,53 +64,55 @@ public:
     typedef sofa::core::topology::BaseMeshTopology::Triangle Triangle;
     typedef sofa::core::topology::BaseMeshTopology::Quad Quad;
     typedef sofa::core::topology::BaseMeshTopology::Index Index;
-    typedef sofa::type::vector< Index > VecIndex;
+    typedef sofa::type::vector<Index> VecIndex;
+
 
     enum State { INCREASE, DECREASE };
 
-protected:
-    Data< Real >	m_pressure;					///< Scalar pressure value applied on the surfaces.
-    Data< Coord >	m_min;						///< Lower bound of the pressured box.
-    Data< Coord >	m_max;						///< Upper bound of the pressured box.
-    Data< VecIndex >	m_triangleIndices;		///< Specify triangles by indices.
-    Data< VecIndex >	m_quadIndices;			///< Specify quads by indices.
-    Data< bool >	m_pulseMode;				///< In this mode, the pressure increases (or decreases) from 0 to m_pressure cyclicly.
-    Data< Real >	m_pressureLowerBound;		///< In pulseMode, the pressure increases(or decreases) from m_pressureLowerBound to m_pressure cyclicly.
-    Data< Real >	m_pressureSpeed;			///< Pressure variation in Pascal by second.
-    Data< bool >	m_volumeConservationMode;	///< In this mode, pressure variation is related to the object volume variation.
-    Data< bool >	m_useTangentStiffness;	    ///< The tangent stiffness matrix is not symmetric and could create issues with some linear solvers. Set to false to not use it.
-    Data< Real >	m_defaultVolume;			///< Default Volume.
-    Data< Deriv >	m_mainDirection;			///< Main axis for pressure application.
+    Data<Real> m_pressure; ///< Scalar pressure value applied on the surfaces.
+    Data<Coord> m_min; ///< Lower bound of the pressured box.
+    Data<Coord> m_max; ///< Upper bound of the pressured box.
+    Data<VecIndex> m_triangleIndices; ///< Specify triangles by indices.
+    Data<VecIndex> m_quadIndices; ///< Specify quads by indices.
+    Data<bool> m_pulseMode; ///< In this mode, the pressure increases (or decreases) from 0 to m_pressure cyclicly.
+    Data<Real> m_pressureLowerBound; ///< In pulseMode, the pressure increases(or decreases) from m_pressureLowerBound to m_pressure cyclicly.
+    Data<Real> m_pressureSpeed; ///< Pressure variation in Pascal by second.
+    Data<bool> m_volumeConservationMode; ///< In this mode, pressure variation is related to the object volume variation.
+    Data<bool> m_useTangentStiffness; ///< The tangent stiffness matrix is not symmetric and could create issues with some linear solvers. Set to false to not use it.
+    Data<Real> m_defaultVolume; ///< Default Volume.
+    Data<Deriv> m_mainDirection; ///< Main axis for pressure application.
 
-    Data< Real > m_drawForceScale;  ///< scale used to render force vectors
-    type::vector< Deriv> m_f;             ///< store forces for visualization
+    Data<Real> m_drawForceScale; ///< scale used to render force vectors
+
+protected:
+    type::vector<Deriv> m_f; ///< store forces for visualization
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<SurfacePressureForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
-    State state;								///< In pulse mode, says wether pressure is increasing or decreasing.
-    Real m_pulseModePressure;					///< Current pressure computed in pulse mode.
+    State state; ///< In pulse mode, says wether pressure is increasing or decreasing.
+    Real m_pulseModePressure; ///< Current pressure computed in pulse mode.
 
     SurfacePressureForceField();
     virtual ~SurfacePressureForceField();
+
 public:
     void init() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& /* d_df */, const DataVecDeriv& /* d_dx */) override;
-    void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix ) override;
-    SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override;
+    void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord& /* x */) const override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 
     void setPressure(const Real _pressure);
 
 protected:
-
     /**
      * @brief Compute mesh volume.
      */
-    Real computeMeshVolume(const VecDeriv& f,const VecCoord& x);
+    Real computeMeshVolume(const VecDeriv& f, const VecCoord& x);
 
     /**
      * @brief Triangle based surface pressure computation method.
@@ -143,27 +146,26 @@ protected:
      */
     VecVec3DerivValues derivTriNormalValues;
     VecVec3DerivIndices derivTriNormalIndices;
-    void verifyDerivative(VecDeriv& v_plus, VecDeriv& v,  VecVec3DerivValues& DVval, VecVec3DerivIndices& DVind, const VecDeriv& Din);
+    void verifyDerivative(VecDeriv& v_plus, VecDeriv& v, VecVec3DerivValues& DVval, VecVec3DerivIndices& DVind, const VecDeriv& Din);
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 };
 
-template<>
+
+template <>
 void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& /* d_df */, const DataVecDeriv& /* d_dx */);
 
-template<>
-SurfacePressureForceField<defaulttype::Rigid3Types>::Real SurfacePressureForceField<defaulttype::Rigid3Types>::computeMeshVolume(const VecDeriv& f,const VecCoord& x);
+template <>
+SurfacePressureForceField<defaulttype::Rigid3Types>::Real SurfacePressureForceField<defaulttype::Rigid3Types>::computeMeshVolume(const VecDeriv& f, const VecCoord& x);
 
-template<>
+template <>
 void SurfacePressureForceField<defaulttype::Rigid3Types>::addTriangleSurfacePressure(unsigned int triId, VecDeriv& /*f*/, const VecCoord& /*x*/, const VecDeriv& /*v*/, const Real& /*pressure*/, bool computeDerivatives);
 
-template<>
+template <>
 void SurfacePressureForceField<defaulttype::Rigid3Types>::addQuadSurfacePressure(unsigned int quadId, VecDeriv& /*f*/, const VecCoord& /*x*/, const VecDeriv& /*v*/, const Real& /*pressure*/);
 
-template<>
-void SurfacePressureForceField<defaulttype::Rigid3Types>::verifyDerivative(VecDeriv& v_plus, VecDeriv& v,  VecVec3DerivValues& DVval, VecVec3DerivIndices& DVind, const VecDeriv& Din);
-
-
+template <>
+void SurfacePressureForceField<defaulttype::Rigid3Types>::verifyDerivative(VecDeriv& v_plus, VecDeriv& v, VecVec3DerivValues& DVval, VecVec3DerivIndices& DVind, const VecDeriv& Din);
 
 
 #if  !defined(SOFA_COMPONENT_FORCEFIELD_SURFACEPRESSUREFORCEFIELD_CPP)

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/SurfacePressureForceField.inl
@@ -32,46 +32,41 @@
 #include <set>
 #include <iostream>
 
+
 namespace sofa::component::mechanicalload
 {
 
 template <class DataTypes>
-SurfacePressureForceField<DataTypes>::SurfacePressureForceField():
-    m_pressure(initData(&m_pressure, (Real)0.0, "pressure", "Pressure force per unit area")),
-    m_min(initData(&m_min, Coord(), "min", "Lower bond of the selection box")),
-    m_max(initData(&m_max, Coord(), "max", "Upper bond of the selection box")),
-    m_triangleIndices(initData(&m_triangleIndices, "triangleIndices", "Indices of affected triangles")),
-    m_quadIndices(initData(&m_quadIndices, "quadIndices", "Indices of affected quads")),
-    m_pulseMode(initData(&m_pulseMode, false, "pulseMode", "Cyclic pressure application")),
-    m_pressureLowerBound(initData(&m_pressureLowerBound, (Real)0.0, "pressureLowerBound", "Pressure lower bound force per unit area (active in pulse mode)")),
-    m_pressureSpeed(initData(&m_pressureSpeed, (Real)0.0, "pressureSpeed", "Continuous pressure application in Pascal per second. Only active in pulse mode")),
-    m_volumeConservationMode(initData(&m_volumeConservationMode, false, "volumeConservationMode", "Pressure variation follow the inverse of the volume variation")),
-	m_useTangentStiffness(initData(&m_useTangentStiffness, true, "useTangentStiffness", "Whether (non-symmetric) stiffness matrix should be used")),
-    m_defaultVolume(initData(&m_defaultVolume, (Real)-1.0, "defaultVolume", "Default Volume")),
-    m_mainDirection(initData(&m_mainDirection, Deriv(), "mainDirection", "Main direction for pressure application")),
-    m_drawForceScale(initData(&m_drawForceScale, (Real)0, "drawForceScale", "DEBUG: scale used to render force vectors"))
+SurfacePressureForceField<DataTypes>::SurfacePressureForceField()
+    : m_pressure(initData(&m_pressure, (Real)0.0, "pressure", "Pressure force per unit area"))
+    , m_min(initData(&m_min, Coord(), "min", "Lower bond of the selection box"))
+    , m_max(initData(&m_max, Coord(), "max", "Upper bond of the selection box"))
+    , m_triangleIndices(initData(&m_triangleIndices, "triangleIndices", "Indices of affected triangles"))
+    , m_quadIndices(initData(&m_quadIndices, "quadIndices", "Indices of affected quads"))
+    , m_pulseMode(initData(&m_pulseMode, false, "pulseMode", "Cyclic pressure application"))
+    , m_pressureLowerBound(initData(&m_pressureLowerBound, (Real)0.0, "pressureLowerBound", "Pressure lower bound force per unit area (active in pulse mode)"))
+    , m_pressureSpeed(initData(&m_pressureSpeed, (Real)0.0, "pressureSpeed", "Continuous pressure application in Pascal per second. Only active in pulse mode"))
+    , m_volumeConservationMode(initData(&m_volumeConservationMode, false, "volumeConservationMode", "Pressure variation follow the inverse of the volume variation"))
+    , m_useTangentStiffness(initData(&m_useTangentStiffness, true, "useTangentStiffness", "Whether (non-symmetric) stiffness matrix should be used"))
+    , m_defaultVolume(initData(&m_defaultVolume, (Real)-1.0, "defaultVolume", "Default Volume"))
+    , m_mainDirection(initData(&m_mainDirection, Deriv(), "mainDirection", "Main direction for pressure application"))
+    , m_drawForceScale(initData(&m_drawForceScale, (Real)0, "drawForceScale", "DEBUG: scale used to render force vectors"))
     , l_topology(initLink("topology", "link to the topology container"))
     , state(INCREASE)
     , m_topology(nullptr)
-{
-
-}
-
+{}
 
 
 template <class DataTypes>
 SurfacePressureForceField<DataTypes>::~SurfacePressureForceField()
-{
-
-}
-
+{}
 
 
 template <class DataTypes>
 void SurfacePressureForceField<DataTypes>::init()
 {
     this->core::behavior::ForceField<DataTypes>::init();
-   
+
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
@@ -92,36 +87,34 @@ void SurfacePressureForceField<DataTypes>::init()
 
     if (m_pulseMode.getValue() && (m_pressureSpeed.getValue() == 0.0))
     {
-        msg_warning() << "Default pressure speed value has been set in SurfacePressureForceField" ;
-        m_pressureSpeed.setValue((Real)fabs( m_pressure.getValue()));
+        msg_warning() << "Default pressure speed value has been set in SurfacePressureForceField";
+        m_pressureSpeed.setValue((Real)fabs(m_pressure.getValue()));
     }
 
     m_pulseModePressure = 0.0;
 }
 
 
-
 template <class DataTypes>
-void SurfacePressureForceField<DataTypes>::verifyDerivative(VecDeriv& v_plus, VecDeriv& v,  VecVec3DerivValues& DVval, VecVec3DerivIndices& DVind,
-        const VecDeriv& Din)
+void SurfacePressureForceField<DataTypes>::verifyDerivative(VecDeriv& v_plus, VecDeriv& v, VecVec3DerivValues& DVval, VecVec3DerivIndices& DVind,
+                                                            const VecDeriv& Din)
 {
 
     msg_info() <<" verifyDerivative : vplus.size()="<<v_plus.size()<<"  v.size()="<<v.size()
                <<"  DVval.size()="<<DVval.size()<<" DVind.size()="<<DVind.size()<<"  Din.size()="<<Din.size();
 
     std::stringstream s;
-    for (unsigned int i=0; i<v.size(); i++)
+    for (unsigned int i = 0; i < v.size(); i++)
     {
-
         Deriv DV;
         DV.clear();
-        s <<" DVnum["<<i<<"] ="<<v_plus[i]-v[i];
+        s << " DVnum[" << i << "] =" << v_plus[i] - v[i];
 
-        for(unsigned int j=0; j<DVval[i].size(); j++)
+        for (unsigned int j = 0; j < DVval[i].size(); j++)
         {
-            DV+=DVval[i][j]*Din[ (DVind[i][j]) ];
+            DV += DVval[i][j] * Din[(DVind[i][j])];
         }
-        s <<" DVana["<<i<<"] = "<<DV<<" DVval[i].size() = "<<DVval[i].size()<<msgendl;
+        s << " DVana[" << i << "] = " << DV << " DVval[i].size() = " << DVval[i].size() << msgendl;
     }
 
     msg_info() << s.str();
@@ -135,7 +128,11 @@ void SurfacePressureForceField<DataTypes>::addForce(const core::MechanicalParams
     const VecCoord& x = d_x.getValue();
     const VecDeriv& v = d_v.getValue();
 
-    m_f.resize(f.size());  for(unsigned int i=0;i<m_f.size();i++) m_f[i].clear(); // store forces for visualization
+    m_f.resize(f.size());
+    for (unsigned int i = 0; i < m_f.size(); i++)
+    {
+        m_f[i].clear(); // store forces for visualization
+    }
 
     Real p = m_pulseMode.getValue() ? computePulseModePressure() : m_pressure.getValue();
 
@@ -145,14 +142,14 @@ void SurfacePressureForceField<DataTypes>::addForce(const core::MechanicalParams
         {
             if (m_defaultVolume.getValue() == -1)
             {
-                m_defaultVolume.setValue(computeMeshVolume(f,x));
+                m_defaultVolume.setValue(computeMeshVolume(f, x));
             }
             else if (m_defaultVolume.getValue() != 0)
             {
-                p *= m_defaultVolume.getValue() / computeMeshVolume(f,x);
+                p *= m_defaultVolume.getValue() / computeMeshVolume(f, x);
             }
         }
-		bool useStiffness=m_useTangentStiffness.getValue();
+        bool useStiffness = m_useTangentStiffness.getValue();
         // Triangles
 
         derivTriNormalValues.clear();
@@ -160,7 +157,7 @@ void SurfacePressureForceField<DataTypes>::addForce(const core::MechanicalParams
         derivTriNormalIndices.clear();
         derivTriNormalIndices.resize(x.size());
 
-        for (unsigned int i=0; i<x.size(); i++)
+        for (unsigned int i = 0; i < x.size(); i++)
         {
             derivTriNormalValues[i].clear();
             derivTriNormalIndices[i].clear();
@@ -170,7 +167,7 @@ void SurfacePressureForceField<DataTypes>::addForce(const core::MechanicalParams
         {
             for (unsigned int i = 0; i < m_triangleIndices.getValue().size(); i++)
             {
-                addTriangleSurfacePressure(m_triangleIndices.getValue()[i], m_f,x,v,p, useStiffness);
+                addTriangleSurfacePressure(m_triangleIndices.getValue()[i], m_f, x, v, p, useStiffness);
             }
         }
         else if (m_topology->getNbTriangles() > 0)
@@ -178,12 +175,11 @@ void SurfacePressureForceField<DataTypes>::addForce(const core::MechanicalParams
             for (unsigned int i = 0; i < (unsigned int)m_topology->getNbTriangles(); i++)
             {
                 Triangle t = m_topology->getTriangle(i);
-                if ( isInPressuredBox(x[t[0]]) && isInPressuredBox(x[t[1]]) && isInPressuredBox(x[t[2]]) )
+                if (isInPressuredBox(x[t[0]]) && isInPressuredBox(x[t[1]]) && isInPressuredBox(x[t[2]]))
                 {
-                    addTriangleSurfacePressure(i, m_f,x,v,p, useStiffness);
+                    addTriangleSurfacePressure(i, m_f, x, v, p, useStiffness);
                 }
             }
-
         }
 
         // Quads
@@ -192,7 +188,7 @@ void SurfacePressureForceField<DataTypes>::addForce(const core::MechanicalParams
         {
             for (unsigned int i = 0; i < m_quadIndices.getValue().size(); i++)
             {
-                addQuadSurfacePressure(m_quadIndices.getValue()[i], m_f,x,v,p);
+                addQuadSurfacePressure(m_quadIndices.getValue()[i], m_f, x, v, p);
             }
         }
         else if (m_topology->getNbQuads() > 0)
@@ -201,80 +197,81 @@ void SurfacePressureForceField<DataTypes>::addForce(const core::MechanicalParams
             {
                 Quad q = m_topology->getQuad(i);
 
-                if ( isInPressuredBox(x[q[0]]) && isInPressuredBox(x[q[1]]) && isInPressuredBox(x[q[2]]) && isInPressuredBox(x[q[3]]) )
+                if (isInPressuredBox(x[q[0]]) && isInPressuredBox(x[q[1]]) && isInPressuredBox(x[q[2]]) && isInPressuredBox(x[q[3]]))
                 {
-                    addQuadSurfacePressure(i, m_f,x,v,p);
+                    addQuadSurfacePressure(i, m_f, x, v, p);
                 }
             }
         }
-
     }
 
-    for(unsigned int i=0;i<m_f.size();i++) f[i]+=m_f[i];
+    for (unsigned int i = 0; i < m_f.size(); i++)
+    {
+        f[i] += m_f[i];
+    }
     d_f.endEdit();
 }
 
 template <class DataTypes>
-void SurfacePressureForceField<DataTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv&  d_df , const DataVecDeriv&  d_dx )
+void SurfacePressureForceField<DataTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
 {
-	Real kFactor = (Real)mparams->kFactor();
-	if (m_useTangentStiffness.getValue()) {
-		VecDeriv& df       = *(d_df.beginEdit());
-		const VecDeriv& dx =   d_dx.getValue()  ;
+    Real kFactor = (Real)mparams->kFactor();
+    if (m_useTangentStiffness.getValue())
+    {
+        VecDeriv& df = *(d_df.beginEdit());
+        const VecDeriv& dx = d_dx.getValue();
 
-		for (unsigned int i=0; i<derivTriNormalIndices.size(); i++)
-		{
-
-			for (unsigned int j=0; j<derivTriNormalIndices[i].size(); j++)
-			{
-				unsigned int v = derivTriNormalIndices[i][j];
-				df[i] += (derivTriNormalValues[i][j] * dx[v])*kFactor;
-
-			}
-		} 
-		d_df.endEdit();
-	}
+        for (unsigned int i = 0; i < derivTriNormalIndices.size(); i++)
+        {
+            for (unsigned int j = 0; j < derivTriNormalIndices[i].size(); j++)
+            {
+                unsigned int v = derivTriNormalIndices[i][j];
+                df[i] += (derivTriNormalValues[i][j] * dx[v]) * kFactor;
+            }
+        }
+        d_df.endEdit();
+    }
 }
 
 
-template<class DataTypes>
-void SurfacePressureForceField<DataTypes>::addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix )
+template <class DataTypes>
+void SurfacePressureForceField<DataTypes>::addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     const sofa::core::behavior::MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
     sofa::linearalgebra::BaseMatrix* mat = mref.matrix;
     unsigned int offset = mref.offset;
     Real kFact = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
-    return;
 
     const int N = Coord::total_size;
-	if (m_useTangentStiffness.getValue()) {
-		for (unsigned int i=0; i<derivTriNormalIndices.size(); i++)
-		{
-			for (unsigned int j=0; j<derivTriNormalIndices[i].size(); j++)
-			{
-				unsigned int v = derivTriNormalIndices[i][j];
-				Mat33 Kiv = derivTriNormalValues[i][j];
+    if (m_useTangentStiffness.getValue())
+    {
+        for (unsigned int i = 0; i < derivTriNormalIndices.size(); i++)
+        {
+            for (unsigned int j = 0; j < derivTriNormalIndices[i].size(); j++)
+            {
+                unsigned int v = derivTriNormalIndices[i][j];
+                Mat33 Kiv = derivTriNormalValues[i][j];
 
-				for (unsigned int l=0; l<3; l++)
-				{
-					for (unsigned int c=0; c<3; c++)
-					{
-						mat->add(offset + N * i + l, offset + N * v + c, kFact * Kiv[l][c]);
-					}
-				}
-			}
-		}
-	}
+                for (unsigned int l = 0; l < 3; l++)
+                {
+                    for (unsigned int c = 0; c < 3; c++)
+                    {
+                        mat->add(offset + N * i + l, offset + N * v + c, kFact * Kiv[l][c]);
+                    }
+                }
+            }
+        }
+    }
 }
 
-template<class DataTypes>
-SReal SurfacePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
+template <class DataTypes>
+SReal SurfacePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord& /* x */) const
 {
     msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 
-template<class DataTypes>
+template <class DataTypes>
 void SurfacePressureForceField<DataTypes>::setPressure(const Real _pressure)
 {
     this->m_pressure.setValue(_pressure);
@@ -313,7 +310,7 @@ typename SurfacePressureForceField<DataTypes>::Real SurfacePressureForceField<Da
         const Coord a = x[t[0]];
         const Coord b = x[t[1]];
         const Coord c = x[t[2]];
-        volume += dot(cross(a,b),c);
+        volume += dot(cross(a, b), c);
     }
 
     unsigned int nQuads = 0;
@@ -343,8 +340,8 @@ typename SurfacePressureForceField<DataTypes>::Real SurfacePressureForceField<Da
         const Coord b = x[q[1]];
         const Coord c = x[q[2]];
         const Coord d = x[q[3]];
-        volume += dot(cross(a,b),c);
-        volume += dot(cross(a,c),d);
+        volume += dot(cross(a, b), c);
+        volume += dot(cross(a, c), d);
     }
 
     // Divide by 6 when computing tetrahedron volume
@@ -364,7 +361,7 @@ void SurfacePressureForceField<DataTypes>::addTriangleSurfacePressure(unsigned i
     Deriv p = (ab.cross(ac)) * (pressure / static_cast<Real>(6.0));
 
 
-    if(computeDerivatives)
+    if (computeDerivatives)
     {
         Mat33 DcrossDA;
         DcrossDA[0][0]=0;       DcrossDA[0][1]=-bc[2];  DcrossDA[0][2]=bc[1];
@@ -382,21 +379,17 @@ void SurfacePressureForceField<DataTypes>::addTriangleSurfacePressure(unsigned i
         DcrossDC[1][0]=ab[2];   DcrossDC[1][1]=0;       DcrossDC[1][2]=-ab[0];
         DcrossDC[2][0]=-ab[1];  DcrossDC[2][1]=ab[0];   DcrossDC[2][2]=0;
 
-        for (unsigned int j=0; j<3; j++)
+        for (unsigned int j = 0; j < 3; j++)
         {
-            derivTriNormalValues[t[j]].push_back( DcrossDA * (pressure / static_cast<Real>(6.0))  );
-            derivTriNormalValues[t[j]].push_back( DcrossDB * (pressure / static_cast<Real>(6.0))  );
-            derivTriNormalValues[t[j]].push_back( DcrossDC * (pressure / static_cast<Real>(6.0))  );
+            derivTriNormalValues[t[j]].push_back(DcrossDA * (pressure / static_cast<Real>(6.0)));
+            derivTriNormalValues[t[j]].push_back(DcrossDB * (pressure / static_cast<Real>(6.0)));
+            derivTriNormalValues[t[j]].push_back(DcrossDC * (pressure / static_cast<Real>(6.0)));
 
-            derivTriNormalIndices[t[j]].push_back( t[0] );
-            derivTriNormalIndices[t[j]].push_back( t[1] );
-            derivTriNormalIndices[t[j]].push_back( t[2] );
+            derivTriNormalIndices[t[j]].push_back(t[0]);
+            derivTriNormalIndices[t[j]].push_back(t[1]);
+            derivTriNormalIndices[t[j]].push_back(t[2]);
         }
-
-
-
     }
-
 
 
     if (m_mainDirection.getValue() != Deriv())
@@ -411,7 +404,6 @@ void SurfacePressureForceField<DataTypes>::addTriangleSurfacePressure(unsigned i
     f[t[1]] += p;
     f[t[2]] += p;
 }
-
 
 
 template <class DataTypes>
@@ -435,22 +427,23 @@ void SurfacePressureForceField<DataTypes>::addQuadSurfacePressure(unsigned int q
 }
 
 
-
 template <class DataTypes>
-bool SurfacePressureForceField<DataTypes>::isInPressuredBox(const Coord &x) const
+bool SurfacePressureForceField<DataTypes>::isInPressuredBox(const Coord& x) const
 {
-    if ( (m_max.getValue() == Coord()) && (m_min.getValue() == Coord()) )
+    if ((m_max.getValue() == Coord()) && (m_min.getValue() == Coord()))
+    {
         return true;
+    }
 
-    return ( (x[0] >= m_min.getValue()[0])
-            && (x[0] <= m_max.getValue()[0])
-            && (x[1] >= m_min.getValue()[1])
-            && (x[1] <= m_max.getValue()[1])
-            && (x[2] >= m_min.getValue()[2])
-            && (x[2] <= m_max.getValue()[2]) );
+    return ((x[0] >= m_min.getValue()[0])
+        && (x[0] <= m_max.getValue()[0])
+        && (x[1] >= m_min.getValue()[1])
+        && (x[1] <= m_max.getValue()[1])
+        && (x[2] >= m_min.getValue()[2])
+        && (x[2] <= m_max.getValue()[2]));
 }
 
-template<class DataTypes>
+template <class DataTypes>
 typename SurfacePressureForceField<DataTypes>::Real SurfacePressureForceField<DataTypes>::computePulseModePressure()
 {
     SReal dt = this->getContext()->getDt();
@@ -488,16 +481,20 @@ typename SurfacePressureForceField<DataTypes>::Real SurfacePressureForceField<Da
     return 0.0;
 }
 
-template<class DataTypes>
+template <class DataTypes>
 void SurfacePressureForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    if (!vparams->displayFlags().getShowForceFields()) return;
-    if (!this->mstate) return;
+    if (!vparams->displayFlags().getShowForceFields())
+        return;
+    if (!this->mstate)
+        return;
 
     const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     if (vparams->displayFlags().getShowWireFrame())
+    {
         vparams->drawTool()->setPolygonMode(0, true);
+    }
 
     vparams->drawTool()->disableLighting();
 
@@ -507,207 +504,24 @@ void SurfacePressureForceField<DataTypes>::draw(const core::visual::VisualParams
     vparams->drawTool()->drawBoundingBox(DataTypes::getCPos(m_min.getValue()), DataTypes::getCPos(m_max.getValue()));
 
     if (vparams->displayFlags().getShowWireFrame())
+    {
         vparams->drawTool()->setPolygonMode(0, false);
+    }
 
 
     helper::ReadAccessor<DataVecCoord> x = this->mstate->read(core::ConstVecCoordId::position());
-    if (m_drawForceScale.getValue() && m_f.size()==x.size())
+    if (m_drawForceScale.getValue() && m_f.size() == x.size())
     {
-        std::vector< type::Vec3 > points;
-        constexpr sofa::type::RGBAColor color(0,1,0.5,1);
+        std::vector<type::Vec3> points;
+        constexpr sofa::type::RGBAColor color(0, 1, 0.5, 1);
 
-        for (unsigned int i=0; i<x.size(); i++)
+        for (unsigned int i = 0; i < x.size(); i++)
         {
             points.push_back(DataTypes::getCPos(x[i]));
-            points.push_back(DataTypes::getCPos(x[i]) + DataTypes::getDPos(m_f[i])*m_drawForceScale.getValue());
+            points.push_back(DataTypes::getCPos(x[i]) + DataTypes::getDPos(m_f[i]) * m_drawForceScale.getValue());
         }
         vparams->drawTool()->drawLines(points, 1, color);
     }
-
-
-}
-
-template<>
-void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::MechanicalParams* mparams ,
-                                                                     DataVecDeriv& d_df , const DataVecDeriv& d_dx)
-{
-    const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
-	VecDeriv& df       = *(d_df.beginEdit());
-	const VecDeriv& dx =   d_dx.getValue()  ;
-
-
-	for (unsigned int i=0; i<derivTriNormalIndices.size(); i++)
-	{
-
-		for (unsigned int j=0; j<derivTriNormalIndices[i].size(); j++)
-		{
-            const unsigned int v = derivTriNormalIndices[i][j];
-			df[i].getVCenter() += (derivTriNormalValues[i][j] * dx[v].getVCenter())*kFactor;
-
-		}
-
-	}
-
-	d_df.endEdit();
-
-
-}
-
-template <>
-SurfacePressureForceField<defaulttype::Rigid3Types>::Real SurfacePressureForceField<defaulttype::Rigid3Types>::computeMeshVolume(const VecDeriv& /*f*/, const VecCoord& x)
-{
-    typedef core::topology::BaseMeshTopology::Triangle Triangle;
-    typedef core::topology::BaseMeshTopology::Quad Quad;
-
-    Real volume = 0;
-
-    unsigned int nTriangles = 0;
-    const VecIndex& triangleIndices = m_triangleIndices.getValue();
-    if (!triangleIndices.empty())
-    {
-        nTriangles = triangleIndices.size();
-    }
-    else
-    {
-        nTriangles = m_topology->getNbTriangles();
-    }
-
-    unsigned int triangleIdx = 0;
-    for (unsigned int i = 0; i < nTriangles; i++)
-    {
-        if (!triangleIndices.empty())
-        {
-            triangleIdx = triangleIndices[i];
-        }
-        else
-        {
-            triangleIdx = i;
-        }
-        Triangle t = m_topology->getTriangle(triangleIdx);
-        const defaulttype::Rigid3Types::CPos a = x[t[0]].getCenter();
-        const defaulttype::Rigid3Types::CPos b = x[t[1]].getCenter();
-        const defaulttype::Rigid3Types::CPos c = x[t[2]].getCenter();
-        volume += dot(cross(a,b),c);
-    }
-
-    unsigned int nQuads = 0;
-    const VecIndex& quadIndices = m_quadIndices.getValue();
-    if (!quadIndices.empty())
-    {
-        nQuads = quadIndices.size();
-    }
-    else
-    {
-        nQuads = m_topology->getNbQuads();
-    }
-
-    unsigned int quadIdx = 0;
-    for (unsigned int i = 0; i < nQuads; i++)
-    {
-        if (!quadIndices.empty())
-        {
-            quadIdx = quadIndices[i];
-        }
-        else
-        {
-            quadIdx = i;
-        }
-        Quad q = m_topology->getQuad(quadIdx);
-        const defaulttype::Rigid3Types::CPos a = x[q[0]].getCenter();
-        const defaulttype::Rigid3Types::CPos b = x[q[1]].getCenter();
-        const defaulttype::Rigid3Types::CPos c = x[q[2]].getCenter();
-        const defaulttype::Rigid3Types::CPos d = x[q[3]].getCenter();
-        volume += dot(cross(a,b),c);
-        volume += dot(cross(a,c),d);
-    }
-
-    // Divide by 6 when computing tetrahedron volume
-    return volume / 6.0;
-}
-
-template <>
-void SurfacePressureForceField<defaulttype::Rigid3Types>::addTriangleSurfacePressure(unsigned int triId, VecDeriv& f, const VecCoord& x, const VecDeriv& /*v*/, const Real& pressure, bool computeDerivatives)
-{
-	Triangle t = m_topology->getTriangle(triId);
-
-    defaulttype::Rigid3Types::CPos ab = x[t[1]].getCenter() - x[t[0]].getCenter();
-    defaulttype::Rigid3Types::CPos ac = x[t[2]].getCenter() - x[t[0]].getCenter();
-    defaulttype::Rigid3Types::CPos bc = x[t[2]].getCenter() - x[t[1]].getCenter();
-
-    defaulttype::Rigid3Types::CPos p = (ab.cross(ac)) * (pressure / static_cast<Real>(6.0));
-
-
-	if(computeDerivatives)
-	{
-		Mat33 DcrossDA;
-		DcrossDA[0][0]=0;       DcrossDA[0][1]=-bc[2];  DcrossDA[0][2]=bc[1];
-		DcrossDA[1][0]=bc[2];   DcrossDA[1][1]=0;       DcrossDA[1][2]=-bc[0];
-		DcrossDA[2][0]=-bc[1];  DcrossDA[2][1]=bc[0];   DcrossDA[2][2]=0;
-
-		Mat33 DcrossDB;
-		DcrossDB[0][0]=0;       DcrossDB[0][1]=ac[2];   DcrossDB[0][2]=-ac[1];
-		DcrossDB[1][0]=-ac[2];  DcrossDB[1][1]=0;       DcrossDB[1][2]=ac[0];
-		DcrossDB[2][0]=ac[1];  DcrossDB[2][1]=-ac[0];   DcrossDB[2][2]=0;
-
-
-		Mat33 DcrossDC;
-		DcrossDC[0][0]=0;       DcrossDC[0][1]=-ab[2];  DcrossDC[0][2]=ab[1];
-		DcrossDC[1][0]=ab[2];   DcrossDC[1][1]=0;       DcrossDC[1][2]=-ab[0];
-		DcrossDC[2][0]=-ab[1];  DcrossDC[2][1]=ab[0];   DcrossDC[2][2]=0;
-
-		for (unsigned int j=0; j<3; j++)
-		{
-			derivTriNormalValues[t[j]].push_back( DcrossDA * (pressure / static_cast<Real>(6.0))  );
-			derivTriNormalValues[t[j]].push_back( DcrossDB * (pressure / static_cast<Real>(6.0))  );
-			derivTriNormalValues[t[j]].push_back( DcrossDC * (pressure / static_cast<Real>(6.0))  );
-
-			derivTriNormalIndices[t[j]].push_back( t[0] );
-			derivTriNormalIndices[t[j]].push_back( t[1] );
-			derivTriNormalIndices[t[j]].push_back( t[2] );
-		}
-
-
-
-	}
-
-
-
-    if (m_mainDirection.getValue().getVCenter() != defaulttype::Rigid3Types::CPos())
-	{
-        defaulttype::Rigid3Types::CPos n = ab.cross(ac);
-		n.normalize();
-        const Real scal = n * m_mainDirection.getValue().getVCenter();
-		p *= fabs(scal);
-	}
-
-	f[t[0]].getVCenter() += p;
-	f[t[1]].getVCenter() += p;
-	f[t[2]].getVCenter() += p;
-}
-
-template <>
-void SurfacePressureForceField<defaulttype::Rigid3Types>::addQuadSurfacePressure(unsigned int quadId, VecDeriv& f, const VecCoord& x, const VecDeriv& /*v*/, const Real& pressure)
-{
-	Quad q = m_topology->getQuad(quadId);
-
-    const defaulttype::Rigid3Types::CPos ab = x[q[1]].getCenter() - x[q[0]].getCenter();
-    const defaulttype::Rigid3Types::CPos ac = x[q[2]].getCenter() - x[q[0]].getCenter();
-    const defaulttype::Rigid3Types::CPos ad = x[q[3]].getCenter() - x[q[0]].getCenter();
-
-    const defaulttype::Rigid3Types::CPos p1 = (ab.cross(ac)) * (pressure / static_cast<Real>(6.0));
-    const defaulttype::Rigid3Types::CPos p2 = (ac.cross(ad)) * (pressure / static_cast<Real>(6.0));
-
-    const defaulttype::Rigid3Types::CPos p = p1 + p2;
-
-	f[q[0]].getVCenter() += p;
-	f[q[1]].getVCenter() += p1;
-	f[q[2]].getVCenter() += p;
-	f[q[3]].getVCenter() += p2;
-}
-
-template<>
-void SurfacePressureForceField<defaulttype::Rigid3Types>::verifyDerivative(VecDeriv& /*v_plus*/, VecDeriv& /*v*/,  VecVec3DerivValues& /*DVval*/, VecVec3DerivIndices& /*DVind*/, const VecDeriv& /*Din*/)
-{
 }
 
 } // namespace sofa::component::mechanicalload

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.inl
@@ -36,20 +36,19 @@ template <class DataTypes> TrianglePressureForceField<DataTypes>::~TrianglePress
 {
 }
 
-template <class DataTypes>  TrianglePressureForceField<DataTypes>::TrianglePressureForceField()    
-        : pressure(initData(&pressure, "pressure", "Pressure force per unit area"))
-		, cauchyStress(initData(&cauchyStress, MatSym3(),"cauchyStress", "Cauchy Stress applied on the normal of each triangle"))
-        , triangleList(initData(&triangleList,"triangleList", "Indices of triangles separated with commas where a pressure is applied"))
-        , normal(initData(&normal,"normal", "Normal direction for the plane selection of triangles"))
-        , dmin(initData(&dmin,(Real)0.0, "dmin", "Minimum distance from the origin along the normal direction"))
-        , dmax(initData(&dmax,(Real)0.0, "dmax", "Maximum distance from the origin along the normal direction"))
-        , p_showForces(initData(&p_showForces, (bool)false, "showForces", "draw triangles which have a given pressure"))
-		, p_useConstantForce(initData(&p_useConstantForce, (bool)true, "useConstantForce", "applied force is computed as the pressure vector times the area at rest"))
-        , l_topology(initLink("topology", "link to the topology container"))
-        , trianglePressureMap(initData(&trianglePressureMap, "trianglePressureMap", "map between edge indices and their pressure"))
-        , m_topology(nullptr)
-    {
-    }
+template <class DataTypes>  TrianglePressureForceField<DataTypes>::TrianglePressureForceField()
+    : pressure(initData(&pressure, "pressure", "Pressure force per unit area"))
+    , cauchyStress(initData(&cauchyStress, MatSym3(),"cauchyStress", "Cauchy Stress applied on the normal of each triangle"))
+    , triangleList(initData(&triangleList,"triangleList", "Indices of triangles separated with commas where a pressure is applied"))
+    , normal(initData(&normal,"normal", "Normal direction for the plane selection of triangles"))
+    , dmin(initData(&dmin,(Real)0.0, "dmin", "Minimum distance from the origin along the normal direction"))
+    , dmax(initData(&dmax,(Real)0.0, "dmax", "Maximum distance from the origin along the normal direction"))
+    , p_showForces(initData(&p_showForces, (bool)false, "showForces", "draw triangles which have a given pressure"))
+    , p_useConstantForce(initData(&p_useConstantForce, (bool)true, "useConstantForce", "applied force is computed as the pressure vector times the area at rest"))
+    , l_topology(initLink("topology", "link to the topology container"))
+    , trianglePressureMap(initData(&trianglePressureMap, "trianglePressureMap", "map between edge indices and their pressure"))
+    , m_topology(nullptr)
+{}
 
 template <class DataTypes> void TrianglePressureForceField<DataTypes>::init()
 {

--- a/Sofa/Component/MechanicalLoad/tests/CMakeLists.txt
+++ b/Sofa/Component/MechanicalLoad/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCE_FILES
     PlaneForceField_test.cpp
     QuadPressureForceField_test.cpp
     SkeletalMotionConstraint_test.cpp
+    SurfacePressureForceField_test.cpp
     TrianglePressureForceField_test.cpp
 )
 

--- a/Sofa/Component/MechanicalLoad/tests/SurfacePressureForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/SurfacePressureForceField_test.cpp
@@ -1,0 +1,134 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+//Force field
+#include <sofa/component/mechanicalload/SurfacePressureForceField.h>
+
+#include <sofa/component/solidmechanics/testing/ForceFieldTestCreation.h>
+
+
+namespace sofa
+{
+
+/**  Test SurfacePressureForceField.
+  */
+template <typename SurfacePressureForceFieldType>
+struct SurfacePressureForceField_test : public ForceField_test<SurfacePressureForceFieldType>
+{
+    typedef ForceField_test<SurfacePressureForceFieldType> Inherited;
+    typedef SurfacePressureForceFieldType ForceType;
+    typedef typename ForceType::DataTypes DataTypes;
+
+    typedef typename ForceType::VecCoord VecCoord;
+    typedef typename ForceType::VecDeriv VecDeriv;
+    typedef typename ForceType::Coord Coord;
+    typedef typename ForceType::Deriv Deriv;
+    typedef typename Coord::value_type Real;
+    typedef type::Vec<3, Real> Vec3;
+
+    VecCoord x;
+    VecDeriv v, f;
+
+    SurfacePressureForceField_test()
+        : Inherited::ForceField_test(std::string(SOFA_COMPONENT_MECHANICALLOAD_TEST_SCENES_DIR) + "/" + "SurfacePressureForceField.scn")
+    {
+        // potential energy is not implemented and won't be tested
+        this->flags &= ~Inherited::TEST_POTENTIAL_ENERGY;
+
+        // Set vectors, using DataTypes::set to cope with tests in dimension 2
+        //Position
+        x.resize(3);
+        DataTypes::set(x[0], 0, 0, 0);
+        DataTypes::set(x[1], 1, 0, 0);
+        DataTypes::set(x[2], 1, 1, 0);
+
+        //Velocity
+        v.resize(3);
+        DataTypes::set(v[0], 0, 0, 0);
+        DataTypes::set(v[1], 0, 0, 0);
+        DataTypes::set(v[2], 0, 0, 0);
+
+        //Force
+        f.resize(3);
+        Vec3 f0(0, 0, 0.1);
+        DataTypes::set(f[0], f0[0], f0[1], f0[2]);
+        DataTypes::set(f[1], f0[0], f0[1], f0[2]);
+        DataTypes::set(f[2], f0[0], f0[1], f0[2]);
+
+        // Set the properties of the force field
+        Inherited::force->m_pressure.setValue(0.6);
+    }
+
+    //Test the value of the force it should be equal for each vertex to Pressure*area/4
+    void test_valueForce()
+    {
+        // run the forcefield_test
+        Inherited::run_test(x, v, f);
+    }
+
+    // Test that the force value is constant
+    void test_constantForce()
+    {
+        sofa::simulation::getSimulation()->init(Inherited::node.get());
+
+        // Do a few animation steps
+        for (int k = 0; k < 10; k++)
+        {
+            sofa::simulation::getSimulation()->animate(Inherited::node.get(), 0.5);
+        }
+
+        // run the forcefield_test
+        Inherited::run_test(x, v, f, false);
+    }
+
+};
+
+
+// Types to instantiate.
+typedef ::testing::Types<
+    component::mechanicalload::SurfacePressureForceField<defaulttype::Vec3Types>
+> TestTypes;
+
+
+// Tests to run for each instantiated type
+TYPED_TEST_SUITE(SurfacePressureForceField_test, TestTypes);
+
+// first test case: test force value
+TYPED_TEST(SurfacePressureForceField_test, surfacePressureForceFieldTest)
+{
+    this->errorMax = 1;
+    this->deltaRange.first = 1e7;
+    this->deltaRange.second = 1e8;
+
+    this->test_valueForce();
+}
+
+// second test case: test that force is constant
+TYPED_TEST(SurfacePressureForceField_test, constantSurfacePressureForceFieldTest)
+{
+    this->errorMax = 1;
+    this->deltaRange.first = 1e7;
+    this->deltaRange.second = 1e8;
+
+    this->test_constantForce();
+}
+} // namespace sofa

--- a/Sofa/Component/MechanicalLoad/tests/scenes/SurfacePressureForceField.scn
+++ b/Sofa/Component/MechanicalLoad/tests/scenes/SurfacePressureForceField.scn
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<Node 	name="Root" gravity="0 0 0" time="0" animate="0"  dt="0.5" showAxis="true">
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetGeometryAlgorithms TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
+
+    <DefaultAnimationLoop />
+
+    <MechanicalObject name="DOFs" showObject="1"  showObjectScale="5"  showIndices="1"  showIndicesScale="0.0003" position="0 0 0 1 0 0 0 1 0" />
+    <MeshTopology name="triangle" triangles="0 1 2"  drawTriangles="1" position="@DOFs.position"/>
+
+    <TriangleSetTopologyContainer name="TriangleContainer" triangles="@triangle.triangles"/>
+    <TriangleSetTopologyModifier />
+    <TriangleSetGeometryAlgorithms template="Vec3d" />
+    <!--<SurfacePressureForceField pressure="0.6"/>-->
+
+</Node>

--- a/Sofa/Component/ODESolver/Backward/tests/StaticSolver_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/StaticSolver_test.cpp
@@ -60,9 +60,10 @@ public:
         root = getSimulation()->createNewNode("root");
 
         createObject(root, "RequiredPlugin", {{"pluginName", "Sofa.Component"}});
+        createObject(root, "DefaultAnimationLoop");
         createObject(root, "RegularGridTopology", {{"name", "grid"}, {"min", "-7.5 -7.5 0"}, {"max", "7.5 7.5 80"}, {"n", "3 3 9"}});
         auto s = createObject(root, "StaticSolver", {{"newton_iterations", "10"}});
-        createObject(root, "SparseLDLSolver");
+        createObject(root, "SparseLDLSolver", {{"template", "CompressedRowSparseMatrixd"}});
         createObject(root, "MechanicalObject", {{"name", "mo"}, {"src", "@grid"}});
         createObject(root, "TetrahedronSetTopologyContainer", {{"name", "mechanical_topology"}});
         createObject(root, "TetrahedronSetTopologyModifier");
@@ -107,16 +108,16 @@ TEST_F(StaticSolverTest, Residuals) {
     // These are the expected force residual if we do not activate any convergence threshold
     // and force the solve to do 10 Newton iterations
     std::vector<double> expected_force_residual_norms = {
-        1.237102e+03,
-        6.931312e+00,
-        2.634097e-01,
-        2.829366e-02,
-        2.928456e-03,
-        3.017181e-04,
-        3.108847e-05,
-        3.203062e-06,
-        3.300435e-07,
-        3.398669e-08
+        2551.7326458060306,
+        381.91182992522732,
+        44.367042885694701,
+        3.4122807603419312,
+        0.40321094066950214,
+        0.023070078859990586,
+        0.0036006702672518268,
+        0.00014283984897951575,
+        0.000030818164546577138,
+        0.0000012847345051708047
     };
 
     // Disable all convergence criteria
@@ -148,14 +149,10 @@ TEST_F(StaticSolverTest, RelativeResiduals) {
     dynamic_cast< Data<SReal> *   > ( this->solver->findData("relative_residual_tolerance_threshold")   )->setValue(1e-5);
     dynamic_cast< Data<bool> *     > ( this->solver->findData("should_diverge_when_residual_is_growing") )->setValue(false);
 
-    // The list of relative residuals are
-    //       1             2             3             4             5             6             7             8             9             10
-    // 1.000000e+00, 5.602864e-03, 2.129249e-04, 2.287093e-05, 2.367191e-06, 2.438911e-07, 2.513007e-08, 2.589194e-09,  2.668053e-10, 2.748057e-11
-    // Setting a relative criterion of 1e-5 should therefore converge after the 5th Newton iteration.
-
-    std::vector<SReal> actual_force_residual_norms = this->execute().first;
-    EXPECT_EQ(actual_force_residual_norms.size(), 5)
-    << "The static ODE solver is supposed to converge after 5 Newton steps when using a relative residual threshold of 1e-5.";
+    sofa::type::vector<SReal> actual_force_residual_norms = this->execute().first;
+    EXPECT_EQ(actual_force_residual_norms.size(), 6)
+    << "The static ODE solver is supposed to converge after 6 Newton steps when using a relative residual threshold of 1e-5.\n"
+    << actual_force_residual_norms;
 }
 
 TEST_F(StaticSolverTest, AbsoluteResiduals) {
@@ -168,14 +165,10 @@ TEST_F(StaticSolverTest, AbsoluteResiduals) {
     dynamic_cast< Data<SReal> *   > ( this->solver->findData("relative_residual_tolerance_threshold")   )->setValue(-1);
     dynamic_cast< Data<bool> *     > ( this->solver->findData("should_diverge_when_residual_is_growing") )->setValue(false);
 
-    // The list of relative residuals are
-    //       1             2             3             4             5             6             7             8             9             10
-    // 1.237102e+03, 6.931312e+00, 2.634097e-01, 2.829366e-02, 2.928456e-03, 3.017181e-04, 3.108845e-05, 3.203097e-06, 3.300652e-07, 3.399625e-08
-    // Setting an absolute criterion of 1e-5 should therefore converge after the 8th Newton iteration.
-
-    std::vector<SReal> actual_force_residual_norms = this->execute().first;
-    EXPECT_EQ(actual_force_residual_norms.size(), 8)
-    << "The static ODE solver is supposed to converge after 8 Newton steps when using an absolute residual threshold of 1e-5.";
+    sofa::type::vector<SReal> actual_force_residual_norms = this->execute().first;
+    EXPECT_EQ(actual_force_residual_norms.size(), 10)
+    << "The static ODE solver is supposed to converge after 10 Newton steps when using an absolute residual threshold of 1e-5.\n"
+    << actual_force_residual_norms;
 }
 
 TEST_F(StaticSolverTest, Increments) {
@@ -183,16 +176,16 @@ TEST_F(StaticSolverTest, Increments) {
     // These are the expected correction increment norms if we do not activate any convergence threshold
     // and force the solve to do 10 Newton iterations
     std::vector<double> expected_increment_norms = {
-            1.781729e+01,
-            5.043276e-01,
-            1.201313e-02,
-            1.237255e-03,
-            1.250073e-04,
-            1.289042e-05,
-            1.329191e-06,
-            1.369818e-07,
-            1.411500e-08,
-            1.454314e-09,
+        23.149116745347889,
+        4.7185304859032309,
+        0.95755125409873631,
+        0.053244570231523215,
+        0.0040133773093344888,
+        0.0003421565281377296,
+        0.000036312620114208186,
+        0.0000019664565731698484,
+        0.00000033108990100908061,
+        0.0000000073088563878990673,
     };
 
     // Disable all convergence criteria
@@ -224,14 +217,10 @@ TEST_F(StaticSolverTest, RelativeIncrements) {
     dynamic_cast< Data<SReal> *   > ( this->solver->findData("relative_residual_tolerance_threshold")   )->setValue(-1);
     dynamic_cast< Data<bool> *     > ( this->solver->findData("should_diverge_when_residual_is_growing") )->setValue(false);
 
-    // The list of relative corrections are
-    //       1             2             3             4             5             6             7             8             9             10
-    // 1.000000e+00, 2.819276e-02, 6.711671e-04, 6.912001e-05, 6.983561e-06, 7.201258e-07, 7.425552e-08, 7.652517e-09,  7.885371e-10, 8.124548e-11
-    // Setting a relative criterion of 1e-5 should therefore converge after the 5th Newton iteration.
-
-    std::vector<SReal> actual_increment_norms = this->execute().second;
-    EXPECT_EQ(actual_increment_norms.size(), 5)
-    << "The static ODE solver is supposed to converge after 5 Newton steps when using a relative correction threshold of 1e-5.";
+    const sofa::type::vector<SReal> actual_increment_norms = this->execute().second;
+    EXPECT_EQ(actual_increment_norms.size(), 7)
+    << "The static ODE solver is supposed to converge after 7 Newton steps when using a relative correction threshold of 1e-5.\n"
+    << actual_increment_norms;
 }
 
 TEST_F(StaticSolverTest, AbsoluteIncrements) {
@@ -244,12 +233,8 @@ TEST_F(StaticSolverTest, AbsoluteIncrements) {
     dynamic_cast< Data<SReal> *   > ( this->solver->findData("relative_residual_tolerance_threshold")   )->setValue(-1);
     dynamic_cast< Data<bool> *     > ( this->solver->findData("should_diverge_when_residual_is_growing") )->setValue(false);
 
-    // The list of absolute corrections are
-    //       1             2             3             4             5             6             7             8             9             10
-    // 1.781729e+01, 5.043276e-01, 1.201313e-02, 1.237255e-03, 1.250073e-04, 1.289042e-05, 1.329191e-06, 1.369819e-07, 1.411500e-08, 1.454313e-09
-    // Setting an absolute criterion of 1e-5 should therefore converge after the 7th Newton iteration.
-
-    std::vector<SReal> actual_increment_norms = this->execute().second;
-    EXPECT_EQ(actual_increment_norms.size(), 7)
-    << "The static ODE solver is supposed to converge after 7 Newton steps when using a relative correction threshold of 1e-5.";
+    const sofa::type::vector<SReal> actual_increment_norms = this->execute().second;
+    EXPECT_EQ(actual_increment_norms.size(), 8)
+    << "The static ODE solver is supposed to converge after 8 Newton steps when using a relative correction threshold of 1e-5.\n"
+    << actual_increment_norms;
 }


### PR DESCRIPTION
- The function `addKToMatrix` in `SurfacePressureForceField` had a `return` statement before doing anything. I removed it. The reason of this statement is not known, but it has been identified here: https://github.com/sofa-framework/sofa/commit/2ad1468eea45325af9d727185fc5ba0c288b7608#r31731863
- Unit test is added for `SurfacePressureForceField`. It verifies the correctness of the function `addKToMatrix`. It would fail without the removal of the `return` statement.
- Template specializations have been moved from the inl to the cpp
- Cosmetic cleaning



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
