### PR TITLE
[LinearAlgebra] CompressedRowSparseMatrix: add virtual destructor

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
@@ -238,6 +238,8 @@ public :
     {
     }
 
+    virtual ~CompressedRowSparseMatrixGeneric() = default;
+
     /// \returns the number of row blocks
     Index rowBSize() const
     {
@@ -1610,7 +1612,7 @@ protected:
     }
 };
 
-#if !defined(SOFA_COMPONENT_LINEARSOLVER_COMPRESSEDROWSPARSEMATRIXGENERIC_CPP) 
+#if !defined(SOFA_COMPONENT_LINEARSOLVER_COMPRESSEDROWSPARSEMATRIXGENERIC_CPP)
 extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixGeneric<double>;
 extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixGeneric<float>;
 extern template class SOFA_LINEARALGEBRA_API CompressedRowSparseMatrixGeneric<type::Mat1x1d>;


### PR DESCRIPTION
Warnings were triggered from the gcc flag `-Wdelete-non-abstract-non-virtual-dtor `

https://devblogs.microsoft.com/oldnewthing/20200618-00/?p=103874



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
