### PR TITLE
[SofaMatrix] Remove CImgPlugin dependency

### DIFF
--- a/applications/plugins/SofaMatrix/CMakeLists.txt
+++ b/applications/plugins/SofaMatrix/CMakeLists.txt
@@ -5,7 +5,6 @@ project(SofaMatrix VERSION 1.0 LANGUAGES CXX)
 sofa_find_package(Sofa.Core REQUIRED)
 sofa_find_package(Sofa.Component.Constraint.Lagrangian.Solver REQUIRED)
 sofa_find_package(Sofa.Component.LinearSolver.Direct REQUIRED)
-sofa_find_package(CImgPlugin REQUIRED)
 sofa_find_package(Eigen3 REQUIRED)
 sofa_find_package(Sofa.GUI.Qt QUIET)
 
@@ -13,7 +12,6 @@ set(SOFA_MODULES
     Sofa.Component.Constraint.Lagrangian.Solver
     Sofa.Component.LinearSolver.Direct
     Sofa.Core
-    CImgPlugin
     Eigen3::Eigen
 )
 

--- a/applications/plugins/SofaMatrix/SofaMatrixConfig.cmake.in
+++ b/applications/plugins/SofaMatrix/SofaMatrixConfig.cmake.in
@@ -9,7 +9,6 @@ set(SOFAMATRIX_HAVE_QT5CORE @SOFAMATRIX_HAVE_QT5CORE@)
 find_package(Sofa.Core QUIET REQUIRED)
 find_package(Sofa.Component.Constraint.Lagrangian.Solver QUIET REQUIRED)
 find_package(Sofa.Component.LinearSolver.Direct QUIET REQUIRED)
-find_package(CImgPlugin QUIET REQUIRED)
 find_package(Eigen3 QUIET REQUIRED)
 
 if(SOFAMATRIX_HAVE_SOFA_GUI_QT )

--- a/applications/plugins/SofaMatrix/src/SofaMatrix/MatrixImageExporter.cpp
+++ b/applications/plugins/SofaMatrix/src/SofaMatrix/MatrixImageExporter.cpp
@@ -22,7 +22,8 @@
 #include <SofaMatrix/MatrixImageExporter.h>
 #include <sofa/defaulttype/MatrixExporter.h>
 #include <sofa/linearalgebra/BaseMatrix.h>
-#include <CImgPlugin/ImageCImg.h>
+#include <sofa/helper/io/STBImage.h>
+
 
 namespace sofa::defaulttype
 {
@@ -34,7 +35,7 @@ bool writeMatrixImage(const std::string& filename, sofa::linearalgebra::BaseMatr
         const auto nx = matrix->colSize();
         const auto ny = matrix->rowSize();
 
-        sofa::helper::io::ImageCImg image;
+        sofa::helper::io::STBImage image;
         image.init(nx, ny, 1, 1, sofa::helper::io::Image::DataType::UNORM8, sofa::helper::io::Image::ChannelFormat::L);
 
         unsigned char* pixels = image.getPixels();
@@ -69,15 +70,11 @@ void initializeMatrixExporterComponents()
             sofa::defaulttype::matrixExporterOptionsGroup.setItemName(sofa::defaulttype::matrixExporterOptionsGroup.size() - 1, format);
         };
 
-#if CIMGPLUGIN_HAVE_JPEG
-        addMatrixExporter("jpg", sofa::defaulttype::writeMatrixImage);
-#endif // CIMGPLUGIN_HAVE_JPEG
-
-#if CIMGPLUGIN_HAVE_PNG
         addMatrixExporter("png", sofa::defaulttype::writeMatrixImage);
-#endif // CIMGPLUGIN_HAVE_PNG
-
+        addMatrixExporter("jpg", sofa::defaulttype::writeMatrixImage);
+        addMatrixExporter("jpeg", sofa::defaulttype::writeMatrixImage);
         addMatrixExporter("bmp", sofa::defaulttype::writeMatrixImage);
+        addMatrixExporter("tga", sofa::defaulttype::writeMatrixImage);
 
         first = false;
     }


### PR DESCRIPTION
CImgPlugin is no longer required since the only usage is to save an image, which can be done via STB.

As a bonus, TGA format is now supported.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
