### PR TITLE
[SofaCUDA] Implement buildStiffnessMatrix and buildDampingMatrix in TLED

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
@@ -503,12 +503,6 @@ void CudaHexahedronTLEDForceField::addDForce (const sofa::core::MechanicalParams
 
 }
 
-void CudaHexahedronTLEDForceField::buildDampingMatrix(core::behavior::DampingMatrix* damping_matrix)
-{
-    // No damping in this ForceField
-}
-
-
 // --------------------------------------------------------------------------------------
 // Computes Jacobian determinant
 // --------------------------------------------------------------------------------------

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.h
@@ -110,7 +110,8 @@ public:
     virtual void addForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv& dataF, const DataVecCoord& dataX, const DataVecDeriv& /*dataV*/ ) override;
 //    void addDForce (VecDeriv& /*df*/, const VecDeriv& /*dx*/);
     virtual void addDForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv& datadF, const DataVecDeriv& datadX ) override;
-    void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix*) final {}
+    void buildDampingMatrix(core::behavior::DampingMatrix*) final {}
     SReal getPotentialEnergy(const sofa::core::MechanicalParams* , const DataVecCoord&) const override { return 0.0; }
 
     // Computes lambda and mu based on Young's modulus and Poisson ratio

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp
@@ -516,12 +516,6 @@ void CudaTetrahedronTLEDForceField::addDForce (const sofa::core::MechanicalParam
 
 }
 
-void CudaTetrahedronTLEDForceField::buildDampingMatrix(core::behavior::DampingMatrix* damping_matrix)
-{
-    // No damping in this ForceField
-}
-
-
 // --------------------------------------------------------------------------------------
 // Computes element volumes for tetrahedral elements
 // --------------------------------------------------------------------------------------

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -114,7 +114,8 @@ public:
     virtual void addForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv& dataF, const DataVecCoord& dataX, const DataVecDeriv& /*dataV*/ ) override;
 //    void addDForce (VecDeriv& /*df*/, const VecDeriv& /*dx*/);
     virtual void addDForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv& datadF, const DataVecDeriv& datadX ) override;
-    void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix*) final {}
+    void buildDampingMatrix(core::behavior::DampingMatrix*) final {}
     SReal getPotentialEnergy(const sofa::core::MechanicalParams* , const DataVecCoord&) const override { return 0.0; }
     // Computes lambda and mu based on Young's modulus and Poisson ratio
     void updateLameCoefficients();


### PR DESCRIPTION
Since the components are explicit formulations, they don't contribute into an implicit scheme.
A task from #3967


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
