### PR TITLE
[Constraint.Lagrangian.Solver] LCPConstraintSolver: remove useless computation if printLog is enabled

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -853,12 +853,6 @@ int LCPConstraintSolver::nlcp_gaussseidel_unbuilt(SReal *dfree, SReal *f, std::v
     {
         core::behavior::BaseConstraintCorrection* cc = l_constraintCorrections[i];
         cc->resetForUnbuiltResolution(f, contact_sequence);
-
-        if(notMuted())
-        {
-            core::ConstraintParams cparams;
-            cc->addComplianceInConstraintSpace(&cparams, _W);
-        }
     }
 
     sofa::helper::advancedtimer::stepEnd("build_constraints");


### PR DESCRIPTION
I dont see why `addComplianceInConstraintSpace` is called if printLog() is enabled 🤔

This block of code just appears from nowhere in the git history, and this part is not even in the frictionless version.

and _W is normally not used in the unbuilt case anyway,,,,

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
