### PR TITLE
[Core] Suggestion of a better displayFlag name : ContactInteractions

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/DisplayFlagsDataWidget.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/DisplayFlagsDataWidget.cpp
@@ -73,7 +73,7 @@ DisplayFlagWidget::DisplayFlagWidget(QWidget* parent, const char* name,  Qt::Win
     itemShowFlag[FORCEFIELDS]   = new QTreeWidgetItem(itemShowBehavior, itemShowFlag[BEHAVIORMODELS]);
     this->setTreeWidgetCheckable(itemShowFlag[FORCEFIELDS], "Force Fields");
     itemShowFlag[INTERACTIONFORCEFIELDS]   = new QTreeWidgetItem(itemShowBehavior, itemShowFlag[FORCEFIELDS]);
-    this->setTreeWidgetCheckable(itemShowFlag[INTERACTIONFORCEFIELDS], "Interactions");
+    this->setTreeWidgetCheckable(itemShowFlag[INTERACTIONFORCEFIELDS], "Contact Interactions");
 
     QTreeWidgetItem* itemShowCollision = new QTreeWidgetItem(itemShowAll, itemShowBehavior);
     this->setTreeWidgetNodeCheckable(itemShowCollision, "Collision");

--- a/Sofa/framework/Core/src/sofa/core/visual/DisplayFlags.cpp
+++ b/Sofa/framework/Core/src/sofa/core/visual/DisplayFlags.cpp
@@ -70,7 +70,7 @@ DisplayFlags::DisplayFlags(const DisplayFlags & other):
     m_showBehavior(FlagTreeItem("showBehavior","hideBehavior",&m_showAll)),
     m_showBehaviorModels(FlagTreeItem("showBehaviorModels","hideBehaviorModels",&m_showBehavior)),
     m_showForceFields(FlagTreeItem("showForceFields","hideForceFields",&m_showBehavior)),
-    m_showInteractionForceFields(FlagTreeItem("showInteractionForceFields","hideInteractionForceFields",&m_showBehavior)),
+    m_showInteractionForceFields(FlagTreeItem("showContactInteractions","hideContactInteractions",&m_showBehavior)),
     m_showCollision(FlagTreeItem("showCollision","hideCollision",&m_showAll)),
     m_showCollisionModels(FlagTreeItem("showCollisionModels","hideCollisionModels",&m_showCollision)),
     m_showBoundingCollisionModels(FlagTreeItem("showBoundingCollisionModels","hideBoundingCollisionModels",&m_showCollision)),


### PR DESCRIPTION
So far, we used the "Interactions" DisplayFlag in the GUI (actually named as "InteractionForceFields" in the list:
1. it's confusing
2. this name is :question: $ :exclamation: :boom: :bird: 

Here is a new suggestion: :white_flower: "ContactInteractions"  :white_flower: 
Obviously, compat and generalization in the code will be done if we agree

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
