### PR TITLE
[Core.Topology] Restore invalid ids in invalid containers

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.h
@@ -86,7 +86,7 @@ public:
 protected:
     RestShapeSpringsForceField();
 
-    static const type::fixed_array<bool, coord_total_size> s_defaultActiveDirections;
+    static constexpr type::fixed_array<bool, coord_total_size> s_defaultActiveDirections = sofa::type::makeHomogeneousArray<bool, coord_total_size>(true);
 
 public:
     /// BaseObject initialization method.
@@ -132,11 +132,11 @@ protected :
     VecIndex m_ext_indices;
     type::vector<CPos> m_pivots;
 
-    SReal lastUpdatedStep;
+    SReal lastUpdatedStep{};
 
 private :
 
-    bool useRestMState; /// An external MechanicalState is used as rest reference.
+    bool useRestMState{}; /// An external MechanicalState is used as rest reference.
 };
 
 #if  !defined(SOFA_COMPONENT_FORCEFIELD_RESTSHAPESPRINGSFORCEFIELD_CPP)

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
@@ -73,11 +73,6 @@ using type::vector;
 using core::visual::VisualParams;
 
 template<class DataTypes>
-const type::fixed_array<bool, RestShapeSpringsForceField<DataTypes>::coord_total_size>
-RestShapeSpringsForceField<DataTypes>::s_defaultActiveDirections =
-    []{type::fixed_array<bool, coord_total_size> v; std::fill(v.begin(), v.end(), true); return v; }();
-
-template<class DataTypes>
 RestShapeSpringsForceField<DataTypes>::RestShapeSpringsForceField()
     : d_points(initData(&d_points, "points", "points controlled by the rest shape springs"))
     , d_stiffness(initData(&d_stiffness, "stiffness", "stiffness values between the actual position and the rest shape position"))

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyChecker.cpp
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyChecker.cpp
@@ -127,8 +127,14 @@ bool TopologyChecker::checkEdgeContainer()
     for (sofa::Index i = 0; i < nbE; ++i)
     {
         const auto& edge = my_edges[i];
-        if (edge[0] == edge[1]) {
+        if (edge[0] == edge[1])
+        {
             msg_error() << "CheckEdgeTopology failed: edge " << i << " has 2 identical vertices: " << edge;
+            res = false;
+        }
+        if (std::any_of(edge.begin(), edge.end(), [](const auto v){ return v == sofa::InvalidID;}))
+        {
+            msg_error() << "CheckEdgeTopology failed: edge " << i << " has an invalid vertex id: " << edge;
             res = false;
         }
     }
@@ -148,15 +154,23 @@ bool TopologyChecker::checkEdgeToVertexCrossContainer()
         const auto& EdgesAV = m_topology->getEdgesAroundVertex(i);
         for (size_t j = 0; j < EdgesAV.size(); ++j)
         {
-            const Topology::Edge& edge = my_edges[EdgesAV[j]];
-            if (!(edge[0] == i || edge[1] == i))
+            if (EdgesAV[j] != sofa::InvalidID)
             {
-                msg_error() << "CheckEdgeTopology failed: edge " << EdgesAV[j] << ": [" << edge << "] not around vertex: " << i;
+                const Topology::Edge& edge = my_edges[EdgesAV[j]];
+                if (!(edge[0] == i || edge[1] == i))
+                {
+                    msg_error() << "CheckEdgeTopology failed: edge " << EdgesAV[j] << ": [" << edge << "] not around vertex: " << i;
+                    res = false;
+                }
+
+                // count number of edge
+                edgeSet.insert(EdgesAV[j]);
+            }
+            else
+            {
+                msg_error() << "CheckEdgeTopology failed: edge " << j << " around vertex " << i << " is an invalid id";
                 res = false;
             }
-
-            // count number of edge
-            edgeSet.insert(EdgesAV[j]);
         }
     }
 
@@ -203,8 +217,14 @@ bool TopologyChecker::checkTriangleContainer()
     for (sofa::Index i = 0; i < nbT; ++i)
     {
         const auto& triangle = my_triangles[i];
-        if (triangle[0] == triangle[1] || triangle[0] == triangle[2] || triangle[1] == triangle[2]) {
+        if (triangle[0] == triangle[1] || triangle[0] == triangle[2] || triangle[1] == triangle[2])
+        {
             msg_error() << "CheckTriangleTopology failed: triangle " << i << " has 2 identical vertices: " << triangle;
+            res = false;
+        }
+        if (std::any_of(triangle.begin(), triangle.end(), [](const auto v){ return v == sofa::InvalidID;}))
+        {
+            msg_error() << "CheckEdgeTopology failed: triangle " << i << " has an invalid vertex id: " << triangle;
             res = false;
         }
     }
@@ -301,15 +321,23 @@ bool TopologyChecker::checkTriangleToVertexCrossContainer()
         const auto& triAV = m_topology->getTrianglesAroundVertex(i);
         for (size_t j = 0; j < triAV.size(); ++j)
         {
-            const Topology::Triangle& triangle = my_triangles[triAV[j]];
-            const bool check_triangle_vertex_shell = (triangle[0] == i) || (triangle[1] == i) || (triangle[2] == i);
-            if (!check_triangle_vertex_shell)
+            if (triAV[j] != sofa::InvalidID)
             {
-                msg_error() << "CheckTriangleTopology failed: triangle " << triAV[j] << ": [" << triangle << "] not around vertex: " << i;
+                const Topology::Triangle& triangle = my_triangles[triAV[j]];
+                const bool check_triangle_vertex_shell = (triangle[0] == i) || (triangle[1] == i) || (triangle[2] == i);
+                if (!check_triangle_vertex_shell)
+                {
+                    msg_error() << "CheckTriangleTopology failed: triangle " << triAV[j] << ": [" << triangle << "] not around vertex: " << i;
+                    ret = false;
+                }
+
+                triangleSet.insert(triAV[j]);
+            }
+            else
+            {
+                msg_error() << "CheckTriangleTopology failed: triangle " << j << " around vertex " << i << " is an invalid id";
                 ret = false;
             }
-
-            triangleSet.insert(triAV[j]);
         }
     }
 
@@ -366,6 +394,11 @@ bool TopologyChecker::checkQuadContainer()
                     res = false;
                 }
             }
+        }
+        if (std::any_of(quad.begin(), quad.end(), [](const auto v){ return v == sofa::InvalidID;}))
+        {
+            msg_error() << "CheckEdgeTopology failed: quad " << i << " has an invalid vertex id: " << quad;
+            res = false;
         }
     }
 
@@ -460,15 +493,23 @@ bool TopologyChecker::checkQuadToVertexCrossContainer()
         const auto& quadAV = m_topology->getQuadsAroundVertex(i);
         for (size_t j = 0; j < quadAV.size(); ++j)
         {
-            const Topology::Quad& quad = my_quads[quadAV[j]];
-            const bool check_quad_vertex_shell = (quad[0] == i) || (quad[1] == i) || (quad[2] == i) || (quad[3] == i);
-            if (!check_quad_vertex_shell)
+            if (quadAV[j] != sofa::InvalidID)
             {
-                msg_error() << "CheckQuadTopology failed: quad " << quadAV[j] << ": [" << quad << "] not around vertex: " << i;
+                const Topology::Quad& quad = my_quads[quadAV[j]];
+                const bool check_quad_vertex_shell = (quad[0] == i) || (quad[1] == i) || (quad[2] == i) || (quad[3] == i);
+                if (!check_quad_vertex_shell)
+                {
+                    msg_error() << "CheckQuadTopology failed: quad " << quadAV[j] << ": [" << quad << "] not around vertex: " << i;
+                    ret = false;
+                }
+
+                quadSet.insert(quadAV[j]);
+            }
+            else
+            {
+                msg_error() << "CheckQuadTopology failed: quad " << j << " around vertex " << i << " is an invalid id";
                 ret = false;
             }
-
-            quadSet.insert(quadAV[j]);
         }
     }
 
@@ -527,6 +568,11 @@ bool TopologyChecker::checkTetrahedronContainer()
                     res = false;
                 }
             }
+        }
+        if (std::any_of(tetra.begin(), tetra.end(), [](const auto v){ return v == sofa::InvalidID;}))
+        {
+            msg_error() << "CheckEdgeTopology failed: tetrahedron " << i << " has an invalid vertex id: " << tetra;
+            res = false;
         }
     }
 
@@ -698,18 +744,26 @@ bool TopologyChecker::checkTetrahedronToVertexCrossContainer()
         const auto& tetraAV = m_topology->getTetrahedraAroundVertex(pId);
         for (auto tetraId : tetraAV)
         {
-            const Topology::Tetrahedron& tetra = my_tetrahedra[tetraId];
-            const bool check_tetra_vertex_shell = (tetra[0] == pId)
-                || (tetra[1] == pId)
-                || (tetra[2] == pId)
-                || (tetra[3] == pId);
-            if (!check_tetra_vertex_shell)
+            if (tetraId != sofa::InvalidID)
             {
-                msg_error() << "checkTetrahedronTopology failed: Tetrahedron " << tetraId << ": [" << tetra << "] not around vertex: " << pId;
+                const Topology::Tetrahedron& tetra = my_tetrahedra[tetraId];
+                const bool check_tetra_vertex_shell = (tetra[0] == pId)
+                    || (tetra[1] == pId)
+                    || (tetra[2] == pId)
+                    || (tetra[3] == pId);
+                if (!check_tetra_vertex_shell)
+                {
+                    msg_error() << "checkTetrahedronTopology failed: Tetrahedron " << tetraId << ": [" << tetra << "] not around vertex: " << pId;
+                    ret = false;
+                }
+
+                tetrahedronSet.insert(tetraId);
+            }
+            else
+            {
+                msg_error() << "checkTetrahedronTopology failed: Tetrahedron around vertex " << pId << " is an invalid id";
                 ret = false;
             }
-
-            tetrahedronSet.insert(tetraId);
         }
     }
 
@@ -768,6 +822,11 @@ bool TopologyChecker::checkHexahedronContainer()
                     res = false;
                 }
             }
+        }
+        if (std::any_of(hexahedron.begin(), hexahedron.end(), [](const auto v){ return v == sofa::InvalidID;}))
+        {
+            msg_error() << "CheckEdgeTopology failed: hexahedron " << i << " has an invalid vertex id: " << hexahedron;
+            res = false;
         }
     }
 
@@ -871,15 +930,23 @@ bool TopologyChecker::checkHexahedronToEdgeCrossContainer()
 
         for (unsigned int j = 0; j < 6; j++)
         {
-            const Topology::Edge& edge = my_edges[eInHexa[j]];
-            int cptFound = 0;
-            for (unsigned int k = 0; k < 8; k++)
-                if (edge[0] == hexahedron[k] || edge[1] == hexahedron[k])
-                    cptFound++;
-
-            if (cptFound != 2)
+            if (eInHexa[j] != sofa::InvalidID)
             {
-                msg_error() << "checkHexahedronTopology failed: edge: " << eInHexa[j] << ": [" << edge << "] not found in hexahedron: " << i << ": " << hexahedron;
+                const Topology::Edge& edge = my_edges[eInHexa[j]];
+                int cptFound = 0;
+                for (unsigned int k = 0; k < 8; k++)
+                    if (edge[0] == hexahedron[k] || edge[1] == hexahedron[k])
+                        cptFound++;
+
+                if (cptFound != 2)
+                {
+                    msg_error() << "checkHexahedronTopology failed: edge: " << eInHexa[j] << ": [" << edge << "] not found in hexahedron: " << i << ": " << hexahedron;
+                    ret = false;
+                }
+            }
+            else
+            {
+                msg_error() << "checkHexahedronTopology failed: edge " << j << " in hexahedron " << i << " has an invalid id" ;
                 ret = false;
             }
         }
@@ -939,23 +1006,31 @@ bool TopologyChecker::checkHexahedronToVertexCrossContainer()
         const auto& hexaAV = m_topology->getHexahedraAroundVertex(pId);
         for (auto hexaId : hexaAV)
         {
-            const Topology::Hexahedron& hexa = my_hexahedra[hexaId];
-            bool check_hexa_vertex_shell = false;
-            for (int j = 0; j < 8; ++j)
+            if (hexaId != sofa::InvalidID)
             {
-                if (hexa[j] == pId) {
-                    check_hexa_vertex_shell = true;
-                    break;
+                const Topology::Hexahedron& hexa = my_hexahedra[hexaId];
+                bool check_hexa_vertex_shell = false;
+                for (int j = 0; j < 8; ++j)
+                {
+                    if (hexa[j] == pId) {
+                        check_hexa_vertex_shell = true;
+                        break;
+                    }
                 }
-            }
 
-            if (!check_hexa_vertex_shell)
+                if (!check_hexa_vertex_shell)
+                {
+                    msg_error() << "checkHexahedronTopology failed: Hexahedron " << hexaId << ": [" << hexa << "] not around vertex: " << pId;
+                    ret = false;
+                }
+
+                hexahedronSet.insert(hexaId);
+            }
+            else
             {
-                msg_error() << "checkHexahedronTopology failed: Hexahedron " << hexaId << ": [" << hexa << "] not around vertex: " << pId;
+                msg_error() << "checkHexahedronTopology failed: hexahedron around vertex " << pId << " is an invalid id";
                 ret = false;
             }
-
-            hexahedronSet.insert(hexaId);
         }
     }
 

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyChecker.cpp
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyChecker.cpp
@@ -625,17 +625,26 @@ bool TopologyChecker::checkTetrahedronToEdgeCrossContainer()
 
         for (unsigned int j = 0; j < 6; j++)
         {
-            const Topology::Edge& edge = my_edges[eInTetra[j]];
-            int cptFound = 0;
-            for (unsigned int k = 0; k < 4; k++)
-                if (edge[0] == tetrahedron[k] || edge[1] == tetrahedron[k])
-                    cptFound++;
-
-            if (cptFound != 2)
+            if (eInTetra[j] != sofa::InvalidID)
             {
-                msg_error() << "checkTetrahedronTopology failed: edge: " << eInTetra[j] << ": [" << edge << "] not found in tetrahedron: " << i << ": " << tetrahedron;
+                const Topology::Edge& edge = my_edges[eInTetra[j]];
+                int cptFound = 0;
+                for (unsigned int k = 0; k < 4; k++)
+                    if (edge[0] == tetrahedron[k] || edge[1] == tetrahedron[k])
+                        cptFound++;
+
+                if (cptFound != 2)
+                {
+                    msg_error() << "checkTetrahedronTopology failed: edge: " << eInTetra[j] << ": [" << edge << "] not found in tetrahedron: " << i << ": " << tetrahedron;
+                    ret = false;
+                }
+            }
+            else
+            {
+                msg_error() << "checkTetrahedronTopology failed: edge " << j << " in tetrahedron " << i << " (" << tetrahedron << ") is an invalid id";
                 ret = false;
             }
+
         }
     }
 

--- a/Sofa/Component/Topology/Utility/tests/TopologyChecker_test.cpp
+++ b/Sofa/Component/Topology/Utility/tests/TopologyChecker_test.cpp
@@ -873,7 +873,7 @@ struct TetrahedronTopologyChecker_test : TopologyChecker_test
         // Add triangle without updating cross container
         tetra.push_back(Topology::Tetrahedron(0, 2, 8, 12));
 
-        // Topology checher should detect an error
+        // Topology checker should detect an error
         EXPECT_MSG_EMIT(Error);
         EXPECT_EQ(checker->checkTetrahedronToEdgeCrossContainer(), false);
         // restore good container

--- a/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -31,27 +31,6 @@ using namespace sofa::defaulttype;
 using type::vector;
 using type::fixed_array;
 
-
-BaseMeshTopology::EdgesInTriangle BaseMeshTopology::InvalidEdgesInTriangles;
-BaseMeshTopology::EdgesInQuad     BaseMeshTopology::InvalidEdgesInQuad;
-BaseMeshTopology::TrianglesInTetrahedron BaseMeshTopology::InvalidTrianglesInTetrahedron;
-BaseMeshTopology::EdgesInTetrahedron BaseMeshTopology::InvalidEdgesInTetrahedron;
-BaseMeshTopology::QuadsInHexahedron BaseMeshTopology::InvalidQuadsInHexahedron;
-BaseMeshTopology::EdgesInHexahedron BaseMeshTopology::InvalidEdgesInHexahedron;
-
-int initStaticStructures()
-{
-    BaseMeshTopology::InvalidEdgesInTriangles.assign(sofa::InvalidID);
-    BaseMeshTopology::InvalidEdgesInQuad.assign(sofa::InvalidID);
-    BaseMeshTopology::InvalidTrianglesInTetrahedron.assign(sofa::InvalidID);
-    BaseMeshTopology::InvalidEdgesInTetrahedron.assign(sofa::InvalidID);
-    BaseMeshTopology::InvalidQuadsInHexahedron.assign(sofa::InvalidID);
-    BaseMeshTopology::InvalidEdgesInHexahedron.assign(sofa::InvalidID);
-    return 0;
-}
-
-[[maybe_unused]] static const int _init_  = initStaticStructures();
-
 BaseMeshTopology::BaseMeshTopology()
     : fileTopology(initData(&fileTopology,"filename","Filename of the mesh"))
 {

--- a/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -50,6 +50,8 @@ int initStaticStructures()
     return 0;
 }
 
+[[maybe_unused]] static const int _init_  = initStaticStructures();
+
 BaseMeshTopology::BaseMeshTopology()
     : fileTopology(initData(&fileTopology,"filename","Filename of the mesh"))
 {

--- a/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.h
@@ -59,12 +59,12 @@ public:
     typedef sofa::type::fixed_array<QuadID,6>		QuadsInHexahedron;
     typedef sofa::type::fixed_array<EdgeID,12>    EdgesInHexahedron;
 
-    static EdgesInTriangle        InvalidEdgesInTriangles;
-    static EdgesInQuad            InvalidEdgesInQuad;
-    static TrianglesInTetrahedron InvalidTrianglesInTetrahedron;
-    static EdgesInTetrahedron     InvalidEdgesInTetrahedron;
-    static QuadsInHexahedron      InvalidQuadsInHexahedron;
-    static EdgesInHexahedron      InvalidEdgesInHexahedron;
+    static constexpr EdgesInTriangle        InvalidEdgesInTriangles       = type::makeHomogeneousArray<EdgesInTriangle>(sofa::InvalidID);
+    static constexpr EdgesInQuad            InvalidEdgesInQuad            = type::makeHomogeneousArray<EdgesInQuad>(sofa::InvalidID);
+    static constexpr TrianglesInTetrahedron InvalidTrianglesInTetrahedron = type::makeHomogeneousArray<TrianglesInTetrahedron>(sofa::InvalidID);
+    static constexpr EdgesInTetrahedron     InvalidEdgesInTetrahedron     = type::makeHomogeneousArray<EdgesInTetrahedron>(sofa::InvalidID);
+    static constexpr QuadsInHexahedron      InvalidQuadsInHexahedron      = type::makeHomogeneousArray<QuadsInHexahedron>(sofa::InvalidID);
+    static constexpr EdgesInHexahedron      InvalidEdgesInHexahedron      = type::makeHomogeneousArray<EdgesInHexahedron>(sofa::InvalidID);
 
     /// @}
 

--- a/Sofa/framework/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Core/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCE_FILES
     objectmodel/RemovedData_test.cpp
     objectmodel/SingleLink_test.cpp
     objectmodel/VectorData_test.cpp
+    topology/BaseMeshTopology_test.cpp
     DataEngine_test.cpp
     Engine_test.cpp
     MatrixAccumulator_test.cpp

--- a/Sofa/framework/Core/test/topology/BaseMeshTopology_test.cpp
+++ b/Sofa/framework/Core/test/topology/BaseMeshTopology_test.cpp
@@ -1,0 +1,46 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/topology/BaseMeshTopology.h>
+#include <gtest/gtest.h>
+
+namespace sofa
+{
+
+using core::topology::BaseMeshTopology;
+
+template<class Container>
+bool testInvalidContent(const Container& container)
+{
+    return std::all_of(container.begin(), container.end(), [](const auto id) { return id == sofa::InvalidID;});
+}
+
+TEST(BaseMeshTopology, invalidContainers)
+{
+    EXPECT_TRUE(testInvalidContent(BaseMeshTopology::InvalidEdgesInTriangles));
+    EXPECT_TRUE(testInvalidContent(BaseMeshTopology::InvalidEdgesInQuad));
+    EXPECT_TRUE(testInvalidContent(BaseMeshTopology::InvalidTrianglesInTetrahedron));
+    EXPECT_TRUE(testInvalidContent(BaseMeshTopology::InvalidEdgesInTetrahedron));
+    EXPECT_TRUE(testInvalidContent(BaseMeshTopology::InvalidQuadsInHexahedron));
+    EXPECT_TRUE(testInvalidContent(BaseMeshTopology::InvalidEdgesInHexahedron));
+}
+
+}

--- a/Sofa/framework/Type/src/sofa/type/fixed_array.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array.h
@@ -288,6 +288,24 @@ constexpr auto make_array(Ts&&... ts) -> fixed_array<std::common_type_t<Ts...>, 
     return { std::forward<Ts>(ts)... };
 }
 
+/// Builds a fixed_array in which all elements have the same value
+template<typename T, sofa::Size N>
+constexpr sofa::type::fixed_array<T, N> makeHomogeneousArray(const T& value)
+{
+    sofa::type::fixed_array<T, N> container{};
+    container.assign(value);
+    return container;
+}
+
+/// Builds a fixed_array in which all elements have the same value
+template<typename FixedArray>
+constexpr FixedArray makeHomogeneousArray(const typename FixedArray::value_type& value)
+{
+    FixedArray container{};
+    container.assign(value);
+    return container;
+}
+
 /// Checks if v1 is lexicographically less than v2. Similar to std::lexicographical_compare
 template<typename T, sofa::Size N>
 constexpr bool


### PR DESCRIPTION
Issue introduced in https://github.com/sofa-framework/sofa/pull/1167. The static variables were no longer initialized.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
