### PR TITLE
[Geometry] Add methods getBarycentricCoordinates and isPointInTriangle in Triangle class

### DIFF
--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -103,9 +103,10 @@ struct Triangle
         baryCoefs[2] = T(1) - baryCoefs[0] - baryCoefs[1];
         std::cout << "baryCoefs: " << baryCoefs << std::endl;
 
-        if (abs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon())
+        if (abs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon()){
             baryCoefs[2] = 0;
-
+            std::cout << "abs(baryCoefs[2]): " << abs(baryCoefs[2]) << std::endl;
+        }
         std::cout << "baryCoefs after: " << baryCoefs << " | " << std::numeric_limits<T>::epsilon() << std::endl;
         
         return baryCoefs;

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -100,14 +100,11 @@ struct Triangle
         sofa::type::Vec<3, T> baryCoefs(type::NOINIT);
         baryCoefs[0] = A0 / area;
         baryCoefs[1] = A1 / area;
-        baryCoefs[2] = T(1) - baryCoefs[0] - baryCoefs[1];
-        std::cout << "baryCoefs: " << baryCoefs << std::endl;
+        baryCoefs[2] = 1 - baryCoefs[0] - baryCoefs[1];
 
-        if (abs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon()){
+        if (fabs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon()){
             baryCoefs[2] = 0;
-            std::cout << "abs(baryCoefs[2]): " << abs(baryCoefs[2]) << std::endl;
         }
-        std::cout << "baryCoefs after: " << baryCoefs << " | " << std::numeric_limits<T>::epsilon() << std::endl;
         
         return baryCoefs;
     }

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -100,7 +100,7 @@ struct Triangle
         sofa::type::Vec<3, T> baryCoefs(type::NOINIT);
         baryCoefs[0] = A0 / area;
         baryCoefs[1] = A1 / area;
-        baryCoefs[2] = 1 - baryCoefs[0] - baryCoefs[1];
+        baryCoefs[2] = T(1) - baryCoefs[0] - baryCoefs[1];
 
         if (abs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon())
             baryCoefs[2] = 0;

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -88,20 +88,23 @@ struct Triangle
     {
         // Point can be written: p0 = a*n0 + b*n1 + c*n2
         // with a = area(n1n2p0)/area(n0n1n2), b = area(n0n2p0)/area(n0n1n2) and c = area(n0n1p0)/area(n0n1n2) 
-        sofa::type::Vec<3, T> baryCoefs;
         const auto area = Triangle::area(n0, n1, n2);
-        if (area < std::numeric_limits<T>::epsilon()) // triangle is flat
+        if (abs(area) < std::numeric_limits<T>::epsilon()) // triangle is flat
         {
-            return sofa::type::Vec<3, T>(1/3, 1/3, 1/3);
+            return sofa::type::Vec<3, T>(-1, -1, -1);
         }
         
         const auto A0 = Triangle::area(n1, n2, p0);
         const auto A1 = Triangle::area(n0, p0, n2);
 
+        sofa::type::Vec<3, T> baryCoefs(type::NOINIT);
         baryCoefs[0] = A0 / area;
         baryCoefs[1] = A1 / area;
         baryCoefs[2] = 1 - baryCoefs[0] - baryCoefs[1];
 
+        if (abs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon())
+            baryCoefs[2] = 0;
+        
         return baryCoefs;
     }
 

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -89,7 +89,7 @@ struct Triangle
         // Point can be written: p0 = a*n0 + b*n1 + c*n2
         // with a = area(n1n2p0)/area(n0n1n2), b = area(n0n2p0)/area(n0n1n2) and c = area(n0n1p0)/area(n0n1n2) 
         const auto area = Triangle::area(n0, n1, n2);
-        if (abs(area) < std::numeric_limits<T>::epsilon()) // triangle is flat
+        if (fabs(area) < std::numeric_limits<T>::epsilon()) // triangle is flat
         {
             return sofa::type::Vec<3, T>(-1, -1, -1);
         }

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -160,9 +160,9 @@ struct Triangle
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
-        static constexpr bool isPointInTriangle(const Node& p0, const Node& n0, const Node& n1, const Node& n2)
+        static constexpr bool isPointInTriangle(const Node& p0, const Node& n0, const Node& n1, const Node& n2, sofa::type::Vec<3, T>& baryCoefs)
     {
-        const sofa::type::Vec<3, T> baryCoefs = Triangle::pointBaryCoefs(p0, n0, n1, n2);
+        baryCoefs = Triangle::pointBaryCoefs(p0, n0, n1, n2);
 
         for (int i = 0; i < 3; ++i)
         {

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -105,6 +105,8 @@ struct Triangle
 
         if (abs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon())
             baryCoefs[2] = 0;
+
+        std::cout << "baryCoefs after: " << baryCoefs << " | " << std::numeric_limits<T>::epsilon() << std::endl;
         
         return baryCoefs;
     }

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -73,18 +73,18 @@ struct Triangle
 
 
     /**
-    * @brief	Compute the barycentric coefficients of the input point according to the Triangle vertices: (n0, n1, n2)
+    * @brief	Compute the barycentric coordinates of the input point in the Triangle. It can be interpreted as masses placed at the vertices of Triangle (n0, n1, n2), such that the point is the center of mass of these masses.
     * @tparam   Node iterable container
     * @tparam   T scalar
     * @param	p0: position of the input point to compute the coefficients
     * @param	n0, n1, n2: nodes of the triangle
-    * @return	sofa::type::Vec<3, T> barycentric coefficients 
+    * @return	sofa::type::Vec<3, T> barycentric coefficients of each vertex of the Triangle. These masses can be zero or negative; they are all positive if and only if the point is inside the Triangle. 
     */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
-        static constexpr auto pointBaryCoefs(const Node& p0, const Node& n0, const Node& n1, const Node& n2)
+        static constexpr auto getBarycentricCoordinates(const Node& p0, const Node& n0, const Node& n1, const Node& n2)
     {
         // Point can be written: p0 = a*n0 + b*n1 + c*n2
         // with a = area(n1n2p0)/area(n0n1n2), b = area(n0n2p0)/area(n0n1n2) and c = area(n0n1p0)/area(n0n1n2) 
@@ -150,12 +150,12 @@ struct Triangle
 
 
     /**
-    * @brief	Test if input point is inside Triangle (n0, n1, n2)
+    * @brief	Test if input point is inside Triangle (n0, n1, n2) using Triangle @sa getBarycentricCoordinates . The point is inside the Triangle if and only if Those coordinates are all positive.
     * @tparam   Node iterable container
     * @tparam   T scalar
     * @param	p0: position of the point to test
     * @param	n0, n1, n2: nodes of the triangle
-    * @param	output parameter: sofa::type::Vec<3, T> barycentric coefficients of the input point in Triangle
+    * @param	output parameter: sofa::type::Vec<3, T> barycentric coordinates of the input point in Triangle
     * @return	bool result if point is inside Triangle.
     */
     template<typename Node,
@@ -164,7 +164,7 @@ struct Triangle
     >
         static constexpr bool isPointInTriangle(const Node& p0, const Node& n0, const Node& n1, const Node& n2, sofa::type::Vec<3, T>& baryCoefs)
     {
-        baryCoefs = Triangle::pointBaryCoefs(p0, n0, n1, n2);
+        baryCoefs = Triangle::getBarycentricCoordinates(p0, n0, n1, n2);
 
         for (int i = 0; i < 3; ++i)
         {

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -101,6 +101,7 @@ struct Triangle
         baryCoefs[0] = A0 / area;
         baryCoefs[1] = A1 / area;
         baryCoefs[2] = T(1) - baryCoefs[0] - baryCoefs[1];
+        std::cout << "baryCoefs: " << baryCoefs << std::endl;
 
         if (abs(baryCoefs[2]) <= std::numeric_limits<T>::epsilon())
             baryCoefs[2] = 0;

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -73,12 +73,12 @@ struct Triangle
 
 
     /**
-    * @brief	Compute the barycentric coefficients of input point on Edge (n0, n1)
+    * @brief	Compute the barycentric coefficients of the input point according to the Triangle vertices: (n0, n1, n2)
     * @tparam   Node iterable container
     * @tparam   T scalar
-    * @param	point: position of the point to compute the coefficients
-    * @param	n0,n1: nodes of the edge
-    * @return	sofa::type::Vec<2, T> barycentric coefficients
+    * @param	p0: position of the input point to compute the coefficients
+    * @param	n0, n1, n2: nodes of the triangle
+    * @return	sofa::type::Vec<3, T> barycentric coefficients 
     */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
@@ -149,12 +149,13 @@ struct Triangle
 
 
     /**
-    * @brief	Test if a point is on Edge (n0, n1)
+    * @brief	Test if input point is inside Triangle (n0, n1, n2)
     * @tparam   Node iterable container
     * @tparam   T scalar
     * @param	p0: position of the point to test
-    * @param	n0,n1: nodes of the edge
-    * @return	bool result if point is on Edge.
+    * @param	n0, n1, n2: nodes of the triangle
+    * @param	output parameter: sofa::type::Vec<3, T> barycentric coefficients of the input point in Triangle
+    * @return	bool result if point is inside Triangle.
     */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,

--- a/Sofa/framework/Geometry/test/Triangle_test.cpp
+++ b/Sofa/framework/Geometry/test/Triangle_test.cpp
@@ -142,7 +142,6 @@ TYPED_TEST(GeometryVec2DTriangle_test, isPointInTriangle)
     //// point inside
     TypeParam p0{ 1.5, 0.5 };
     auto res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
-    std::cout << "bary: " << bary << std::endl;
     EXPECT_TRUE(res);
     EXPECT_FLOAT_EQ(float(bary[0]), 0.25f);
     EXPECT_FLOAT_EQ(float(bary[1]), 0.5f);
@@ -153,9 +152,9 @@ TYPED_TEST(GeometryVec2DTriangle_test, isPointInTriangle)
     const auto bVal = float(1.f / 3.f);
     res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
     EXPECT_TRUE(res);
-    EXPECT_NEAR(bary[0], 0.3333, 1e-4);
-    EXPECT_NEAR(bary[1], 0.3333, 1e-4);
-    EXPECT_NEAR(bary[2], 0.3333, 1e-4);
+    EXPECT_NEAR(bary[0], bVal, 1e-4);
+    EXPECT_NEAR(bary[1], bVal, 1e-4);
+    EXPECT_NEAR(bary[2], bVal, 1e-4);
 
     // on edge
     p0 = { 1., 0. };
@@ -223,9 +222,9 @@ TYPED_TEST(GeometryVec3DTriangle_test, isPointInTriangle)
     const auto bVal = float(1.f / 3.f);
     res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
     EXPECT_TRUE(res);
-    EXPECT_NEAR(bary[0], 0.3333, 1e-4);
-    EXPECT_NEAR(bary[1], 0.3333, 1e-4);
-    EXPECT_NEAR(bary[2], 0.3333, 1e-4);
+    EXPECT_NEAR(bary[0], bVal, 1e-4);
+    EXPECT_NEAR(bary[1], bVal, 1e-4);
+    EXPECT_NEAR(bary[2], bVal, 1e-4);
 
     // on edge
     p0 = { 1., 1., 1. };

--- a/Sofa/framework/Geometry/test/Triangle_test.cpp
+++ b/Sofa/framework/Geometry/test/Triangle_test.cpp
@@ -142,6 +142,7 @@ TYPED_TEST(GeometryVec2DTriangle_test, isPointInTriangle)
     //// point inside
     TypeParam p0{ 1.5, 0.5 };
     auto res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    std::cout << "bary: " << bary << std::endl;
     EXPECT_TRUE(res);
     EXPECT_FLOAT_EQ(float(bary[0]), 0.25f);
     EXPECT_FLOAT_EQ(float(bary[1]), 0.5f);

--- a/Sofa/framework/Geometry/test/Triangle_test.cpp
+++ b/Sofa/framework/Geometry/test/Triangle_test.cpp
@@ -115,6 +115,67 @@ TYPED_TEST(Geometry3DTriangle_test, normal)
     EXPECT_FLOAT_EQ(normal[2], 0.f);
 }
 
+
+TEST(GeometryTriangle_test, isPointInTriangle2)
+{
+    const sofa::type::Vec2 a{ 0., 0. };
+    const sofa::type::Vec2 b{ 2., 0. };
+    const sofa::type::Vec2 c{ 2., 2. };
+    sofa::type::Vec3 bary;
+
+    sofa::type::Vec2 p0{ 1., 0.5 };
+    auto res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
+    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    EXPECT_TRUE(res);
+    EXPECT_FLOAT_EQ(bary[0], 0.5f);
+    EXPECT_FLOAT_EQ(bary[1], 0.25f);
+    EXPECT_FLOAT_EQ(bary[2], 0.25f);
+
+    p0 = { 1., 1. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
+    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    EXPECT_TRUE(res);
+    EXPECT_FLOAT_EQ(bary[0], 1.0f);
+    EXPECT_FLOAT_EQ(bary[1], 0.5f);
+    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+
+    p0 = { 2., 0. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
+    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    EXPECT_TRUE(res);
+    EXPECT_FLOAT_EQ(bary[0], 1.0f);
+    EXPECT_FLOAT_EQ(bary[1], 0.5f);
+    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+
+
+    p0 = { 0., 4. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
+    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    EXPECT_FALSE(res);
+    EXPECT_FLOAT_EQ(bary[0], 1.0f);
+    EXPECT_FLOAT_EQ(bary[1], 0.5f);
+    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+
+    p0 = { 2.1, 2.1 };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
+    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    EXPECT_FALSE(res);
+    EXPECT_FLOAT_EQ(bary[0], 1.0f);
+    EXPECT_FLOAT_EQ(bary[1], 0.5f);
+    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+
+
+    const sofa::type::Vec2 d{ 3., 0. };
+    p0 = { 2.5, 0. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, d);
+    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, d);
+    EXPECT_FALSE(res);
+    EXPECT_FLOAT_EQ(bary[0], 1.0f);
+    EXPECT_FLOAT_EQ(bary[1], 0.5f);
+    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+}
+
+
 TEST(GeometryTriangle_test, rayIntersectionVec3)
 {
     const sofa::type::Vec3 a{ 0., 3., 0. };

--- a/Sofa/framework/Geometry/test/Triangle_test.cpp
+++ b/Sofa/framework/Geometry/test/Triangle_test.cpp
@@ -39,6 +39,15 @@ class Geometry3DTriangle_test : public ::testing::Test
 {
 };
 
+template <typename VecType>
+class GeometryVec2DTriangle_test : public ::testing::Test
+{
+};
+template <typename VecType>
+class GeometryVec3DTriangle_test : public ::testing::Test
+{
+};
+
 using Vec2Types = ::testing::Types <
     std::array<float, 2>, sofa::type::fixed_array<float, 2>, sofa::type::Vec < 2, float >,
     std::array<double, 2>, sofa::type::fixed_array<double, 2>, sofa::type::Vec < 2, double >>;
@@ -49,6 +58,13 @@ using Vec3Types = ::testing::Types <
     std::array<double, 3>, sofa::type::fixed_array<double, 3>, sofa::type::Vec < 3, double >>;
 TYPED_TEST_SUITE(Geometry3DTriangle_test, Vec3Types);
 
+using SofaVec2Types = ::testing::Types <sofa::type::Vec < 2, float >, sofa::type::Vec < 2, double > >;
+TYPED_TEST_SUITE(GeometryVec2DTriangle_test, SofaVec2Types);
+
+using SofaVec3Types = ::testing::Types <sofa::type::Vec < 3, float >, sofa::type::Vec < 3, double > >;
+TYPED_TEST_SUITE(GeometryVec3DTriangle_test, SofaVec3Types);
+
+
 
 TYPED_TEST(Geometry2DTriangle_test, area)
 {
@@ -58,7 +74,7 @@ TYPED_TEST(Geometry2DTriangle_test, area)
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
 
-    EXPECT_FLOAT_EQ(testArea, 12.5f);
+    EXPECT_FLOAT_EQ(float(testArea), 12.5f);
 }
 
 TYPED_TEST(Geometry3DTriangle_test, area)
@@ -68,7 +84,7 @@ TYPED_TEST(Geometry3DTriangle_test, area)
     const TypeParam c{ 2.f, -3.f, 4.f };
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
-    EXPECT_FLOAT_EQ(testArea, 19.306734f);
+    EXPECT_FLOAT_EQ(float(testArea), 19.306734f);
 }
 
 TYPED_TEST(Geometry2DTriangle_test, flat_area)
@@ -78,7 +94,7 @@ TYPED_TEST(Geometry2DTriangle_test, flat_area)
     const TypeParam c{ 0.f, 1.f };
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
-    EXPECT_FLOAT_EQ(testArea, 0.f);
+    EXPECT_FLOAT_EQ(testArea, 0);
 }
 
 TYPED_TEST(Geometry3DTriangle_test, flat_area)
@@ -88,7 +104,7 @@ TYPED_TEST(Geometry3DTriangle_test, flat_area)
     const TypeParam c{ 0.f, 1.f, 0.f };
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
-    EXPECT_FLOAT_EQ(testArea, 0.f);
+    EXPECT_EQ(testArea, 0);
 }
 
 
@@ -98,11 +114,11 @@ TYPED_TEST(Geometry3DTriangle_test, normal)
     const TypeParam a{ 0.f, 0.f, 0.f };
     const TypeParam b{ 0.f, 2.f, 0.f };
     const TypeParam c{ 0.f, 0.f, 2.f };
-
+    
     auto normal = sofa::geometry::Triangle::normal(a, b, c);
-    EXPECT_FLOAT_EQ(normal[0], 4.f);
-    EXPECT_FLOAT_EQ(normal[1], 0.f);
-    EXPECT_FLOAT_EQ(normal[2], 0.f);
+    EXPECT_FLOAT_EQ(float(normal[0]), 4.f);
+    EXPECT_FLOAT_EQ(float(normal[1]), 0.f);
+    EXPECT_FLOAT_EQ(float(normal[2]), 0.f);
 
     // flat triangle case
     const TypeParam a2{ 0.f, 0.f, 0.f };
@@ -110,69 +126,149 @@ TYPED_TEST(Geometry3DTriangle_test, normal)
     const TypeParam c2{ 0.f, 1.f, 0.f };
     
     normal = sofa::geometry::Triangle::normal(a2, b2, c2);
-    EXPECT_FLOAT_EQ(normal[0], 0.f);
-    EXPECT_FLOAT_EQ(normal[1], 0.f);
-    EXPECT_FLOAT_EQ(normal[2], 0.f);
+    EXPECT_FLOAT_EQ(float(normal[0]), 0.f);
+    EXPECT_FLOAT_EQ(float(normal[1]), 0.f);
+    EXPECT_FLOAT_EQ(float(normal[2]), 0.f);
 }
 
 
-TEST(GeometryTriangle_test, isPointInTriangle2)
+TYPED_TEST(GeometryVec2DTriangle_test, isPointInTriangle)
 {
-    const sofa::type::Vec2 a{ 0., 0. };
-    const sofa::type::Vec2 b{ 2., 0. };
-    const sofa::type::Vec2 c{ 2., 2. };
+    const TypeParam a{ 0., 0. };
+    const TypeParam b{ 2., 0. };
+    const TypeParam c{ 2., 2. };
     sofa::type::Vec3 bary;
 
-    sofa::type::Vec2 p0{ 1., 0.5 };
-    auto res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
-    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    //// point inside
+    TypeParam p0{ 1.5, 0.5 };
+    auto res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
     EXPECT_TRUE(res);
-    EXPECT_FLOAT_EQ(bary[0], 0.5f);
-    EXPECT_FLOAT_EQ(bary[1], 0.25f);
-    EXPECT_FLOAT_EQ(bary[2], 0.25f);
+    EXPECT_FLOAT_EQ(float(bary[0]), 0.25f);
+    EXPECT_FLOAT_EQ(float(bary[1]), 0.5f);
+    EXPECT_FLOAT_EQ(float(bary[2]), 0.25f);
 
-    p0 = { 1., 1. };
-    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
-    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    // barycenter
+    p0 = { 4./3., 2./3. };
+    const auto bVal = float(1.f / 3.f);
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
     EXPECT_TRUE(res);
-    EXPECT_FLOAT_EQ(bary[0], 1.0f);
-    EXPECT_FLOAT_EQ(bary[1], 0.5f);
-    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+    EXPECT_NEAR(bary[0], 0.3333, 1e-4);
+    EXPECT_NEAR(bary[1], 0.3333, 1e-4);
+    EXPECT_NEAR(bary[2], 0.3333, 1e-4);
 
+    // on edge
+    p0 = { 1., 0. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    EXPECT_TRUE(res);
+    EXPECT_NEAR(bary[0], 0.5f, 1e-4);
+    EXPECT_NEAR(bary[1], 0.5f, 1e-4);
+    EXPECT_NEAR(bary[2], 0.0f, 1e-4);
+
+    // on corner
     p0 = { 2., 0. };
-    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
-    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
     EXPECT_TRUE(res);
-    EXPECT_FLOAT_EQ(bary[0], 1.0f);
-    EXPECT_FLOAT_EQ(bary[1], 0.5f);
-    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+    EXPECT_FLOAT_EQ(float(bary[0]), 0.0f);
+    EXPECT_FLOAT_EQ(float(bary[1]), 1.0f);
+    EXPECT_FLOAT_EQ(float(bary[2]), 0.0f);
 
-
-    p0 = { 0., 4. };
-    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
-    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+    // False case
+    p0 = { 4., 10. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
     EXPECT_FALSE(res);
-    EXPECT_FLOAT_EQ(bary[0], 1.0f);
-    EXPECT_FLOAT_EQ(bary[1], 0.5f);
-    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+    EXPECT_NEAR(bary[0], -1.0f, 1e-4);
+    EXPECT_NEAR(bary[1], -3.0f, 1e-4);
+    EXPECT_NEAR(bary[2], 5.0f, 1e-4);
 
-    p0 = { 2.1, 2.1 };
-    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c);
-    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, c);
+
+    // Special cases
+    // flat triangle
+    const TypeParam d{ 1., 0. };
+    p0 = { 0.5, 0. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, d, bary);
     EXPECT_FALSE(res);
-    EXPECT_FLOAT_EQ(bary[0], 1.0f);
-    EXPECT_FLOAT_EQ(bary[1], 0.5f);
-    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+    EXPECT_EQ(bary[0], -1);
+    EXPECT_EQ(bary[1], -1);
+    EXPECT_EQ(bary[2], -1);
 
-
-    const sofa::type::Vec2 d{ 3., 0. };
-    p0 = { 2.5, 0. };
-    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, d);
-    bary = sofa::geometry::Triangle::pointBaryCoefs(p0, a, b, d);
+    //special False cases along edge
+    p0 = { 3., 3. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
     EXPECT_FALSE(res);
-    EXPECT_FLOAT_EQ(bary[0], 1.0f);
-    EXPECT_FLOAT_EQ(bary[1], 0.5f);
-    EXPECT_FLOAT_EQ(bary[2], 0.5f);
+    EXPECT_NEAR(bary[0], -0.5f, 1e-4);
+    EXPECT_NEAR(bary[1], 0.f, 1e-4);
+    EXPECT_NEAR(bary[2], 1.5f, 1e-4);
+}
+
+
+TYPED_TEST(GeometryVec3DTriangle_test, isPointInTriangle)
+{
+    const TypeParam a{ 0., 0., 0. };
+    const TypeParam b{ 2., 0., 2. };
+    const TypeParam c{ 0., 2., 0. };
+    
+    sofa::type::Vec3 bary;
+
+    // point inside
+    TypeParam p0{ 0.5, 0.5, 0.5 };
+    auto res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    EXPECT_TRUE(res);
+    EXPECT_NEAR(bary[0], 0.5f, 1e-4);
+    EXPECT_NEAR(bary[1], 0.25f, 1e-4);
+    EXPECT_NEAR(bary[2], 0.25f, 1e-4);
+
+    // barycenter
+    p0 = { 2. / 3., 2. / 3. , 2. / 3. };
+    const auto bVal = float(1.f / 3.f);
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    EXPECT_TRUE(res);
+    EXPECT_NEAR(bary[0], 0.3333, 1e-4);
+    EXPECT_NEAR(bary[1], 0.3333, 1e-4);
+    EXPECT_NEAR(bary[2], 0.3333, 1e-4);
+
+    // on edge
+    p0 = { 1., 1., 1. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    EXPECT_TRUE(res);
+    EXPECT_NEAR(bary[0], 0.f, 1e-4);
+    EXPECT_NEAR(bary[1], 0.5f, 1e-4);
+    EXPECT_NEAR(bary[2], 0.5f, 1e-4);
+
+    // on corner
+    p0 = { 0., 2., 0. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    EXPECT_TRUE(res);
+    EXPECT_EQ(bary[0], 0);
+    EXPECT_EQ(bary[1], 0);
+    EXPECT_EQ(bary[2], 1);
+
+    // False cases
+    // out of plan
+    p0 = { 1., 0.2, 0.2 };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    EXPECT_FALSE(res);
+    EXPECT_NEAR(bary[0], 0.69282, 1e-4);
+    EXPECT_NEAR(bary[1], 0.360555, 1e-4);
+    EXPECT_NEAR(bary[2], -0.0533754, 1e-4);
+
+    // in plan but out of triangle
+    p0 = { 2., 2., 2. };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, c, bary);
+    EXPECT_FALSE(res);
+    EXPECT_EQ(bary[0], 1);
+    EXPECT_EQ(bary[1], 1);
+    EXPECT_EQ(bary[2], -1);
+
+
+    // Special cases
+    // flat triangle
+    const TypeParam d{ 1., 0., 1. };
+    p0 = { 0.5, 0., 0.5 };
+    res = sofa::geometry::Triangle::isPointInTriangle(p0, a, b, d, bary);
+    EXPECT_FALSE(res);
+    EXPECT_EQ(bary[0], -1);
+    EXPECT_EQ(bary[1], -1);
+    EXPECT_EQ(bary[2], -1);
 }
 
 


### PR DESCRIPTION
Add method:
- pointBaryCoefs to Compute the barycentric coefficients of input point in the current Triangle
- method isPointInTriangle  using the barycentric coefficients
- Add unit tests with positive and negative cases



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
