### PR TITLE
[GUI.Qt] Fix crash if filename is null

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -736,7 +736,10 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
         m_saveReloadFile=temporaryFile;
         setTitle ( filename );
 #if(SOFA_GUI_QT_HAVE_QT5_WEBENGINE)
-        m_docbrowser->loadHtml( filename );
+        if (m_docbrowser && filename)
+        {
+            m_docbrowser->loadHtml( filename );
+        }
 #endif
     }
 
@@ -789,7 +792,10 @@ void RealGUI::setScene(Node::SPtr root, const char* filename, bool temporaryFile
     }
     setSceneWithoutMonitor(root, filename, temporaryFile) ;
 #if(SOFA_GUI_QT_HAVE_QT5_WEBENGINE)
-    m_docbrowser->loadHtml( filename ) ;
+    if (m_docbrowser && filename)
+    {
+        m_docbrowser->loadHtml( filename ) ;
+    }
 #endif
 }
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/panels/QDocBrowser.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/panels/QDocBrowser.cpp
@@ -207,7 +207,11 @@ DocBrowser::DocBrowser(RealGUI* g) : QDialog(g)
 
 void DocBrowser::loadHtml(const std::string& filename)
 {
-    const bool showView = true ;
+    if (filename.empty())
+    {
+        return;
+    }
+
     std::string htmlfile = filename ;
     std::string rootdir = FileSystem::getParentDirectory(filename) ;
 
@@ -228,6 +232,8 @@ void DocBrowser::loadHtml(const std::string& filename)
         return;
 
     m_htmlPage->load( QUrl::fromLocalFile(QString(htmlfile.c_str())) );
+
+    constexpr bool showView = true ;
     setVisible(showView);
 }
 


### PR DESCRIPTION
Fixes https://github.com/sofa-framework/sofa/discussions/4100



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
