### PR TITLE
[FEM.Linear] Implement buildStiffnessMatrix and addKToMatrix for TriangularFEMForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.h
@@ -107,13 +107,17 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* mparams, const DataVecCoord& x) const override;
 
+    void computeElementStiffnessMatrix(type::Mat<9, 9, Real>& S, type::Mat<9, 9, Real>& SR, const MaterialStiffness& K, const StrainDisplacement& J, const Transformation& Rot);
+    void addKToMatrix(sofa::linearalgebra::BaseMatrix *mat, SReal k, unsigned int &offset) override;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
+
     void draw(const core::visual::VisualParams* vparams) override;
 
     /// Class to store FEM information on each triangle, for topology modification handling
     class TriangleInformation
     {
     public:
-        /// material stiffness matrices of each tetrahedron
+        /// material stiffness matrices of each triangle
         MaterialStiffness materialMatrix;
         ///< the strain-displacement matrices vector
         StrainDisplacement strainDisplacementMatrix;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
@@ -396,7 +396,7 @@ void TriangularFEMForceField<DataTypes>::computeElementStiffnessMatrix(type::Mat
 }
 
 template <class DataTypes>
-void TriangularFEMForceField<DataTypes>::addKToMatrix(sofa::linearalgebra::BaseMatrix* mat, SReal k, unsigned& offset)
+void TriangularFEMForceField<DataTypes>::addKToMatrix(sofa::linearalgebra::BaseMatrix* mat, SReal k, unsigned int& offset)
 {
     const auto& triangleInf = triangleInfo.getValue();
     const auto& triangles = m_topology->getTriangles();

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
@@ -360,6 +360,93 @@ SReal TriangularFEMForceField<DataTypes>::getPotentialEnergy(const core::Mechani
 }
 
 template <class DataTypes>
+void TriangularFEMForceField<DataTypes>::computeElementStiffnessMatrix(type::Mat<9, 9, typename TriangularFEMForceField<DataTypes>::Real>& S, type::Mat<9, 9, typename TriangularFEMForceField<DataTypes>::Real>& SR, const MaterialStiffness& K, const StrainDisplacement& J, const Transformation& Rot)
+{
+    type::MatNoInit<3, 6, Real> Jt;
+    Jt.transpose(J);
+
+    type::MatNoInit<6, 6, Real> JKJt;
+    JKJt = J * K * Jt;  // in-plane stiffness matrix, 6x6
+
+    // stiffness JKJt expanded to 3 dimensions
+    type::Mat<9, 9, Real> Ke; // initialized to 0
+    // for each 2x2 block i,j
+    for (unsigned i = 0; i < 3; i++)
+    {
+        for (unsigned j = 0; j < 3; j++)
+        {
+            // copy the block in the expanded matrix
+            for (unsigned k = 0; k < 2; k++)
+                for (unsigned l = 0; l < 2; l++)
+                    Ke[3 * i + k][3 * j + l] = JKJt[2 * i + k][2 * j + l];
+        }
+    }
+
+    // rotation matrices. TODO: use block-diagonal matrices, more efficient.
+    type::Mat<9, 9, Real> RR, RRt; // initialized to 0
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+        {
+            RR[i][j] = RR[i + 3][j + 3] = RR[i + 6][j + 6] = Rot[i][j];
+            RRt[i][j] = RRt[i + 3][j + 3] = RRt[i + 6][j + 6] = Rot[j][i];
+        }
+
+    S = RR * Ke;
+    SR = S * RRt;
+}
+
+template <class DataTypes>
+void TriangularFEMForceField<DataTypes>::addKToMatrix(sofa::linearalgebra::BaseMatrix* mat, SReal k, unsigned& offset)
+{
+    const auto& triangleInf = triangleInfo.getValue();
+    const auto& triangles = m_topology->getTriangles();
+    const auto nbTriangles = m_topology->getNbTriangles();
+
+    for (sofa::Index i = 0; i < nbTriangles; i++)
+    {
+        const TriangleInformation& tInfo = triangleInf[i];
+        const Triangle& tri = triangles[i];
+
+        type::Mat<9, 9, Real> JKJt(type::NOINIT), RJKJtRt(type::NOINIT);
+        computeElementStiffnessMatrix(JKJt, RJKJtRt, tInfo.materialMatrix, tInfo.strainDisplacementMatrix, tInfo.rotation);
+        this->addToMatrix(mat, offset, tri, RJKJtRt, -k);
+    }
+}
+
+template <class DataTypes>
+void TriangularFEMForceField<DataTypes>::buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix)
+{
+    type::Mat<9, 9, Real> JKJt, RJKJtRt;
+    sofa::type::Mat<3, 3, Real> localMatrix(type::NOINIT);
+
+    constexpr auto S = DataTypes::deriv_total_size; // size of node blocks
+
+    auto dfdx = matrix->getForceDerivativeIn(this->mstate)
+                       .withRespectToPositionsIn(this->mstate);
+
+    const auto& triangleInf = triangleInfo.getValue();
+    const auto& triangles = m_topology->getTriangles();
+    const auto nbTriangles = m_topology->getNbTriangles();
+
+    for (sofa::Index i = 0; i < nbTriangles; i++)
+    {
+        const TriangleInformation& tInfo = triangleInf[i];
+        const Triangle& tri = triangles[i];
+
+        computeElementStiffnessMatrix(JKJt, RJKJtRt, tInfo.materialMatrix, tInfo.strainDisplacementMatrix, tInfo.rotation);
+
+        for (sofa::Index n1 = 0; n1 < Element::size(); ++n1)
+        {
+            for (sofa::Index n2 = 0; n2 < Element::size(); ++n2)
+            {
+                RJKJtRt.getsub(S * n1, S * n2, localMatrix); //extract the submatrix corresponding to the coupling of nodes n1 and n2
+                dfdx(tri[n1] * S, tri[n2] * S) += -localMatrix;
+            }
+        }
+    }
+}
+
+template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::setPoisson(Real val)
 {
     if (val < 0)


### PR DESCRIPTION
Interestingly, `addKToMatrix` was not implemented for TriangularFEMForceField. It means, it was not possible to use this component with a linear solver which assembles its matrix.
The implementations are strongly based on the implementations in TriangleFEMForceField.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
