### PR TITLE
[plugins] Remove references to external deleted plugins

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -22,19 +22,15 @@ sofa_add_subdirectory(plugin DiffusionSolver DiffusionSolver) # Depends on CImgP
 sofa_add_subdirectory(plugin image image) # Depends on CImgPlugin, DiffusionSolver, MultiThreading (soft)
 sofa_add_subdirectory(plugin SofaNewmat SofaNewmat)
 
-sofa_add_subdirectory(plugin Compliant Compliant EXTERNAL)
 sofa_add_subdirectory(directory SofaPython3 SofaPython3 EXTERNAL)
 sofa_add_subdirectory(plugin CGALPlugin CGALPlugin EXTERNAL)     # Depends on image
-sofa_add_subdirectory(plugin Flexible Flexible EXTERNAL)         # Depends on image, CImgPlugin, SofaHighOrderTopology (soft)
 sofa_add_subdirectory(plugin Registration Registration EXTERNAL) # Depends on image, SofaPython, SofaGui and SofaDistanceGrid
 sofa_add_subdirectory(plugin BulletCollisionDetection BulletCollisionDetection) # Depends on Compliant and LMConstraint
-sofa_add_subdirectory(plugin PreassembledMass PreassembledMass EXTERNAL) # Depends on Flexible and Compliant
 sofa_add_subdirectory(plugin ExternalBehaviorModel ExternalBehaviorModel OFF WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 sofa_add_subdirectory(plugin InvertibleFVM InvertibleFVM EXTERNAL)
 sofa_add_subdirectory(plugin MeshSTEPLoader MeshSTEPLoader)
 sofa_add_subdirectory(plugin PluginExample PluginExample EXTERNAL)
 sofa_add_subdirectory(plugin ManifoldTopologies ManifoldTopologies EXTERNAL)
-sofa_add_subdirectory(plugin OptiTrackNatNet OptiTrackNatNet EXTERNAL)
 sofa_add_subdirectory(plugin SixenseHydra SixenseHydra)
 sofa_add_subdirectory(plugin SofaOpenCL SofaOpenCL)
 sofa_add_subdirectory(plugin Xitact Xitact)
@@ -44,14 +40,11 @@ sofa_add_subdirectory(plugin PersistentContact PersistentContact)
 sofa_add_subdirectory(plugin Sensable Sensable)
 sofa_add_subdirectory(plugin SensableEmulation SensableEmulation)
 sofa_add_subdirectory(plugin SofaHAPI SofaHAPI)
-sofa_add_subdirectory(plugin THMPGSpatialHashing THMPGSpatialHashing EXTERNAL)
 sofa_add_subdirectory(plugin SofaCarving SofaCarving)
-sofa_add_subdirectory(plugin RigidScale RigidScale EXTERNAL)
 sofa_add_subdirectory(plugin LeapMotion LeapMotion)
 sofa_add_subdirectory(plugin Geomagic Geomagic)
 sofa_add_subdirectory(plugin SofaAssimp SofaAssimp) # ColladaSceneLoader Depends on Flexible and image
 sofa_add_subdirectory(plugin SofaMatrix SofaMatrix ON) # Depends on image, CImgPlugin
-sofa_add_subdirectory(plugin OpenCTMPlugin OpenCTMPlugin EXTERNAL)
 sofa_add_subdirectory(plugin BeamAdapter BeamAdapter EXTERNAL)
 sofa_add_subdirectory(plugin CollisionAlgorithm CollisionAlgorithm EXTERNAL)
 sofa_add_subdirectory(plugin ConstraintGeometry ConstraintGeometry EXTERNAL)


### PR DESCRIPTION
These references were not removed in
- #3960 

There should be errors like
`CMake Error: File applications/plugins/Flexible/ExternalProjectConfig.cmake.in does not exist.`  occuring. 🤐

Not sure why the CI did not detect this, maybe because of CMake caches not cleaned or something like that.

EDIT: seems it depend on some factors, I get "only" warning on other configuration
`applications/plugins/Compliant does not exist and will be ignored.`
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
