### PR TITLE
[FEM.Linear] FIX & Minor refactor of buildStiffnessMatrix in TriangleFEMForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangleFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangleFEMForceField.inl
@@ -620,6 +620,9 @@ void TriangleFEMForceField<DataTypes>::addKToMatrix(sofa::linearalgebra::BaseMat
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix)
 {
+    StiffnessMatrix JKJt, RJKJtRt;
+    sofa::type::Mat<3, 3, Real> localMatrix(type::NOINIT);
+
     constexpr auto S = DataTypes::deriv_total_size; // size of node blocks
     unsigned int i = 0;
 
@@ -628,29 +631,18 @@ void TriangleFEMForceField<DataTypes>::buildStiffnessMatrix(core::behavior::Stif
 
     for (const auto nodeIndex : *_indexedElements)
     {
-        StiffnessMatrix JKJt,RJKJtRt;
         computeElementStiffnessMatrix(JKJt, RJKJtRt, _materialsStiffnesses[i], _strainDisplacements[i], _rotations[i]);
 
-        for (unsigned n1 = 0; n1 < nodeIndex.size(); n1++)
+        for (sofa::Index n1 = 0; n1 < Element::size(); ++n1)
         {
-            for(unsigned j = 0; j < S; j++)
+            for (sofa::Index n2 = 0; n2 < Element::size(); ++n2)
             {
-                unsigned ROW = S*nodeIndex[n1] + j;
-                unsigned row = S*n1+j;
-
-                for (unsigned n2=0; n2<nodeIndex.size(); n2++)
-                {
-                    for (unsigned k=0; k<S; k++)
-                    {
-                        unsigned COLUMN = S*nodeIndex[n2] +k;
-                        unsigned column = 3*n2+k;
-                        dfdx( ROW,COLUMN) += - RJKJtRt[row][column];
-                    }
-                }
+                RJKJtRt.getsub(S * n1, S * n2, localMatrix); //extract the submatrix corresponding to the coupling of nodes n1 and n2
+                dfdx(nodeIndex[n1] * S, nodeIndex[n2] * S) += -localMatrix;
             }
         }
+        ++i;
     }
-    ++i;
 }
 
 template<class DataTypes>


### PR DESCRIPTION
In the spirit of #3983 (more readable, more efficient, more consistent)

Also it fixes the function, by moving the `++i` inside the loop.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
