### PR TITLE
[LinearSystem] Optim: Only account for affected DoFs

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
@@ -174,7 +174,7 @@ protected:
      * Build the jacobian matrices of mappings from a mapped state to its top most parents (in the
      * sense of mappings)
      */
-    MappingJacobians<JacobianMatrixType> computeJacobiansFrom(BaseMechanicalState* mstate, const core::MechanicalParams* mparams);
+    MappingJacobians<JacobianMatrixType> computeJacobiansFrom(BaseMechanicalState* mstate, const core::MechanicalParams* mparams, LocalMappedMatrixType<Real>* crs);
 
     /**
      * Assemble the matrices under mappings into the global matrix
@@ -218,6 +218,9 @@ protected:
 
     void buildGroupsOfComponentAssociatedToMechanicalStates(
         std::map< PairMechanicalStates, GroupOfComponentsAssociatedToAPairOfMechanicalStates>& groups);
+
+    /// Given a Mechanical State and its matrix, identifies the nodes affected by the matrix
+    std::vector<unsigned int> identifyAffectedDoFs(BaseMechanicalState* mstate, LocalMappedMatrixType<Real>* crs);
 };
 
 template<Contribution c, class Real>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
@@ -757,12 +757,12 @@ void MatrixLinearSystem<TMatrix, TVector>::projectMappedMatrices(const core::Mec
             continue;
         }
 
-        const MappingJacobians<JacobianMatrixType> J0 = computeJacobiansFrom(pair[0], mparams);
-        const MappingJacobians<JacobianMatrixType> J1 = computeJacobiansFrom(pair[1], mparams);
+        LocalMappedMatrixType<Real>* crs = mappedMatrix.get();
+
+        const MappingJacobians<JacobianMatrixType> J0 = computeJacobiansFrom(pair[0], mparams, crs);
+        const MappingJacobians<JacobianMatrixType> J1 = computeJacobiansFrom(pair[1], mparams, crs);
 
         const sofa::type::fixed_array<MappingJacobians<JacobianMatrixType>, 2> mappingMatricesMap { J0, J1 };
-
-        LocalMappedMatrixType<Real>* crs = mappedMatrix.get();
 
         sofa::component::linearsystem::addMappedMatrixToGlobalMatrixEigen(
             pair, crs, mappingMatricesMap, m_mappingGraph, this->getSystemMatrix());
@@ -770,7 +770,31 @@ void MatrixLinearSystem<TMatrix, TVector>::projectMappedMatrices(const core::Mec
 }
 
 template <class TMatrix, class TVector>
-auto MatrixLinearSystem<TMatrix, TVector>::computeJacobiansFrom(BaseMechanicalState* mstate, const core::MechanicalParams* mparams)
+std::vector<unsigned int> MatrixLinearSystem<TMatrix, TVector>::identifyAffectedDoFs(BaseMechanicalState* mstate, LocalMappedMatrixType<Real>* crs)
+{
+    const auto blockSize = mstate->getMatrixBlockSize();
+    std::set<unsigned int> setAffectedDoFs;
+
+    for (std::size_t it_rows_k = 0; it_rows_k < crs->rowIndex.size(); it_rows_k++)
+    {
+        typename LocalMappedMatrixType<Real>::Range rowRange(crs->rowBegin[it_rows_k], crs->rowBegin[it_rows_k + 1]);
+        for (auto xj = rowRange.begin(); xj < rowRange.end(); ++xj) // for each non-null block
+        {
+            const sofa::SignedIndex col = crs->colsIndex[xj];
+            const auto k = crs->colsValue[xj];
+            if (k != static_cast<Real>(0))
+            {
+                const sofa::SignedIndex dofId = col / blockSize;
+                setAffectedDoFs.insert(dofId);
+            }
+        }
+    }
+
+    return std::vector( setAffectedDoFs.begin(), setAffectedDoFs.end() );
+}
+
+template <class TMatrix, class TVector>
+auto MatrixLinearSystem<TMatrix, TVector>::computeJacobiansFrom(BaseMechanicalState* mstate, const core::MechanicalParams* mparams, LocalMappedMatrixType<Real>* crs)
 -> MappingJacobians<JacobianMatrixType>
 {
     auto cparams = core::ConstraintParams(*mparams);
@@ -786,9 +810,10 @@ auto MatrixLinearSystem<TMatrix, TVector>::computeJacobiansFrom(BaseMechanicalSt
 
     auto mappingJacobianId = sofa::core::MatrixDerivId::mappingJacobian();
 
-    sofa::type::vector<unsigned int> listAffectedDoFs(mstate->getSize());
-    std::iota(listAffectedDoFs.begin(), listAffectedDoFs.end(), 0);
-    mstate->buildIdentityBlocksInJacobian(listAffectedDoFs, mappingJacobianId);
+    {
+        const std::vector<unsigned> listAffectedDoFs = identifyAffectedDoFs(mstate, crs);
+        mstate->buildIdentityBlocksInJacobian(listAffectedDoFs, mappingJacobianId);
+    }
 
     const auto parentMappings = getMappingGraph().getBottomUpMappingsFrom(mstate);
     for (auto* mapping : parentMappings)

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -2335,7 +2335,7 @@ void MechanicalObject<DataTypes>::getConstraintJacobian(const core::ConstraintPa
 template <class DataTypes>
 void MechanicalObject<DataTypes>::buildIdentityBlocksInJacobian(const sofa::type::vector<unsigned int>& list_n, core::MatrixDerivId &mID)
 {
-    const auto N = Deriv::size();
+    static constexpr auto N = Deriv::size();
     Data<MatrixDeriv>* cMatrix= this->write(mID);
 
     MatrixDeriv& jacobian = *cMatrix->beginEdit();


### PR DESCRIPTION
Build the mapping Jacobian using only the affected DoFs (the DoFs which contributes to the matrix), filtering the rest. This is particularly more efficient for PenalityForceField, when in general only a few DoFs are in contacts.

On the caduceus, before:
```
10000 iterations done in 41.6872 s ( 239.882 FPS).
```

after:
```
10000 iterations done in 16.8157 s ( 594.681 FPS).
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
