### PR TITLE
[Diffusion] Fix buildStiffnessMatrix in TetrahedronDiffusionFEMForceField

### DIFF
--- a/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
+++ b/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
@@ -406,10 +406,10 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::buildStiffnessMatrix(
         const auto v0 = edge[0];
         const auto v1 = edge[1];
 
-        dfdx(N*v1, N*v0) += edgeDiffusionCoefficient[edgeId];
-        dfdx(N*v0, N*v1) += edgeDiffusionCoefficient[edgeId];
-        dfdx(N*v0, N*v0) += edgeDiffusionCoefficient[edgeId];
-        dfdx(N*v1, N*v1) += edgeDiffusionCoefficient[edgeId];
+        dfdx(N * v1, N * v0) += -edgeDiffusionCoefficient[edgeId];
+        dfdx(N * v0, N * v1) += -edgeDiffusionCoefficient[edgeId];
+        dfdx(N * v0, N * v0) += edgeDiffusionCoefficient[edgeId];
+        dfdx(N * v1, N * v1) += edgeDiffusionCoefficient[edgeId];
 
         ++edgeId;
     }


### PR DESCRIPTION
Missing minus signs. Introduced in #2777.
Problem identified thanks to #4010






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
