### PR TITLE
[Sofa.Simulation] Remove Node::bwdInit

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.cpp
@@ -66,7 +66,6 @@ void InitVisitor::processNodeBottomUp(simulation::Node* node)
     }
 
     node->f_bbox.endEdit();
-    node->bwdInit();
 }
 
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -833,17 +833,6 @@ void Node::setDefaultVisualContextValue()
     */
 }
 
-void Node::bwdInit()
-{
-    if (mechanicalMapping && !mechanicalMapping->isMechanical())
-    {
-        // BUGFIX: the mapping was configured as not mechanical -> remove it from mechanicalMapping and put it in mapping
-        core::BaseMapping* bmap = mechanicalMapping.get();
-        mapping.add(bmap);
-        mechanicalMapping.remove(bmap);
-    }
-}
-
 void Node::initialize()
 {
     initialized = true;  // flag telling is the node is initialized

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -509,8 +509,6 @@ public:
     /// Must be called after each graph modification. Do not call it directly, apply an InitVisitor instead.
     virtual void initialize();
 
-    virtual void bwdInit();
-
     /// Called after initialization to set the default value of the visual context.
     virtual void setDefaultVisualContextValue();
 


### PR DESCRIPTION
The bwdInit is used to implement a bugfix that seems to be fixed in a more approriate way elegant way in BaseMapping
```cpp
bool BaseMapping::insertInNode( objectmodel::BaseNode* node )
{
    if( isMechanical() ) node->addMechanicalMapping(this);
    else node->addMapping(this);
    Inherit1::insertInNode(node);
    return true;
}
```

That said, I find annoying these two approaches because they are considering a a problem to have mechanicalmapping in the two list (mechanicalmapping and mapping). If a mechanicalmapping *is a* mapping it makes sense for it to be in the two lists. I don't know what would happend if I remove this behavior... a future PR maybe) . 






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
