### PR TITLE
[IO.Mesh] More debug info in the error message in MeshSTLLoader

### DIFF
--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshSTLLoader.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshSTLLoader.cpp
@@ -91,7 +91,7 @@ bool isBinarySTLValid(const char* filename, const MeshSTLLoader* _this)
 {
     // Binary STL files have 80-bytes headers. The following 4-bytes is the number of triangular facets in the file
     // Each facet is described with a 50-bytes field, so a valid binary STL file verifies the following condition:
-    // nFacets * 50 + 84-bytes header == filename
+    // nFacets * 50 + 84-bytes header == filesize
 
     long filesize;
     std::ifstream f(filename, std::ifstream::ate | std::ifstream::binary);
@@ -106,9 +106,11 @@ bool isBinarySTLValid(const char* filename, const MeshSTLLoader* _this)
     f.read(buffer, 80);
     uint32_t ntriangles;
     f.read(reinterpret_cast<char*>(&ntriangles), 4);
-    if (filesize != ntriangles * 50 + 84)
+    const uint32_t expectedFileSize = ntriangles * 50 + 84;
+    if (filesize != expectedFileSize)
     {
-        msg_error(_this) << filename << " isn't  binary STL file";
+        msg_error(_this) << filename << " isn't binary STL file. File size expected to be "
+            << expectedFileSize << " (with " << ntriangles << " triangles) but it is " << filesize;
         return false;
     }
     return true;


### PR DESCRIPTION
In my case, it helped me to understand that the file was corrupted, via the nonsensical number of triangles that was printed.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
