### PR TITLE
[plugins] Fix OptionGroup deprecated constructor in image and SofaCUDA plugin

### DIFF
--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.h
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.h
@@ -335,11 +335,11 @@ public:
 
     void initPtrData(Main* m)
     {
-        m->_gatherPt.beginEdit()->setNames(3,"1","4","8");
+        m->_gatherPt.beginEdit()->setNames({"1","4","8"});
         m->_gatherPt.beginEdit()->setSelectedItem("8");
         m->_gatherPt.endEdit();
 
-        m->_gatherBsize.beginEdit()->setNames(4,"32","64","128","256");
+        m->_gatherBsize.beginEdit()->setNames({"32","64","128","256"});
         m->_gatherBsize.beginEdit()->setSelectedItem("256");
         m->_gatherBsize.endEdit();
     }

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.h
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.h
@@ -257,11 +257,11 @@ public:
 
     void initPtrData(Main* m)
     {
-        m->_gatherPt.beginEdit()->setNames(3,"1","4","8");
+        m->_gatherPt.beginEdit()->setNames({"1","4","8"});
         m->_gatherPt.beginEdit()->setSelectedItem("8");
         m->_gatherPt.endEdit();
 
-        m->_gatherBsize.beginEdit()->setNames(4,"32","64","128","256");
+        m->_gatherBsize.beginEdit()->setNames({"32","64","128","256"});
         m->_gatherBsize.beginEdit()->setSelectedItem("256");
         m->_gatherBsize.endEdit();
     }

--- a/applications/plugins/image/ImageCoordValuesFromPositions.h
+++ b/applications/plugins/image/ImageCoordValuesFromPositions.h
@@ -186,7 +186,7 @@ public:
       , addPosition(initData(&addPosition,true,"addPosition","add positions to interpolated values (to get translated positions)"))
       , time((unsigned int)0)
     {
-        helper::OptionsGroup InterpolationOptions(3,"Nearest", "Linear", "Cubic");
+        helper::OptionsGroup InterpolationOptions{"Nearest", "Linear", "Cubic"};
         InterpolationOptions.setSelectedItem(INTERPOLATION_LINEAR);
         Interpolation.setValue(InterpolationOptions);
 

--- a/applications/plugins/image/ImageFilter.h
+++ b/applications/plugins/image/ImageFilter.h
@@ -123,7 +123,7 @@ public:
         inputTransform.setReadOnly(true);
         outputImage.setReadOnly(true);
         outputTransform.setReadOnly(true);
-        helper::OptionsGroup filterOptions(30	,"0 - None"
+        helper::OptionsGroup filterOptions{"0 - None"
                                            ,"1 - Blur ( sigma )"
                                            ,"2 - Blur Median ( n )"
                                            ,"3 - Blur Bilateral ( sigma_s, sigma_r)"
@@ -153,7 +153,7 @@ public:
                                            ,"27 - Mirror (axis=0)"
                                            ,"28 - Sharpen (sigma)"
                                            ,"29 - Expand ( size )"
-                                           );
+                                          };
         filterOptions.setSelectedItem(NONE);
         filter.setValue(filterOptions);
     }

--- a/applications/plugins/image/ImageOperation.h
+++ b/applications/plugins/image/ImageOperation.h
@@ -81,13 +81,13 @@ public:
         inputImage1.setReadOnly(true);  this->addAlias(&inputImage1, "image1");
         inputImage2.setReadOnly(true);  this->addAlias(&inputImage2, "image2");
         outputImage.setReadOnly(true);  this->addAlias(&outputImage, "image");
-        helper::OptionsGroup operationOptions(6	,"0 - Addition"
-                                              ,"1 - Subtraction"
-                                              ,"2 - Multiplication"
-                                              ,"3 - Division"
-                                              ,"4 - Dice coefficient"
-                                              ,"5 - Concatenate in two channels"
-                                              );
+        helper::OptionsGroup operationOptions{"0 - Addition"
+                                             ,"1 - Subtraction"
+                                             ,"2 - Multiplication"
+                                             ,"3 - Division"
+                                             ,"4 - Dice coefficient"
+                                             ,"5 - Concatenate in two channels"
+                                             };
         operationOptions.setSelectedItem(SUBTRACTION);
         operation.setValue(operationOptions);
     }

--- a/applications/plugins/image/ImageSampler.h
+++ b/applications/plugins/image/ImageSampler.h
@@ -535,9 +535,9 @@ public:
         transform.setReadOnly(true);
         f_listening.setValue(true);
 
-        helper::OptionsGroup methodOptions(2,"0 - Regular sampling (at voxel center(0) or corners (1)) "
-                                           ,"1 - Uniform sampling using Fast Marching and Lloyd relaxation (nbSamples | bias distances=false | nbiterations=100  | FastMarching(0)/Dijkstra(1)/ParallelMarching(2)=1 | PMM max iter | PMM tolerance)"
-                                           );
+        helper::OptionsGroup methodOptions{"0 - Regular sampling (at voxel center(0) or corners (1)) "
+                                          ,"1 - Uniform sampling using Fast Marching and Lloyd relaxation (nbSamples | bias distances=false | nbiterations=100  | FastMarching(0)/Dijkstra(1)/ParallelMarching(2)=1 | PMM max iter | PMM tolerance)"
+                                          };
         methodOptions.setSelectedItem(REGULAR);
         method.setValue(methodOptions);
 

--- a/applications/plugins/image/ImageTransform.h
+++ b/applications/plugins/image/ImageTransform.h
@@ -78,7 +78,7 @@ public:
 
         f_listening.setValue(true);
 
-        helper::OptionsGroup fluidOptions(3,"No update", "Every time step", "Every draw");
+        helper::OptionsGroup fluidOptions{"No update", "Every time step", "Every draw"};
         _update.setValue(fluidOptions);
     }
 

--- a/applications/plugins/image/ImageValuesFromPositions.h
+++ b/applications/plugins/image/ImageValuesFromPositions.h
@@ -1,24 +1,24 @@
 /******************************************************************************
-*                 SOFA, Simulation Open-Framework Architecture                *
-*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
-*                                                                             *
-* This program is free software; you can redistribute it and/or modify it     *
-* under the terms of the GNU Lesser General Public License as published by    *
-* the Free Software Foundation; either version 2.1 of the License, or (at     *
-* your option) any later version.                                             *
-*                                                                             *
-* This program is distributed in the hope that it will be useful, but WITHOUT *
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
-* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
-* for more details.                                                           *
-*                                                                             *
-* You should have received a copy of the GNU Lesser General Public License    *
-* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
-*******************************************************************************
-* Authors: The SOFA Team and external contributors (see Authors.txt)          *
-*                                                                             *
-* Contact information: contact@sofa-framework.org                             *
-******************************************************************************/
+ *                 SOFA, Simulation Open-Framework Architecture                *
+ *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+ *                                                                             *
+ * This program is free software; you can redistribute it and/or modify it     *
+ * under the terms of the GNU Lesser General Public License as published by    *
+ * the Free Software Foundation; either version 2.1 of the License, or (at     *
+ * your option) any later version.                                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful, but WITHOUT *
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+ * for more details.                                                           *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+ *******************************************************************************
+ * Authors: The SOFA Team and external contributors (see Authors.txt)          *
+ *                                                                             *
+ * Contact information: contact@sofa-framework.org                             *
+ ******************************************************************************/
 #ifndef SOFA_IMAGE_ImageValuesFromPositions_H
 #define SOFA_IMAGE_ImageValuesFromPositions_H
 
@@ -162,7 +162,7 @@ public:
         , outValue(initData(&outValue,(Real)0,"outValue","default value outside image"))
         , time((unsigned int)0)
     {
-        helper::OptionsGroup InterpolationOptions(3,"Nearest", "Linear", "Cubic");
+        helper::OptionsGroup InterpolationOptions{"Nearest", "Linear", "Cubic"};
         InterpolationOptions.setSelectedItem(INTERPOLATION_LINEAR);
         Interpolation.setValue(InterpolationOptions);
 

--- a/applications/plugins/image/ImageValuesFromPositions.h
+++ b/applications/plugins/image/ImageValuesFromPositions.h
@@ -1,24 +1,24 @@
 /******************************************************************************
- *                 SOFA, Simulation Open-Framework Architecture                *
- *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
- *                                                                             *
- * This program is free software; you can redistribute it and/or modify it     *
- * under the terms of the GNU Lesser General Public License as published by    *
- * the Free Software Foundation; either version 2.1 of the License, or (at     *
- * your option) any later version.                                             *
- *                                                                             *
- * This program is distributed in the hope that it will be useful, but WITHOUT *
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
- * for more details.                                                           *
- *                                                                             *
- * You should have received a copy of the GNU Lesser General Public License    *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
- *******************************************************************************
- * Authors: The SOFA Team and external contributors (see Authors.txt)          *
- *                                                                             *
- * Contact information: contact@sofa-framework.org                             *
- ******************************************************************************/
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
 #ifndef SOFA_IMAGE_ImageValuesFromPositions_H
 #define SOFA_IMAGE_ImageValuesFromPositions_H
 

--- a/applications/plugins/image/Kinect.h
+++ b/applications/plugins/image/Kinect.h
@@ -142,19 +142,19 @@ public:
         depthTransform.setGroup("Transform");
         f_listening.setValue(true);  // to update camera during animate
 
-        helper::OptionsGroup opt1(3 ,"320x240" ,"640x480" ,"1280x1024" );
+        helper::OptionsGroup opt1{"320x240" ,"640x480" ,"1280x1024"};
         opt1.setSelectedItem(1);
         resolution.setValue(opt1);
 
-        helper::OptionsGroup opt2(4 ,"RGB" ,"IR_8bits" ,"YUV_RGB" ,"YUV_RAW");
+        helper::OptionsGroup opt2{"RGB" ,"IR_8bits" ,"YUV_RGB" ,"YUV_RAW"};
         opt2.setSelectedItem(0);
         videoMode.setValue(opt2);
 
-        helper::OptionsGroup opt3(2 ,"Raw" ,"Registered" );
+        helper::OptionsGroup opt3{"Raw" ,"Registered"};
         opt3.setSelectedItem(1);
         depthMode.setValue(opt3);
 
-        helper::OptionsGroup opt4(6 ,"Off" ,"Green" ,"Red" ,"Yellow" ,"Blink Green" ,"Blink Yellow");
+        helper::OptionsGroup opt4{"Off" ,"Green" ,"Red" ,"Yellow" ,"Blink Green" ,"Blink Yellow"};
         opt4.setSelectedItem(1);
         ledMode.setValue(opt4);
 

--- a/applications/plugins/image/MergeImages.h
+++ b/applications/plugins/image/MergeImages.h
@@ -106,17 +106,17 @@ public:
         this->addAlias(&image, "outputImage");
         this->addAlias(&transform, "outputTransform");
 
-        helper::OptionsGroup overlapOptions(6	,"0 - Average pixels"
-                ,"1 - Use image order as priority"
-                ,"2 - Alpha blending according to distance from border"
-                ,"3 - Take farthest pixel from border"
-                ,"4 - Add pixels of each images"
-                ,"5 - Set overlapping pixels of the first image to zero (only if the corresponding pixel in the other images different to zero)"
-                                           );
+        helper::OptionsGroup overlapOptions{"0 - Average pixels"
+                                           ,"1 - Use image order as priority"
+                                           ,"2 - Alpha blending according to distance from border"
+                                           ,"3 - Take farthest pixel from border"
+                                           ,"4 - Add pixels of each images"
+                                           ,"5 - Set overlapping pixels of the first image to zero (only if the corresponding pixel in the other images different to zero)"
+                                           };
         overlapOptions.setSelectedItem(ALPHABLEND);
         overlap.setValue(overlapOptions);
 
-        helper::OptionsGroup InterpolationOptions(3,"Nearest", "Linear", "Cubic");
+        helper::OptionsGroup InterpolationOptions{"Nearest", "Linear", "Cubic"};
         InterpolationOptions.setSelectedItem(INTERPOLATION_LINEAR);
         Interpolation.setValue(InterpolationOptions);
     }


### PR DESCRIPTION
The warning/deprecation message from OptionGroup containing the string "error-prone" was bothering me to find the real error in compilation outputs!

I therefore worked on upgrading the SOFA codebase to remove these warnings by replacing the deprecated constructor


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
