### PR TITLE
[Constraint.Lagrangian.Solver] GenericConstraintSolver: use given re-ordered list for unbuilt GS

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintProblem.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintProblem.cpp
@@ -317,7 +317,6 @@ void GenericConstraintProblem::unbuiltGaussSeidel(SReal timeout, GenericConstrai
 
     tabErrors.resize(dimension);
 
-
     for(iter=0; iter<maxIterations; iter++)
     {
         bool constraintsAreVerified = true;
@@ -327,8 +326,9 @@ void GenericConstraintProblem::unbuiltGaussSeidel(SReal timeout, GenericConstrai
         }
 
         error=0.0;
-        for(int j=0; j<dimension; ) // increment of j realized at the end of the loop
+        for (auto it_c = this->constraints_sequence.begin(); it_c != constraints_sequence.end(); )  // increment of it_c realized at the end of the loop
         {
+            const auto j = *it_c;
             //1. nbLines provide the dimension of the constraint
             nb = constraintsResolutions[j]->getNbLines();
 
@@ -404,7 +404,7 @@ void GenericConstraintProblem::unbuiltGaussSeidel(SReal timeout, GenericConstrai
                 std::copy(tempF.begin(), tempF.end(), &force[j]);
             }
 
-            j += nb;
+            std::advance(it_c, nb);
         }
 
         if(showGraphs)

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -289,6 +289,12 @@ void GenericConstraintSolver::buildSystem_matrixFree(unsigned int numConstraints
     for (auto* cc : constraintCorrections)
     {
         if (!cc->isActive()) continue;
+
+        current_cp->constraints_sequence.resize(numConstraints);
+        std::iota(current_cp->constraints_sequence.begin(), current_cp->constraints_sequence.end(), 0);
+
+        // some constraint corrections (e.g LinearSolverConstraintCorrection)
+        // can change the order of the constraints, to optimize later computations
         cc->resetForUnbuiltResolution(current_cp->getF(), current_cp->constraints_sequence);
     }
 


### PR DESCRIPTION
The (potential) renumbering of the constraints by the ConstraintCorrection was not used in GenericConstraintSolver.
It is (only?) re-ordered when LinearSolverCC is set with "wire optimization" and gives a big speed-up when used with the partial_solve of BTDLinearSolver (and not building matrices)

This optimization was already in the LCPConstraintSolver and explain (but not totally) the big difference of speed for the scenes with LinearCC/BTD and unbuilt gaussseidel.

Numbers from `BeamAdapter/examples/3instruments_collis.scn -g batch -n 5000` , all constraint solvers use unbuilt GS.
```
(mu=0.1)
LCP        = [INFO]    [BatchGUI] 5000 iterations done in 61.9292 s ( 80.7373 FPS).
GCS before = [INFO]    [BatchGUI] 5000 iterations done in 261.396 s ( 19.1281 FPS)
GCS after  = [INFO]    [BatchGUI] 5000 iterations done in 85.083 s ( 58.7661 FPS)
```
```
(mu=0.0)
LCP        = [INFO]    [BatchGUI] 5000 iterations done in 43.2622 s ( 115.574 FPS).
GCS before = [INFO]    [BatchGUI] 5000 iterations done in 230.029 s ( 21.7364 FPS)
GCS after  = [INFO]    [BatchGUI] 5000 iterations done in 68.9986 s ( 72.4652 FPS)
```

As for the simulation itself, the results are not exactly the same (even if visually, looks the same) between LCPCS or GCS
`regression step-by-step, 2000 steps`
```
(mu=0.1)
TOTALERROR: 3.18005
ERRORBYDOF: 0.00310931
```
```
(mu=0.0)
TOTALERROR: 1.55088
ERRORBYDOF: 0.00154138
```

But I cannot tell which one of the two (LCPCS or GCS) is the most "precise" 🤷

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
