### PR TITLE
[Sofa.GL] Fix doDrawVisual for OglLabel

### DIFF
--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
@@ -141,15 +141,6 @@ void OglLabel::handleEvent(sofa::core::objectmodel::Event *event)
 
 void OglLabel::doDrawVisual(const core::visual::VisualParams* vparams)
 {
-    // Save state and disable clipping plane
-    glPushAttrib(GL_ENABLE_BIT);
-    for(int i = 0; i < GL_MAX_CLIP_PLANES; ++i)
-        glDisable(GL_CLIP_PLANE0+i);
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_TEXTURE_1D);
-    glDisable(GL_BLEND);
-    glDepthMask(1);
-
     vparams->drawTool()->setLightingEnabled(false);
 
     // color of the text
@@ -168,9 +159,6 @@ void OglLabel::doDrawVisual(const core::visual::VisualParams* vparams)
         d_x.getValue(), d_y.getValue(), d_fontsize.getValue(),  // x, y, size
         d_color.getValue(),
         text.c_str());
-
-    // Restore state
-    glPopAttrib();
 }
 
 void OglLabel::setColor(float r, float g, float b, float a)

--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
@@ -141,6 +141,12 @@ void OglLabel::handleEvent(sofa::core::objectmodel::Event *event)
 
 void OglLabel::doDrawVisual(const core::visual::VisualParams* vparams)
 {
+    // Workaround: Disable showWireframe (polygon mode set to true forcefully in VisualModel drawVisual())
+    if (vparams->displayFlags().getShowWireFrame())
+    {
+        vparams->drawTool()->setPolygonMode(0, false);
+    }
+
     vparams->drawTool()->setLightingEnabled(false);
 
     const std::string text = d_prefix.getValue() + m_internalLabel.c_str() + d_suffix.getValue();
@@ -149,6 +155,12 @@ void OglLabel::doDrawVisual(const core::visual::VisualParams* vparams)
         d_x.getValue(), d_y.getValue(), d_fontsize.getValue(),  // x, y, size
         d_color.getValue(),
         text.c_str());
+
+    // restore polygon mode if needed
+    if (vparams->displayFlags().getShowWireFrame())
+    {
+        vparams->drawTool()->setPolygonMode(0, true);
+    }
 }
 
 void OglLabel::setColor(float r, float g, float b, float a)

--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
@@ -143,16 +143,6 @@ void OglLabel::doDrawVisual(const core::visual::VisualParams* vparams)
 {
     vparams->drawTool()->setLightingEnabled(false);
 
-    // color of the text
-    glColor4fv( d_color.getValue().data() );
-
-    glMaterialfv (GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, d_color.getValue().data() );
-    static const float emissive[4] = { 0.0f, 0.0f, 0.0f, 0.0f};
-    static const float specular[4] = { 1.0f, 1.0f, 1.0f, 1.0f};
-    glMaterialfv (GL_FRONT_AND_BACK, GL_EMISSION, emissive);
-    glMaterialfv (GL_FRONT_AND_BACK, GL_SPECULAR, specular);
-    glMaterialf  (GL_FRONT_AND_BACK, GL_SHININESS, 20);
-
     const std::string text = d_prefix.getValue() + m_internalLabel.c_str() + d_suffix.getValue();
 
     vparams->drawTool()->writeOverlayText(


### PR DESCRIPTION
While assisting people on GH Discussions noticed this issue from OglLabel .

Example scene : `examples/Demos/rigidifiedSectionsInBeam.scn` 
Before fix:
![](https://github.com/sofa-framework/sofa/assets/17544719/d903f7ee-bb9c-4225-aa8e-21c996d8e650)


After fix:
![rigidifiedSectionsInBeam_00000001](https://github.com/sofa-framework/sofa/assets/17544719/879ef541-cf58-4051-a8d2-5ec37f8d09dd)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
