### PR TITLE
[LinearSolver.Direct] Parallelization of H A^-1 H^T in SparseLDLSolver

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
@@ -56,6 +56,7 @@ public :
     typedef typename Inherit::JMatrixType JMatrixType;
     typedef SparseLDLImplInvertData<type::vector<int>, type::vector<Real> > InvertData;
 
+    void init() override;
     void parse( sofa::core::objectmodel::BaseObjectDescription* arg ) override;
     void solve (Matrix& M, Vector& x, Vector& b) override;
     void invert(Matrix& M) override;
@@ -72,6 +73,8 @@ public :
     SOFA_ATTRIBUTE_DISABLED__SPARSELDLSOLVER_MATRIXEXPORT
     DeprecatedAndRemoved d_precision;
 
+    Data<bool> d_parallelInverseProduct;
+
     MatrixInvertData * createInvertData() override {
         return new InvertData();
     }
@@ -79,7 +82,7 @@ public :
 protected :
     SparseLDLSolver();
 
-    type::vector<int> Jlocal2global;
+    type::vector<sofa::SignedIndex> Jlocal2global;
     sofa::linearalgebra::FullMatrix<Real> JLinvDinv, JLinv;
     sofa::linearalgebra::CompressedRowSparseMatrix<Real> Mfiltered;
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -229,7 +229,7 @@ bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::doAddJMInvJtLocal(ResMat
             for (auto i = range.start; i != range.end; ++i)
             {
                 Real* line = JLinv[i];
-                sofa::linearalgebra::solveLowerTriangularSystem(data->n, line, line, data->LT_colptr.data(), data->LT_rowind.data(), data->LT_values.data());
+                sofa::linearalgebra::solveLowerUnitriangularSystemCSR(data->n, line, line, data->LT_colptr.data(), data->LT_rowind.data(), data->LT_values.data());
             }
         });
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -65,7 +65,7 @@ SparseLDLSolver<TMatrix,TVector,TThreadManager>::SparseLDLSolver()
                 msg_info() << "Task scheduler already initialized on " << taskScheduler->getThreadCount() << " threads";
             }
         }
-        return d_componentState.getValue();
+        return this->d_componentState.getValue();
     },
     {});
 }

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -31,13 +31,52 @@
 #include <fstream>
 #include <iomanip>      // std::setprecision
 #include <string>
+#include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <sofa/simulation/ParallelForEach.h>
+
 
 namespace sofa::component::linearsolver::direct 
 {
 
 template<class TMatrix, class TVector, class TThreadManager>
 SparseLDLSolver<TMatrix,TVector,TThreadManager>::SparseLDLSolver()
-    : numStep(0){}
+    : numStep(0)
+    , d_parallelInverseProduct(initData(&d_parallelInverseProduct, false,
+        "parallelInverseProduct", "Parallelize the computation of the product J*M^{-1}*J^T "
+                                  "where M is the matrix of the linear system and J is any "
+                                  "matrix with compatible dimensions"))
+{
+    this->addUpdateCallback("parallelODESolving", {&d_parallelInverseProduct},
+    [this](const core::DataTracker& tracker) -> sofa::core::objectmodel::ComponentState
+    {
+        SOFA_UNUSED(tracker);
+        if (d_parallelInverseProduct.getValue())
+        {
+            simulation::TaskScheduler* taskScheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+            assert(taskScheduler);
+
+            if (taskScheduler->getThreadCount() < 1)
+            {
+                taskScheduler->init(0);
+                msg_info() << "Task scheduler initialized on " << taskScheduler->getThreadCount() << " threads";
+            }
+            else
+            {
+                msg_info() << "Task scheduler already initialized on " << taskScheduler->getThreadCount() << " threads";
+            }
+        }
+        return d_componentState.getValue();
+    },
+    {});
+}
+
+template <class TMatrix, class TVector, class TThreadManager>
+void SparseLDLSolver<TMatrix, TVector, TThreadManager>::init()
+{
+    Inherit::init();
+
+    this->d_componentState.setValue(core::objectmodel::ComponentState::Valid);
+}
 
 template <class TMatrix, class TVector, class TThreadManager>
 void SparseLDLSolver<TMatrix, TVector, TThreadManager>::parse(sofa::core::objectmodel::BaseObjectDescription* arg)
@@ -128,72 +167,101 @@ void SparseLDLSolver<TMatrix,TVector,TThreadManager>::invert(Matrix& M)
 template <class TMatrix, class TVector, class TThreadManager>
 bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::doAddJMInvJtLocal(ResMatrixType* result, const JMatrixType* J, SReal fact, InvertData* data)
 {
-    if (J->rowSize()==0) return true;
+    if (!this->isComponentStateValid())
+    {
+        return true;
+    }
+
+    /*
+    J * M^-1 * J^T = J * (L*D*L^T)^-1 * J^t
+                   = (J * (L^T)^-1) * D^-1 * (L^-1 * J^T)
+                   = (L^-1 * J^T)^T * D^-1 * (L^-1 * J^T)
+    */
+
+    if (J->rowSize() == 0)
+    {
+        return true;
+    }
 
     Jlocal2global.clear();
     Jlocal2global.reserve(J->rowSize());
-    for (auto jit = J->begin(), jitend = J->end(); jit != jitend; ++jit) {
-        int l = jit->first;
+    for (auto jit = J->begin(), jitend = J->end(); jit != jitend; ++jit)
+    {
+        sofa::SignedIndex l = jit->first;
         Jlocal2global.push_back(l);
     }
 
-    if (Jlocal2global.empty()) return true;
+    if (Jlocal2global.empty())
+    {
+        return true;
+    }
 
     const unsigned int JlocalRowSize = (unsigned int)Jlocal2global.size();
 
+    const simulation::ForEachExecutionPolicy execution = d_parallelInverseProduct.getValue() ?
+        simulation::ForEachExecutionPolicy::PARALLEL :
+        simulation::ForEachExecutionPolicy::SEQUENTIAL;
 
+    simulation::TaskScheduler* taskScheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
+    assert(taskScheduler);
 
     JLinv.clear();
     JLinv.resize(J->rowSize(), data->n);
     JLinvDinv.resize(J->rowSize(), data->n);
 
+    // copy J in to JLinv taking into account the permutation
     unsigned int localRow = 0;
-    for (auto jit = J->begin(), jitend = J->end(); jit != jitend; ++jit, ++localRow) {
+    for (auto jit = J->begin(), jitend = J->end(); jit != jitend; ++jit, ++localRow)
+    {
         Real* line = JLinv[localRow];
-        for (auto it = jit->second.begin(), i2end = jit->second.end(); it != i2end; ++it) {
+        for (auto it = jit->second.begin(), i2end = jit->second.end(); it != i2end; ++it)
+        {
             int col = data->invperm[it->first];
-            double val = it->second;
+            Real val = it->second;
 
             line[col] = val;
         }
     }
 
-    //Solve the lower triangular system
-    for (unsigned c = 0; c < JlocalRowSize; c++) {
-        Real* line = JLinv[c];
-
-        for (int j=0; j<data->n; j++) {
-            for (int p = data->LT_colptr[j] ; p<data->LT_colptr[j+1] ; p++) {
-                int col = data->LT_rowind[p];
-                double val = data->LT_values[p];
-                line[j] -= val * line[col];
+    simulation::forEachRange(execution, *taskScheduler, 0u, JlocalRowSize,
+        [&data, this](const auto& range)
+        {
+            for (auto i = range.start; i != range.end; ++i)
+            {
+                Real* line = JLinv[i];
+                sofa::linearalgebra::solveLowerTriangularSystem(data->n, line, line, data->LT_colptr.data(), data->LT_rowind.data(), data->LT_values.data());
             }
-        }
-    }
+        });
 
-    //apply diagonal
-    for (unsigned j = 0; j < JlocalRowSize; j++) {
-        Real* lineD = JLinv[j];
-        Real* lineM = JLinvDinv[j];
-        for (unsigned i = 0; i < (unsigned)data->n; i++) {
-            lineM[i] = lineD[i] * data->invD[i];
-        }
-    }
+    simulation::forEachRange(execution, *taskScheduler, 0u, JlocalRowSize,
+        [&data, this](const auto& range)
+        {
+            for (auto i = range.start; i != range.end; ++i)
+            {
+                Real* lineD = JLinv[i];
+                Real* lineM = JLinvDinv[i];
+                sofa::linearalgebra::solveDiagonalSystemUsingInvertedValues(data->n, lineD, lineM, data->invD.data());
+            }
+        });
 
-    for (unsigned j = 0; j < JlocalRowSize; j++) {
+    for (unsigned j = 0; j < JlocalRowSize; j++)
+    {
         Real* lineJ = JLinvDinv[j];
         int globalRowJ = Jlocal2global[j];
-        for (unsigned i = j; i < JlocalRowSize; i++) {
+        for (unsigned i = j; i < JlocalRowSize; i++)
+        {
             Real* lineI = JLinv[i];
             int globalRowI = Jlocal2global[i];
 
             double acc = 0.0;
-            for (unsigned k = 0; k < (unsigned)data->n; k++) {
+            for (unsigned k = 0; k < (unsigned)data->n; k++)
+            {
                 acc += lineJ[k] * lineI[k];
             }
             acc *= fact;
             result->add(globalRowJ, globalRowI, acc);
-            if (globalRowI != globalRowJ) result->add(globalRowI, globalRowJ, acc);
+            if (globalRowI != globalRowJ)
+                result->add(globalRowI, globalRowJ, acc);
         }
     }
 

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolverImpl.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolverImpl.h
@@ -180,8 +180,14 @@ protected :
         //   <=> L^T * x = D^-1 * L^-1 * b      # Step 2: compute D^-1 * L^-1 * b
         //   <=> x = L^T^-1 * D^1 * L^-1 * b    # Step 3: compute L^T^-1 * D^1 * L^-1 * b
 
+        // apply the permutation to the right-hand side
+        for (int i = 0; i < n; ++i)
+        {
+            Tmp[i] = b[perm[i]];
+        }
+
         // Step 1: compute L^-1 * b
-        sofa::linearalgebra::solveLowerTriangularSystem(n, b, perm, Tmp.data(), data->LT_colptr.data(), data->LT_rowind.data(), data->LT_values.data());
+        sofa::linearalgebra::solveLowerTriangularSystem(n, Tmp.data(), Tmp.data(), data->LT_colptr.data(), data->LT_rowind.data(), data->LT_values.data());
 
         // Step 2: compute D^-1 * [L^-1 * b]
         sofa::linearalgebra::solveDiagonalSystemUsingInvertedValues(n, Tmp.data(), Tmp.data(), data->invD.data());

--- a/Sofa/framework/LinearAlgebra/CMakeLists.txt
+++ b/Sofa/framework/LinearAlgebra/CMakeLists.txt
@@ -25,6 +25,7 @@ set(HEADER_FILES
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixGeneric.h
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrixMechanical.h
     ${SOFALINEARALGEBRASRC_ROOT}/DiagonalMatrix.h
+    ${SOFALINEARALGEBRASRC_ROOT}/DiagonalSystemSolver.h
     ${SOFALINEARALGEBRASRC_ROOT}/EigenBaseSparseMatrix.h
     ${SOFALINEARALGEBRASRC_ROOT}/EigenSparseMatrix.h
     ${SOFALINEARALGEBRASRC_ROOT}/EigenVector.h
@@ -40,6 +41,7 @@ set(HEADER_FILES
     ${SOFALINEARALGEBRASRC_ROOT}/SparseMatrixProduct[EigenSparseMatrix].h
     ${SOFALINEARALGEBRASRC_ROOT}/SparseMatrixStorageOrder.h
     ${SOFALINEARALGEBRASRC_ROOT}/SparseMatrixStorageOrder[EigenSparseMatrix].h
+    ${SOFALINEARALGEBRASRC_ROOT}/TriangularSystemSolver.h
     ${SOFALINEARALGEBRASRC_ROOT}/matrix_bloc_traits.h
 )
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/DiagonalSystemSolver.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/DiagonalSystemSolver.h
@@ -25,6 +25,11 @@
 namespace sofa::linearalgebra
 {
 
+/// Solves a linear system D*x = b, where:
+/// D is a diagonal matrix
+/// x is the solution vector
+/// b is the right-hand side vector
+/// The diagonal matrix is stored as the list of entries in the diagonal
 template<typename Real>
 void solveDiagonalSystem(
     const sofa::Size systemSize,
@@ -38,6 +43,11 @@ void solveDiagonalSystem(
     }
 }
 
+/// Solves a linear system D*x = b, where:
+/// D is a diagonal matrix
+/// x is the solution vector
+/// b is the right-hand side vector
+/// The diagonal matrix is stored as the list of the inverse of the entries in the diagonal
 template<typename Real>
 void solveDiagonalSystemUsingInvertedValues(
     const sofa::Size systemSize,

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/DiagonalSystemSolver.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/DiagonalSystemSolver.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/config.h>
+
+namespace sofa::linearalgebra
+{
+
+template<typename Real>
+void solveDiagonalSystem(
+    const sofa::Size systemSize,
+    const Real* rightHandSideVector,
+    Real* solution,
+    const Real* const D_values)
+{
+    for (sofa::Size i = 0 ; i < systemSize; ++i)
+    {
+        solution[i] = rightHandSideVector[i] / D_values[i];
+    }
+}
+
+template<typename Real>
+void solveDiagonalSystemUsingInvertedValues(
+    const sofa::Size systemSize,
+    const Real* rightHandSideVector,
+    Real* solution,
+    const Real* const Dinv_values)
+{
+    for (sofa::Size i = 0 ; i < systemSize; ++i)
+    {
+        solution[i] = rightHandSideVector[i] * Dinv_values[i];
+    }
+}
+
+}

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
@@ -1,0 +1,81 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/config.h>
+
+namespace sofa::linearalgebra
+{
+
+/// Use forward substitution to solve a linear system L*x = b, where:
+/// L is a lower triangular matrix
+/// x is the solution vector
+/// b is the right-hand side vector
+/// The lower triangular matrix must be provided in compressed sparse row (CSR) format
+template<typename Real, typename Integer>
+void solveLowerTriangularSystem(
+    const sofa::Size systemSize,
+    const Real* rightHandSideVector,
+    const Integer* const permutationAppliedOnRHS,
+    Real* solution,
+    const Integer* const L_columns,
+    const Integer* const L_row,
+    const Real* const L_values
+    )
+{
+    for (sofa::Size i = 0; i < systemSize; ++i)
+    {
+        Real x_i = rightHandSideVector[permutationAppliedOnRHS[i]];
+        for (Integer p = L_columns[i]; p < L_columns[i + 1]; ++p)
+        {
+            x_i -= L_values[p] * solution[L_row[p]];
+        }
+        solution[i] = x_i;
+    }
+}
+
+/// Use backward substitution to solve a linear system U*x = b, where:
+/// U is a upper triangular matrix
+/// x is the solution vector
+/// b is the right-hand side vector
+/// The upper triangular matrix must be provided in compressed sparse row (CSR) format
+template<typename Real, typename Integer>
+void solveUpperTriangularSystem(
+    const sofa::Size systemSize,
+    const Real* rightHandSideVector,
+    Real* solution,
+    const Integer* const U_columns,
+    const Integer* const U_row,
+    const Real* const U_values
+    )
+{
+    for (sofa::Size i = systemSize - 1; i != 0; --i)
+    {
+        Real x_i = rightHandSideVector[i];
+        for (Integer p = U_columns[i]; p < U_columns[i + 1]; ++p)
+        {
+            x_i -= U_values[p] * solution[U_row[p]];
+        }
+        solution[i] = x_i;
+    }
+}
+
+}

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
@@ -34,7 +34,6 @@ template<typename Real, typename Integer>
 void solveLowerTriangularSystem(
     const sofa::Size systemSize,
     const Real* rightHandSideVector,
-    const Integer* const permutationAppliedOnRHS,
     Real* solution,
     const Integer* const L_columns,
     const Integer* const L_row,
@@ -43,7 +42,7 @@ void solveLowerTriangularSystem(
 {
     for (sofa::Size i = 0; i < systemSize; ++i)
     {
-        Real x_i = rightHandSideVector[permutationAppliedOnRHS[i]];
+        Real x_i = rightHandSideVector[i];
         for (Integer p = L_columns[i]; p < L_columns[i + 1]; ++p)
         {
             x_i -= L_values[p] * solution[L_row[p]];

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
@@ -21,59 +21,78 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/config.h>
+#include <cstring>
 
 namespace sofa::linearalgebra
 {
 
-/// Use forward substitution to solve a linear system L*x = b, where:
-/// L is a lower triangular matrix
+/// Solves a lower unitriangular system where the matrix is represented in CSR format
+///
+/// Forward substitution is used to solve a linear system L*x = b, where:
+/// L is a lower unitriangular matrix
 /// x is the solution vector
 /// b is the right-hand side vector
-/// The lower triangular matrix must be provided in compressed sparse row (CSR) format
+/// The lower unitriangular matrix must be provided in compressed sparse row (CSR) format
+///
+/// \param systemSize The size of the system. All other parameters must comply with this size
+/// \param rightHandSideVector The right-hand side vector
+/// \param solutionVector The solution vector
+/// \param CSR_rows The array storing the starting index of each row in the data array.
+/// \param CSR_columns The array storing the column indices of the nonzero values in the data array.
+/// \param CSR_values The array containing the nonzero values of the matrix
 template<typename Real, typename Integer>
-void solveLowerTriangularSystem(
+void solveLowerUnitriangularSystemCSR(
     const sofa::Size systemSize,
     const Real* rightHandSideVector,
-    Real* solution,
-    const Integer* const L_columns,
-    const Integer* const L_row,
-    const Real* const L_values
+    Real* solutionVector,
+    const Integer* const CSR_rows,
+    const Integer* const CSR_columns,
+    const Real* const CSR_values
     )
 {
     for (sofa::Size i = 0; i < systemSize; ++i)
     {
         Real x_i = rightHandSideVector[i];
-        for (Integer p = L_columns[i]; p < L_columns[i + 1]; ++p)
+        for (Integer p = CSR_rows[i]; p < CSR_rows[i + 1]; ++p)
         {
-            x_i -= L_values[p] * solution[L_row[p]];
+            x_i -= CSR_values[p] * solutionVector[CSR_columns[p]];
         }
-        solution[i] = x_i;
+        solutionVector[i] = x_i;
     }
 }
 
-/// Use backward substitution to solve a linear system U*x = b, where:
-/// U is a upper triangular matrix
+/// Solves a upper unitriangular system where the matrix is represented in CSR format
+///
+/// Backward substitution is used to solve a linear system U*x = b, where:
+/// U is a upper unitriangular matrix
 /// x is the solution vector
 /// b is the right-hand side vector
-/// The upper triangular matrix must be provided in compressed sparse row (CSR) format
+/// The upper unitriangular matrix must be provided in compressed sparse row (CSR) format
+///
+/// \param systemSize The size of the system. All other parameters must comply with this size
+/// \param rightHandSideVector The right-hand side vector
+/// \param solutionVector The solution vector
+/// \param CSR_rows The array storing the starting index of each row in the data array.
+/// \param CSR_columns The array storing the column indices of the nonzero values in the data array.
+/// \param CSR_values The array containing the nonzero values of the matrix
 template<typename Real, typename Integer>
-void solveUpperTriangularSystem(
+void solveUpperUnitriangularSystemCSR(
     const sofa::Size systemSize,
     const Real* rightHandSideVector,
-    Real* solution,
-    const Integer* const U_columns,
-    const Integer* const U_row,
-    const Real* const U_values
+    Real* solutionVector,
+    const Integer* const CSR_rows,
+    const Integer* const CSR_columns,
+    const Real* const CSR_values
     )
 {
     for (sofa::Size i = systemSize - 1; i != static_cast<sofa::Size>(-1); --i)
     {
         Real x_i = rightHandSideVector[i];
-        for (Integer p = U_columns[i]; p < U_columns[i + 1]; ++p)
+        for (Integer p = CSR_rows[i]; p < CSR_rows[i + 1]; ++p)
         {
-            x_i -= U_values[p] * solution[U_row[p]];
+            x_i -= CSR_values[p] * solutionVector[CSR_columns[p]];
         }
-        solution[i] = x_i;
+        solutionVector[i] = x_i;
     }
 }
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
@@ -66,7 +66,7 @@ void solveUpperTriangularSystem(
     const Real* const U_values
     )
 {
-    for (sofa::Size i = systemSize - 1; i != 0; --i)
+    for (sofa::Size i = systemSize - 1; i != static_cast<sofa::Size>(-1); --i)
     {
         Real x_i = rightHandSideVector[i];
         for (Integer p = U_columns[i]; p < U_columns[i + 1]; ++p)

--- a/Sofa/framework/LinearAlgebra/test/CMakeLists.txt
+++ b/Sofa/framework/LinearAlgebra/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE_FILES
     RotationMatrix_test.cpp
     SparseMatrixProduct_test.cpp
     SparseMatrixStorageOrder_test.cpp
+    TriangularSystemSolver_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/Sofa/framework/LinearAlgebra/test/TriangularSystemSolver_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/TriangularSystemSolver_test.cpp
@@ -1,0 +1,128 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/linearalgebra/TriangularSystemSolver.h>
+#include <gtest/gtest.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <sofa/testing/NumericTest.h>
+
+
+namespace sofa
+{
+
+TEST(TriangularSystemSolver, empty)
+{
+    const SReal* rightHandSideVector { nullptr };
+    SReal* solution { nullptr };
+    const sofa::Size* const L_columns { nullptr };
+    const sofa::Size* const L_row { nullptr };
+    const SReal* const L_values { nullptr };
+    EXPECT_NO_THROW(
+        sofa::linearalgebra::solveLowerUnitriangularSystemCSR(0, rightHandSideVector, solution, L_columns, L_row, L_values);
+    );
+}
+
+TEST(TriangularSystemSolver, lower2x2)
+{
+    constexpr std::array<SReal, 2> rightHandSideVector { 6, 8 };
+    std::array<SReal, 2> solution {};
+
+    /**
+     * [ 1 0 ]  *  [  6 ]  =  [ 6 ]
+     * [ 2 1 ]  *  [ -4 ]  =  [ 8 ]
+     */
+
+    // CSR format
+    constexpr std::array<sofa::Size, 3> L_columns { 0, 0, 1 };
+    constexpr std::array<sofa::Size, 3> L_row { 0, 1, 3 };
+    constexpr std::array<SReal, 3> L_values { 1, 2, 1 };
+
+    sofa::linearalgebra::solveLowerUnitriangularSystemCSR(2, rightHandSideVector.data(), solution.data(), L_row.data(), L_columns.data(), L_values.data());
+    EXPECT_FLOATINGPOINT_EQ(solution[0], static_cast<SReal>(6))
+    EXPECT_FLOATINGPOINT_EQ(solution[1], static_cast<SReal>(8 - 2 * 6))
+}
+
+TEST(TriangularSystemSolver, lower3x3)
+{
+    constexpr std::array<SReal, 3> rightHandSideVector { 5, -9, 3 };
+    std::array<SReal, 3> solution {};
+
+    /**
+     * [ 1 0 0 ]  *  [   5 ]  =  [  5 ]
+     * [ 2 1 0 ]  *  [ -19 ]  =  [ -9 ]
+     * [ 3 4 1 ]  *  [  64 ]  =  [  3 ]
+     */
+
+    // CSR format
+    constexpr std::array<sofa::Size, 6> L_columns { 0, 0, 1, 0, 1, 2 };
+    constexpr std::array<sofa::Size, 4> L_row { 0, 1, 3, 6 };
+    constexpr std::array<SReal, 6> L_values { 1, 2, 1, 3, 4, 1 };
+
+    sofa::linearalgebra::solveLowerUnitriangularSystemCSR(3, rightHandSideVector.data(), solution.data(), L_row.data(), L_columns.data(), L_values.data());
+    EXPECT_FLOATINGPOINT_EQ(solution[0], static_cast<SReal>(5))
+    EXPECT_FLOATINGPOINT_EQ(solution[1], static_cast<SReal>(-9 - 2 * 5))
+    EXPECT_FLOATINGPOINT_EQ(solution[2], static_cast<SReal>(64))
+}
+
+
+TEST(TriangularSystemSolver, upper2x2)
+{
+    constexpr std::array<SReal, 2> rightHandSideVector { 6, 8 };
+    std::array<SReal, 2> solution {};
+
+    /**
+     * [ 1 2 ]  *  [ -10 ]  =  [ 6 ]
+     * [ 0 1 ]  *  [   8 ]  =  [ 8 ]
+     */
+
+    // CSR format
+    constexpr std::array<sofa::Size, 3> L_columns { 0, 1, 1 };
+    constexpr std::array<sofa::Size, 3> L_row { 0, 2, 3 };
+    constexpr std::array<SReal, 3> L_values { 1, 2, 1 };
+
+    sofa::linearalgebra::solveUpperUnitriangularSystemCSR(2, rightHandSideVector.data(), solution.data(), L_row.data(), L_columns.data(), L_values.data());
+    EXPECT_FLOATINGPOINT_EQ(solution[1], static_cast<SReal>(8))
+    EXPECT_FLOATINGPOINT_EQ(solution[0], static_cast<SReal>(-10))
+}
+
+TEST(TriangularSystemSolver, upper3x3)
+{
+    constexpr std::array<SReal, 3> rightHandSideVector { 5, -9, 3 };
+    std::array<SReal, 3> solution {};
+
+    /**
+     * [ 1 2 3 ]  *  [  38 ]  =  [  5 ]
+     * [ 0 1 4 ]  *  [ -21 ]  =  [ -9 ]
+     * [ 0 0 1 ]  *  [   3 ]  =  [  3 ]
+     */
+
+    // CSR format
+    constexpr std::array<sofa::Size, 6> L_columns { 0, 1, 2, 1, 2, 2 };
+    constexpr std::array<sofa::Size, 4> L_row { 0, 3, 5, 6 };
+    constexpr std::array<SReal, 6> L_values { 1, 2, 3, 1, 4, 1 };
+
+    sofa::linearalgebra::solveUpperUnitriangularSystemCSR(3, rightHandSideVector.data(), solution.data(), L_row.data(), L_columns.data(), L_values.data());
+    EXPECT_FLOATINGPOINT_EQ(solution[2], static_cast<SReal>(3))
+    EXPECT_FLOATINGPOINT_EQ(solution[1], static_cast<SReal>(-21))
+    EXPECT_FLOATINGPOINT_EQ(solution[0], static_cast<SReal>(38))
+}
+
+}

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -16,7 +16,7 @@ Demos/chainHybridNoGroup.scn 100 1e-2 1 1
 Demos/collisionMultiple.scn 100 1e-4 1 1
 Demos/liver.scn 100 1e-4 1 1
 Demos/simpleBoundaryConditions.scn 100 1e-4 1 1
-Demos/fallingBeamLagrangianCollision.scn 46 1e-8 1 1
+Demos/fallingBeamLagrangianCollision.scn 46 1e-7 1 1
 
 
 ### Component scenes ###

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -16,7 +16,7 @@ Demos/chainHybridNoGroup.scn 100 1e-2 1 1
 Demos/collisionMultiple.scn 100 1e-4 1 1
 Demos/liver.scn 100 1e-4 1 1
 Demos/simpleBoundaryConditions.scn 100 1e-4 1 1
-Demos/fallingBeamLagrangianCollision.scn 46 1e-4 1 1
+Demos/fallingBeamLagrangianCollision.scn 46 1e-8 1 1
 
 
 ### Component scenes ###


### PR DESCRIPTION
The parallelized function is `SparseLDLSolver::doAddJMInvJtLocal`.

# Benchmarks

I rely on the scene provided by @bakpaul with light changes: https://gist.github.com/alxbilger/1b82b1488a2741be845d7d9da18c25e5. The SOFA timer to focus on is `Get Compliance` as it is the deepest timer in the hierarchy containing the `doAddJMInvJtLocal` function.

- Master branch (commit df49f3a754264489b14db69b38862a5b45d57168)

```
100 iterations done in 12.9731 s ( 7.70827 FPS).
```

```
 LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
   5      15.41    1       0.01  121.72   98.03   20.57   98.03   77.48 .....Get Compliance
```

- This PR (without parallelization)

The benchmark should be similar to the master branch

```
100 iterations done in 13.1572 s ( 7.6004 FPS).
```

```
 LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
   5      16.31    1       0.01  134.76   98.34   22.21   98.34   76.54 .....Get Compliance
```

- This PR (with parallelization)

```
100 iterations done in 5.94345 s ( 16.8253 FPS).
```

```
 LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
   5      15.76    1       0.01   30.62   26.85    5.55   26.85   47.91 .....Get Compliance
```

On my machine there is a nice speedup of x3.66 on the `Get Compliance` timer, and x2.18 in terms of global FPS.

# Additional Benchmarks

I wanted to make sure that the usual solve of SparseLDLSolver did not regress in terms of performances. I benchmarked `examples/Component/LinearSolver/Direct/FEMBAR_SparseLDLSolver.scn` on 10000 steps.

- Master branch (commit df49f3a754264489b14db69b38862a5b45d57168)

```
10000 iterations done in 28.2657 s ( 353.785 FPS).
```

- This PR

```
10000 iterations done in 28.3223 s ( 353.078 FPS).
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
