### PR TITLE
[SofaSphFluid] Fix: internal draw method not restoring default parameters

### DIFF
--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSink.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSink.inl
@@ -211,7 +211,7 @@ void ParticleSink<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (!d_showPlane.getValue())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
 
     type::Vec3d normal; normal = d_planeNormal.getValue();
 
@@ -243,8 +243,6 @@ void ParticleSink<DataTypes>::draw(const core::visual::VisualParams* vparams)
     vertices.push_back(sofa::type::Vec3(corners[2]));
     vertices.push_back(sofa::type::Vec3(corners[3]));
     vparams->drawTool()->drawQuad(vertices[0],vertices[1],vertices[2],vertices[3], cross((vertices[1] - vertices[0]), (vertices[2] - vertices[0])), sofa::type::RGBAColor(0.0f, 0.5f, 0.2f, 1.0f));
-
-    vparams->drawTool()->restoreLastState();
 }
 
 } // namespace misc

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
@@ -333,6 +333,8 @@ void ParticleSource<DataTypes>::draw(const core::visual::VisualParams* vparams)
     if (time < d_start.getValue() || time > d_stop.getValue())
         return;
 
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
+
     Deriv dpos = d_velocity.getValue()*(time - m_lastTime);
 
     std::vector< sofa::type::Vec3 > pointsInit;

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
@@ -187,7 +187,7 @@ void ParticlesRepulsionForceField<DataTypes>::draw(const core::visual::VisualPar
     if (!vparams->displayFlags().getShowForceFields() && !vparams->displayFlags().getShowInteractionForceFields())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
@@ -217,7 +217,6 @@ void ParticlesRepulsionForceField<DataTypes>::draw(const core::visual::VisualPar
         }
     }
     vparams->drawTool()->drawLines(vertices,1,colorVector);
-    vparams->drawTool()->restoreLastState();
 }
 
 } // namespace forcefield

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
@@ -451,7 +451,7 @@ void SPHFluidForceField<DataTypes>::draw(const core::visual::VisualParams* vpara
     if (!vparams->displayFlags().getShowForceFields())
         return;
 
-    vparams->drawTool()->saveLastState();
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->disableLighting();
     vparams->drawTool()->enableBlending();
     vparams->drawTool()->disableDepthTest();
@@ -552,8 +552,6 @@ void SPHFluidForceField<DataTypes>::draw(const core::visual::VisualParams* vpara
     vparams->drawTool()->drawPoints(vertices,5,colorVector);
     vertices.clear();
     colorVector.clear();
-
-    vparams->drawTool()->restoreLastState();
 }
 
 } // namespace forcefield

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidSurfaceMapping.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidSurfaceMapping.inl
@@ -489,6 +489,7 @@ void SPHFluidSurfaceMapping<In,Out>::draw(const core::visual::VisualParams* vpar
     if (!grid)
         return;
 
+    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     grid->draw(vparams);
 
     float scale = (float)d_mStep.getValue();


### PR DESCRIPTION
Fix similar problem encountered in #4142 where the global rendering stays red. 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
