### PR TITLE
[Geometry] Add method isPointOnEdge in Edge structure

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
@@ -351,24 +351,14 @@ typename DataTypes::Coord EdgeSetGeometryAlgorithms<DataTypes>::computeRestEdgeD
 template<class DataTypes>
 bool EdgeSetGeometryAlgorithms<DataTypes>::isPointOnEdge(const sofa::type::Vec<3,Real> &pt, const EdgeID ind_e) const
 {
-    constexpr Real ZERO = static_cast<Real>(1e-12);
-
-    sofa::type::Vec<3,Real> p0 = pt;
-
     Coord vertices[2];
     getEdgeVertexCoordinates(ind_e, vertices);
+    sofa::type::Vec<3, Real> p1, p2;
 
-    sofa::type::Vec<3,Real> p1; //(vertices[0][0], vertices[0][1], vertices[0][2]);
-    sofa::type::Vec<3,Real> p2; //(vertices[1][0], vertices[1][1], vertices[1][2]);
     DataTypes::get(p1[0], p1[1], p1[2], vertices[0]);
     DataTypes::get(p2[0], p2[1], p2[2], vertices[1]);
-
-    sofa::type::Vec<3,Real> v = (p0 - p1).cross(p0 - p2);
-
-    if(v.norm2() < ZERO)
-        return true;
-    else
-        return false;
+    
+    return sofa::geometry::Edge::isPointOnEdge(pt, p1, p2);
 }
 
 //

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
@@ -353,7 +353,7 @@ bool EdgeSetGeometryAlgorithms<DataTypes>::isPointOnEdge(const sofa::type::Vec<3
 {
     Coord vertices[2];
     getEdgeVertexCoordinates(ind_e, vertices);
-    sofa::type::Vec<3, Real> p1, p2;
+    sofa::type::Vec<3, Real> p1(type::NOINIT), p2(type::NOINIT);
 
     DataTypes::get(p1[0], p1[1], p1[2], vertices[0]);
     DataTypes::get(p2[0], p2[1], p2[2], vertices[1]);

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -122,6 +122,51 @@ struct Edge
 
 
     /**
+    * @brief	Test if a point is on Edge (n0, n1)
+    * @tparam   Node iterable container
+    * @tparam   T scalar
+    * @param	p0: position of the point to test
+    * @param	n0,n1: nodes of the edge
+    * @return	bool result if point is on Edge.
+    */
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+        static constexpr bool isPointOnEdge(const Node& p0, const Node& n0, const Node& n1)
+    {
+        // 1. check if the point, n0 and n1 are aligned
+        const auto AB = n0 - n1;
+        const auto AC = n0 - p0;
+
+        T N2 = T(0);
+        if constexpr (std::is_same_v < Node, sofa::type::Vec<2, T> >)
+        {            
+            N2 = sofa::type::cross(AB, AC);
+        }
+        else
+        {
+            N2 = sofa::type::cross(AB, AC).norm2();
+        }
+
+        if (N2 > EQUALITY_THRESHOLD || N2 < 0.0f)
+            return false;
+
+
+        // 2. check if point is between {n0; n1}
+        const auto Ln0p0 = sofa::type::dot(AB, AC);
+        const auto Ln0n1 = sofa::type::dot(AB, AB);
+
+        if (Ln0p0 < 0.0f || Ln0p0 > Ln0n1) // out of bounds [n0; n1]
+            return false;
+        else if (Ln0n1 < EQUALITY_THRESHOLD) // null edge
+            return false;
+        else
+            return true;
+    }
+
+
+    /**
     * @brief	Compute the intersection between a plane (defined by a point and a normal) and the Edge (n0, n1)
     * @tparam   Node iterable container
     * @tparam   T scalar

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -135,10 +135,23 @@ struct Edge
     >
         static constexpr bool isPointOnEdge(const Node& p0, const Node& n0, const Node& n1)
     {
-        // 1. check if the point, n0 and n1 are aligned
+        static_assert(std::is_same_v < Node, sofa::type::Vec<2, T> > || std::is_same_v < Node, sofa::type::Vec<3, T> >,
+            "Method to check if point is on Edge can only be computed in 2 or 3 dimensions.");
+        
+        // 1. check if point is between {n0; n1}
         const auto AB = n0 - n1;
         const auto AC = n0 - p0;
+        
+        const auto Ln0n1 = sofa::type::dot(AB, AB);
+        if (Ln0n1 < EQUALITY_THRESHOLD) // null edge
+            return false;
 
+        const auto Ln0p0 = sofa::type::dot(AB, AC);
+        if (Ln0p0 < 0 || Ln0p0 > Ln0n1) // out of bounds [n0; n1]
+            return false;
+
+
+        // 2. check if the point, n0 and n1 are aligned
         T N2 = T(0);
         if constexpr (std::is_same_v < Node, sofa::type::Vec<2, T> >)
         {            
@@ -149,20 +162,10 @@ struct Edge
             N2 = sofa::type::cross(AB, AC).norm2();
         }
 
-        if (N2 > EQUALITY_THRESHOLD || N2 < 0.0f)
+        if (N2 > EQUALITY_THRESHOLD || N2 < 0)
             return false;
-
-
-        // 2. check if point is between {n0; n1}
-        const auto Ln0p0 = sofa::type::dot(AB, AC);
-        const auto Ln0n1 = sofa::type::dot(AB, AB);
-
-        if (Ln0p0 < 0.0f || Ln0p0 > Ln0n1) // out of bounds [n0; n1]
-            return false;
-        else if (Ln0n1 < EQUALITY_THRESHOLD) // null edge
-            return false;
-        else
-            return true;
+        
+        return true;
     }
 
 

--- a/Sofa/framework/Geometry/test/Edge_test.cpp
+++ b/Sofa/framework/Geometry/test/Edge_test.cpp
@@ -230,6 +230,91 @@ TEST(GeometryEdge_test, pointBaryCoefs3f)
 }
 
 
+TEST(GeometryEdge_test, isPointOnEdge2f)
+{
+    const sofa::type::Vec2f a1{ 0.f, 0.f };
+    const sofa::type::Vec2f b1{ 2.f, 2.f };
+
+    // True case
+    const sofa::type::Vec2f p1{ 1.f, 1.f };
+    const auto res1 = sofa::geometry::Edge::isPointOnEdge(p1, a1, b1);
+    EXPECT_TRUE(res1);
+
+    // True case
+    const sofa::type::Vec2f p2{ 0.25f, 0.25f };
+    const auto res2 = sofa::geometry::Edge::isPointOnEdge(p2, a1, b1);
+    EXPECT_TRUE(res2);
+
+    // False case
+    const sofa::type::Vec2f p3{ 1.0f, 0.25f };
+    const auto res3 = sofa::geometry::Edge::isPointOnEdge(p3, a1, b1);
+    EXPECT_FALSE(res3);
+
+
+    //special cases
+    // Edge null
+    const sofa::type::Vec2f c1{ 2.f, 2.f };
+    const auto res4 = sofa::geometry::Edge::isPointOnEdge(p1, b1, c1);
+    EXPECT_FALSE(res4);
+
+    // Point on one Node
+    const auto res5 = sofa::geometry::Edge::isPointOnEdge(b1, a1, b1);
+    EXPECT_TRUE(res5);
+
+    // Point out of Edge borders
+    const sofa::type::Vec2f p4{ -1.0f, -1.0f };
+    const sofa::type::Vec2f p5{ 2.5f, 2.5f };
+    const auto res6 = sofa::geometry::Edge::isPointOnEdge(p4, a1, b1);
+    const auto res7 = sofa::geometry::Edge::isPointOnEdge(p5, a1, b1);
+
+    EXPECT_FALSE(res6);
+    EXPECT_FALSE(res7);
+}
+
+
+TEST(GeometryEdge_test, isPointOnEdge3f)
+{
+    const sofa::type::Vec3f a1{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b1{ 2.f, 2.f, 2.f };
+
+    // True case
+    const sofa::type::Vec3f p1{ 1.f, 1.f, 1.f };
+    const auto res1 = sofa::geometry::Edge::isPointOnEdge(p1, a1, b1);
+    EXPECT_TRUE(res1);
+
+    // True case
+    const sofa::type::Vec3f p2{ 0.25f, 0.25f, 0.25f };
+    const auto res2 = sofa::geometry::Edge::isPointOnEdge(p2, a1, b1);
+    EXPECT_TRUE(res2);
+
+    // False case
+    const sofa::type::Vec3f p3{ 1.0f, 0.25f, 0.25f };
+    const auto res3 = sofa::geometry::Edge::isPointOnEdge(p3, a1, b1);
+    EXPECT_FALSE(res3);
+
+
+    //special cases
+    // Edge null
+    const sofa::type::Vec3f c1{ 2.f, 2.f, 2.f };
+    const auto res4 = sofa::geometry::Edge::isPointOnEdge(p1, b1, c1);
+    EXPECT_FALSE(res4);
+
+    // Point on one Node
+    const auto res5 = sofa::geometry::Edge::isPointOnEdge(b1, a1, b1);
+    EXPECT_TRUE(res5);
+
+    // Point out of Edge borders
+    const sofa::type::Vec3f p4{ -1.0f, -1.0f, -1.0f };
+    const sofa::type::Vec3f p5{ 2.5f, 2.5f, 2.5f };
+    const auto res6 = sofa::geometry::Edge::isPointOnEdge(p4, a1, b1);
+    const auto res7 = sofa::geometry::Edge::isPointOnEdge(p5, a1, b1);
+
+    EXPECT_FALSE(res6);
+    EXPECT_FALSE(res7);
+}
+
+
+
 TEST(GeometryEdge_test, intersectionWithPlane3f)
 {
     const sofa::type::Vec3f a1{ 0.f, 0.f, 0.f };


### PR DESCRIPTION
- Update EdgeSetTopologyContainer to use this new version. The old code was not working in several tricky cases.
- Add unit tests



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
