### PR TITLE
[Helper.System] Introduce function append for paths

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -43,6 +43,7 @@
 #include <sstream>
 #include <list>
 #include <iomanip>
+#include <sofa/helper/system/FileSystem.h>
 
 //#define NEW_METHOD_UNBUILT
 
@@ -133,12 +134,13 @@ bool PrecomputedConstraintCorrection<DataTypes>::loadCompliance(std::string file
         std::string dir = fileDir.getValue();
         if (!dir.empty())
         {
-            std::ifstream compFileIn((dir + "/" + fileName).c_str(), std::ifstream::binary);
+            const std::string path = helper::system::FileSystem::append(dir, fileName);
+            std::ifstream compFileIn(path, std::ifstream::binary);
             if (compFileIn.is_open())
             {
                 invM->data = new Real[nbRows * nbCols];
 
-                msg_info() << "File " << dir + "/" + fileName << " found. Loading..." ;
+                msg_info() << "File " << path << " found. Loading..." ;
 
                 compFileIn.read((char*)invM->data, nbCols * nbRows * sizeof(Real));
                 compFileIn.close();
@@ -181,9 +183,14 @@ void PrecomputedConstraintCorrection<DataTypes>::saveCompliance(const std::strin
     std::string filePathInSofaShare;
     std::string dir = fileDir.getValue();
     if (!dir.empty())
-        filePathInSofaShare = dir + "/" + fileName;
+    {
+        filePathInSofaShare = helper::system::FileSystem::append(dir, fileName);
+    }
     else
-        filePathInSofaShare  = sofa::helper::system::DataRepository.getFirstPath() + "/" + fileName;
+    {
+        filePathInSofaShare = helper::system::FileSystem::append(
+            sofa::helper::system::DataRepository.getFirstPath(), fileName);
+    }
 
     std::ofstream compFileOut(filePathInSofaShare.c_str(), std::fstream::out | std::fstream::binary);
     compFileOut.write((char*)invM->data, nbCols * nbRows * sizeof(Real));

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
@@ -22,6 +22,8 @@
 #include <sofa/component/io/mesh/BlenderExporter.h>
 #include <iomanip>
 #include <iostream>
+#include <sofa/helper/system/FileSystem.h>
+
 
 namespace sofa::component::_blenderexporter_
 {
@@ -51,7 +53,8 @@ void BlenderExporter<T>::init()
     if(simulationType.getValue()==Hair)
     {
         ostringstream iss;
-        iss<<path.getValue()<<"/"<<baseName.getValue()<<"_000000_00.bphys";
+        iss << helper::system::FileSystem::append(path.getValue(), baseName.getValue())
+            << "_000000_00.bphys";
         string fileName = iss.str();
         // create the file
         ofstream file(fileName.c_str(), ios::out|ios::binary);
@@ -85,7 +88,7 @@ void BlenderExporter<T>::handleEvent(sofa::core::objectmodel::Event* event)
         {
             int frameNumber = frameCounter/simulationStep.getValue();
             ostringstream iss;
-            iss<<path.getValue()<<"/"<<baseName.getValue()<<"_";
+            iss << helper::system::FileSystem::append(path.getValue(), baseName.getValue()) << "_";
             iss<<std::setfill('0') << std::setw(6) << frameNumber+1<<"_00.bphys";
             string fileName = iss.str();
 

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/AddResourceRepository.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/AddResourceRepository.cpp
@@ -64,7 +64,7 @@ bool BaseAddResourceRepository::updateRepositoryPath()
     //else prepend (absolute) current directory to the given path and add it
     if (!sofa::helper::system::FileSystem::isAbsolute(tmpAddedPath))
     {
-        tmpAddedPath = sofa::helper::system::SetDirectory::GetCurrentDir() + "/" + tmpAddedPath;
+        tmpAddedPath = FileSystem::append(sofa::helper::system::SetDirectory::GetCurrentDir(), tmpAddedPath);
     }
     //second, check if the path exists
     if (!sofa::helper::system::FileSystem::exists(tmpAddedPath))

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/viewer/SofaViewer.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/viewer/SofaViewer.cpp
@@ -28,6 +28,7 @@
 #include <sofa/gui/qt/PickHandlerCallBacks.h>
 #include <sofa/gui/common/BaseGUI.h>
 #include <sofa/component/visual/VisualStyle.h>
+#include <sofa/helper/system/FileSystem.h>
 
 using namespace sofa::gui::common;
 
@@ -514,8 +515,9 @@ const std::string SofaViewer::screenshotName()
 
 void SofaViewer::setPrefix(const std::string& prefix, bool prependDirectory)
 {
-    const std::string fullPrefix = (prependDirectory) ? sofa::gui::common::BaseGUI::getScreenshotDirectoryPath() + "/" + prefix
-                                                      : prefix;
+    const std::string fullPrefix = (prependDirectory)
+       ? helper::system::FileSystem::append(sofa::gui::common::BaseGUI::getScreenshotDirectoryPath(), prefix)
+       : prefix;
 
     m_backend->setPrefix(fullPrefix);
 }

--- a/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
@@ -248,7 +248,7 @@ const std::string& Utils::getSofaPathPrefix()
 
 const std::string Utils::getSofaPathTo(const std::string& pathFromBuildDir)
 {
-    std::string path = Utils::getSofaPathPrefix() + "/" + pathFromBuildDir;
+    std::string path = FileSystem::append(Utils::getSofaPathPrefix(), pathFromBuildDir);
     if(FileSystem::exists(path))
     {
         return path;

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
@@ -434,6 +434,32 @@ std::string FileSystem::stripDirectory(const std::string& path)
     }
 }
 
+std::string FileSystem::append(const std::string& existingPath, const std::string& toAppend)
+{
+    if (toAppend.empty())
+    {
+        return existingPath;
+    }
+
+    const auto firstCharacter = toAppend.front();
+    if (firstCharacter == '/')
+    {
+        return append(existingPath, toAppend.substr(1));
+    }
+
+
+    const char lastCharacter = existingPath.back();
+    if (lastCharacter == '\\')
+    {
+        return append(convertBackSlashesToSlashes(existingPath), toAppend);
+    }
+    else if (lastCharacter == '/')
+    {
+        return append(existingPath.substr(0, existingPath.size() - 1), toAppend);
+    }
+    return existingPath + "/" + toAppend;
+}
+
 
 } // namespace system
 } // namespace helper

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
@@ -434,30 +434,25 @@ std::string FileSystem::stripDirectory(const std::string& path)
     }
 }
 
-std::string FileSystem::append(const std::string& existingPath, const std::string& toAppend)
+std::string FileSystem::append(const std::string_view& existingPath, const std::string_view& toAppend)
 {
     if (toAppend.empty())
     {
-        return existingPath;
+        return std::string(existingPath);
     }
 
-    const auto firstCharacter = toAppend.front();
-    if (firstCharacter == '/')
+    constexpr auto isADirectorySeparator = [](const char c) { return c == '/' || c == '\\'; };
+
+    if (isADirectorySeparator(toAppend.front()))
     {
         return append(existingPath, toAppend.substr(1));
     }
 
-
-    const char lastCharacter = existingPath.back();
-    if (lastCharacter == '\\')
-    {
-        return append(convertBackSlashesToSlashes(existingPath), toAppend);
-    }
-    else if (lastCharacter == '/')
+    if (isADirectorySeparator(existingPath.back()))
     {
         return append(existingPath.substr(0, existingPath.size() - 1), toAppend);
     }
-    return existingPath + "/" + toAppend;
+    return std::string(existingPath) + "/" + std::string(toAppend);
 }
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.h
@@ -141,6 +141,22 @@ static std::string getParentDirectory(const std::string& path);
 /// E.g. /a/b/c --> c
 static std::string stripDirectory(const std::string& path);
 
+
+/// Appends a string to an existing path, ensuring exactly one directory
+/// separator (/) between each part. It may convert \p existingPath if the
+/// last character is a back-slash.
+static std::string append(const std::string& existingPath, const std::string& toAppend);
+
+/// Appends strings to an existing path, ensuring exactly one directory
+/// separator (/) between each part.
+/// @note The function requires all arguments to be of type std::string.
+template<typename... Args>
+static std::string append(const std::string& existingPath, const std::string& toAppend, Args&&... args)
+{
+    static_assert((std::is_same_v<Args, std::string> && ...), "All arguments must be of type std::string.");
+    return append(append(existingPath, toAppend), args...);
+}
+
 };
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.h
@@ -143,17 +143,14 @@ static std::string stripDirectory(const std::string& path);
 
 
 /// Appends a string to an existing path, ensuring exactly one directory
-/// separator (/) between each part. It may convert \p existingPath if the
-/// last character is a back-slash.
-static std::string append(const std::string& existingPath, const std::string& toAppend);
+/// separator (/) between each part.
+static std::string append(const std::string_view& existingPath, const std::string_view& toAppend);
 
 /// Appends strings to an existing path, ensuring exactly one directory
 /// separator (/) between each part.
-/// @note The function requires all arguments to be of type std::string.
 template<typename... Args>
-static std::string append(const std::string& existingPath, const std::string& toAppend, Args&&... args)
+static std::string append(const std::string_view& existingPath, const std::string_view& toAppend, Args&&... args)
 {
-    static_assert((std::is_same_v<Args, std::string> && ...), "All arguments must be of type std::string.");
     return append(append(existingPath, toAppend), args...);
 }
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -408,12 +408,13 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
     const std::string libName = DynamicLibrary::prefix + name + "." + DynamicLibrary::extension;
 
     // First try: case sensitive
-    for (const auto & prefix : searchPaths) {
+    for (const auto & prefix : searchPaths)
+    {
         const std::array<std::string, 4> paths = {
-                prefix + "/" + libName,
-                prefix + "/" + pluginName + "/" + libName,
-                prefix + "/" + pluginName + "/bin/" + libName,
-                prefix + "/" + pluginName + "/lib/" + libName
+            FileSystem::append(prefix, libName),
+            FileSystem::append(prefix, pluginName, libName),
+            FileSystem::append(prefix, pluginName, "bin", libName),
+            FileSystem::append(prefix, pluginName, "lib", libName)
         };
         for (const auto & path : paths) {
             if (FileSystem::isFile(path)) {

--- a/Sofa/framework/Helper/test/system/FileSystem_test.cpp
+++ b/Sofa/framework/Helper/test/system/FileSystem_test.cpp
@@ -339,3 +339,23 @@ TEST(FileSystemTest, stripDirectory)
     EXPECT_EQ("ghi", FileSystem::stripDirectory("C:/abc/def/ghi"));
     EXPECT_EQ("ghi", FileSystem::stripDirectory("C:/abc/def/ghi/"));
 }
+
+TEST(FileSystemTest, append)
+{
+    EXPECT_EQ(FileSystem::append("C:/", "folder"), "C:/folder");
+    EXPECT_EQ(FileSystem::append("C:", "folder"), "C:/folder");
+    EXPECT_EQ(FileSystem::append("C:\\", "folder"), "C:/folder");
+
+    EXPECT_EQ(FileSystem::append("", "folder"), "/folder");
+
+    EXPECT_EQ(FileSystem::append("a/b/c/d", ""), "a/b/c/d");
+    EXPECT_EQ(FileSystem::append("a/b/c/d", "/folder"), "a/b/c/d/folder");
+    EXPECT_EQ(FileSystem::append("a/b/c/d/", "/folder"), "a/b/c/d/folder");
+    EXPECT_EQ(FileSystem::append("a/b/c/d//", "/folder"), "a/b/c/d/folder");
+
+    EXPECT_EQ(FileSystem::append("a/b/c/d", "e", "f", "g"), "a/b/c/d/e/f/g");
+    EXPECT_EQ(FileSystem::append("a/b/c/d/", "e", "f", "g"), "a/b/c/d/e/f/g");
+    EXPECT_EQ(FileSystem::append("a/b/c/d/", "e", "/f", "g"), "a/b/c/d/e/f/g");
+    EXPECT_EQ(FileSystem::append("a/b/c/d/", "e", "/f", "/g"), "a/b/c/d/e/f/g");
+    EXPECT_EQ(FileSystem::append("a/b/c/d/", "/e", "/f", "/g"), "a/b/c/d/e/f/g");
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.cpp
@@ -56,8 +56,9 @@ BaseSimulationExporter::BaseSimulationExporter() :
 const std::string BaseSimulationExporter::getOrCreateTargetPath(const std::string& filename, bool autonumbering)
 {
     std::string path = FileSystem::cleanPath(filename) ;
-    if( FileSystem::exists(path) && FileSystem::isDirectory(path) ){
-        path += "/" + getName() ;
+    if( FileSystem::exists(path) && FileSystem::isDirectory(path) )
+    {
+        path = FileSystem::append(path, getName());
     }
 
     /// If the path does not exists on the FS...we create It

--- a/applications/projects/runSofa/runSofaValidation.cpp
+++ b/applications/projects/runSofa/runSofaValidation.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <runSofaValidation.h>
+#include <sofa/helper/system/FileSystem.h>
 
 #include <sofa/helper/system/SetDirectory.h>
 using sofa::helper::system::SetDirectory;
@@ -39,11 +40,7 @@ void Validation::execute(const std::string& directory, const std::string& filena
 {
     msg_info("runSofa::Validation") << "load verification data from " << directory << " and file " << filename;
 
-    std::string refFile;
-
-    refFile += directory;
-    refFile += '/';
-    refFile += SetDirectory::GetFileName(filename.c_str());
+    std::string refFile = sofa::helper::system::FileSystem::append(directory, SetDirectory::GetFileName(filename.c_str()));
 
     msg_info("runSofa::Validation") << "reference file: " << refFile;
 


### PR DESCRIPTION
A cosmetic helper function to concatenate paths ensuring exactly one directory separator between each part

I happen to see paths such as `C:/Users/Temp//filename.ext`, and it hurt my cornea.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
