### PR TITLE
[test] Make quaternion test deterministic and portable

### DIFF
--- a/Sofa/framework/Testing/CMakeLists.txt
+++ b/Sofa/framework/Testing/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADER_FILES
     ${SOFATESTINGSRC_ROOT}/config.h.in
     ${SOFATESTINGSRC_ROOT}/initSofa.Testing.h
     ${SOFATESTINGSRC_ROOT}/BaseTest.h
+    ${SOFATESTINGSRC_ROOT}/LinearCongruentialRandomGenerator.h
     ${SOFATESTINGSRC_ROOT}/NumericTest.h
     ${SOFATESTINGSRC_ROOT}/TestMessageHandler.h
     ${SOFATESTINGSRC_ROOT}/BaseSimulationTest.h
@@ -24,6 +25,7 @@ set(HEADER_FILES
 set(SOURCE_FILES
     ${SOFATESTINGSRC_ROOT}/initSofa.Testing.cpp
     ${SOFATESTINGSRC_ROOT}/BaseTest.cpp
+    ${SOFATESTINGSRC_ROOT}/LinearCongruentialRandomGenerator.cpp
     ${SOFATESTINGSRC_ROOT}/NumericTest.cpp
     ${SOFATESTINGSRC_ROOT}/TestMessageHandler.cpp
     ${SOFATESTINGSRC_ROOT}/BaseSimulationTest.cpp

--- a/Sofa/framework/Testing/src/sofa/testing/LinearCongruentialRandomGenerator.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/LinearCongruentialRandomGenerator.cpp
@@ -1,0 +1,51 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/testing/LinearCongruentialRandomGenerator.h>
+
+namespace sofa::testing
+{
+
+LinearCongruentialRandomGenerator::LinearCongruentialRandomGenerator(const unsigned int initialSeed)
+: m_seed(initialSeed)
+{}
+
+unsigned LinearCongruentialRandomGenerator::generateRandom()
+{
+    // Parameters for the LCG formula (adjust as needed)
+    constexpr unsigned int a = 1664525;
+    constexpr unsigned int c = 1013904223;
+
+    m_seed = a * m_seed + c; // LCG formula
+    return m_seed;
+}
+
+double LinearCongruentialRandomGenerator::generateInRange(const double rmin, const double rmax)
+{
+    return rmin + generateInUnitRange<double>() * (rmax - rmin);
+}
+
+float LinearCongruentialRandomGenerator::generateInRange(const float rmin, const float rmax)
+{
+    return rmin + generateInUnitRange<float>() * (rmax - rmin);
+}
+
+}

--- a/Sofa/framework/Testing/src/sofa/testing/LinearCongruentialRandomGenerator.h
+++ b/Sofa/framework/Testing/src/sofa/testing/LinearCongruentialRandomGenerator.h
@@ -1,0 +1,110 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <limits>
+#include <sofa/testing/config.h>
+
+namespace sofa::testing
+{
+
+/**
+ * @class LinearCongruentialRandomGenerator
+ * @brief A simple deterministic and portable random number generator.
+ *
+ * This class implements a Linear Congruential Generator (LCG) algorithm to generate
+ * pseudo-random numbers. It is designed to provide deterministic and portable random
+ * number generation, making it well-suited for testing purposes.
+ */
+class SOFA_TESTING_API LinearCongruentialRandomGenerator
+{
+    unsigned int m_seed; ///< The current seed value for random number generation.
+
+public:
+    explicit LinearCongruentialRandomGenerator(unsigned int initialSeed);
+
+    /**
+     * @brief Generates the next pseudo-random number.
+     * @return The generated pseudo-random number.
+     *
+     * This method uses a Linear Congruential Generator (LCG) algorithm to update
+     * the seed and produce the next pseudo-random number.
+     */
+    unsigned int generateRandom();
+
+    /**
+     * @brief Generates a pseudo-random value within the unit interval [0, 1].
+     *
+     * This templated function generates a pseudo-random value of the specified scalar type
+     * within the unit interval [0, 1]. It utilizes the underlying random number generator
+     * to produce a normalized random value within the unit range.
+     *
+     * @tparam Scalar The scalar type for the generated value (e.g., float, double).
+     * @return A pseudo-random value of the specified scalar type within the range [0, 1].
+     *
+     * Example usage:
+     * @code
+     * float randomFloat = generateInUnitRange<float>();
+     * double randomDouble = generateInUnitRange<double>();
+     * @endcode
+     */
+    template<class Scalar>
+    Scalar generateInUnitRange()
+    {
+        return static_cast<Scalar>(generateRandom()) / static_cast<Scalar>(std::numeric_limits<unsigned int>::max());
+    }
+
+    /**
+     * @brief Generates a pseudo-random double value within a specified range.
+     *
+     * This function generates a pseudo-random double value between the provided
+     * minimum (`rmin`) and maximum (`rmax`) values.
+     *
+     * @param rmin The minimum value of the desired range (inclusive).
+     * @param rmax The maximum value of the desired range (inclusive).
+     * @return A pseudo-random double value in the specified range [rmin, rmax].
+     *
+     * Example usage:
+     * @code
+     * double randomValue = generateInRange(10.0, 20.0);
+     * @endcode
+     */
+    double generateInRange(double rmin, double rmax);
+
+    /**
+     * @brief Generates a pseudo-random float value within a specified range.
+     *
+     * This function generates a pseudo-random float value between the provided
+     * minimum (`rmin`) and maximum (`rmax`) values.
+     *
+     * @param rmin The minimum value of the desired range (inclusive).
+     * @param rmax The maximum value of the desired range (inclusive).
+     * @return A pseudo-random float value in the specified range [rmin, rmax].
+     *
+     * Example usage:
+     * @code
+     * float randomValue = generateInRange(10.f, 20.f);
+     * @endcode
+     */
+    float generateInRange(float rmin, float rmax);
+};
+
+}


### PR DESCRIPTION
The unit test in this PR relied on `rand()`, which was seeded by `srand(time(nullptr))`. However, it means that every time the test is executed, the generated input values are different. The test is not repeatable. And sometimes, the generated values lead to singularities, which are values not supported by the tested functions.
The changes in this PR made the random generation deterministic and portable, so that the test is repeatable. We also make sure that the generated values don't lead to singularities.

For more information about the singularities, see https://github.com/sofa-framework/sofa/pull/4122



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
