### PR TITLE
[Sofa.Component] FIX default color for TetrahedronFEMForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -1879,7 +1879,12 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
             }
         }
 
-        // create corresponding colors
+        // create the bluish default colors
+        color[0] = sofa::type::RGBAColor(0.0, 0.0, 1.0, 1.0);
+        color[1] = sofa::type::RGBAColor(0.0, 0.5, 1.0, 1.0);
+        color[2] = sofa::type::RGBAColor(0.0, 1.0, 1.0, 1.0);
+        color[3] = sofa::type::RGBAColor(0.5, 1.0, 1.0, 1.0);
+
         if (drawVonMisesStress){
             if (showVonMisesStressPerElement)
             {
@@ -1911,13 +1916,6 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
                 color[1] = evalColor(vMN[(*it)[1]]);
                 color[2] = evalColor(vMN[(*it)[2]]);
                 color[3] = evalColor(vMN[(*it)[3]]);
-            }
-            else
-            {
-                color[0] = sofa::type::RGBAColor(0.0, 0.0, 1.0, 1.0);
-                color[1] = sofa::type::RGBAColor(0.0, 0.5, 1.0, 1.0);
-                color[2] = sofa::type::RGBAColor(0.0, 1.0, 1.0, 1.0);
-                color[3] = sofa::type::RGBAColor(0.5, 1.0, 1.0, 1.0);
             }
         }
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -1880,10 +1880,10 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
         }
 
         // create the bluish default colors
-        color[0] = sofa::type::RGBAColor(0.0, 0.0, 1.0, 1.0);
-        color[1] = sofa::type::RGBAColor(0.0, 0.5, 1.0, 1.0);
-        color[2] = sofa::type::RGBAColor(0.0, 1.0, 1.0, 1.0);
-        color[3] = sofa::type::RGBAColor(0.5, 1.0, 1.0, 1.0);
+        color[0] = sofa::type::RGBAColor(0.0f, 0.0f, 1.0f, 1.0f);
+        color[1] = sofa::type::RGBAColor(0.0f, 0.5f, 1.0f, 1.0f);
+        color[2] = sofa::type::RGBAColor(0.0f, 1.0f, 1.0f, 1.0f);
+        color[3] = sofa::type::RGBAColor(0.5f, 1.0f, 1.0f, 1.0f);
 
         if (drawVonMisesStress){
             if (showVonMisesStressPerElement)


### PR DESCRIPTION
PR #3821 introduce new rendering features which breaks the default rendering mode of TetrahedronFEMForceField (it is rendered pure white instead of our classical bluish tetra rendering). 

In current PR I restore the default rendering to use the blueish mode still preserving the features added in 3821.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
