### PR TITLE
[Constraint.Lagrangian.Solver] Unify lists of constraint corrections into a MultiLink

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
@@ -83,6 +83,11 @@ void ConstraintSolverImpl::cleanup()
     ConstraintSolver::cleanup();
 }
 
+void ConstraintSolverImpl::removeConstraintCorrection(core::behavior::BaseConstraintCorrection* s)
+{
+    l_constraintCorrections.remove(s);
+}
+
 void ConstraintSolverImpl::postBuildSystem(const core::ConstraintParams* cParams)
 {
     sofa::simulation::BuildConstraintSystemEndEvent evBegin;

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
@@ -54,8 +54,34 @@ unsigned int ConstraintProblem::getProblemId()
     return problemId;
 }
 
+ConstraintSolverImpl::ConstraintSolverImpl()
+    : l_constraintCorrections(initLink("constraintCorrections", "List of constraint corrections handled by this constraint solver"))
+{}
+
 ConstraintSolverImpl::~ConstraintSolverImpl()
 {}
+
+void ConstraintSolverImpl::init()
+{
+    ConstraintSolver::init();
+
+    // Prevents ConstraintCorrection accumulation due to multiple AnimationLoop initialization on dynamic components Add/Remove operations.
+    clearConstraintCorrections();
+
+    // add all BaseConstraintCorrection from this context to the list of links and register this solver
+    for (const auto& constraintCorrection :
+        getContext()->getObjects<core::behavior::BaseConstraintCorrection>(core::objectmodel::BaseContext::SearchDown))
+    {
+        l_constraintCorrections.add(constraintCorrection);
+        constraintCorrection->addConstraintSolver(this);
+    }
+}
+
+void ConstraintSolverImpl::cleanup()
+{
+    clearConstraintCorrections();
+    ConstraintSolver::cleanup();
+}
 
 void ConstraintSolverImpl::postBuildSystem(const core::ConstraintParams* cParams)
 {
@@ -70,6 +96,15 @@ void ConstraintSolverImpl::postSolveSystem(const core::ConstraintParams* cParams
     sofa::simulation::SolveConstraintSystemEndEvent evBegin;
     sofa::simulation::PropagateEventVisitor eventPropagation( cParams, &evBegin);
     eventPropagation.execute(this->getContext());
+}
+
+void ConstraintSolverImpl::clearConstraintCorrections()
+{
+    for (const auto& constraintCorrection : l_constraintCorrections)
+    {
+        constraintCorrection->removeConstraintSolver(this);
+    }
+    l_constraintCorrections.clear();
 }
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -91,7 +91,7 @@ protected:
 
     MultiLink< ConstraintSolverImpl,
         core::behavior::BaseConstraintCorrection,
-        BaseLink::FLAG_STOREPATH | BaseLink::FLAG_DOUBLELINK> l_constraintCorrections;
+        BaseLink::FLAG_STOREPATH> l_constraintCorrections;
 
 };
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -29,6 +29,7 @@
 #include <sofa/linearalgebra/FullMatrix.h>
 
 #include <sofa/core/ConstraintParams.h>
+#include <sofa/core/behavior/BaseConstraintCorrection.h>
 
 namespace sofa::component::constraint::lagrangian::solver
 {
@@ -67,7 +68,11 @@ class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API ConstraintSolverImpl : pub
 public:
     SOFA_ABSTRACT_CLASS(ConstraintSolverImpl, sofa::core::behavior::ConstraintSolver)
 
+    ConstraintSolverImpl();
     ~ConstraintSolverImpl() override;
+
+    void init() override;
+    void cleanup() override;
 
     virtual ConstraintProblem* getConstraintProblem() = 0;
 
@@ -79,6 +84,13 @@ protected:
 
     void postBuildSystem(const core::ConstraintParams* cParams) override;
     void postSolveSystem(const core::ConstraintParams* cParams) override;
+
+    void clearConstraintCorrections();
+
+    MultiLink< ConstraintSolverImpl,
+        core::behavior::BaseConstraintCorrection,
+        BaseLink::FLAG_STOREPATH | BaseLink::FLAG_DOUBLELINK | BaseLink::FLAG_MULTILINK > l_constraintCorrections;
+
 };
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -80,6 +80,8 @@ public:
     /// This is used to prevent concurent access to the LCP when using a LCPForceFeedback through an haptic thread.
     virtual void lockConstraintProblem(sofa::core::objectmodel::BaseObject* from, ConstraintProblem* p1, ConstraintProblem* p2=nullptr) = 0;
 
+    void removeConstraintCorrection(core::behavior::BaseConstraintCorrection *s) override;
+
 protected:
 
     void postBuildSystem(const core::ConstraintParams* cParams) override;

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -91,7 +91,7 @@ protected:
 
     MultiLink< ConstraintSolverImpl,
         core::behavior::BaseConstraintCorrection,
-        BaseLink::FLAG_STOREPATH | BaseLink::FLAG_DOUBLELINK | BaseLink::FLAG_MULTILINK > l_constraintCorrections;
+        BaseLink::FLAG_STOREPATH | BaseLink::FLAG_DOUBLELINK> l_constraintCorrections;
 
 };
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -133,7 +133,7 @@ GenericConstraintSolver::~GenericConstraintSolver()
 
 void GenericConstraintSolver::init()
 {
-    core::behavior::ConstraintSolver::init();
+    ConstraintSolverImpl::init();
 
     // Prevents ConstraintCorrection accumulation due to multiple AnimationLoop initialization on dynamic components Add/Remove operations.
     if (!constraintCorrections.empty())
@@ -147,7 +147,9 @@ void GenericConstraintSolver::init()
     constraintCorrectionIsActive.resize(constraintCorrections.size());
     for (auto* constraintCorrection : constraintCorrections)
         constraintCorrection->addConstraintSolver(this);
+
     context = getContext();
+
     simulation::common::VectorOperations vop(sofa::core::execparams::defaultInstance(), this->getContext());
     {
         sofa::core::behavior::MultiVecDeriv lambda(&vop, m_lambdaId);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -135,19 +135,7 @@ void GenericConstraintSolver::init()
 {
     ConstraintSolverImpl::init();
 
-    // Prevents ConstraintCorrection accumulation due to multiple AnimationLoop initialization on dynamic components Add/Remove operations.
-    if (!constraintCorrections.empty())
-    {
-        for (auto* constraintCorrection : constraintCorrections)
-            constraintCorrection->removeConstraintSolver(this);
-        constraintCorrections.clear();
-    }
-
-    getContext()->get<core::behavior::BaseConstraintCorrection>(&constraintCorrections, core::objectmodel::BaseContext::SearchDown);
-    constraintCorrectionIsActive.resize(constraintCorrections.size());
-    for (auto* constraintCorrection : constraintCorrections)
-        constraintCorrection->addConstraintSolver(this);
-
+    constraintCorrectionIsActive.resize(l_constraintCorrections.size());
     context = getContext();
 
     simulation::common::VectorOperations vop(sofa::core::execparams::defaultInstance(), this->getContext());
@@ -178,19 +166,10 @@ void GenericConstraintSolver::init()
 
 void GenericConstraintSolver::cleanup()
 {
-    for (auto* constraintCorrection : constraintCorrections)
-        constraintCorrection->removeConstraintSolver(this);
-    constraintCorrections.clear();
-
     simulation::common::VectorOperations vop(sofa::core::execparams::defaultInstance(), this->getContext());
     vop.v_free(m_lambdaId, false, true);
     vop.v_free(m_dxId, false, true);
-    core::behavior::ConstraintSolver::cleanup();
-}
-
-void GenericConstraintSolver::removeConstraintCorrection(core::behavior::BaseConstraintCorrection *s)
-{
-    constraintCorrections.erase(std::remove(constraintCorrections.begin(), constraintCorrections.end(), s), constraintCorrections.end());
+    sofa::component::constraint::lagrangian::solver::ConstraintSolverImpl::cleanup();
 }
 
 bool GenericConstraintSolver::prepareStates(const core::ConstraintParams *cParams, MultiVecId /*res1*/, MultiVecId /*res2*/)
@@ -258,8 +237,8 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
     msg_info() <<"GenericConstraintSolver: "<<numConstraints<<" constraints";
 
     // Test if the nodes containing the constraint correction are active (not sleeping)
-    for (unsigned int i = 0; i < constraintCorrections.size(); i++)
-        constraintCorrectionIsActive[i] = !constraintCorrections[i]->getContext()->isSleeping();
+    for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
+        constraintCorrectionIsActive[i] = !l_constraintCorrections[i]->getContext()->isSleeping();
 
     // Resolution depending on the method selected
     switch ( d_resolutionMethod.getValue().getSelectedId() )
@@ -288,7 +267,7 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
 
 void GenericConstraintSolver::buildSystem_matrixFree(unsigned int numConstraints)
 {
-    for (auto* cc : constraintCorrections)
+    for (const auto& cc : l_constraintCorrections)
     {
         if (!cc->isActive()) continue;
 
@@ -306,7 +285,7 @@ void GenericConstraintSolver::buildSystem_matrixFree(unsigned int numConstraints
     // for each contact, the constraint corrections that are involved with the contact are memorized
     current_cp->cclist_elems.clear();
     current_cp->cclist_elems.resize(numConstraints);
-    const int nbCC = constraintCorrections.size();
+    const int nbCC = l_constraintCorrections.size();
     for (unsigned int i = 0; i < numConstraints; i++)
         current_cp->cclist_elems[i].resize(nbCC, nullptr);
 
@@ -317,9 +296,9 @@ void GenericConstraintSolver::buildSystem_matrixFree(unsigned int numConstraints
         nbObjects++;
         const unsigned int l = current_cp->constraintsResolutions[c_id]->getNbLines();
 
-        for (unsigned int j = 0; j < constraintCorrections.size(); j++)
+        for (unsigned int j = 0; j < l_constraintCorrections.size(); j++)
         {
-            core::behavior::BaseConstraintCorrection* cc = constraintCorrections[j];
+            core::behavior::BaseConstraintCorrection* cc = l_constraintCorrections[j];
             if (!cc->isActive()) continue;
             if (cc->hasConstraintNumber(c_id))
             {
@@ -376,7 +355,7 @@ void GenericConstraintSolver::ComplianceWrapper::assembleMatrix() const
 void GenericConstraintSolver::buildSystem_matrixAssembly(const core::ConstraintParams *cParams)
 {
     sofa::helper::ScopedAdvancedTimer getComplianceTimer("Get Compliance");
-    dmsg_info() <<" computeCompliance in "  << constraintCorrections.size()<< " constraintCorrections" ;
+    dmsg_info() <<" computeCompliance in "  << l_constraintCorrections.size()<< " constraintCorrections" ;
 
     const bool multithreading = d_multithreading.getValue();
 
@@ -389,7 +368,7 @@ void GenericConstraintSolver::buildSystem_matrixAssembly(const core::ConstraintP
 
     std::mutex mutex;
 
-    simulation::forEachRange(execution, *taskScheduler, constraintCorrections.begin(), constraintCorrections.end(),
+    simulation::forEachRange(execution, *taskScheduler, l_constraintCorrections.begin(), l_constraintCorrections.end(),
         [&cParams, this, &multithreading, &mutex](const auto& range)
         {
             ComplianceWrapper compliance(current_cp->W, multithreading);
@@ -412,7 +391,7 @@ void GenericConstraintSolver::buildSystem_matrixAssembly(const core::ConstraintP
 
 void GenericConstraintSolver::rebuildSystem(SReal massFactor, SReal forceFactor)
 {
-    for (auto* cc : constraintCorrections)
+    for (const auto& cc : l_constraintCorrections)
     {
         if (!cc->isActive()) continue;
         cc->rebuildSystem(massFactor, forceFactor);
@@ -519,7 +498,7 @@ bool GenericConstraintSolver::solveSystem(const core::ConstraintParams * /*cPara
 
 void GenericConstraintSolver::computeResidual(const core::ExecParams* eparam)
 {
-    for (auto* cc : constraintCorrections)
+    for (const auto& cc : l_constraintCorrections)
     {
         cc->computeResidual(eparam,&current_cp->f);
     }
@@ -539,10 +518,10 @@ bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cPar
     {
         const core::MultiVecCoordId xId(res1);
         const core::MultiVecDerivId vId(res2);
-        for (unsigned int i = 0; i < constraintCorrections.size(); i++)
+        for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
         {
             if (!constraintCorrectionIsActive[i]) continue;
-            BaseConstraintCorrection* cc = constraintCorrections[i];
+            BaseConstraintCorrection* cc = l_constraintCorrections[i];
             if (!cc->isActive()) continue;
 
             sofa::helper::AdvancedTimer::stepBegin("ComputeCorrection on: " + cc->getName());
@@ -557,10 +536,10 @@ bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cPar
     else if (cParams->constOrder() == core::ConstraintParams::POS)
     {
         const core::MultiVecCoordId xId(res1);
-        for (unsigned int i = 0; i < constraintCorrections.size(); i++)
+        for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
         {
             if (!constraintCorrectionIsActive[i]) continue;
-            BaseConstraintCorrection* cc = constraintCorrections[i];
+            BaseConstraintCorrection* cc = l_constraintCorrections[i];
             if (!cc->isActive()) continue;
 
             {
@@ -577,10 +556,10 @@ bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cPar
     else if (cParams->constOrder() == core::ConstraintParams::VEL)
     {
         const core::MultiVecDerivId vId(res1);
-        for (unsigned int i = 0; i < constraintCorrections.size(); i++)
+        for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
         {
             if (!constraintCorrectionIsActive[i]) continue;
-            BaseConstraintCorrection* cc = constraintCorrections[i];
+            BaseConstraintCorrection* cc = l_constraintCorrections[i];
             if (!cc->isActive()) continue;
 
             {

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -37,7 +37,6 @@ namespace sofa::component::constraint::lagrangian::solver
 
 class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API GenericConstraintSolver : public ConstraintSolverImpl
 {
-    typedef std::vector<core::behavior::BaseConstraintCorrection*> list_cc;
     typedef sofa::core::MultiVecId MultiVecId;
 
 public:

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -59,7 +59,6 @@ public:
     void computeResidual(const core::ExecParams* /*params*/) override;
     ConstraintProblem* getConstraintProblem() override;
     void lockConstraintProblem(sofa::core::objectmodel::BaseObject* from, ConstraintProblem* p1, ConstraintProblem* p2 = nullptr) override;
-    void removeConstraintCorrection(core::behavior::BaseConstraintCorrection *s) override;
 
     Data< sofa::helper::OptionsGroup > d_resolutionMethod; ///< Method used to solve the constraint problem, among: \"ProjectedGaussSeidel\", \"UnbuiltGaussSeidel\" or \"for NonsmoothNonlinearConjugateGradient\"
 
@@ -109,7 +108,7 @@ protected:
     sofa::type::fixed_array<GenericConstraintProblem,CP_BUFFER_SIZE> m_cpBuffer;
     sofa::type::fixed_array<bool,CP_BUFFER_SIZE> m_cpIsLocked;
     GenericConstraintProblem *current_cp, *last_cp;
-    type::vector<core::behavior::BaseConstraintCorrection*> constraintCorrections;
+    DeprecatedAndRemoved constraintCorrections; //use ConstraintSolverImpl::l_constraintCorrections instead
     type::vector<bool> constraintCorrectionIsActive; // for each constraint correction, a boolean that is false if the parent node is sleeping
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -108,7 +108,7 @@ protected:
     sofa::type::fixed_array<GenericConstraintProblem,CP_BUFFER_SIZE> m_cpBuffer;
     sofa::type::fixed_array<bool,CP_BUFFER_SIZE> m_cpIsLocked;
     GenericConstraintProblem *current_cp, *last_cp;
-    DeprecatedAndRemoved constraintCorrections; //use ConstraintSolverImpl::l_constraintCorrections instead
+    SOFA_ATTRIBUTE_DISABLED__GENERICCONSTRAINTSOLVER_CONSTRAINTCORRECTIONS() DeprecatedAndRemoved constraintCorrections; //use ConstraintSolverImpl::l_constraintCorrections instead
     type::vector<bool> constraintCorrectionIsActive; // for each constraint correction, a boolean that is false if the parent node is sleeping
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -67,7 +67,7 @@ bool LCPConstraintSolver::prepareStates(const core::ConstraintParams * /*cParams
 
     helper::ScopedAdvancedTimer resetContactForceTimer("resetContactForce");
 
-    for (const auto cc : constraintCorrections)
+    for (const auto cc : l_constraintCorrections)
     {
         cc->resetContactForce();
     }
@@ -79,9 +79,9 @@ bool LCPConstraintSolver::buildSystem(const core::ConstraintParams * /*cParams*/
 {
 
     // Test if the nodes containing the constraint correction are active (not sleeping)
-    for (unsigned int i = 0; i < constraintCorrections.size(); i++)
+    for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
     {
-        constraintCorrectionIsActive[i] = !constraintCorrections[i]->getContext()->isSleeping();
+        constraintCorrectionIsActive[i] = !l_constraintCorrections[i]->getContext()->isSleeping();
     }
 
     if(build_lcp.getValue())
@@ -206,10 +206,10 @@ bool LCPConstraintSolver::applyCorrection(const core::ConstraintParams * /*cPara
 
     sofa::helper::AdvancedTimer::stepBegin("Apply Contact Force");
 
-    for (unsigned int i = 0; i < constraintCorrections.size(); i++)
+    for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
     {
         if (!constraintCorrectionIsActive[i]) continue;
-        core::behavior::BaseConstraintCorrection* cc = constraintCorrections[i];
+        core::behavior::BaseConstraintCorrection* cc = l_constraintCorrections[i];
         cc->applyContactForce(_result);
     }
     sofa::helper::AdvancedTimer::stepEnd  ("Apply Contact Force");
@@ -271,37 +271,8 @@ void LCPConstraintSolver::init()
 {
     ConstraintSolverImpl::init();
 
-    // Prevents ConstraintCorrection accumulation due to multiple AnimationLoop initialization on dynamic components Add/Remove operations.
-    if (!constraintCorrections.empty())
-    {
-        for (unsigned int i = 0; i < constraintCorrections.size(); i++)
-            constraintCorrections[i]->removeConstraintSolver(this);
-        constraintCorrections.clear();
-    }
-
-    getContext()->get<core::behavior::BaseConstraintCorrection>(&constraintCorrections, core::objectmodel::BaseContext::SearchDown);
-    constraintCorrectionIsActive.resize(constraintCorrections.size());
-    for (unsigned int i = 0; i < constraintCorrections.size(); i++)
-        constraintCorrections[i]->addConstraintSolver(this);
-
+    constraintCorrectionIsActive.resize(l_constraintCorrections.size());
     context = getContext();
-}
-
-void LCPConstraintSolver::cleanup()
-{
-    if (!constraintCorrections.empty())
-    {
-        for (unsigned int i = 0; i < constraintCorrections.size(); i++)
-            constraintCorrections[i]->removeConstraintSolver(this);
-        constraintCorrections.clear();
-    }
-
-    core::behavior::ConstraintSolver::cleanup();
-}
-
-void LCPConstraintSolver::removeConstraintCorrection(core::behavior::BaseConstraintCorrection *s)
-{
-    constraintCorrections.erase(std::remove(constraintCorrections.begin(), constraintCorrections.end(), s), constraintCorrections.end());
 }
 
 void LCPConstraintSolver::resetConstraints(core::ConstraintParams cparams)
@@ -366,11 +337,11 @@ void LCPConstraintSolver::addComplianceInConstraintSpace(core::ConstraintParams 
 {
     sofa::helper::AdvancedTimer::stepBegin("Get Compliance");
 
-    dmsg_info() <<" computeCompliance in "  << constraintCorrections.size()<< " constraintCorrections" ;
+    dmsg_info() <<" computeCompliance in "  << l_constraintCorrections.size()<< " constraintCorrections" ;
 
-    for (unsigned int i=0; i<constraintCorrections.size(); i++)
+    for (unsigned int i=0; i<l_constraintCorrections.size(); i++)
     {
-        core::behavior::BaseConstraintCorrection* cc = constraintCorrections[i];
+        core::behavior::BaseConstraintCorrection* cc = l_constraintCorrections[i];
         cc->addComplianceInConstraintSpace(&cparams, _W);
     }
 
@@ -424,9 +395,9 @@ void LCPConstraintSolver::build_Coarse_Compliance(std::vector<int> &constraint_m
     dmsg_error_when(sizeCoarseSystem==0) <<"no constraint" ;
 
     _Wcoarse.resize(sizeCoarseSystem,sizeCoarseSystem);
-    for (unsigned int i=0; i<constraintCorrections.size(); i++)
+    for (unsigned int i=0; i<l_constraintCorrections.size(); i++)
     {
-        core::behavior::BaseConstraintCorrection* cc = constraintCorrections[i];
+        core::behavior::BaseConstraintCorrection* cc = l_constraintCorrections[i];
         cc->getComplianceWithConstraintMerge(&_Wcoarse, constraint_merge);
     }
 }
@@ -878,9 +849,9 @@ int LCPConstraintSolver::nlcp_gaussseidel_unbuilt(SReal *dfree, SReal *f, std::v
     }
 
 
-    for (unsigned int i=0; i<constraintCorrections.size(); i++)
+    for (unsigned int i=0; i<l_constraintCorrections.size(); i++)
     {
-        core::behavior::BaseConstraintCorrection* cc = constraintCorrections[i];
+        core::behavior::BaseConstraintCorrection* cc = l_constraintCorrections[i];
         cc->resetForUnbuiltResolution(f, contact_sequence);
 
         if(notMuted())
@@ -904,7 +875,7 @@ int LCPConstraintSolver::nlcp_gaussseidel_unbuilt(SReal *dfree, SReal *f, std::v
         bool elem1 = false;
         bool elem2 = false;
 
-        for (auto* cc : constraintCorrections)
+        for (const auto& cc : l_constraintCorrections)
         {
             if(cc->hasConstraintNumber(3*c1))
             {
@@ -1141,9 +1112,9 @@ int LCPConstraintSolver::lcp_gaussseidel_unbuilt(SReal *dfree, SReal *f, std::ve
     }
 
 
-    for (unsigned int i=0; i<constraintCorrections.size(); i++)
+    for (unsigned int i=0; i<l_constraintCorrections.size(); i++)
     {
-        core::behavior::BaseConstraintCorrection* cc = constraintCorrections[i];
+        core::behavior::BaseConstraintCorrection* cc = l_constraintCorrections[i];
         cc->resetForUnbuiltResolution(f, contact_sequence);
     }
 
@@ -1159,7 +1130,7 @@ int LCPConstraintSolver::lcp_gaussseidel_unbuilt(SReal *dfree, SReal *f, std::ve
     {
         bool elem1 = false;
         bool elem2 = false;
-        for (const auto cc : constraintCorrections)
+        for (const auto cc : l_constraintCorrections)
         {
             if(cc->hasConstraintNumber(c1))
             {

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -269,7 +269,7 @@ LCPConstraintSolver::~LCPConstraintSolver()
 
 void LCPConstraintSolver::init()
 {
-    core::behavior::ConstraintSolver::init();
+    ConstraintSolverImpl::init();
 
     // Prevents ConstraintCorrection accumulation due to multiple AnimationLoop initialization on dynamic components Add/Remove operations.
     if (!constraintCorrections.empty())

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -67,8 +67,6 @@ protected:
 public:
     void init() override;
 
-    void cleanup() override;
-
     bool prepareStates(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
     bool buildSystem(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
     bool solveSystem(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
@@ -105,10 +103,7 @@ public:
     ConstraintProblem* getConstraintProblem() override;
     void lockConstraintProblem(sofa::core::objectmodel::BaseObject* from, ConstraintProblem* p1, ConstraintProblem* p2=nullptr) override; ///< Do not use the following LCPs until the next call to this function. This is used to prevent concurent access to the LCP when using a LCPForceFeedback through an haptic thread
 
-    void removeConstraintCorrection(core::behavior::BaseConstraintCorrection *s) override;
-
 private:
-    type::vector<core::behavior::BaseConstraintCorrection*> constraintCorrections;
     type::vector<bool> constraintCorrectionIsActive; // for each constraint correction, a boolean that is false if the parent node is sleeping
     void computeInitialGuess();
     void keepContactForcesValue();

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -52,7 +52,6 @@ class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API LCPConstraintSolver : publ
 public:
     SOFA_CLASS(LCPConstraintSolver, ConstraintSolverImpl);
 
-    typedef std::vector<core::behavior::BaseConstraintCorrection*> list_cc;
     typedef sofa::core::MultiVecId MultiVecId;
 
 protected:

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/config.h.in
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/config.h.in
@@ -53,3 +53,11 @@ namespace sofa::component::constraint::lagrangian::solver
     SOFA_ATTRIBUTE_DISABLED( \
         "v23.12", "v24.06", "_mu is not a member anymore. Use the Data \"mu\" to get the friction value.")
 #endif // SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER
+
+#ifdef SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER
+#define SOFA_ATTRIBUTE_DISABLED__GENERICCONSTRAINTSOLVER_CONSTRAINTCORRECTIONS()
+#else
+#define SOFA_ATTRIBUTE_DISABLED__GENERICCONSTRAINTSOLVER_CONSTRAINTCORRECTIONS() \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v23.12", "v23.12", "Use ConstraintSolverImpl::l_constraintCorrections instead")
+#endif // SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER


### PR DESCRIPTION
In both `LCPConstraintSolver` and `GenericConstraintSolver`, there is a list of constraint corrections as a class member. Both class inherits from the same base class and the lists are used equivalently. Therefore, I move them into the base class. I changed them from a `vector<BaseConstraintCorrection*>` to a `MultiLink`.

These changes allows to unify `init`, `cleanup` and `removeConstraintCorrection` methods.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
