### PR TITLE
[Constraint.Lagrangian.Correction] Decrease the severity of not finding a file in PrecomputedConstraintCorrection

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -152,7 +152,8 @@ bool PrecomputedConstraintCorrection<DataTypes>::loadCompliance(std::string file
         }
         else if (recompute.getValue() == false)
         {
-            if(sofa::helper::system::DataRepository.findFile(fileName))
+            std::stringstream ss;
+            if (sofa::helper::system::DataRepository.findFile(fileName, "", &ss))
             {
                 invM->data = new Real[nbRows * nbCols];
 
@@ -164,6 +165,11 @@ bool PrecomputedConstraintCorrection<DataTypes>::loadCompliance(std::string file
                 compFileIn.close();
 
                 return true;
+            }
+            else
+            {
+                msg_info() << sofa::helper::removeTrailingCharacters(ss.str(), {'\n', '\r'})
+                    << ". Compliance will be pre-computed and saved into a file";
             }
         }
 

--- a/Sofa/framework/Helper/src/sofa/helper/StringUtils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/StringUtils.cpp
@@ -85,6 +85,25 @@ std::string safeCharToString(const char* c)
     return std::string(c);
 }
 
+std::string_view removeTrailingCharacter(std::string_view sv, char character)
+{
+    auto end = sv.end();
+    while (end != sv.begin() && *(end - 1) == character)
+    {
+        --end;
+    }
+    return sv.substr(0, end - sv.begin());
+}
+
+std::string_view removeTrailingCharacters(std::string_view sv, const std::initializer_list<char> characters)
+{
+    auto end = sv.end();
+    while (end != sv.begin() && std::find(characters.begin(), characters.end(), *(end - 1)) != characters.end())
+    {
+        --end;
+    }
+    return sv.substr(0, end - sv.begin());
+}
 
 } // namespace helper
 

--- a/Sofa/framework/Helper/src/sofa/helper/StringUtils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/StringUtils.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <cstring>
 #include <sofa/helper/StringUtils.h>
+#include <algorithm>
 
 namespace sofa
 {

--- a/Sofa/framework/Helper/src/sofa/helper/StringUtils.h
+++ b/Sofa/framework/Helper/src/sofa/helper/StringUtils.h
@@ -19,19 +19,17 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_HELPER_STRING_UTILS_H
-#define SOFA_HELPER_STRING_UTILS_H
+#pragma once
 
 #include <sofa/helper/config.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
 #include <sstream>
 
-namespace sofa
-{
 
-namespace helper
+namespace sofa::helper
 {
 
 ///@brief Split one string by a given delimiter and returns that into a std::vector
@@ -89,8 +87,10 @@ SOFA_HELPER_API bool ends_with(const std::string& suffix, const std::string& ful
 ///@brief converts a char* string into a c++ string. The special case with nullptr is coerced to an empty string.
 SOFA_HELPER_API std::string safeCharToString(const char* c);
 
-} // namespace helper
+///@brief Removes specified trailing character from a string view
+SOFA_HELPER_API std::string_view removeTrailingCharacter(std::string_view sv, char character);
 
-} // namespace sofa
+///@brief Removes specified trailing characters from a string view.
+SOFA_HELPER_API std::string_view removeTrailingCharacters(std::string_view sv, std::initializer_list<char> characters);
 
-#endif //SOFA_HELPER_STRING_UTILS_H
+} // namespace sofa::helper

--- a/Sofa/framework/Helper/test/CMakeLists.txt
+++ b/Sofa/framework/Helper/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCE_FILES
     KdTree_test.cpp
     NameDecoder_test.cpp
     OptionsGroup_test.cpp
+    StringUtils_test.cpp
     TagFactory_test.cpp
     Utils_test.cpp
     accessor/ReadAccessor.cpp

--- a/Sofa/framework/Helper/test/StringUtils_test.cpp
+++ b/Sofa/framework/Helper/test/StringUtils_test.cpp
@@ -1,0 +1,94 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/StringUtils.h>
+#include <gtest/gtest.h>
+
+namespace sofa
+{
+
+// Test cases for removeTrailingCharacter
+TEST(removeTrailingCharacterTest, emptyString)
+{
+    std::string_view input = "";
+    constexpr char character = ' ';
+    std::string_view result = sofa::helper::removeTrailingCharacter(input, character);
+    EXPECT_EQ(result, "");
+}
+
+TEST(removeTrailingCharacterTest, singleTrailingCharacter)
+{
+    std::string_view input = "Hello!";
+    constexpr char character = '!';
+    std::string_view result = sofa::helper::removeTrailingCharacter(input, character);
+    EXPECT_EQ(result, "Hello");
+}
+
+TEST(removeTrailingCharacterTest, multipleTrailingCharacters)
+{
+    std::string_view input = "Hello...";
+    constexpr char character = '.';
+    std::string_view result = sofa::helper::removeTrailingCharacter(input, character);
+    EXPECT_EQ(result, "Hello");
+}
+
+// Test cases for removeTrailingCharacters
+TEST(removeTrailingCharactersTest, emptyString)
+{
+    constexpr std::string_view input = "";
+    constexpr std::initializer_list<char> characters = {' ', '\t'};
+    const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
+    EXPECT_EQ(result, "");
+}
+
+TEST(removeTrailingCharactersTest, noTrailingCharacters)
+{
+    constexpr std::string_view input = "Hello";
+    constexpr std::initializer_list<char> characters = {'o', 'x'};
+    const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
+    EXPECT_EQ(result, "Hell");
+}
+
+TEST(removeTrailingCharactersTest, singleTrailingCharacter)
+{
+    std::string_view input = "Hello!";
+    constexpr std::initializer_list<char> characters = {'!'};
+    const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
+    EXPECT_EQ(result, "Hello");
+}
+
+TEST(removeTrailingCharactersTest, multipleTrailingCharacters)
+{
+    constexpr std::string_view input = "Hello...";
+    constexpr std::initializer_list<char> characters = {'.'};
+    const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
+    EXPECT_EQ(result, "Hello");
+}
+
+TEST(removeTrailingCharactersTest, mixOfCharacters)
+{
+    constexpr std::string_view input = "Hello!!!\t";
+    constexpr std::initializer_list<char> characters = {'!', '\t'};
+    const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
+    EXPECT_EQ(result, "Hello");
+}
+
+}

--- a/Sofa/framework/Helper/test/StringUtils_test.cpp
+++ b/Sofa/framework/Helper/test/StringUtils_test.cpp
@@ -54,7 +54,7 @@ TEST(removeTrailingCharacterTest, multipleTrailingCharacters)
 TEST(removeTrailingCharactersTest, emptyString)
 {
     constexpr std::string_view input = "";
-    constexpr std::initializer_list<char> characters = {' ', '\t'};
+    const std::initializer_list<char> characters = {' ', '\t'};
     const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
     EXPECT_EQ(result, "");
 }
@@ -62,7 +62,7 @@ TEST(removeTrailingCharactersTest, emptyString)
 TEST(removeTrailingCharactersTest, noTrailingCharacters)
 {
     constexpr std::string_view input = "Hello";
-    constexpr std::initializer_list<char> characters = {'o', 'x'};
+    const std::initializer_list<char> characters = {'o', 'x'};
     const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
     EXPECT_EQ(result, "Hell");
 }
@@ -70,7 +70,7 @@ TEST(removeTrailingCharactersTest, noTrailingCharacters)
 TEST(removeTrailingCharactersTest, singleTrailingCharacter)
 {
     std::string_view input = "Hello!";
-    constexpr std::initializer_list<char> characters = {'!'};
+    const std::initializer_list<char> characters = {'!'};
     const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
     EXPECT_EQ(result, "Hello");
 }
@@ -78,7 +78,7 @@ TEST(removeTrailingCharactersTest, singleTrailingCharacter)
 TEST(removeTrailingCharactersTest, multipleTrailingCharacters)
 {
     constexpr std::string_view input = "Hello...";
-    constexpr std::initializer_list<char> characters = {'.'};
+    const std::initializer_list<char> characters = {'.'};
     const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
     EXPECT_EQ(result, "Hello");
 }
@@ -86,7 +86,7 @@ TEST(removeTrailingCharactersTest, multipleTrailingCharacters)
 TEST(removeTrailingCharactersTest, mixOfCharacters)
 {
     constexpr std::string_view input = "Hello!!!\t";
-    constexpr std::initializer_list<char> characters = {'!', '\t'};
+    const std::initializer_list<char> characters = {'!', '\t'};
     const std::string_view result = sofa::helper::removeTrailingCharacters(input, characters);
     EXPECT_EQ(result, "Hello");
 }


### PR DESCRIPTION
The function `sofa::helper::system::DataRepository.findFile` triggers a `msg_error` if the file is not found. In the case of `PrecomputedConstraintCorrection`, an error is not appropriate because the file can be generated. Instead I used `msg_info`.

Because the log message contained trailing line breaks, I introduced a couple of utility functions to remove them.

Example of output:

```
[INFO]    [PrecomputedConstraintCorrection(PrecomputedConstraintCorrection1)] File SquareCloth1-675-0.04.comp NOT FOUND in :C:/Users/Alex/Dev/sofa1/src/share:C:/Users/Alex/Dev/sofa1/src/examples:C:/Users/Alex/Dev/sofa1/builds:C:/U
sers/Alex/Dev/sofa1/builds. Compliance will be pre-computed and saved into a file
```

It fixes a scene test from https://github.com/sofa-framework/sofa/pull/4106.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
