### PR TITLE
[FEM.HyperElastic] Implement buildStiffnessMatrix for StandardTetrahedralFEMForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.h
@@ -184,6 +184,7 @@ public:
         msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
     void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
 
     void draw(const core::visual::VisualParams* vparams) override;

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
@@ -567,6 +567,35 @@ void  StandardTetrahedralFEMForceField<DataTypes>::addKToMatrix(sofa::linearalge
 }
 
 template <class DataTypes>
+void StandardTetrahedralFEMForceField<DataTypes>::buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix)
+{
+    const sofa::Size nbEdges = m_topology->getNbEdges();
+    const type::vector< Edge>& edgeArray=m_topology->getEdges();
+
+    const edgeInformationVector& edgeInf = edgeInfo.getValue();
+
+    auto dfdx = matrix->getForceDerivativeIn(this->mstate)
+                       .withRespectToPositionsIn(this->mstate);
+
+    for (sofa::Size l = 0; l < nbEdges; ++l)
+    {
+        const auto& einfo = edgeInf[l];
+        const Index node0 = edgeArray[l][0];
+        const Index node1 = edgeArray[l][1];
+        const Index N0 = 3 * node0;
+        const Index N1 = 3 * node1;
+
+        const Matrix3& stiff = einfo.DfDx;
+        const Matrix3 stiffTransposed = stiff.transposed();
+
+        dfdx(N0, N0) +=  stiffTransposed;
+        dfdx(N1, N1) +=  stiff;
+        dfdx(N0, N1) += -stiffTransposed;
+        dfdx(N1, N0) += -stiff;
+    }
+}
+
+template <class DataTypes>
 void StandardTetrahedralFEMForceField<DataTypes>::buildDampingMatrix(core::behavior::DampingMatrix*)
 {
     // No damping in this ForceField

--- a/examples/Component/SolidMechanics/FEM/StandardTetrahedralFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/StandardTetrahedralFEMForceField.scn
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" ?>
 <Node name="root" dt="0.005" showBoundingTree="0" gravity="0 -9 0">
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
     <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
     <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
     <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
@@ -18,11 +15,6 @@
 
     <DefaultAnimationLoop/>
     <VisualStyle displayFlags="showForceFields showBehaviorModels" />
-    <CollisionPipeline verbose="0" />
-    <BruteForceBroadPhase/>
-    <BVHNarrowPhase/>
-    <CollisionResponse response="PenalityContactForceField" />
-    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
 
     <Node name="Corrotational">
         <EulerImplicitSolver name="cg_odesolver" printLog="false" />


### PR DESCRIPTION
A task from #3967






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
