### PR TITLE
[Mapping.NonLinear] Fix assert in RigidMapping

### DIFF
--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
@@ -487,7 +487,7 @@ static void fill_block(Eigen::Matrix<U, 6, 6>& block, const Coord& v) {
     U z = v[2];
 
     // note: this is -hat(v)
-    block.template rightCols<3>() <<
+    block.template topRightCorner<3, 3>() <<
 
         0,   z,  -y,
         -z,  0,   x,


### PR DESCRIPTION
In a `Eigen::Matrix<U, 6, 6>`, it is not possible to call `rightCols<3>` with a `3x3` matrix. The dimensions don't match. The should have been a `6x3`. To provide a `3x3` matrix, we must explicitly define the row AND the column. In that case, we use `topRightCorner`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
