### PR TITLE
[FEM.Elastic] Add option to compute principal stress direction in TriangularFEMForceFieldOptim 

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.h
@@ -109,6 +109,8 @@ public:
     void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
     SReal getPotentialEnergy(const core::MechanicalParams* mparams, const DataVecCoord& x) const override;
+    
+    void computePrincipalStress();
     void getTrianglePrincipalStress(Index i, Real& stressValue, Deriv& stressDirection);
 
     void draw(const core::visual::VisualParams* vparams) override;
@@ -123,6 +125,11 @@ public:
         //Index ia, ib, ic;
         Real bx, cx, cy, ss_factor;
         Transformation init_frame; // Mat<2,3,Real>
+
+        Real stress;
+        Deriv stressVector;
+        Real stress2;
+        Deriv stressVector2;
 
         TriangleInfo() :bx(0), cx(0), cy(0), ss_factor(0) { }
 
@@ -234,17 +241,17 @@ public:
     Data<Real> d_damping; ///< Ratio damping/stiffness
     Data<Real> d_restScale; ///< Scale factor applied to rest positions (to simulate pre-stretched materials)
 
+    Data<bool> d_computePrincipalStress; ///< Compute principal stress for each triangle
+    Data<Real> d_stressMaxValue; ///< Max stress value computed over the triangulation
+
     /// Display parameters
-    Data<bool> d_showStressValue;
     Data<bool> d_showStressVector; ///< Flag activating rendering of stress directions within each triangle
-    Data<Real> d_showStressMaxValue; ///< Max value for rendering of stress values
+    Data<Real> d_showStressThreshold; ///< Minimum Stress value for rendering of stress vectors
 
     /// Link to be set to the topology container in the component graph. 
     SingleLink<TriangularFEMForceFieldOptim<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
-    Real drawPrevMaxStress;
-
     /// Pointer to the topology container. Will be set by link @sa l_topology
     sofa::core::topology::BaseMeshTopology* m_topology;
 };

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
@@ -42,14 +42,16 @@ TriangularFEMForceFieldOptim<DataTypes>::TriangularFEMForceFieldOptim()
     , d_young(initData(&d_young,(Real)(1000.0),"youngModulus","Young modulus in Hooke's law"))
     , d_damping(initData(&d_damping,(Real)0.,"damping","Ratio damping/stiffness"))
     , d_restScale(initData(&d_restScale,(Real)1.,"restScale","Scale factor applied to rest positions (to simulate pre-stretched materials)"))
+    , d_computePrincipalStress(initData(&d_computePrincipalStress, false, "computePrincipalStress", "Compute principal stress for each triangle"))
+    , d_stressMaxValue(initData(&d_stressMaxValue, (Real)0., "stressMaxValue", "Max stress value computed over the triangulation"))
     , d_showStressVector(initData(&d_showStressVector,false,"showStressVector","Flag activating rendering of stress directions within each triangle"))
-    , d_showStressMaxValue(initData(&d_showStressMaxValue,(Real)0.0,"showStressMaxValue","Max value for rendering of stress values"))
+    , d_showStressThreshold(initData(&d_showStressThreshold,(Real)0.0,"showStressThreshold","Threshold value to render only stress vectors higher to this threshold"))
     , l_topology(initLink("topology", "link to the topology container"))
-    , drawPrevMaxStress((Real)-1.0)
     , m_topology(nullptr)
 {
     d_poisson.setRequired(true);
     d_young.setRequired(true);
+    d_stressMaxValue.setReadOnly(true);
 }
 
 
@@ -334,6 +336,12 @@ void TriangularFEMForceFieldOptim<DataTypes>::addForce(const core::MechanicalPar
         // store data for re-use
         ts.stress = stress;
     }
+
+    // compute principal stress if requested or for rendering
+    if (this->d_computePrincipalStress.getValue() || this->d_showStressVector.getValue())
+    {
+        computePrincipalStress();
+    }
 }
 
 // --------------------------------------------------------------------------------------
@@ -557,6 +565,38 @@ void TriangularFEMForceFieldOptim<DataTypes>::getTrianglePrincipalStress(Index i
     }
 }
 
+
+template<class DataTypes>
+void TriangularFEMForceFieldOptim<DataTypes>::computePrincipalStress()
+{
+    const VecElement& triangles = m_topology->getTriangles();
+
+    sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleState > > triStates = d_triangleState;
+    sofa::helper::WriteAccessor< core::objectmodel::Data< VecTriangleInfo > > triInfos = d_triangleInfo;
+
+    Real minStress = 0;
+    Real maxStress = 0;
+
+    for (unsigned int i = 0; i < triangles.size(); i++)
+    {
+        TriangleInfo& triInfo = triInfos[i];
+
+        getTrianglePrincipalStress(i, triInfo.stress, triInfo.stressVector, triInfo.stress2, triInfo.stressVector2);
+
+        if (triInfo.stress < minStress) minStress = triInfo.stress;
+        if (triInfo.stress > maxStress) maxStress = triInfo.stress;
+        if (triInfo.stress2 < minStress) minStress = triInfo.stress2;
+        if (triInfo.stress2 > maxStress) maxStress = triInfo.stress2;
+    }
+
+    maxStress = std::max(-minStress, maxStress);
+    d_stressMaxValue.setValue(maxStress);
+
+    if (!d_showStressThreshold.isSet() && d_showStressVector.getValue())
+        d_showStressThreshold.setValue(minStress);
+}
+
+
 template<class DataTypes>
 type::fixed_array <typename TriangularFEMForceFieldOptim<DataTypes>::Coord, 3> TriangularFEMForceFieldOptim<DataTypes>::getRotatedInitialElement(Index elemId)
 {
@@ -666,94 +706,46 @@ void TriangularFEMForceFieldOptim<DataTypes>::draw(const core::visual::VisualPar
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     unsigned int nbTriangles=m_topology->getNbTriangles();
     const VecElement& triangles = m_topology->getTriangles();
+    const Real& stressThresold = d_showStressThreshold.getValue();
 
-    sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleState > > triState = d_triangleState;
-    sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleInfo > > triInfo = d_triangleInfo;
-    const bool showStressValue = this->d_showStressValue.getValue();
-    const bool showStressVector = this->d_showStressVector.getValue();
-    if (showStressValue || showStressVector)
+    sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleInfo > > triInfos = d_triangleInfo;
+    if (this->d_showStressVector.getValue() && stressThresold > 0)
     {
-        Real minStress = 0;
-        Real maxStress = 0;
-        std::vector<Real> stresses;
-        std::vector<std::pair<int,Real> > pstresses;
-        std::vector<Deriv> stressVectors;
-        std::vector<Real> stresses2;
-        std::vector<Deriv> stressVectors2;
-        stresses.resize(nbTriangles);
-        stressVectors.resize(nbTriangles);
-        stresses2.resize(nbTriangles);
-        stressVectors2.resize(nbTriangles);
-
-        if (showStressValue)
-        {
-            pstresses.resize(x.size());
-        }
+        std::vector< Vec3 > points[2];
+        const Real& maxStress = d_stressMaxValue.getValue();
         for (unsigned int i=0; i<nbTriangles; i++)
         {
-            getTrianglePrincipalStress(i,stresses[i],stressVectors[i],stresses2[i],stressVectors2[i]);
+            const TriangleInfo& triInfo = triInfos[i];
+            Real s1 = triInfo.stress;
+            Real s2 = triInfo.stress2;
 
-            if ( stresses[i] < minStress ) minStress = stresses[i];
-            if ( stresses[i] > maxStress ) maxStress = stresses[i];
-            if ( stresses2[i] < minStress ) minStress = stresses2[i];
-            if ( stresses2[i] > maxStress ) maxStress = stresses2[i];
-            if (showStressValue)
-            {
-                Real maxs = std::min(stresses[i],stresses2[i]);
-                Triangle t = triangles[i];
-                for (const auto p : t)
-                {
-                    pstresses[p].first += 1;
-                    pstresses[p].second += helper::rabs(maxs);
-                }
-            }
-        }
-        maxStress = std::max(-minStress, maxStress);
-        minStress = 0;
-        if (drawPrevMaxStress > maxStress)
-        {
-            maxStress = drawPrevMaxStress;
-        }
-        else
-        {
-            drawPrevMaxStress = maxStress;
-            msg_info() << "max stress = " << maxStress;
-        }
-        if (d_showStressMaxValue.isSet())
-        {
-            maxStress = d_showStressMaxValue.getValue();
-        }
-        if (showStressVector && maxStress > 0)
-        {
-            std::vector< Vec3 > points[2];
-            for (unsigned int i=0; i<nbTriangles; i++)
-            {
-                Triangle t = triangles[i];
-                Vec3 a = x[t[0]];
-                Vec3 b = x[t[1]];
-                Vec3 c = x[t[2]];
-                Vec3 d1 = stressVectors[i];
-                Real s1 = stresses[i];
-                Vec3 d2 = stressVectors2[i];
-                Real s2 = stresses2[i];
-                Vec3 center = (a+b+c)/3;
-                Vec3 n = cross(b-a,c-a);
-                Real fact = (Real)helper::rsqrt(n.norm())*(Real)0.5;
-                const int g1 = (s1 < 0) ? 1 : 0;
-                const int g2 = (s2 < 0) ? 1 : 0;
-                d1 *= fact*helper::rsqrt(helper::rabs(s1)/maxStress);
-                d2 *= fact*helper::rsqrt(helper::rabs(s2)/maxStress);
-                points[g1].push_back(center - d1);
-                points[g1].push_back(center + d1);
-                points[g2].push_back(center - d2);
-                points[g2].push_back(center + d2);
-            }
-            vparams->drawTool()->drawLines(points[0], 2, sofa::type::RGBAColor::yellow());
-            vparams->drawTool()->drawLines(points[1], 2, sofa::type::RGBAColor::magenta());
+            if (helper::rabs(s1) < stressThresold)
+                continue;
+            
+            const Triangle& t = triangles[i];
+            Vec3 a = x[t[0]];
+            Vec3 b = x[t[1]];
+            Vec3 c = x[t[2]];
+            Vec3 center = (a + b + c) / 3;
+
+            Vec3 d1 = triInfo.stressVector;            
+            Vec3 d2 = triInfo.stressVector2;
+                        
+            d1.normalize();
+            Vec3 colorD1 = (d1 + Vec3(1, 1, 1)) * 0.5; 
+            d1 *= helper::rabs(s1) / maxStress;
+
+            d2.normalize();
+            Vec3 colorD2 = (d2 + Vec3(1, 1, 1)) * 0.5;
+            d2 *= helper::rabs(s2) / maxStress;
+            
+            vparams->drawTool()->drawArrow(center, sofa::type::Vec3(center + d1), 0.01, sofa::type::RGBAColor(colorD1[0], colorD1[1], colorD1[2], 1));
+            vparams->drawTool()->drawArrow(center, sofa::type::Vec3(center + d2), 0.01, sofa::type::RGBAColor(colorD2[0], colorD2[1], colorD2[2], 1));
         }
     }
     else
     {
+        sofa::helper::ReadAccessor< core::objectmodel::Data< VecTriangleState > > triState = d_triangleState;
         std::vector< Vec3 > points[4];
 
         constexpr sofa::type::RGBAColor c0 = sofa::type::RGBAColor::red();
@@ -768,7 +760,7 @@ void TriangularFEMForceFieldOptim<DataTypes>::draw(const core::visual::VisualPar
         for (unsigned int i=0; i<nbTriangles; ++i)
         {
             Triangle t = triangles[i];
-            const TriangleInfo& ti = triInfo[i];
+            const TriangleInfo& ti = triInfos[i];
             const TriangleState& ts = triState[i];
             Coord a = x[t[0]];
             Coord b = x[t[1]];

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
@@ -577,16 +577,14 @@ void TriangularFEMForceFieldOptim<DataTypes>::computePrincipalStress()
     Real minStress = 0;
     Real maxStress = 0;
 
-    for (unsigned int i = 0; i < triangles.size(); i++)
+    for (std::size_t i = 0; i < triangles.size(); i++)
     {
         TriangleInfo& triInfo = triInfos[i];
 
         getTrianglePrincipalStress(i, triInfo.stress, triInfo.stressVector, triInfo.stress2, triInfo.stressVector2);
 
-        if (triInfo.stress < minStress) minStress = triInfo.stress;
-        if (triInfo.stress > maxStress) maxStress = triInfo.stress;
-        if (triInfo.stress2 < minStress) minStress = triInfo.stress2;
-        if (triInfo.stress2 > maxStress) maxStress = triInfo.stress2;
+        minStress = std::min({minStress, triInfo.stress, triInfo.stress2});
+        maxStress = std::max({maxStress , triInfo.stress, triInfo.stress2});
     }
 
     maxStress = std::max(-minStress, maxStress);

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceFieldOptim.inl
@@ -587,7 +587,6 @@ void TriangularFEMForceFieldOptim<DataTypes>::computePrincipalStress()
         maxStress = std::max({maxStress , triInfo.stress, triInfo.stress2});
     }
 
-    maxStress = std::max(-minStress, maxStress);
     d_stressMaxValue.setValue(maxStress);
 
     if (!d_showStressThreshold.isSet() && d_showStressVector.getValue())


### PR DESCRIPTION
Several improvments regarding principal stress computation in `TriangularFEMForceFieldOptim`:
- Add Data `d_computePrincipalStress` to force the computation no matter if stress vector is displayed or not.
- Move the computation out from the draw loop, in addForce if `d_computePrincipalStress` or `d_showStressVector` is true
- Store principal stress info into the TriangleInfo structure so it can be accessed outside from the component
- Update drawing to use arrow with color orientation.
- Add Data `d_showStressThreshold` to display only vectors above a threshold


![image](https://github.com/sofa-framework/sofa/assets/21199245/9da6ebe5-38b7-4e3a-a37c-7d25fc8724f4)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
