### PR TITLE
[Mass] Fix UniformMass vertexMass value should not be set to 0 if nbr of points reach 0

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
@@ -375,7 +375,6 @@ void UniformMass<DataTypes>::updateMassOnResize(sofa::Size newSize)
 {
     if (newSize == 0)
     {
-        d_vertexMass.setValue(static_cast<MassType>(0.0));
         d_totalMass.setValue(Real(0));
         return;
     }


### PR DESCRIPTION
Fix problem encountered in SPH scenes where the number of particles is 0 at start. 
Therefor the vertexMass was set to 0 during the first steps and all particles created during the next simulation steps were still having no mass. 






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
