### PR TITLE
[IO.Mesh.Tests] Reduce number of logs by unactivating printlog

### DIFF
--- a/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
@@ -107,7 +107,7 @@ public:
                 "   <DefaultAnimationLoop/>                                        \n"
                 "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
                 "   <RegularGridTopology name='grid' n='6 6 6' min='-10 -10 -10' max='10 10 10' p0='-30 -10 -10' computeHexaList='1'/> \n"
-                "   <MeshExporter name='exporter1' format='" << format << "' printLog='true' filename='" << filename << "' exportAtBegin='true' /> \n"
+                "   <MeshExporter name='exporter1' format='" << format << "' printLog='false' filename='" << filename << "' exportAtBegin='true' /> \n"
                 "</Node>                                                           \n";
 
         const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
@@ -138,7 +138,7 @@ public:
                 "   <DefaultAnimationLoop/>                                        \n"
                 "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
                 "   <RegularGridTopology name='grid' n='6 6 6' min='-10 -10 -10' max='10 10 10' p0='-30 -10 -10' computeHexaList='1'/> \n"
-                "   <MeshExporter name='exporterA' format='" << format << "' printLog='true' filename='" << filename << "' exportEveryNumberOfSteps='5' /> \n"
+                "   <MeshExporter name='exporterA' format='" << format << "' printLog='false' filename='" << filename << "' exportEveryNumberOfSteps='5' /> \n"
                 "</Node>                                                           \n";
 
         const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());

--- a/Sofa/Component/IO/Mesh/tests/MeshXspLoader_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshXspLoader_test.cpp
@@ -34,6 +34,7 @@ public:
         const auto simulation = sofa::simpleapi::createSimulation();
         const Node::SPtr root = sofa::simpleapi::createRootNode(simulation, "root");
 
+        sofa::simpleapi::createObject(root, "DefaultAnimationLoop");
         sofa::simpleapi::createObject(root, "RequiredPlugin", { { "name","Sofa.Component.IO.Mesh" } });
         auto loader = sofa::simpleapi::createObject(root, "MeshXspLoader",
                                       {{"filename", std::string(SOFA_COMPONENT_IO_MESH_TEST_FILES_DIR)+"test.xs3"}});
@@ -47,6 +48,7 @@ public:
     {
         const auto simulation = sofa::simpleapi::createSimulation();
         const Node::SPtr root = sofa::simpleapi::createRootNode(simulation, "root");
+        sofa::simpleapi::createObject(root, "DefaultAnimationLoop");
 
         {
             EXPECT_MSG_EMIT(Error);

--- a/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
@@ -95,7 +95,7 @@ public:
                 "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
                 "   <MeshOBJLoader name='loader' filename='mesh/liver-smooth.obj'/> \n"
                 "   <VisualModel src='@loader'/>                                      \n"
-                "   <STLExporter name='exporter1' printLog='true' filename='"<< filename << "' exportAtBegin='true' /> \n"
+                "   <STLExporter name='exporter1' printLog='false' filename='"<< filename << "' exportAtBegin='true' /> \n"
                 "</Node>                                                           \n" ;
 
         const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
@@ -126,7 +126,7 @@ public:
                 "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
                 "   <MeshOBJLoader name='loader' filename='mesh/liver-smooth.obj'/> \n"
                 "   <VisualModel src='@loader'/>                                      \n"
-                "   <STLExporter name='exporterA' printLog='true' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
+                "   <STLExporter name='exporterA' printLog='false' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
                 "</Node>                                                           \n" ;
 
         const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());

--- a/Sofa/Component/IO/Mesh/tests/VisualModelOBJExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/VisualModelOBJExporter_test.cpp
@@ -87,7 +87,7 @@ public:
                 "<?xml version='1.0'?> \n"
                 "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >       \n"
                 "   <DefaultAnimationLoop/>                                        \n"
-                "   <VisualModelOBJExporter name='exporter1' printLog='true' filename='"<< filename << "' exportAtBegin='true' /> \n"
+                "   <VisualModelOBJExporter name='exporter1' printLog='false' filename='"<< filename << "' exportAtBegin='true' /> \n"
                 "</Node>                                                           \n" ;
 
         const Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene", scene1.str().c_str());
@@ -113,7 +113,7 @@ public:
                 "<?xml version='1.0'?> \n"
                 "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >       \n"
                 "   <DefaultAnimationLoop/>                                        \n"
-                "   <VisualModelOBJExporter name='exporterA' printLog='true' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
+                "   <VisualModelOBJExporter name='exporterA' printLog='false' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
                 "</Node>                                                           \n" ;
 
         const Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene", scene1.str().c_str());


### PR DESCRIPTION
- Set printLog to false in scenes creations in MeshExporter tests
- Also remove some warnings in scenes creations






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
