### PR TITLE
Revert "[Sofa.Core] minor refactoring for Data::read() to move into BaseData the reading code"

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.cpp
@@ -329,35 +329,6 @@ std::string BaseData::decodeTypeName(const std::type_info& t)
     return sofa::helper::NameDecoder::decodeTypeName(t);
 }
 
-bool BaseData::read(const std::string& s)
-{
-    if (s.empty())
-    {
-        doClear();
-        return true;
-    }
-
-    std::istringstream istr( s.c_str() );
-
-    // capture std::cerr output (if any)
-    std::stringstream cerrbuffer;
-    std::streambuf* old = std::cerr.rdbuf(cerrbuffer.rdbuf());
-
-    doRead(istr);
-
-    // restore the previous cerr
-    std::cerr.rdbuf(old);
-
-    if( istr.fail() )
-    {
-        // transcript the std::cerr buffer into the Messaging system
-        msg_warning(this->getName()) << cerrbuffer.str();
-        return false;
-    }
-
-    return true;
-}
-
 std::ostream& operator<<(std::ostream &out, const sofa::core::objectmodel::BaseData& df)
 {
     out<<df.getValueString();

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
@@ -104,7 +104,7 @@ public:
 
     /// Assign a value to this %Data from a string representation.
     /// \return true on success.
-    virtual bool read(const std::string& value);
+    virtual bool read(const std::string& value) = 0;
 
     /// Print the value of this %Data to a stream.
     virtual void printValue(std::ostream&) const = 0;
@@ -327,9 +327,6 @@ private:
     virtual void* doBeginEditVoidPtr() = 0;
     virtual void doEndEditVoidPtr() = 0;
     virtual void doOnUpdate() {}
-
-    virtual void doClear() = 0;
-    virtual void doRead(std::istringstream& stream) = 0;
 };
 
 /** A WriteAccessWithRawPtr is a RAII class, holding a reference to a given container

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Data.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Data.cpp
@@ -32,33 +32,31 @@ namespace core
 namespace objectmodel
 {
 
+/// Specialization for reading strings
+template<>
+bool SOFA_CORE_API Data<std::string>::read( const std::string& str )
+{
+    setValue(str);
+    return true;
+}
+
 /// Specialization for reading booleans
 template<>
-void  SOFA_CORE_API Data<bool>::doRead( std::istringstream& str )
+bool SOFA_CORE_API Data<bool>::read( const std::string& str )
 {
+    if (str.empty())
+        return false;
     bool val;
-    int c = str.peek();
-    if(c==EOF)
-    {
-        str.setstate(std::ios::failbit);
-        return;
-    }
-
-    if (c == 'T' || c == 't')
+    if (str[0] == 'T' || str[0] == 't')
         val = true;
-    else if (c == 'F' || c == 'f')
+    else if (str[0] == 'F' || str[0] == 'f')
         val = false;
-    else if ((c >= '0' && c <= '9') || c == '-')
-    {
-        int numericValue;
-        str >> numericValue;
-        val = (numericValue != 0);
-    }
-    else{
-        str.setstate(std::ios::failbit);
-        return;
-    }
+    else if ((str[0] >= '0' && str[0] <= '9') || str[0] == '-')
+        val = (atoi(str.c_str()) != 0);
+    else
+        return false;
     setValue(val);
+    return true;
 }
 
 template class SOFA_CORE_API Data< std::string >;

--- a/Sofa/framework/Core/test/objectmodel/BaseData_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseData_test.cpp
@@ -40,15 +40,13 @@ public:
     const void* getValueVoidPtr() const {return nullptr;}
     void* beginEditVoidPtr(){return nullptr;}
     void* beginWriteOnlyVoidPtr(){return nullptr;}
-    void endEditVoidPtr() {}
+    void endEditVoidPtr(){}
     bool doIsExactSameDataType(const BaseData* ) override{ return false; }
     bool doCopyValueFrom(const BaseData* ) override{ return false; }
     bool doSetValueFromLink(const BaseData* ) override{ return false; }
     const void* doGetValueVoidPtr() const override { return nullptr; }
     void* doBeginEditVoidPtr() override { return nullptr; }
-    void doEndEditVoidPtr() override {}
-    void doClear() override {}
-    void doRead(std::istringstream&) override {}
+    void doEndEditVoidPtr() override { }
 };
 
 class MyObject : public BaseObject


### PR DESCRIPTION
Revert #3278 remove un-inded merge. Sorry for the mess






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
