### PR TITLE
[AnimationLoop] Change the default constraint solver in FreeMotionAnimationLoop

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -22,7 +22,7 @@
 #include <sofa/component/animationloop/FreeMotionAnimationLoop.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#include <sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h>
+#include <sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h>
 
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/VecId.h>
@@ -67,13 +67,14 @@ using namespace core::behavior;
 using namespace sofa::simulation;
 using sofa::helper::ScopedAdvancedTimer;
 
+using DefaultConstraintSolver = sofa::component::constraint::lagrangian::solver::GenericConstraintSolver;
+
 FreeMotionAnimationLoop::FreeMotionAnimationLoop(simulation::Node* gnode)
     : Inherit1(gnode)
     , m_solveVelocityConstraintFirst(initData(&m_solveVelocityConstraintFirst , false, "solveVelocityConstraintFirst", "solve separately velocity constraint violations before position constraint violations"))
     , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
     , d_parallelCollisionDetectionAndFreeMotion(initData(&d_parallelCollisionDetectionAndFreeMotion, false, "parallelCollisionDetectionAndFreeMotion", "If true, executes free motion step and collision detection step in parallel."))
     , d_parallelODESolving(initData(&d_parallelODESolving, false, "parallelODESolving", "If true, solves all the ODEs in parallel during the free motion step."))
-    , defaultSolver(nullptr)
     , l_constraintSolver(initLink("constraintSolver", "The ConstraintSolver used in this animation loop (required)"))
 {
     d_parallelCollisionDetectionAndFreeMotion.setGroup("Multithreading");
@@ -81,20 +82,7 @@ FreeMotionAnimationLoop::FreeMotionAnimationLoop(simulation::Node* gnode)
 }
 
 FreeMotionAnimationLoop::~FreeMotionAnimationLoop()
-{
-    if (defaultSolver != nullptr)
-        defaultSolver.reset();
-}
-
-void FreeMotionAnimationLoop::parse ( sofa::core::objectmodel::BaseObjectDescription* arg )
-{
-    simulation::CollisionAnimationLoop::parse(arg);
-
-    defaultSolver = sofa::core::objectmodel::New<constraint::lagrangian::solver::LCPConstraintSolver>();
-    defaultSolver->parse(arg);
-    defaultSolver->setName(defaultSolver->getContext()->getNameHelper().resolveName(defaultSolver->getClassName(), core::ComponentNameHelper::Convention::python));
-}
-
+= default;
 
 void FreeMotionAnimationLoop::init()
 {
@@ -113,32 +101,31 @@ void FreeMotionAnimationLoop::init()
         l_constraintSolver.set(this->getContext()->get<sofa::core::behavior::ConstraintSolver>(core::objectmodel::BaseContext::SearchDown));
         if (!l_constraintSolver)
         {
-            if (defaultSolver != nullptr)
+            if (const auto constraintSolver = sofa::core::objectmodel::New<DefaultConstraintSolver>())
             {
+                getContext()->addObject(constraintSolver);
+                constraintSolver->setName( this->getContext()->getNameHelper().resolveName(constraintSolver->getClassName(), {}));
+                constraintSolver->f_printLog.setValue(this->f_printLog.getValue());
+                l_constraintSolver.set(constraintSolver);
+
                 msg_warning() << "A ConstraintSolver is required by " << this->getClassName() << " but has not been found:"
-                    " a default " << defaultSolver->getClassName() << " is automatically added in the scene for you. To remove this warning, add"
+                    " a default " << constraintSolver->getClassName() << " is automatically added in the scene for you. To remove this warning, add"
                     " a ConstraintSolver in the scene. The list of available constraint solvers is: "
                     << core::ObjectFactory::getInstance()->listClassesDerivedFrom<sofa::core::behavior::ConstraintSolver>();
-                getContext()->addObject(defaultSolver);
-                l_constraintSolver.set(defaultSolver);
-                defaultSolver = nullptr;
             }
             else
             {
                 msg_fatal() << "A ConstraintSolver is required by " << this->getClassName() << " but has not been found:"
-                    " a default LCPConstraintSolver could not be automatically added in the scene. To remove this error, add"
+                    " a default " << DefaultConstraintSolver::GetClass()->className << " could not be automatically added in the scene. To remove this error, add"
                     " a ConstraintSolver in the scene. The list of available constraint solvers is: "
                     << core::ObjectFactory::getInstance()->listClassesDerivedFrom<sofa::core::behavior::ConstraintSolver>();
+                this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
             }
         }
         else
         {
             msg_info() << "Constraint solver found: '" << l_constraintSolver->getPathName() << "'";
         }
-    }
-    else
-    {
-        defaultSolver.reset();
     }
 
     auto* taskScheduler = sofa::simulation::MainTaskSchedulerFactory::createInRegistry();

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -120,6 +120,7 @@ void FreeMotionAnimationLoop::init()
                     " a ConstraintSolver in the scene. The list of available constraint solvers is: "
                     << core::ObjectFactory::getInstance()->listClassesDerivedFrom<sofa::core::behavior::ConstraintSolver>();
                 this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+                return;
             }
         }
         else
@@ -142,6 +143,8 @@ void FreeMotionAnimationLoop::init()
             msg_info() << "Task scheduler already initialized on " << taskScheduler->getThreadCount() << " threads";
         }
     }
+
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.h
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.h
@@ -41,7 +41,6 @@ public:
 public:
     void step (const sofa::core::ExecParams* params, SReal dt) override;
     void init() override;
-    void parse ( sofa::core::objectmodel::BaseObjectDescription* arg ) override;
 
     /// Construction method called by ObjectFactory. An animation loop can only
     /// be created if
@@ -63,9 +62,6 @@ public:
 protected:
     FreeMotionAnimationLoop(simulation::Node* gnode);
     ~FreeMotionAnimationLoop() override ;
-
-    ///< pointer towards a default ConstraintSolver (LCPConstraintSolver) used in case none was found in the scene graph
-    sofa::core::sptr<sofa::core::behavior::ConstraintSolver> defaultSolver;
 
     ///< The ConstraintSolver used in this animation loop (required)
     SingleLink<FreeMotionAnimationLoop, sofa::core::behavior::ConstraintSolver, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_constraintSolver;


### PR DESCRIPTION
- The solver that is created if none is found is no longer always created. It is created only if need be.
- The type of the solver has changed from `LCPConstraintSolver` to `GenericConstraintSolver`




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
