### PR TITLE
[LinearAlgebra] Fix matrix sizes when filtering

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.cpp
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.cpp
@@ -70,8 +70,8 @@ void CompressedRowSparseMatrixMechanical<double>::filterValues(CompressedRowSpar
     M.compress();
     nRow = M.rowSize();
     nCol = M.colSize();
-    nBlockRow = 1;
-    nBlockCol = 1;
+    nBlockRow = M.rowSize();
+    nBlockCol = M.colSize();
     rowIndex.clear();
     rowBegin.clear();
     colsIndex.clear();
@@ -135,8 +135,8 @@ void CompressedRowSparseMatrixMechanical<double>::filterValues(CompressedRowSpar
     M.compress();
     nRow = M.rowSize();
     nCol = M.colSize();
-    nBlockRow = 1;
-    nBlockCol = 1;
+    nBlockRow = M.rowSize();
+    nBlockCol = M.colSize();
     rowIndex.clear();
     rowBegin.clear();
     colsIndex.clear();
@@ -200,8 +200,8 @@ void CompressedRowSparseMatrixMechanical<float>::filterValues(CompressedRowSpars
     M.compress();
     nRow = M.rowSize();
     nCol = M.colSize();
-    nBlockRow = 1;
-    nBlockCol = 1;
+    nBlockRow = M.rowSize();
+    nBlockCol = M.colSize();
     rowIndex.clear();
     rowBegin.clear();
     colsIndex.clear();

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
@@ -511,6 +511,8 @@ public:
         M.compress();
         this->nBlockRow = M.rowBSize();
         this->nBlockCol = M.colBSize();
+        this->nRow = M.rowSize();
+        this->nCol = M.colSize();
         this->rowIndex.clear();
         this->rowBegin.clear();
         this->colsIndex.clear();

--- a/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrix_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrix_test.cpp
@@ -218,3 +218,33 @@ TEST(CompressedRowSparseMatrix, fullRowsWithEntries)
     EXPECT_NO_THROW(A.fullRows());
     EXPECT_EQ(A.getRowIndex().size(), 1321);
 }
+
+
+TEST(CompressedRowSparseMatrix, copyNonZeros)
+{
+    sofa::linearalgebra::CompressedRowSparseMatrix<SReal> A;
+    generateMatrix(A, 1321, 3556, 0.0003, 12);
+
+    const auto numberNonZeroValues1 = A.colsValue.size();
+
+    A.add(23, 569, 0);
+    A.add(874, 326, 0);
+    A.add(769, 1789, 0);
+    A.compress();
+
+    const auto numberNonZeroValues2 = A.colsValue.size();
+    EXPECT_GT(numberNonZeroValues2, numberNonZeroValues1);
+
+    sofa::linearalgebra::CompressedRowSparseMatrix<SReal> B;
+
+    B.copyNonZeros(A);
+    const auto numberNonZeroValues3 = B.colsValue.size();
+
+    EXPECT_EQ(B.rowBSize(), A.rowBSize());
+    EXPECT_EQ(B.colBSize(), A.colBSize());
+
+    EXPECT_EQ(B.rowSize(), A.rowSize());
+    EXPECT_EQ(B.colSize(), A.colSize());
+
+    EXPECT_EQ(numberNonZeroValues1, numberNonZeroValues3);
+}


### PR DESCRIPTION
When applying a filter when copying from a matrix to another, the matrix size was not appropriately set.

The introduced unit test would fail without the fix.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
