### PR TITLE
[SofaSphFluid] Fix: scenes warnings and failing examples

### DIFF
--- a/applications/plugins/SofaSphFluid/examples/OglFluidModel_SPH.scn
+++ b/applications/plugins/SofaSphFluid/examples/OglFluidModel_SPH.scn
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <Node dt="0.01" gravity="0 -20 0.0" >
     <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
     <RequiredPlugin name="Sofa.Component.MechanicalLoad"/> <!-- Needed to use components [PlaneForceField] -->
@@ -8,6 +9,7 @@
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [OglFluidModel SPHFluidForceField SpatialGridContainer] -->
     <VisualStyle displayFlags="hideBehaviorModels hideForceFields hideCollisionModels" />
 
+    <DefaultAnimationLoop/>
     <Node name="SPH" >
         <EulerExplicitSolver symplectic="1" />
         <RegularGridTopology nx="5" ny="400" nz="5" xmin="-3.0" xmax="0" ymin="-3" ymax="36" zmin="-3.0" zmax="0" />

--- a/applications/plugins/SofaSphFluid/examples/OglFluidModel_SPHParticles.scn
+++ b/applications/plugins/SofaSphFluid/examples/OglFluidModel_SPHParticles.scn
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Node dt="0.01" gravity="0 -10 0" bbox="-4 -4 -4 4 4 4">
+<Node dt="0.01" gravity="0 -10 0" bbox="-6 -6 -6  6 6 6">
     <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
     <RequiredPlugin name="Sofa.Component.ODESolver.Forward"/> <!-- Needed to use components [EulerExplicitSolver] -->
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
@@ -8,9 +8,10 @@
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [OglFluidModel ParticleSink ParticleSource SPHFluidForceField SpatialGridContainer] -->
     <VisualStyle displayFlags="hideBehaviorModels hideForceFields hideWireframe" />
 
+    <DefaultAnimationLoop/>
     <Node name="Particles">
         <EulerExplicitSolver symplectic="1" />
-        <MechanicalObject name="MModel" />
+        <MechanicalObject name="MModel"/>
         <ParticleSource name="Source" translation="0 20 0" radius="0.01 0.1 0.01" velocity="0 -10 0" delay="0.02" start="0.0" stop="10" printLog="0"
         center="-0.375 0 -0.75 
             0.0 0.0 -0.75 
@@ -34,7 +35,7 @@
             0.0 0.0 0.75 
             0.375 0.0 0.75"  />
         
-        <UniformMass name="M1" totalMass="1.0" />
+        <UniformMass name="M1" vertexMass="1.0" />
         <PointSetTopologyContainer name="con" />
         <PointSetTopologyModifier name="mod" />
         

--- a/applications/plugins/SofaSphFluid/examples/ParticleSink.scn
+++ b/applications/plugins/SofaSphFluid/examples/ParticleSink.scn
@@ -1,15 +1,38 @@
 <?xml version="1.0" ?>
-<Node dt="0.005" gravity="0 -10 0">
+<Node dt="0.005" gravity="0 -10 0" bbox="-6 -6 -6  6 6 6">
     <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
     <RequiredPlugin name="Sofa.Component.ODESolver.Forward"/> <!-- Needed to use components [EulerExplicitSolver] -->
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [ParticleSink ParticleSource] -->
-    <VisualStyle displayFlags="showBehaviorModels showForceFields showWireframe" />
+    <VisualStyle displayFlags="showBehaviorModels showForceFields hideWireframe" />
+    <DefaultAnimationLoop/>
     <Node name="Fluid">
         <EulerExplicitSolver symplectic="1" />
         <MechanicalObject name="MModel" showObject="1"/>
-        <ParticleSource name="Source" center="&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.375 0 -0.75&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.0   0 -0.75&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.375 0 -0.75&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.75  0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.375 0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.0   0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.375 0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.75  0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.75  0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.375 0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.0   0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.375 0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.75  0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.75  0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.375 0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.0   0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.375 0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.75  0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    -0.375 0  0.75&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.0   0  0.75&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    0.375 0  0.75&#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;    " translation="0 3 0" radius="0.01 0.1 0.01" velocity="0 -20 0" delay="0.01875" start="-0.1" stop="2" />
+        <ParticleSource name="Source" 
+            center="-0.375 0 -0.75    
+            0 0 -0.75    
+            0.375 0 -0.75    
+            -0.75  0 -0.375    
+            -0.375 0 -0.375    
+            0 0 -0.375    
+            0.375 0 -0.375    
+            0.75  0 -0.375    
+            -0.75  0  0.0    
+            -0.375 0  0.0    
+            0 0  0    
+            0.375 0  0.0    
+            0.75  0  0.0    
+            -0.75  0  0.375    
+            -0.375 0  0.375    
+            0.0   0  0.375    
+            0.375 0  0.375    
+            0.75  0  0.375    
+            -0.375 0  0.75    
+            0 0  0.75    
+            0.375 0  0.75" 
+            translation="0 3 0" radius="0.01 0.1 0.01" velocity="0 -20 0" delay="0.01875" start="-0.1" stop="2" />
         <ParticleSink normal="0 1 0" d0="-10" d1="-11" showPlane="true" printLog="false" />
         <UniformMass name="M1" vertexMass="1.0" />
     </Node>

--- a/applications/plugins/SofaSphFluid/examples/ParticleSource.scn
+++ b/applications/plugins/SofaSphFluid/examples/ParticleSource.scn
@@ -7,6 +7,7 @@
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [ParticleSource] -->
     <VisualStyle displayFlags="showBehaviorModels showForceFields showWireframe" />
 
+    <DefaultAnimationLoop/>
     <Node name="Particles">
         <EulerExplicitSolver symplectic="1" />
         <MechanicalObject name="MModel" showObject="1"/>        

--- a/applications/plugins/SofaSphFluid/examples/ParticlesRepulsionForceField.scn
+++ b/applications/plugins/SofaSphFluid/examples/ParticlesRepulsionForceField.scn
@@ -18,6 +18,7 @@
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [ParticlesRepulsionForceField SpatialGridContainer] -->
 
+    <DefaultAnimationLoop/>
     <CollisionPipeline verbose="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>

--- a/applications/plugins/SofaSphFluid/examples/PointSplatModel.scn
+++ b/applications/plugins/SofaSphFluid/examples/PointSplatModel.scn
@@ -13,7 +13,7 @@
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel PointSplatModel] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [ParticleSink ParticleSource SPHFluidForceField SpatialGridContainer SpatialGridPointModel] -->
 
-
+    <DefaultAnimationLoop/>
     <CollisionPipeline verbose="0" />
     <NewProximityIntersection alarmDistance="0.5" contactDistance="0.3" />
     <BruteForceBroadPhase/>
@@ -26,7 +26,28 @@
 
 		<PointSetTopologyContainer name="con" />
         <PointSetTopologyModifier name="mod" />
-		<ParticleSource name="Source" center="&#x0A;&#x09;&#x09;&#x09;&#x09;-0.375 0 -0.75&#x0A;&#x09;&#x09;&#x09;&#x09; 0.0   0 -0.75&#x0A;&#x09;&#x09;&#x09;&#x09; 0.375 0 -0.75&#x0A;&#x09;&#x09;&#x09;&#x09;-0.75  0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09;-0.375 0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09; 0.0   0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09; 0.375 0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09; 0.75  0 -0.375&#x0A;&#x09;&#x09;&#x09;&#x09;-0.75  0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09;-0.375 0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09; 0.0   0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09; 0.375 0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09; 0.75  0  0.0&#x0A;&#x09;&#x09;&#x09;&#x09;-0.75  0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09;-0.375 0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09; 0.0   0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09; 0.375 0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09; 0.75  0  0.375&#x0A;&#x09;&#x09;&#x09;&#x09;-0.375 0  0.75&#x0A;&#x09;&#x09;&#x09;&#x09; 0.0   0  0.75&#x0A;&#x09;&#x09;&#x09;&#x09; 0.375 0  0.75&#x0A;&#x09;&#x09;&#x09;&#x09; " translation="0 3 0" radius="0.01 0.1 0.01" velocity="0 -20 0" delay="0.01875" start="-0.1" stop="2" /> 
+		<ParticleSource name="Source" translation="0 3 0" radius="0.01 0.1 0.01" velocity="0 -20 0" delay="0.01875" start="-0.1" stop="2" 
+        center="-0.375 0 -0.75 
+            0.0 0.0 -0.75 
+            0.375 0.0 -0.75 
+            -0.75  0.0 -0.375 
+            -0.375 0.0 -0.375 
+            0.0 0.0 -0.375 
+            0.375 0.0 -0.375 
+            0.75 0.0 -0.375 
+            -0.75 0.0 0.0 
+            -0.375 0.0 0.0 
+            0.0 0.0 0.0 
+            0.375 0.0 0.0 
+            0.75 0.0 0.0 
+            -0.75 0.0 0.375 
+            -0.375 0.0 0.375 
+            0.0 0.0 0.375 
+            0.375 0.0 0.375 
+            0.75 0.0 0.375 
+            -0.375 0.0 0.75 
+            0.0 0.0 0.75 
+            0.375 0.0 0.75"/> 
 		<ParticleSink normal="0 1 0" d0="-10" d1="-11" showPlane="true" printLog="true" />
 
         <UniformMass name="M1" vertexMass="1" />

--- a/applications/plugins/SofaSphFluid/examples/SPHDemo.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHDemo.scn
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <Node dt="0.005" gravity="0 -10 0">
     <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->
     <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
@@ -9,6 +10,8 @@
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [SPHFluidForceField SPHFluidSurfaceMapping SpatialGridContainer] -->
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <DefaultAnimationLoop/>
     <Node name="Liver">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />

--- a/applications/plugins/SofaSphFluid/examples/SPHFluidForceField.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHFluidForceField.scn
@@ -9,11 +9,13 @@
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [SPHFluidForceField SpatialGridContainer] -->
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields showCollisionModels" />
+
+    <DefaultAnimationLoop/>
     <Node>
         <EulerExplicitSolver symplectic="1" />
         <MechanicalObject name="MModel" />
         <!-- A topology is used here just to set initial particles positions. It is a bad idea because this object has no real topology, but it works... -->
-        <RegularGridTopology nx="5" ny="40" nz="5" xmin="-1.5" xmax="0" ymin="-3" ymax="12" zmin="-1.5" zmax="0" drawEdges="1"/>
+        <RegularGridTopology nx="5" ny="40" nz="5" xmin="-1.5" xmax="0" ymin="-3" ymax="12" zmin="-1.5" zmax="0"/>
         <UniformMass name="M1" vertexMass="1" />
         <SpatialGridContainer cellWidth="0.75" />
         <SPHFluidForceField radius="0.745" density="15" kernelType="1" viscosityType="2" viscosity="10" pressure="1000" surfaceTension="-1000" printLog="0" />

--- a/applications/plugins/SofaSphFluid/examples/SPHFluidForceField_benchmarks.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHFluidForceField_benchmarks.scn
@@ -10,6 +10,8 @@
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [SPHFluidForceField SpatialGridContainer] -->
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields showCollisionModels" />
+
+    <DefaultAnimationLoop/>
     <Node name="Less_pressure">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />

--- a/applications/plugins/SofaSphFluid/examples/SPHFluidSurfaceMapping.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHFluidSurfaceMapping.scn
@@ -10,7 +10,8 @@
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [SPHFluidForceField SPHFluidSurfaceMapping SpatialGridContainer] -->
 
-    <VisualStyle displayFlags="hideBehaviorModels showForceFields hideCollisionModels" />   
+    <VisualStyle displayFlags="hideBehaviorModels showForceFields hideCollisionModels" />
+    <DefaultAnimationLoop/>    
     <Node name="SPHSurfaceMapping">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />

--- a/applications/plugins/SofaSphFluid/examples/SPHParticleSink.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHParticleSink.scn
@@ -6,8 +6,9 @@
     <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [PointSetTopologyContainer PointSetTopologyModifier] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [ParticleSink ParticleSource SPHFluidForceField SpatialGridContainer] -->
-    <VisualStyle displayFlags="showBehaviorModels showForceFields showWireframe" />
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
 
+    <DefaultAnimationLoop/>
     <Node name="Particles">
         <EulerExplicitSolver symplectic="1" />
         <MechanicalObject name="MModel" />
@@ -37,7 +38,7 @@
         
         <PointSetTopologyContainer name="con" />
         <PointSetTopologyModifier name="mod" />
-        <UniformMass name="M1" totalMass="1.0" />
+        <UniformMass name="M1" vertexMass="1.0" />
         <SpatialGridContainer cellWidth="0.75" />
         <SPHFluidForceField radius="0.7" density="25" kernelType="1" viscosityType="2" viscosity="10" pressure="1000" surfaceTension="-1000" printLog="0" />
 

--- a/applications/plugins/SofaSphFluid/examples/SPHParticleSink_obstacle.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHParticleSink_obstacle.scn
@@ -9,12 +9,14 @@
     <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
     <RequiredPlugin name="Sofa.Component.ODESolver.Forward"/> <!-- Needed to use components [EulerExplicitSolver] -->
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
     <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [PointSetTopologyContainer PointSetTopologyModifier] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [OglFluidModel ParticleSink ParticleSource SPHFluidForceField SpatialGridContainer] -->
-    <VisualStyle displayFlags="hideBehaviorModels hideForceFields hideWireframe" />
+    <VisualStyle displayFlags="showVisual hideBehaviorModels hideForceFields hideWireframe" />
 
+    <DefaultAnimationLoop/>
     <CollisionPipeline depth="15" verbose="0" draw="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
@@ -50,11 +52,11 @@
         
         <PointSetTopologyContainer name="con" />
         <PointSetTopologyModifier name="mod" />
-        <UniformMass name="M1" totalMass="1.0" />
+        <UniformMass name="M1" vertexMass="1.0" />
         <SpatialGridContainer cellWidth="0.75" />
         <SPHFluidForceField radius="0.7" density="25" kernelType="1" viscosityType="2" viscosity="10" pressure="1000" surfaceTension="-1000" printLog="0" />
 
-        <ParticleSink name="sink" normal="0 1 0" d0="0" d1="-1" showPlane="1" printLog="0" />
+        <ParticleSink name="sink" normal="0 1 0" d0="-3.5" d1="-4" showPlane="1" printLog="0" />
         <Node name="Collision">
             <MechanicalObject />
             <SphereCollisionModel radius="0.05" showImpostors="true" />
@@ -63,19 +65,21 @@
         <Node name="Fluid" >            
             <OglFluidModel template="Vec3d" position="@../MModel.position" 
             debugFBO="9" 
-            spriteRadius="0.5" spriteThickness="0.015" spriteBlurRadius="10" spriteBlurScale="10" spriteBlurDepthFalloff="1"  />
+            spriteRadius="0.5" spriteThickness="0.04" spriteBlurRadius="10" spriteBlurScale="10" spriteBlurDepthFalloff="1"  />
         </Node>
-        
     </Node>
 
-    <Node name="Obstacle" >            
+    
+    <Node name="Obstacle" >      
+        <MeshOBJLoader name='loader' filename='mesh/dragon.obj' scale3d="0.5 0.5 0.5" translation="0 0 1"/>
         <Node name="Collision" >            
-            <MechanicalObject template="Vec3d" position="0 0 0" />
-            <SphereCollisionModel radius="1.0" showImpostors="false" contactStiffness="100" />
+            <MeshTopology src="@../loader" />
+            <MechanicalObject src="@../loader" />
+            <TriangleCollisionModel contactStiffness="50"/>
         </Node>    
         <Node name="Visual" >   
-            <MeshOBJLoader name="loader" filename="mesh/sphere.obj" />         
-            <OglModel src="@loader" />
+            <OglModel src="@../loader" />
         </Node>   
     </Node>
+    
 </Node>

--- a/applications/plugins/SofaSphFluid/examples/SPHParticleSource.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHParticleSource.scn
@@ -7,8 +7,9 @@
     <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [PointSetTopologyContainer PointSetTopologyModifier] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [ParticleSource SPHFluidForceField SpatialGridContainer] -->
-    <VisualStyle displayFlags="showBehaviorModels showForceFields showWireframe" />
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
 
+    <DefaultAnimationLoop/>
     <Node name="Particles">
         <EulerExplicitSolver symplectic="1" />
         <MechanicalObject name="MModel" />
@@ -35,7 +36,7 @@
             0.0 0.0 0.75 
             0.375 0.0 0.75"  />
         
-        <UniformMass name="M1" totalMass="1.0" />
+        <UniformMass name="M1" vertexMass="1.0" />
         <PointSetTopologyContainer name="con" />
         <PointSetTopologyModifier name="mod" />
         

--- a/applications/plugins/SofaSphFluid/examples/SpatialGridContainer.scn
+++ b/applications/plugins/SofaSphFluid/examples/SpatialGridContainer.scn
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <Node dt="0.005" gravity="0 -10 0">
     <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
     <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
@@ -9,6 +10,8 @@
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [SPHFluidForceField SpatialGridContainer] -->
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <DefaultAnimationLoop/>
     <Node name="Liver">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />

--- a/applications/plugins/SofaSphFluid/examples/SpatialGridPointModel.scn
+++ b/applications/plugins/SofaSphFluid/examples/SpatialGridPointModel.scn
@@ -8,30 +8,27 @@
     <RequiredPlugin name="Sofa.Component.ODESolver.Forward"/> <!-- Needed to use components [RungeKutta4Solver] -->
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
     <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [PointSetTopologyContainer PointSetTopologyModifier] -->
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <RequiredPlugin name="SofaSphFluid"/> <!-- Needed to use components [ParticleSink ParticleSource SPHFluidForceField SPHFluidSurfaceMapping SpatialGridContainer SpatialGridPointModel] -->
 
 
-    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+    <VisualStyle displayFlags="showVisual showBehaviorModels hideForceFields" />
+    <DefaultAnimationLoop/>
     <CollisionPipeline verbose="0" />
     <NewProximityIntersection alarmDistance="0.5" contactDistance="0.3" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <CollisionResponse response="PenalityContactForceField" />
     <Node name="Fluid">
-        <RungeKutta4Solver />
-        <PointSetTopologyContainer />
+        <RungeKutta4Solver />        
+        <RegularGridTopology nx="5" ny="30" nz="5" xmin="-1.5" xmax="0" ymin="-3" ymax="9" zmin="-1.5" zmax="0" drawEdges="0"/>
         <MechanicalObject name="MModel" />
-        <PointSetTopologyContainer name="con" />
-        <PointSetTopologyModifier name="mod" />
-        <ParticleSource name="Source" center="&#x0A;-0.375 0 -0.75&#x0A; 0.0   0 -0.75&#x0A; 0.375 0 -0.75&#x0A;-0.75  0 -0.375&#x0A;-0.375 0 -0.375&#x0A; 0.0   0 -0.375&#x0A; 0.375 0 -0.375&#x0A; 0.75  0 -0.375&#x0A;-0.75  0  0.0&#x0A;-0.375 0  0.0&#x0A; 0.0   0  0.0&#x0A; 0.375 0  0.0&#x0A; 0.75  0  0.0&#x0A;-0.75  0  0.375&#x0A;-0.375 0  0.375&#x0A; 0.0   0  0.375&#x0A; 0.375 0  0.375&#x0A; 0.75  0  0.375&#x0A;-0.375 0  0.75&#x0A; 0.0   0  0.75&#x0A; 0.375 0  0.75&#x0A; " translation="0 3 0" radius="0.01 0.1 0.01" velocity="0 -20 0" delay="0.01875" start="-0.1" stop="2" />
-        <ParticleSink normal="0 1 0" d0="-10" d1="-11" showPlane="true" printLog="false" />
         <UniformMass name="M1" vertexMass="1" />
         <SpatialGridContainer cellWidth="0.75" sortPoints="true" />
-        <SPHFluidForceField radius="0.75" density="15" viscosity="10" pressure="1000" surfaceTension="-1000" />
-        <Node id="Visual">
+        <SPHFluidForceField radius="0.745" density="15" viscosity="10" pressure="1000" surfaceTension="-1000" />
+        <Node name="Visual">
             <OglModel name="VModel" color="blue" />
             <SPHFluidSurfaceMapping name="MarchingCube" input="@../MModel" output="@VModel" isoValue="0.5" radius="0.75" step="0.25" />
         </Node>
@@ -43,6 +40,6 @@
         <TriangleCollisionModel contactStiffness="20" moving="false" simulated="false" />
         <LineCollisionModel contactStiffness="20" moving="false" simulated="false" />
         <PointCollisionModel contactStiffness="20" moving="false" simulated="false" />
-        <OglModel name="VModel" color="0.95 1.0 0.95 0.25" printLog="true" />
+        <OglModel name="VModel" color="0.95 1.0 0.95 0.25" printLog="false" />
     </Node>
 </Node>


### PR DESCRIPTION
- Various cleaning to remove SceneChecker warnings
- Fix some examples which should use `vertexMass ` and not `totalMass ` in `uniformMass ` as the number of particles evolve. 
- Fix SpatialGridPointModel scene which was timing out on CI.  There was a problem of init with too many particles created compare to the collision and sphFF distances. 
- Update SPHParticleSink_obstacle.scn to wash the dragon
 

**SpatialGridPointModel new behavior** 
<img src="https://github.com/sofa-framework/sofa/assets/21199245/305fd2a4-c15b-4315-8278-509c3fef6204" width="75%">

And working collisions:
<img src="https://github.com/sofa-framework/sofa/assets/21199245/8a117063-4714-4e0c-8156-401dcba3fde0" width="75%">


**New version of SPHParticleSink_obstacle**
<img src="https://github.com/sofa-framework/sofa/assets/21199245/184dad41-bb91-45f1-9d38-b913610aec78" width="75%">


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
