### PR TITLE
[Topology.Grid] Fix SparseGridTopology and SparseGridRamificationTopology crash at init if mesh file is not found

### DIFF
--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridRamificationTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridRamificationTopology.cpp
@@ -56,6 +56,9 @@ void SparseGridRamificationTopology::init()
 {
     SparseGridTopology::init();
 
+    if (d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
+        return;
+
     if( this->isVirtual || _nbVirtualFinerLevels.getValue() > 0)
         findCoarsestParents(); // in order to compute findCube by beginning by the finnest, by going up and give the coarsest parent
 }
@@ -64,6 +67,11 @@ void SparseGridRamificationTopology::buildAsFinest()
 {
     SparseGridTopology::buildAsFinest();
 
+    if (getNbHexahedra() == 0)
+    {
+        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
 
     if( _finestConnectivity.getValue() || this->isVirtual || _nbVirtualFinerLevels.getValue() > 0 )
     {
@@ -90,7 +98,7 @@ void SparseGridRamificationTopology::findConnexionsAtFinestLevel()
     // Finest level is asked
     if (_finestConnectivity.getValue())
     {
-        const std::string filename = this->fileTopology.getValue();
+        const std::string& filename = this->fileTopology.getValue();
         if (!filename.empty()) // file given, try to load it.
         {
             mesh = helper::io::Mesh::Create(filename.c_str());
@@ -409,7 +417,11 @@ void SparseGridRamificationTopology::buildFromFiner()
 {
     SparseGridRamificationTopology* finerSparseGridRamification = dynamic_cast<SparseGridRamificationTopology*>(_finerSparseGrid);
 
-
+    if (finerSparseGridRamification->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
+    {
+        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
 
     setNx( _finerSparseGrid->getNx()/2+1 );
     setNy( _finerSparseGrid->getNy()/2+1 );

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/SparseGridTopology.cpp
@@ -134,6 +134,12 @@ void SparseGridTopology::init()
     for(unsigned i=0; i<seqPoints.getValue().size(); ++i)
         _nodeAdjacency[i].assign(InvalidID);
 
+    if (_nodeAdjacency.empty())
+    {
+        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+
     const auto& hexahedra = seqHexahedra.getValue();
 
     for(unsigned i=0; i<hexahedra.size(); ++i)
@@ -198,7 +204,7 @@ void SparseGridTopology::buildAsFinest(  )
     }
     else
     {
-        const std::string _filename = fileTopology.getFullPath();
+        const std::string& _filename = fileTopology.getFullPath();
 
         if (_filename.length() > 4 && _filename.compare(_filename.length() - 4, 4, ".raw") == 0)
         {
@@ -998,6 +1004,12 @@ void SparseGridTopology::computeBoundingBox(const type::vector<type::Vec3>& vert
 
 void SparseGridTopology::buildFromFiner()
 {
+    if (_finerSparseGrid->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
+    {
+        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+
     setNx( _finerSparseGrid->getNx()/2+1 );
     setNy( _finerSparseGrid->getNy()/2+1 );
     setNz( _finerSparseGrid->getNz()/2+1 );
@@ -1053,7 +1065,6 @@ void SparseGridTopology::buildFromFiner()
                     if( fineIndices[w] == InvalidID ) inside=false;
                     else
                     {
-
                         if( _finerSparseGrid->getType( fineIndices[w] ) == BOUNDARY ) { inside=false; outside=false; }
                         else if( _finerSparseGrid->getType( fineIndices[w] ) == INSIDE ) {outside=false;}
                     }
@@ -1090,7 +1101,6 @@ void SparseGridTopology::buildFromFiner()
             }
         }
     }
-
 
     // compute corner indices
     int cornerCounter=0;


### PR DESCRIPTION
Error message was already fired if mesh file is not found. This PR just avoid the crash at init.
Only add some check in the finest level and set it to invalid if topology is not loaded.
Then propagate the invalid status to the higher level.

fix #4162 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
