### PR TITLE
[SolidMechanics.TensorMass] Implement buildStiffnessMatrix for TetrahedralTensorMassForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TetrahedralTensorMassForceField.h
+++ b/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TetrahedralTensorMassForceField.h
@@ -58,27 +58,12 @@ public:
 
     using Index = sofa::Index;
 
-    class Mat3 : public type::fixed_array<Deriv,3>
-    {
-    public:
-        Deriv operator*(const Deriv& v) const
-        {
-            return Deriv((*this)[0]*v,(*this)[1]*v,(*this)[2]*v);
-        }
-        Deriv transposeMultiply(const Deriv& v) const
-        {
-            return Deriv(v[0]*((*this)[0])[0]+v[1]*((*this)[1])[0]+v[2]*((*this)[2][0]),
-                    v[0]*((*this)[0][1])+v[1]*((*this)[1][1])+v[2]*((*this)[2][1]),
-                    v[0]*((*this)[0][2])+v[1]*((*this)[1][2])+v[2]*((*this)[2][2]));
-        }
-    };
-
 protected:
 
     class EdgeRestInformation
     {
     public:
-        Mat3 DfDx; /// the edge stiffness matrix
+        sofa::type::Mat<3, 3, Real> DfDx; /// the edge stiffness matrix
         float vertices[2]; // the vertices of this edge
 
         EdgeRestInformation()
@@ -123,6 +108,7 @@ public:
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
+    void buildStiffnessMatrix(sofa::core::behavior::StiffnessMatrix* matrix) override;
     void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {

--- a/examples/Component/SolidMechanics/TensorMass/TetrahedralTensorMassForceField.scn
+++ b/examples/Component/SolidMechanics/TensorMass/TetrahedralTensorMassForceField.scn
@@ -1,0 +1,47 @@
+<Node name="root">
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [EigenSimplicialLDLT] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.TensorMass"/> <!-- Needed to use components [TetrahedralTensorMassForceField] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [QuadSetGeometryAlgorithms,QuadSetTopologyContainer,QuadSetTopologyModifier,TetrahedronSetGeometryAlgorithms,TetrahedronSetTopologyContainer,TetrahedronSetTopologyModifier] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2QuadTopologicalMapping,Hexa2TetraTopologicalMapping] -->
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+    </Node>
+
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <DefaultAnimationLoop name="animationLoop"/>
+    <DefaultVisualManagerLoop name="visualLoop"/>
+
+    <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+    <EigenSimplicialLDLT template="CompressedRowSparseMatrixMat3x3"/>
+    <MechanicalObject name="DoFs" />
+    <UniformMass name="mass" totalMass="320" />
+    <RegularGridTopology name="grid" nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
+    <BoxROI name="box" box="-10 -1 -0.0001  -5 4 0.0001"/>
+    <FixedConstraint indices="@box.indices" />
+
+    <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+    <TetrahedronSetTopologyModifier name="Modifier" />
+    <TetrahedronSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+    <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+    <TetrahedralTensorMassForceField name="deformable" youngModulus="100000" poissonRatio="0.4" />
+
+    <Node name="quads">
+        <QuadSetTopologyContainer  name="Container" />
+        <QuadSetTopologyModifier   name="Modifier" />
+        <QuadSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
+        <Hexa2QuadTopologicalMapping input="@../grid" output="@Container" />
+        <Node name="Visu">
+            <OglModel name="Visual" color="yellow" />
+            <IdentityMapping input="@../../DoFs" output="@Visual" />
+        </Node>
+    </Node>
+</Node>


### PR DESCRIPTION
A task from https://github.com/sofa-framework/sofa/issues/3967

A scene example is introduced because there wasn't one before. It is a simple beam under gravity. Usually, scene examples work with a CG. Here I use a direct solver.

`addKToMatrix` was not implemented for this force field. So `buildStiffnessMatrix` has been written without a "model".

I changed a type and remove a struct. It is therefore breaking.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
