### PR TITLE
[Core] VecId: set correct message for the deleted function holonomicC

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/VecId.h
+++ b/Sofa/framework/Core/src/sofa/core/VecId.h
@@ -182,7 +182,7 @@ public:
     static MyVecId constraintJacobian()    { return MyVecId(1);} // jacobian matrix of constraints
     static MyVecId mappingJacobian() { return MyVecId(2);}         // accumulated matrix of the mappings
 
-    SOFA_ATTRIBUTE_DISABLED("v17.06 (PR#276)", "v21.06", "See VecId.h to remove this message and replace by constraintMatrix")
+    SOFA_ATTRIBUTE_DISABLED("v17.06 (PR#276)", "v21.06", "holonomicC() has been renamed to constraintJacobian()")
     static MyVecId holonomicC() = delete;
     enum { V_FIRST_DYNAMIC_INDEX = 3 }; ///< This is the first index used for dynamically allocated vectors
 


### PR DESCRIPTION
The message was not making sense and was incorrect anyway,



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
