### PR TITLE
[all] Generalize the usage of ScopedAdvancedTimer

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
@@ -65,8 +65,8 @@ void MultiStepAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt
     if (dt == 0)
         dt = node->getDt();
 
+    helper::ScopedAdvancedTimer animationStepTimer("AnimationStep");
 
-    sofa::helper::AdvancedTimer::stepBegin("AnimationStep");
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printNode("Step");
 #endif
@@ -120,16 +120,16 @@ void MultiStepAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt
         node->execute ( act );
     }
 
-    sofa::helper::AdvancedTimer::stepBegin("UpdateMapping");
     //Visual Information update: Ray Pick add a MechanicalMapping used as VisualMapping
-    node->execute<UpdateMappingVisitor>(params);
-    sofa::helper::AdvancedTimer::step("UpdateMappingEndEvent");
+    {
+        helper::ScopedAdvancedTimer updateMappingTimer("UpdateMapping");
+        node->execute<UpdateMappingVisitor>(params);
+    }
     {
         UpdateMappingEndEvent ev ( dt );
         PropagateEventVisitor act ( params , &ev );
         node->execute ( act );
     }
-    sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
 
     if (d_computeBoundingBox.getValue())
     {
@@ -140,8 +140,6 @@ void MultiStepAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printCloseNode("Step");
 #endif
-
-    sofa::helper::AdvancedTimer::stepEnd("AnimationStep");
 }
 
 } // namespace sofa::component::animationloop

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
@@ -71,7 +71,8 @@ void MultiTagAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt)
 {
     auto node = dynamic_cast<sofa::simulation::Node*>(this->l_node.get());
 
-    sofa::helper::AdvancedTimer::stepBegin("AnimationStep");
+    helper::ScopedAdvancedTimer animationStepTimer("AnimationStep");
+
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printNode("Step");
 #endif
@@ -121,16 +122,16 @@ void MultiTagAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt)
         node->execute ( act );
     }
 
-    sofa::helper::AdvancedTimer::stepBegin("UpdateMapping");
     //Visual Information update: Ray Pick add a MechanicalMapping used as VisualMapping
-    node->execute<UpdateMappingVisitor>(params);
-    sofa::helper::AdvancedTimer::step("UpdateMappingEndEvent");
+    {
+        helper::ScopedAdvancedTimer updateMappingTimer("UpdateMapping");
+        node->execute<UpdateMappingVisitor>(params);
+    }
     {
         UpdateMappingEndEvent ev ( dt );
         PropagateEventVisitor act ( params , &ev );
         node->execute ( act );
     }
-    sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
 
     if (d_computeBoundingBox.getValue())
     {
@@ -141,8 +142,6 @@ void MultiTagAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt)
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printCloseNode("Step");
 #endif
-
-    sofa::helper::AdvancedTimer::stepEnd("AnimationStep");
 }
 
 void MultiTagAnimationLoop::clear()

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/IncrSAP.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/IncrSAP.cpp
@@ -22,6 +22,8 @@
 #include <sofa/component/collision/detection/algorithm/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/component/collision/detection/algorithm/IncrSAP.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::collision::detection::algorithm
 {
@@ -368,7 +370,7 @@ void IncrSAP::boxPrune(){
     const int axis1 = (1  << _cur_axis) & 3;
     const int axis2 = (1  << axis1) & 3;
 
-    sofa::helper::AdvancedTimer::stepBegin("Box Prune SAP intersection");
+    helper::ScopedAdvancedTimer timer("Box Prune SAP intersection");
 
     std::deque<int> active_boxes; // active boxes are the one that we encoutered only their min (end point), so if there are two boxes b0 and b1,
                                   // if we encounter b1_min as b0_min < b1_min, on the current axis, the two boxes intersect :  b0_min--------------------b0_max
@@ -393,8 +395,6 @@ void IncrSAP::boxPrune(){
             active_boxes.push_back(new_box);
         }
     }
-
-    sofa::helper::AdvancedTimer::stepEnd("Box Prune SAP intersection");
 }
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -203,33 +203,35 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
 {
     unsigned int numConstraints = 0;
 
-    auto* context = getContext();
+    {
+        helper::ScopedAdvancedTimer timer("Accumulate Constraint");
 
-    sofa::helper::AdvancedTimer::stepBegin("Accumulate Constraint");
-    // mechanical action executed from root node to propagate the constraints
-    MechanicalResetConstraintVisitor(cParams).execute(context);
-    // calling buildConstraintMatrix
-    MechanicalBuildConstraintMatrix(cParams, cParams->j(), numConstraints).execute(context);
+        auto* context = getContext();
 
-    MechanicalAccumulateMatrixDeriv(cParams, cParams->j(), reverseAccumulateOrder.getValue()).execute(context);
+        // mechanical action executed from root node to propagate the constraints
+        MechanicalResetConstraintVisitor(cParams).execute(context);
+        // calling buildConstraintMatrix
+        MechanicalBuildConstraintMatrix(cParams, cParams->j(), numConstraints).execute(context);
 
-    // suppress the constraints that are on DOFS currently concerned by projective constraint
-    core::MechanicalParams mparams = core::MechanicalParams(*cParams);
-    MechanicalProjectJacobianMatrixVisitor(&mparams).execute(context);
+        MechanicalAccumulateMatrixDeriv(cParams, cParams->j(), reverseAccumulateOrder.getValue()).execute(context);
 
-    sofa::helper::AdvancedTimer::stepEnd  ("Accumulate Constraint");
+        // suppress the constraints that are on DOFS currently concerned by projective constraint
+        core::MechanicalParams mparams = core::MechanicalParams(*cParams);
+        MechanicalProjectJacobianMatrixVisitor(&mparams).execute(context);
+    }
+
     sofa::helper::AdvancedTimer::valSet("numConstraints", numConstraints);
 
     current_cp->clear(numConstraints);
 
     {
         sofa::helper::ScopedAdvancedTimer getConstraintValueTimer("Get Constraint Value");
-        MechanicalGetConstraintViolationVisitor(cParams, &current_cp->dFree).execute(context);
+        MechanicalGetConstraintViolationVisitor(cParams, &current_cp->dFree).execute(getContext());
     }
 
     {
         sofa::helper::ScopedAdvancedTimer getConstraintResolutionsTimer("Get Constraint Resolutions");
-        MechanicalGetConstraintResolutionVisitor(cParams, current_cp->constraintsResolutions).execute(context);
+        MechanicalGetConstraintResolutionVisitor(cParams, current_cp->constraintsResolutions).execute(getContext());
     }
 
     msg_info() << numConstraints << " constraints";
@@ -510,82 +512,85 @@ bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cPar
 
     msg_info() << "KeepContactForces done" ;
 
-    AdvancedTimer::stepBegin("Compute And Apply Motion Correction");
-
-    if (cParams->constOrder() == core::ConstraintParams::POS_AND_VEL)
     {
-        const core::MultiVecCoordId xId(res1);
-        const core::MultiVecDerivId vId(res2);
-        for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
+        helper::ScopedAdvancedTimer timer("Compute And Apply Motion Correction");
+
+        if (cParams->constOrder() == core::ConstraintParams::POS_AND_VEL)
         {
-            if (!constraintCorrectionIsActive[i]) continue;
-            BaseConstraintCorrection* cc = l_constraintCorrections[i];
-            if (!cc->isActive()) continue;
-
-            sofa::helper::AdvancedTimer::stepBegin("ComputeCorrection on: " + cc->getName());
-            cc->computeMotionCorrectionFromLambda(cParams, this->getDx(), &current_cp->f);
-            sofa::helper::AdvancedTimer::stepEnd("ComputeCorrection on: " + cc->getName());
-
-            sofa::helper::AdvancedTimer::stepBegin("ApplyCorrection on: " + cc->getName());
-            cc->applyMotionCorrection(cParams, xId, vId, cParams->dx(), this->getDx() );
-            sofa::helper::AdvancedTimer::stepEnd("ApplyCorrection on: " + cc->getName());
-        }
-    }
-    else if (cParams->constOrder() == core::ConstraintParams::POS)
-    {
-        const core::MultiVecCoordId xId(res1);
-        for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
-        {
-            if (!constraintCorrectionIsActive[i]) continue;
-            BaseConstraintCorrection* cc = l_constraintCorrections[i];
-            if (!cc->isActive()) continue;
-
+            const core::MultiVecCoordId xId(res1);
+            const core::MultiVecDerivId vId(res2);
+            for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
             {
-                sofa::helper::ScopedAdvancedTimer computeCorrectionTimer("ComputeCorrection on: " + cc->getName());
-                cc->computeMotionCorrectionFromLambda(cParams, this->getDx(), &current_cp->f);
-            }
+                if (!constraintCorrectionIsActive[i]) continue;
+                BaseConstraintCorrection* cc = l_constraintCorrections[i];
+                if (!cc->isActive()) continue;
 
-            {
-                sofa::helper::ScopedAdvancedTimer applyCorrectionTimer("ApplyCorrection on: " + cc->getName());
-                cc->applyPositionCorrection(cParams, xId, cParams->dx(), this->getDx());
+                {
+                    helper::ScopedAdvancedTimer computeCorrectonFromLambdaTimer("ComputeCorrection on: " + cc->getName());
+                    cc->computeMotionCorrectionFromLambda(cParams, this->getDx(), &current_cp->f);
+                }
+
+                {
+                    helper::ScopedAdvancedTimer applyCorrectonFromLambdaTimer("ApplyCorrection on: " + cc->getName());
+                    cc->applyMotionCorrection(cParams, xId, vId, cParams->dx(), this->getDx() );
+                }
             }
         }
-    }
-    else if (cParams->constOrder() == core::ConstraintParams::VEL)
-    {
-        const core::MultiVecDerivId vId(res1);
-        for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
+        else if (cParams->constOrder() == core::ConstraintParams::POS)
         {
-            if (!constraintCorrectionIsActive[i]) continue;
-            BaseConstraintCorrection* cc = l_constraintCorrections[i];
-            if (!cc->isActive()) continue;
-
+            const core::MultiVecCoordId xId(res1);
+            for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
             {
-                sofa::helper::ScopedAdvancedTimer computeCorrectionTimer("ComputeCorrection on: " + cc->getName());
-                cc->computeMotionCorrectionFromLambda(cParams, this->getDx(), &current_cp->f);
+                if (!constraintCorrectionIsActive[i]) continue;
+                BaseConstraintCorrection* cc = l_constraintCorrections[i];
+                if (!cc->isActive()) continue;
+
+                {
+                    sofa::helper::ScopedAdvancedTimer computeCorrectionTimer("ComputeCorrection on: " + cc->getName());
+                    cc->computeMotionCorrectionFromLambda(cParams, this->getDx(), &current_cp->f);
+                }
+
+                {
+                    sofa::helper::ScopedAdvancedTimer applyCorrectionTimer("ApplyCorrection on: " + cc->getName());
+                    cc->applyPositionCorrection(cParams, xId, cParams->dx(), this->getDx());
+                }
             }
-
+        }
+        else if (cParams->constOrder() == core::ConstraintParams::VEL)
+        {
+            const core::MultiVecDerivId vId(res1);
+            for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
             {
-                sofa::helper::ScopedAdvancedTimer applyCorrectionTimer("ApplyCorrection on: " + cc->getName());
-                cc->applyVelocityCorrection(cParams, vId, cParams->dx(), this->getDx() );
+                if (!constraintCorrectionIsActive[i]) continue;
+                BaseConstraintCorrection* cc = l_constraintCorrections[i];
+                if (!cc->isActive()) continue;
+
+                {
+                    sofa::helper::ScopedAdvancedTimer computeCorrectionTimer("ComputeCorrection on: " + cc->getName());
+                    cc->computeMotionCorrectionFromLambda(cParams, this->getDx(), &current_cp->f);
+                }
+
+                {
+                    sofa::helper::ScopedAdvancedTimer applyCorrectionTimer("ApplyCorrection on: " + cc->getName());
+                    cc->applyVelocityCorrection(cParams, vId, cParams->dx(), this->getDx() );
+                }
             }
         }
     }
-
-    AdvancedTimer::stepEnd("Compute And Apply Motion Correction");
 
     msg_info() << "Compute And Apply Motion Correction in constraintCorrection done" ;
 
-    AdvancedTimer::stepBegin("Store Constraint Lambdas");
+    {
+        helper::ScopedAdvancedTimer timer("Store Constraint Lambdas");
 
-    /// Some constraint correction schemes may have written the constraint motion space lambda in the lambdaId VecId.
-    /// In order to be sure that we are not accumulating things twice, we need to clear.
-    clearMultiVecId(getContext(), cParams, m_lambdaId);
+        /// Some constraint correction schemes may have written the constraint motion space lambda in the lambdaId VecId.
+        /// In order to be sure that we are not accumulating things twice, we need to clear.
+        clearMultiVecId(getContext(), cParams, m_lambdaId);
 
-    /// Store lambda and accumulate.
-    ConstraintStoreLambdaVisitor v(cParams, &current_cp->f);
-    this->getContext()->executeVisitor(&v);
-    AdvancedTimer::stepEnd("Store Constraint Lambdas");
+        /// Store lambda and accumulate.
+        ConstraintStoreLambdaVisitor v(cParams, &current_cp->f);
+        this->getContext()->executeVisitor(&v);
+    }
 
     return true;
 }

--- a/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
+++ b/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
@@ -27,6 +27,8 @@
 #include <sofa/core/behavior/ForceField.inl>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::diffusion
 {
@@ -307,7 +309,7 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::setDiffusionCoefficient(const
 template <class DataTypes>
 void TetrahedronDiffusionFEMForceField<DataTypes>::addForce (const core::MechanicalParams* /*mparams*/, DataVecDeriv& dataf, const DataVecCoord& datax, const DataVecDeriv& /*v*/)
 {
-    helper::AdvancedTimer::stepBegin("addForceDiffusion");
+    helper::ScopedAdvancedTimer timer("addForceDiffusion");
 
     auto f = sofa::helper::getWriteOnlyAccessor(dataf);
     const VecCoord& x = datax.getValue();
@@ -326,15 +328,13 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::addForce (const core::Mechani
         f[v1] += dp;
         f[v0] -= dp;
     }
-
-    sofa::helper::AdvancedTimer::stepEnd("addForceDiffusion");
 }
 
 
 template <class DataTypes>
 void TetrahedronDiffusionFEMForceField<DataTypes>::addDForce(const sofa::core::MechanicalParams* mparams, DataVecDeriv&   datadF , const DataVecDeriv&   datadX)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addDForceDiffusion");
+    helper::ScopedAdvancedTimer timer("addDForceDiffusion");
     auto df = sofa::helper::getWriteOnlyAccessor(datadF);
     const VecDeriv& dx=datadX.getValue();
     Real kFactor = mparams->kFactor();
@@ -353,14 +353,13 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::addDForce(const sofa::core::M
         df[v1]+=dp;
         df[v0]-=dp;
     }
-    sofa::helper::AdvancedTimer::stepEnd("addDForceDiffusion");
 }
 
 
 template <class DataTypes>
 void TetrahedronDiffusionFEMForceField<DataTypes>::addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addKToMatrix");
+    helper::ScopedAdvancedTimer timer("addKToMatrix");
     const auto N = defaulttype::DataTypeInfo<Deriv>::size();
     sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
     sofa::linearalgebra::BaseMatrix* mat = r.matrix;
@@ -387,7 +386,6 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::addKToMatrix(const core::Mech
         mat->add(offset+N*v0, offset+N*v0, kFactor * edgeDiffusionCoefficient[i]);
         mat->add(offset+N*v1, offset+N*v1, kFactor * edgeDiffusionCoefficient[i]);
     }
-    sofa::helper::AdvancedTimer::stepEnd("addKToMatrix");
 }
 
 template <class DataTypes>

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.inl
@@ -139,7 +139,7 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& A, Vector& x, Vector& b)
     unsigned nb_iter = 0;
     const char* endcond = "iterations";
 
-    ScopedAdvancedTimer timer("CG-Solve");
+    sofa::helper::AdvancedTimer::stepBegin("CG-Solve");
 
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printCloseNode("VectorAllocation");
@@ -319,13 +319,15 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& A, Vector& x, Vector& b)
         }
     }
 
+    sofa::helper::AdvancedTimer::stepEnd("CG-Solve");
+
     d_graph.endEdit();
     timeStepCount ++;
 
     sofa::helper::AdvancedTimer::valSet("CG iterations", nb_iter);
 
     msg_info() << "solve, nbiter = "<<nb_iter<<" stop because of "<<endcond;
-    msg_info() << "solve, solution = "<< x ;
+    msg_info() <<"solve, solution = "<< x ;
 
     /// Delete all temporary vectors p, q and r
     vtmp.deleteTempVector(&p);

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.inl
@@ -139,7 +139,7 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& A, Vector& x, Vector& b)
     unsigned nb_iter = 0;
     const char* endcond = "iterations";
 
-    sofa::helper::AdvancedTimer::stepBegin("CG-Solve");
+    ScopedAdvancedTimer timer("CG-Solve");
 
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printCloseNode("VectorAllocation");
@@ -319,15 +319,13 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& A, Vector& x, Vector& b)
         }
     }
 
-    sofa::helper::AdvancedTimer::stepEnd("CG-Solve");
-
     d_graph.endEdit();
     timeStepCount ++;
 
     sofa::helper::AdvancedTimer::valSet("CG iterations", nb_iter);
 
     msg_info() << "solve, nbiter = "<<nb_iter<<" stop because of "<<endcond;
-    msg_info() <<"solve, solution = "<< x ;
+    msg_info() << "solve, solution = "<< x ;
 
     /// Delete all temporary vectors p, q and r
     vtmp.deleteTempVector(&p);

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/ShewchukPCGLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/ShewchukPCGLinearSolver.inl
@@ -92,11 +92,11 @@ template<class TMatrix, class TVector>
 void ShewchukPCGLinearSolver<TMatrix,TVector>::setSystemMBKMatrix(const core::MechanicalParams* mparams)
 {
     sofa::helper::AdvancedTimer::valSet("PCG::buildMBK", 1);
-    sofa::helper::AdvancedTimer::stepBegin("PCG::setSystemMBKMatrix");
 
-    Inherit::setSystemMBKMatrix(mparams);
-
-    sofa::helper::AdvancedTimer::stepEnd("PCG::setSystemMBKMatrix");
+    {
+        helper::ScopedAdvancedTimer timer("PCG::setSystemMBKMatrix");
+        Inherit::setSystemMBKMatrix(mparams);
+    }
 
     if (l_preconditioner.get()==nullptr) return;
 

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/StaticSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/StaticSolver.cpp
@@ -163,20 +163,22 @@ void StaticSolver::solve(const sofa::core::ExecParams* params, SReal dt, sofa::c
     // # Before starting any newton iterations, we first need to compute         #
     // # the residual with the updated right-hand side (the new load increment)  #
     // ###########################################################################
-    sofa::helper::AdvancedTimer::stepBegin("ComputeForce");
-    // Step 1   Assemble the force vector
-    // 1. Clear the force vector (F := 0)
-    // 2. Go down in the current context tree calling addForce on every forcefields
-    // 3. Go up from the current context tree leaves calling applyJT on every mechanical mappings
-    mop.computeForce(force, true /* clear */);
+    {
+        helper::ScopedAdvancedTimer computeForceTimer("ComputeForce");
 
-    // Step 2   Projective constraints
-    // Calls the "projectResponse" method of every BaseProjectiveConstraintSet objects found in the
-    // current context tree. An example of such constraint set is the FixedConstraint. In this case,
-    // it will set to 0 every row (i, _) of the right-hand side (force) vector for the ith degree of
-    // freedom.
-    mop.projectResponse(force);
-    sofa::helper::AdvancedTimer::stepEnd("ComputeForce");
+        // Step 1   Assemble the force vector
+        // 1. Clear the force vector (F := 0)
+        // 2. Go down in the current context tree calling addForce on every forcefields
+        // 3. Go up from the current context tree leaves calling applyJT on every mechanical mappings
+        mop.computeForce(force, true /* clear */);
+
+        // Step 2   Projective constraints
+        // Calls the "projectResponse" method of every BaseProjectiveConstraintSet objects found in the
+        // current context tree. An example of such constraint set is the FixedConstraint. In this case,
+        // it will set to 0 every row (i, _) of the right-hand side (force) vector for the ith degree of
+        // freedom.
+        mop.projectResponse(force);
+    }
 
     // Compute the initial residual
     R_squared_norm = force.dot(force);

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
@@ -26,6 +26,7 @@
 #include <sofa/simulation/VectorOperations.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 
 namespace sofa::component::odesolver::backward
@@ -121,20 +122,24 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 
         MultiVecDeriv acc(&vop, core::VecDerivId::dx()); acc.realloc(&vop, !d_threadSafeVisitor.getValue(), true); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
 
-		sofa::helper::AdvancedTimer::stepBegin("ComputeForce");
-		mop.computeForce(f);
-		sofa::helper::AdvancedTimer::stepEnd("ComputeForce");
-
-		sofa::helper::AdvancedTimer::stepBegin("AccFromF");
-		f.peq(p,1.0/h); 
-
-		mop.accFromF(acc, f); // acc= 1/m (f(q(k)+p(k)/h))
-		if (rM>0) {
-			MultiVecDeriv oldVel(&vop, core::VecDerivId::velocity() );
-			// add rayleigh Mass damping if necessary
-			acc.peq(oldVel,-rM); // equivalent to adding damping force -rM* M*v(k) 
+		{
+		    helper::ScopedAdvancedTimer timer("ComputeForce");
+		    mop.computeForce(f);
 		}
-		sofa::helper::AdvancedTimer::stepEnd("AccFromF");
+
+	    {
+		    helper::ScopedAdvancedTimer timer("AccFromF");
+
+	        f.peq(p,1.0/h);
+
+		    mop.accFromF(acc, f); // acc= 1/m (f(q(k)+p(k)/h))
+		    if (rM>0) {
+		        MultiVecDeriv oldVel(&vop, core::VecDerivId::velocity() );
+		        // add rayleigh Mass damping if necessary
+		        acc.peq(oldVel,-rM); // equivalent to adding damping force -rM* M*v(k)
+		    }
+	    }
+
 		mop.projectResponse(acc);
 
 		mop.solveConstraint(acc, core::ConstraintParams::ACC);
@@ -187,10 +192,12 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 			// where b = f(q(k,i-1)) -K(q(k,i-1)) res(i-1) +(2/h)p^(k)
 			// and matrix=-K+4/h^(2)M
 
-			sofa::helper::AdvancedTimer::stepBegin("ComputeForce");
-            mop.computeForce(f);
+			{
+			    helper::ScopedAdvancedTimer timer("ComputeForce");
+			    mop.computeForce(f);
+			}
 
-			sofa::helper::AdvancedTimer::stepNext ("ComputeForce", "ComputeRHTerm");
+			sofa::helper::AdvancedTimer::stepBegin("ComputeRHTerm");
 
 			// we have b=f(q(k,i-1)+(2/h)p(k)
 			b.peq(f,1.0);
@@ -202,16 +209,21 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 
 
 			mop.projectResponse(b);
+		    sofa::helper::AdvancedTimer::stepEnd("ComputeRHTerm");
+
+		    core::behavior::MultiMatrix<simulation::common::MechanicalOperations> matrix(&mop);
+
 			// add left term : matrix=-K+4/h^(2)M, but with dampings rK and rM
-            core::behavior::MultiMatrix<simulation::common::MechanicalOperations> matrix(&mop);
-            matrix.setSystemMBKMatrix(MechanicalMatrix::K * (-1.0-4*rK/h) +  MechanicalMatrix::M * (4.0/(h*h)+4*rM/h));
+		    {
+			    helper::ScopedAdvancedTimer timer("MBKBuild");
+			    matrix.setSystemMBKMatrix(MechanicalMatrix::K * (-1.0-4*rK/h) +  MechanicalMatrix::M * (4.0/(h*h)+4*rM/h));
+		    }
 
-			sofa::helper::AdvancedTimer::stepNext ("MBKBuild", "MBKSolve");
-
-			// resolution of matrix*res=b
-			matrix.solve(res,b); //Call to ODE resolution.
-
-			sofa::helper::AdvancedTimer::stepEnd  ("MBKSolve");
+            {
+			    helper::ScopedAdvancedTimer timer("MBKSolve");
+                // resolution of matrix*res=b
+                matrix.solve(res, b); //Call to ODE resolution.
+            }
 
 			/// Updates of q(k,i) ///
 			VMultiOp ops;
@@ -257,9 +269,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 		opsfin[0].second.push_back(std::make_pair(res.id(),2.0/h));
 		vop.v_multiop(opsfin);
 
-		sofa::helper::AdvancedTimer::stepBegin("UpdateVAndX");
-
-        sofa::helper::AdvancedTimer::stepNext ("UpdateVAndX", "CorrectV");
+		sofa::helper::AdvancedTimer::stepBegin("CorrectV");
 		mop.solveConstraint(vel_1,core::ConstraintParams::VEL);
 
 		// update position
@@ -328,9 +338,11 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
         }
 	}
 
-    sofa::helper::AdvancedTimer::stepNext ("CorrectV", "CorrectX");
-    mop.solveConstraint(x_1,core::ConstraintParams::POS);
-    sofa::helper::AdvancedTimer::stepEnd  ("CorrectX");
+    sofa::helper::AdvancedTimer::stepEnd("CorrectV");
+    {
+        helper::ScopedAdvancedTimer timer("CorrectX");
+        mop.solveConstraint(x_1,core::ConstraintParams::POS);
+    }
 
 	// update the previous momemtum as the current one for next step
     pPrevious.eq(newp);

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/StandardTetrahedralFEMForceField.inl
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <iterator>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
 
 namespace sofa::component::solidmechanics::fem::hyperelastic
@@ -267,7 +268,7 @@ void StandardTetrahedralFEMForceField<DataTypes>::initNeighbourhoodEdges(){}
 template <class DataTypes>
 void StandardTetrahedralFEMForceField<DataTypes>::addForce(const core::MechanicalParams*  mparams , DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& /* d_v */)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addForceStandardTetraFEM");
+    helper::ScopedAdvancedTimer timer("addForceStandardTetraFEM");
 
     VecDeriv& f = *d_f.beginEdit();
     const VecCoord& x = d_x.getValue();
@@ -442,15 +443,13 @@ void StandardTetrahedralFEMForceField<DataTypes>::addForce(const core::Mechanica
     tetrahedronInfo.endEdit();
     edgeInfo.endEdit();
     d_f.endEdit();
-
-    sofa::helper::AdvancedTimer::stepEnd("addForceStandardTetraFEM");
 }
 
 
 template <class DataTypes>
 void StandardTetrahedralFEMForceField<DataTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addDForceStandardTetraFEM");
+    helper::ScopedAdvancedTimer timer("addDForceStandardTetraFEM");
 
     VecDeriv& df = *d_df.beginEdit();
     const VecDeriv& dx = d_dx.getValue();
@@ -536,8 +535,6 @@ void StandardTetrahedralFEMForceField<DataTypes>::addDForce(const core::Mechanic
     edgeInfo.endEdit();
 //	tetrahedronInfo.endEdit();
     d_df.beginEdit();
-
-    sofa::helper::AdvancedTimer::stepEnd("addDForceStandardTetraFEM");
 }
 
 template<class DataTypes>

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialRestShapeSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialRestShapeSpringsForceField.inl
@@ -28,6 +28,8 @@
 #include <sofa/component/solidmechanics/spring/PolynomialRestShapeSpringsForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::solidmechanics::spring
 {
@@ -453,7 +455,7 @@ void PolynomialRestShapeSpringsForceField<DataTypes>::addKToMatrix(const core::M
 {    
     msg_info() << "[" <<  this->getName() << "]: addKToMatrix";
 
-    sofa::helper::AdvancedTimer::stepBegin("restShapePolynomialSpringAddKToMatrix");
+    helper::ScopedAdvancedTimer timer("restShapePolynomialSpringAddKToMatrix");
 
     const sofa::core::behavior::MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
     sofa::linearalgebra::BaseMatrix* mat = mref.matrix;
@@ -472,8 +474,6 @@ void PolynomialRestShapeSpringsForceField<DataTypes>::addKToMatrix(const core::M
             mat->add(offset + Dimension * curIndex + i, offset + Dimension * curIndex + i, -kFact * jacobVector[i]);
         }
     }
-
-    sofa::helper::AdvancedTimer::stepEnd("restShapePolynomialSpringAddKToMatrix");
 }
 
 template <class DataTypes>

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/PolynomialSpringsForceField.inl
@@ -28,6 +28,8 @@
 #include <sofa/core/behavior/ForceField.inl>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::solidmechanics::spring
 {
@@ -400,7 +402,7 @@ void PolynomialSpringsForceField<DataTypes>::addKToMatrix(const core::Mechanical
 {
     msg_info() << "[" <<  this->getName() << "]: addKToMatrix";
 
-    sofa::helper::AdvancedTimer::stepBegin("restShapeSpringAddKToMatrix");
+    helper::ScopedAdvancedTimer timer("restShapeSpringAddKToMatrix");
 
     Real kFact = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
     unsigned int firstIndex = 0;
@@ -457,8 +459,6 @@ void PolynomialSpringsForceField<DataTypes>::addKToMatrix(const core::Mechanical
             }
         }
     }
-
-    sofa::helper::AdvancedTimer::stepEnd("restShapeSpringAddKToMatrix");
 }
 
 template <class DataTypes>

--- a/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TetrahedralTensorMassForceField.inl
+++ b/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/TetrahedralTensorMassForceField.inl
@@ -27,6 +27,8 @@
 #include <sofa/type/RGBAColor.h>
 #include <sofa/core/topology/TopologyData.inl>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::solidmechanics::tensormass
 {
@@ -340,7 +342,7 @@ void TetrahedralTensorMassForceField<DataTypes>::initNeighbourhoodPoints() {}
 template <class DataTypes>
 SReal  TetrahedralTensorMassForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /* mparams */) const
 {
-    sofa::helper::AdvancedTimer::stepBegin("getPotentialEnergy");
+    helper::ScopedAdvancedTimer timer("getPotentialEnergy");
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
@@ -373,14 +375,13 @@ SReal  TetrahedralTensorMassForceField<DataTypes>::getPotentialEnergy(const core
 
     msg_info() << "energy="<<energy ;
 
-    sofa::helper::AdvancedTimer::stepEnd("getPotentialEnergy");
     return(energy);
 }
 
 template <class DataTypes>
 void TetrahedralTensorMassForceField<DataTypes>::addForce(const core::MechanicalParams* /* mparams */, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& /* d_v */)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addForceTetraTensorMass");
+    helper::ScopedAdvancedTimer timer("addForceTetraTensorMass");
 
     VecDeriv& f = *d_f.beginEdit();
     const VecCoord& x = d_x.getValue();
@@ -409,15 +410,13 @@ void TetrahedralTensorMassForceField<DataTypes>::addForce(const core::Mechanical
 
     edgeInfo.endEdit();
     d_f.endEdit();
-
-    sofa::helper::AdvancedTimer::stepEnd("addForceTetraTensorMass");
 }
 
 
 template <class DataTypes>
 void TetrahedralTensorMassForceField<DataTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addDForceTetraTensorMass");
+    helper::ScopedAdvancedTimer timer("addDForceTetraTensorMass");
 
     VecDeriv& df = *d_df.beginEdit();
     const VecDeriv& dx = d_dx.getValue();
@@ -447,8 +446,6 @@ void TetrahedralTensorMassForceField<DataTypes>::addDForce(const core::Mechanica
     edgeInfo.endEdit();
 
     d_df.endEdit();
-
-    sofa::helper::AdvancedTimer::stepEnd("addDForceTetraTensorMass");
 }
 
 template <class DataTypes>

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyModifier.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyModifier.cpp
@@ -28,6 +28,8 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/core/topology/TopologyHandler.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::topology::container::dynamic
 {
@@ -266,19 +268,22 @@ void PointSetTopologyModifier::addPointsWarning(const sofa::Size nPoints,
 void PointSetTopologyModifier::addPoints(const sofa::Size nPoints,
                                          const bool addDOF)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addPoints");
+    helper::ScopedAdvancedTimer addPointsTimer("addPoints");
 
-    sofa::helper::AdvancedTimer::stepBegin("addPointsProcess");
-    addPointsProcess(nPoints);
+    {
+        helper::ScopedAdvancedTimer timer("addPointsProcess");
+        addPointsProcess(nPoints);
+    }
 
-    sofa::helper::AdvancedTimer::stepNext ("addPointsProcess", "addPointsWarning");
-    addPointsWarning(nPoints, addDOF);
+    {
+        helper::ScopedAdvancedTimer timer("addPointsWarning");
+        addPointsWarning(nPoints, addDOF);
+    }
 
-    sofa::helper::AdvancedTimer::stepNext ("addPointsWarning", "propagateTopologicalChanges");
-    propagateTopologicalChanges();
-    sofa::helper::AdvancedTimer::stepEnd("propagateTopologicalChanges");
-
-    sofa::helper::AdvancedTimer::stepEnd("addPoints");
+    {
+        helper::ScopedAdvancedTimer timer("propagateTopologicalChanges");
+        propagateTopologicalChanges();
+    }
 }
 
 void PointSetTopologyModifier::addPoints(const sofa::Size nPoints,
@@ -286,19 +291,22 @@ void PointSetTopologyModifier::addPoints(const sofa::Size nPoints,
      const sofa::type::vector< sofa::type::vector< SReal> >& coefs,
      const bool addDOF)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addPoints with ancestors");
+    helper::ScopedAdvancedTimer addPointsTimer("addPoints with ancestors");
 
-    sofa::helper::AdvancedTimer::stepBegin("addPointsProcess");
-    addPointsProcess(nPoints);
+    {
+        helper::ScopedAdvancedTimer timer("addPointsProcess");
+        addPointsProcess(nPoints);
+    }
 
-    sofa::helper::AdvancedTimer::stepNext ("addPointsProcess", "addPointsWarning");
-    addPointsWarning(nPoints, ancestors, coefs, addDOF);
+    {
+        helper::ScopedAdvancedTimer timer("addPointsWarning");
+        addPointsWarning(nPoints, ancestors, coefs, addDOF);
+    }
 
-    sofa::helper::AdvancedTimer::stepNext ("addPointsWarning", "propagateTopologicalChanges");
-    propagateTopologicalChanges();
-    sofa::helper::AdvancedTimer::stepEnd("propagateTopologicalChanges");
-
-    sofa::helper::AdvancedTimer::stepEnd("addPoints with ancestors");
+    {
+        helper::ScopedAdvancedTimer timer("propagateTopologicalChanges");
+        propagateTopologicalChanges();
+    }
 }
 
 void PointSetTopologyModifier::addPoints(const sofa::Size nPoints,
@@ -338,39 +346,43 @@ void PointSetTopologyModifier::renumberPoints(const sofa::type::vector< PointID 
     const sofa::type::vector< PointID >& inv_index,
     const bool renumberDOF)
 {
-    sofa::helper::AdvancedTimer::stepBegin("Renumber Points");
+    helper::ScopedAdvancedTimer renumberPointsTimer("Renumber Points");
 
-    sofa::helper::AdvancedTimer::stepBegin("renumberPointsWarning");
-    renumberPointsWarning(index, inv_index, renumberDOF);
+    {
+        helper::ScopedAdvancedTimer timer("renumberPointsWarning");
+        renumberPointsWarning(index, inv_index, renumberDOF);
+    }
 
-    sofa::helper::AdvancedTimer::stepNext("renumberPointsWarning", "propagateTopologicalChanges");
-    propagateTopologicalChanges();
+    {
+        helper::ScopedAdvancedTimer timer("propagateTopologicalChanges");
+        propagateTopologicalChanges();
+    }
 
-    sofa::helper::AdvancedTimer::stepNext("propagateTopologicalChanges", "renumberPointsProcess");
-    renumberPointsProcess(index, inv_index, renumberDOF);
-
-    sofa::helper::AdvancedTimer::stepEnd("renumberPointsProcess");
-
-    sofa::helper::AdvancedTimer::stepEnd("Renumber Points");
+    {
+        helper::ScopedAdvancedTimer timer("renumberPointsProcess");
+        renumberPointsProcess(index, inv_index, renumberDOF);
+    }
 }
 
 
 void PointSetTopologyModifier::removePoints(sofa::type::vector< PointID >& indices, const bool removeDOF)
 {
-    sofa::helper::AdvancedTimer::stepBegin("Remove Points");
+    helper::ScopedAdvancedTimer removePointsTimer("Remove Points");
 
-    sofa::helper::AdvancedTimer::stepBegin("removePointsWarning");
-    removePointsWarning(indices, removeDOF);
+    {
+        helper::ScopedAdvancedTimer timer("removePointsWarning");
+        removePointsWarning(indices, removeDOF);
+    }
 
-    sofa::helper::AdvancedTimer::stepNext("removePointsWarning", "propagateTopologicalChanges");
-    propagateTopologicalChanges();
+    {
+        helper::ScopedAdvancedTimer timer("propagateTopologicalChanges");
+        propagateTopologicalChanges();
+    }
 
-    sofa::helper::AdvancedTimer::stepNext("propagateTopologicalChanges", "removePointsProcess");
-    removePointsProcess(indices, removeDOF);
-
-    sofa::helper::AdvancedTimer::stepEnd("removePointsProcess");
-
-    sofa::helper::AdvancedTimer::stepEnd("Remove Points");
+    {
+        helper::ScopedAdvancedTimer timer("removePointsProcess");
+        removePointsProcess(indices, removeDOF);
+    }
 }
 
 
@@ -378,7 +390,7 @@ void PointSetTopologyModifier::removePoints(sofa::type::vector< PointID >& indic
 void PointSetTopologyModifier::removePointsWarning(sofa::type::vector<PointID> &indices,
         const bool removeDOF)
 {
-    sofa::helper::AdvancedTimer::stepBegin("removePointsWarning");
+    helper::ScopedAdvancedTimer timer("removePointsWarning");
     m_container->setPointTopologyToDirty();
 
     // sort points so that they are removed in a descending order
@@ -393,21 +405,18 @@ void PointSetTopologyModifier::removePointsWarning(sofa::type::vector<PointID> &
         const PointsRemoved *e2 = new PointsRemoved(indices);
         addStateChange(e2);
     }
-    sofa::helper::AdvancedTimer::stepEnd("removePointsWarning");
 }
 
 
 void PointSetTopologyModifier::removePointsProcess(const sofa::type::vector<PointID> & indices,
         const bool removeDOF)
 {
-    sofa::helper::AdvancedTimer::stepBegin("removePointsProcess");
+    helper::ScopedAdvancedTimer timer("removePointsProcess");
     if(removeDOF)
     {
         propagateStateChanges();
     }
     m_container->removePoints(sofa::Size(indices.size()));
-
-    sofa::helper::AdvancedTimer::stepEnd("removePointsProcess");
 }
 
 
@@ -463,7 +472,7 @@ void PointSetTopologyModifier::propagateTopologicalEngineChanges()
     if (!m_container->isPointTopologyDirty()) // triangle Data has not been touched
         return;
 
-    sofa::helper::AdvancedTimer::stepBegin("PointSetTopologyModifier::propagateTopologicalEngineChanges");
+    helper::ScopedAdvancedTimer timer("PointSetTopologyModifier::propagateTopologicalEngineChanges");
     // get directly the list of engines created at init: case of removing.... for the moment
 
     auto& pointTopologyHandlerList = m_container->getTopologyHandlerList(sofa::geometry::ElementType::POINT);
@@ -477,7 +486,6 @@ void PointSetTopologyModifier::propagateTopologicalEngineChanges()
     }
 
     m_container->cleanPointTopologyFromDirty();
-    sofa::helper::AdvancedTimer::stepEnd("PointSetTopologyModifier::propagateTopologicalEngineChanges");
 }
 
 void PointSetTopologyModifier::propagateStateChanges()

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyModifier.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyModifier.cpp
@@ -28,6 +28,8 @@
 #include <sofa/core/topology/TopologyHandler.h>
 
 #include <algorithm>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::topology::container::dynamic
 {
@@ -613,19 +615,22 @@ void TetrahedronSetTopologyModifier::removeTetrahedra(const sofa::type::vector<T
     }
 
     /// add the topological changes in the queue
-    sofa::helper::AdvancedTimer::stepBegin("removeTetrahedraWarning");
-    removeTetrahedraWarning(tetrahedraIds_filtered);
-    sofa::helper::AdvancedTimer::stepEnd("removeTetrahedraWarning");
+    {
+        helper::ScopedAdvancedTimer timer("removeTetrahedraWarning");
+        removeTetrahedraWarning(tetrahedraIds_filtered);
+    }
 
     // inform other objects that the triangles are going to be removed
-    sofa::helper::AdvancedTimer::stepBegin("propagateTopologicalChanges");
-    propagateTopologicalChanges();
-    sofa::helper::AdvancedTimer::stepEnd("propagateTopologicalChanges");
+    {
+        helper::ScopedAdvancedTimer timer("propagateTopologicalChanges");
+        propagateTopologicalChanges();
+    }
 
     // now destroy the old tetrahedra.
-    sofa::helper::AdvancedTimer::stepBegin("removeTetrahedraProcess");
-    removeTetrahedraProcess(tetrahedraIds_filtered , removeIsolatedItems);
-    sofa::helper::AdvancedTimer::stepEnd("removeTetrahedraProcess");
+    {
+        helper::ScopedAdvancedTimer timer("removeTetrahedraProcess");
+        removeTetrahedraProcess(tetrahedraIds_filtered , removeIsolatedItems);
+    }
 
     m_container->checkTopology();
 

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Hexa2QuadTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Hexa2QuadTopologicalMapping.cpp
@@ -36,6 +36,8 @@
 #include <map>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::topology::mapping
 {
@@ -136,7 +138,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
     if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
-    sofa::helper::AdvancedTimer::stepBegin("Update Hexa2QuadTopologicalMapping");
+    helper::ScopedAdvancedTimer timer("Update Hexa2QuadTopologicalMapping");
     container::dynamic::QuadSetTopologyModifier *to_tstm;
     toModel->getContext()->get(to_tstm);
 
@@ -149,7 +151,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
     {
         const TopologyChangeType changeType = (*itBegin)->getChangeType();
         std::string topoChangeType = "Hexa2QuadTopologicalMapping - " + parseTopologyChangeTypeToString(changeType);
-        sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
+        helper::ScopedAdvancedTimer topoChangetimer(topoChangeType);
 
         switch( changeType )
         {
@@ -376,11 +378,8 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
             break;
         };
 
-        sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
         ++itBegin;
     }
-
-    sofa::helper::AdvancedTimer::stepEnd("Update Hexa2QuadTopologicalMapping");
 }
 
 } // namespace sofa::component::topology::mapping

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Quad2TriangleTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Quad2TriangleTopologicalMapping.cpp
@@ -37,6 +37,8 @@
 #include <map>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::topology::mapping
 {
@@ -177,7 +179,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
     if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
-    sofa::helper::AdvancedTimer::stepBegin("Update Quad2TriangleTopologicalMapping");
+    helper::ScopedAdvancedTimer timer("Update Quad2TriangleTopologicalMapping");
 
     TriangleSetTopologyModifier *to_tstm;
     toModel->getContext()->get(to_tstm);
@@ -191,7 +193,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
     {
         TopologyChangeType changeType = (*itBegin)->getChangeType();
         std::string topoChangeType = "Tetra2TriangleTopologicalMapping - " + parseTopologyChangeTypeToString(changeType);
-        sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
+        helper::ScopedAdvancedTimer topoChangetimer(topoChangeType);
 
         switch( changeType )
         {
@@ -401,11 +403,8 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
             break;
         };
 
-        sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
         ++itBegin;
     }
-
-    sofa::helper::AdvancedTimer::stepEnd("Update Quad2TriangleTopologicalMapping");
 }
 
 

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Tetra2TriangleTopologicalMapping.cpp
@@ -36,6 +36,8 @@
 #include <sofa/type/Vec.h>
 #include <map>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::topology::mapping
 {
@@ -146,7 +148,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
     if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
-    sofa::helper::AdvancedTimer::stepBegin("Update Tetra2TriangleTopologicalMapping");
+    helper::ScopedAdvancedTimer timer("Update Tetra2TriangleTopologicalMapping");
 
     auto itBegin=fromModel->beginChange();
     auto itEnd=fromModel->endChange();
@@ -157,7 +159,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
     {
         TopologyChangeType changeType = (*itBegin)->getChangeType();
         std::string topoChangeType = "Tetra2TriangleTopologicalMapping - " + parseTopologyChangeTypeToString(changeType);
-        sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
+        helper::ScopedAdvancedTimer topoChangetimer(topoChangeType);
 
         switch( changeType )
         {
@@ -468,11 +470,9 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
             break;
         };
 
-        sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
         ++itBegin;
     }    
 
-    sofa::helper::AdvancedTimer::stepEnd("Update Tetra2TriangleTopologicalMapping");
 }
 
 

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Triangle2EdgeTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Triangle2EdgeTopologicalMapping.cpp
@@ -35,6 +35,8 @@
 #include <map>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::component::topology::mapping
 {
@@ -132,7 +134,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
     if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
-    sofa::helper::AdvancedTimer::stepBegin("Update Triangle2EdgeTopologicalMapping");
+    helper::ScopedAdvancedTimer timer("Update Triangle2EdgeTopologicalMapping");
 
     std::list<const TopologyChange *>::const_iterator itBegin=fromModel->beginChange();
     std::list<const TopologyChange *>::const_iterator itEnd=fromModel->endChange();
@@ -143,7 +145,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
     {
         TopologyChangeType changeType = (*itBegin)->getChangeType();
         std::string topoChangeType = "Triangle2EdgeTopologicalMapping - " + parseTopologyChangeTypeToString(changeType);
-        sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
+        helper::ScopedAdvancedTimer topoChangetimer(topoChangeType);
 
         switch( changeType )
         {
@@ -429,11 +431,9 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
             break;
         };
 
-        sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
         ++itBegin;
     }
 
-    sofa::helper::AdvancedTimer::stepEnd("Update Triangle2EdgeTopologicalMapping");
 }
 
 } //namespace sofa::component::topology::mapping

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyBoundingTrasher.inl
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyBoundingTrasher.inl
@@ -30,6 +30,7 @@
 #include <sofa/component/topology/container/dynamic/TetrahedronSetTopologyModifier.h>
 #include <sofa/component/topology/container/dynamic/QuadSetTopologyModifier.h>
 #include <sofa/component/topology/container/dynamic/HexahedronSetTopologyModifier.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 
 namespace sofa::component::topology::utility
@@ -148,7 +149,8 @@ void TopologyBoundingTrasher<DataTypes>::reinit()
 template <class DataTypes>
 void TopologyBoundingTrasher<DataTypes>::filterElementsToRemove()
 {
-    sofa::helper::AdvancedTimer::stepBegin("filterElementsToRemove");
+    helper::ScopedAdvancedTimer timer("filterElementsToRemove");
+
     const VecCoord& positions = d_positions.getValue();
     const Vec6& border = d_borders.getValue();
     m_indicesToRemove.clear();
@@ -236,8 +238,6 @@ void TopologyBoundingTrasher<DataTypes>::filterElementsToRemove()
    
     if (!m_indicesToRemove.empty())
         removeElements();
-
-    sofa::helper::AdvancedTimer::stepEnd("filterElementsToRemove");
 }
 
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
@@ -38,34 +38,30 @@ void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVe
 
     bool continueSolving = true;
     {
-        sofa::helper::AdvancedTimer::stepBegin(className + " - PrepareState");
+        helper::ScopedAdvancedTimer timer(className + " - PrepareState");
         continueSolving = prepareStates(cParams, res1, res2);
-        sofa::helper::AdvancedTimer::stepEnd(className + " - PrepareState");
     }
 
     if (continueSolving)
     {
-        sofa::helper::AdvancedTimer::stepBegin(className + " - BuildSystem");
+        helper::ScopedAdvancedTimer timer(className + " - BuildSystem");
         continueSolving = buildSystem(cParams, res1, res2);
-        sofa::helper::AdvancedTimer::stepEnd(className + " - BuildSystem");
 
         postBuildSystem(cParams);
     }
 
     if (continueSolving)
     {
-        sofa::helper::AdvancedTimer::stepBegin(className + " - SolveSystem");
+        helper::ScopedAdvancedTimer timer(className + " - SolveSystem");
         continueSolving = solveSystem(cParams, res1, res2);
-        sofa::helper::AdvancedTimer::stepEnd(className + " - SolveSystem");
 
         postSolveSystem(cParams);
     }
 
     if (continueSolving)
     {
-        sofa::helper::AdvancedTimer::stepBegin(className + " - ApplyCorrection");
+        helper::ScopedAdvancedTimer timer(className + " - ApplyCorrection");
         applyCorrection(cParams, res1, res2);
-        sofa::helper::AdvancedTimer::stepEnd(className + " - ApplyCorrection");
     }
 }
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyHandler.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyHandler.cpp
@@ -22,6 +22,8 @@
 #define SOFA_CORE_TOPOLOGY_TOPOLOGYHANDLER_DEFINITION true
 #include <sofa/core/topology/TopologyHandler.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa::core::topology
 {
@@ -57,7 +59,7 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
     {
         core::topology::TopologyChangeType changeType = (*changeIt)->getChangeType();
         std::string topoChangeType = m_prefix + ": " + m_data_name + " - " + parseTopologyChangeTypeToString(changeType);
-        sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
+        helper::ScopedAdvancedTimer timer(topoChangeType);
 
         // New version using map of callback
         std::map < core::topology::TopologyChangeType, TopologyChangeCallback>::iterator itM;
@@ -122,9 +124,8 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
 #undef SOFA_CASE_EVENT
         default:
             break;
-        }; // switch( changeType )
+        } // switch( changeType )
 
-        sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
         //++changeIt;
     }
 }
@@ -136,9 +137,8 @@ void TopologyHandler::update()
         return;
 
     const std::string msg = this->getName() + " - doUpdate: Nbr changes: " + std::to_string(m_topology->m_changeList.getValue().size());
-    sofa::helper::AdvancedTimer::stepBegin(msg.c_str());
+    helper::ScopedAdvancedTimer timer(msg);
     this->handleTopologyChange();
-    sofa::helper::AdvancedTimer::stepEnd(msg.c_str());
 }
 
 void TopologyHandler::addCallBack(core::topology::TopologyChangeType type, TopologyChangeCallback callback)

--- a/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.cpp
@@ -39,7 +39,14 @@ ScopedAdvancedTimer::ScopedAdvancedTimer( const char* message )
 
 ScopedAdvancedTimer::~ScopedAdvancedTimer()
 {
-    AdvancedTimer::stepEnd( m_id );
+    if (m_objId.has_value())
+    {
+        AdvancedTimer::stepEnd( m_id, *m_objId );
+    }
+    else
+    {
+        AdvancedTimer::stepEnd( m_id );
+    }
 }
 
 } /// sofa::helper

--- a/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <optional>
 #include <sofa/helper/config.h>
 #include<string>
 
@@ -40,11 +41,25 @@ namespace sofa::helper
 struct SOFA_HELPER_API ScopedAdvancedTimer
 {
     AdvancedTimer::IdStep m_id;
+    std::optional<AdvancedTimer::IdObj> m_objId;
 
     explicit ScopedAdvancedTimer(const std::string& message);
     explicit ScopedAdvancedTimer( const char* message );
+
+    template<class T>
+    explicit ScopedAdvancedTimer(const char* message, T* obj);
+
     ~ScopedAdvancedTimer();
 };
+
+
+template <class T>
+ScopedAdvancedTimer::ScopedAdvancedTimer(const char* message, T* obj)
+    : m_id(message)
+    , m_objId(obj->getName())
+{
+    AdvancedTimer::stepBegin(m_id, *m_objId);
+}
 
 } /// sofa::helper
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/AnimateVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/AnimateVisitor.cpp
@@ -34,6 +34,7 @@
 #include <sofa/core/collision/Pipeline.h>
 
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
@@ -71,40 +72,34 @@ AnimateVisitor::AnimateVisitor(const core::ExecParams* params, SReal dt)
 
 void AnimateVisitor::fwdInteractionForceField(simulation::Node*, core::behavior::BaseInteractionForceField* obj)
 {
-    sofa::helper::AdvancedTimer::stepBegin("InteractionFF",obj);
+    helper::ScopedAdvancedTimer timer("InteractionFF", obj);
 
     const MultiVecDerivId   ffId      = VecDerivId::externalForce();
     MechanicalParams mparams;
     mparams.setDt(this->dt);
     obj->addForce(&mparams, ffId);
-
-    sofa::helper::AdvancedTimer::stepEnd("InteractionFF",obj);
 }
 
 void AnimateVisitor::processCollisionPipeline(simulation::Node* node, core::collision::Pipeline* obj)
 {
-    sofa::helper::AdvancedTimer::stepBegin("Collision",obj);
+    helper::ScopedAdvancedTimer collisionTimer("Collision", obj);
 
-    sofa::helper::AdvancedTimer::stepBegin("begin collision",obj);
     {
+        helper::ScopedAdvancedTimer timer("begin collision", obj);
         CollisionBeginEvent evBegin;
         PropagateEventVisitor eventPropagation( params, &evBegin);
         eventPropagation.execute(node->getContext());
     }
-    sofa::helper::AdvancedTimer::stepEnd("begin collision",obj);
 
     CollisionVisitor act(this->params);
     node->execute(&act);
 
-    sofa::helper::AdvancedTimer::stepBegin("end collision",obj);
     {
+        helper::ScopedAdvancedTimer timer("end collision", obj);
         CollisionEndEvent evEnd;
         PropagateEventVisitor eventPropagation( params, &evEnd);
         eventPropagation.execute(node->getContext());
     }
-    sofa::helper::AdvancedTimer::stepEnd("end collision",obj);
-
-    sofa::helper::AdvancedTimer::stepEnd("Collision",obj);
 }
 
 Visitor::Result AnimateVisitor::processNodeTopDown(simulation::Node* node)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/PipelineImpl.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/PipelineImpl.cpp
@@ -30,6 +30,8 @@
 #include <sofa/simulation/Node.h>
 
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 
 namespace sofa
 {
@@ -103,9 +105,9 @@ void PipelineImpl::computeCollisionReset()
         narrowPhaseDetection->setIntersectionMethod(intersectionMethod);
     if (contactManager!=nullptr && contactManager->getIntersectionMethod()!=intersectionMethod)
         contactManager->setIntersectionMethod(intersectionMethod);
-    sofa::helper::AdvancedTimer::stepBegin("CollisionReset");
+
+    helper::ScopedAdvancedTimer timer("CollisionReset");
     doCollisionReset();
-    sofa::helper::AdvancedTimer::stepEnd("CollisionReset");
 }
 
 void PipelineImpl::computeCollisionDetection()
@@ -121,9 +123,9 @@ void PipelineImpl::computeCollisionResponse()
 {
     const simulation::Node* root = dynamic_cast<simulation::Node*>(getContext());
     if(root == nullptr) return;
-    sofa::helper::AdvancedTimer::stepBegin("CollisionResponse");
+
+    helper::ScopedAdvancedTimer timer("CollisionResponse");
     doCollisionResponse();
-    sofa::helper::AdvancedTimer::stepEnd("CollisionResponse");
 }
 
 } // namespace simulation

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SolveVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SolveVisitor.cpp
@@ -34,9 +34,8 @@ namespace sofa::simulation
 
 void SolveVisitor::processSolver(simulation::Node* node, sofa::core::behavior::OdeSolver* s)
 {
-    sofa::helper::AdvancedTimer::stepBegin("Mechanical",node);
+    helper::ScopedAdvancedTimer timer("Mechanical",node);
     s->solve(params, dt, x, v);
-    sofa::helper::AdvancedTimer::stepEnd("Mechanical",node);
 }
 
 void SolveVisitor::fwdInteractionForceField(Node* node, core::behavior::BaseInteractionForceField* forceField)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
@@ -26,6 +26,7 @@
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/core/BehaviorModel.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #ifdef DEBUG_DRAW
 #define DO_DEBUG_DRAW true
@@ -157,9 +158,8 @@ Visitor::Result VisualUpdateVisitor::processNodeTopDown(simulation::Node* node)
 
 void VisualUpdateVisitor::processVisualModel(simulation::Node*, core::visual::VisualModel* vm)
 {
-    sofa::helper::AdvancedTimer::stepBegin("VisualUpdateVisitor process: " + vm->getName());
+    helper::ScopedAdvancedTimer timer("VisualUpdateVisitor process: " + vm->getName());
     vm->updateVisual();
-    sofa::helper::AdvancedTimer::stepEnd("VisualUpdateVisitor process: " + vm->getName());
 }
 
 

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/hyperelastic/CudaStandardTetrahedralFEMForceField.inl
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/fem/hyperelastic/CudaStandardTetrahedralFEMForceField.inl
@@ -23,6 +23,7 @@
 
 #include <SofaCUDA/component/solidmechanics/fem/hyperelastic/CudaStandardTetrahedralFEMForceField.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #define EDGEDEBUG 100
 
@@ -49,7 +50,7 @@ using namespace gpu::cuda;
 template <>
 void StandardTetrahedralFEMForceField<gpu::cuda::CudaVec3fTypes>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& /*d_v*/)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addForceStandardTetraFEM");
+    helper::ScopedAdvancedTimer timer("addForceStandardTetraFEM");
 
     VecDeriv& f = *d_f.beginEdit();
 	const VecCoord& x = d_x.getValue();
@@ -80,14 +81,12 @@ void StandardTetrahedralFEMForceField<gpu::cuda::CudaVec3fTypes>::addForce(const
 	tetrahedronInfo.endEdit();
 
 	d_f.endEdit();
-
-    sofa::helper::AdvancedTimer::stepEnd("addForceStandardTetraFEM");
 }
 
 template <>
 void StandardTetrahedralFEMForceField<gpu::cuda::CudaVec3fTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
 {
-    sofa::helper::AdvancedTimer::stepBegin("addDForceStandardTetraFEM");
+    helper::ScopedAdvancedTimer timer("addDForceStandardTetraFEM");
 
     VecDeriv& df = *d_df.beginEdit();
 	const VecDeriv& dx = d_dx.getValue();
@@ -139,8 +138,6 @@ void StandardTetrahedralFEMForceField<gpu::cuda::CudaVec3fTypes>::addDForce(cons
     edgeInfo.endEdit();
 	tetrahedronInfo.endEdit();
 	d_df.beginEdit();
-
-    sofa::helper::AdvancedTimer::stepEnd("addDForceStandardTetraFEM");
 }
 
 template<>

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/tensormass/CudaTetrahedralTensorMassForceField.inl
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/solidmechanics/tensormass/CudaTetrahedralTensorMassForceField.inl
@@ -52,7 +52,7 @@ using namespace gpu::cuda;
     template <>
     void TetrahedralTensorMassForceField<gpu::cuda::CudaVec3fTypes>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& /*d_v*/)
     {
-		sofa::helper::AdvancedTimer::stepBegin("addForceTetraTensorMass");
+		helper::ScopedAdvancedTimer timer("addForceTetraTensorMass");
 
         VecDeriv& f = *d_f.beginEdit();
         const VecCoord& x = d_x.getValue();
@@ -67,13 +67,12 @@ using namespace gpu::cuda;
 
         edgeInfo.endEdit();
         d_f.endEdit();
-		sofa::helper::AdvancedTimer::stepEnd("addForceTetraTensorMass");
     }
 
     template <>
     void TetrahedralTensorMassForceField<gpu::cuda::CudaVec3fTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
     {
-		sofa::helper::AdvancedTimer::stepBegin("addDForceTetraTensorMass");
+		helper::ScopedAdvancedTimer timer("addDForceTetraTensorMass");
 
         VecDeriv& df = *d_df.beginEdit();
         const VecDeriv& dx = d_dx.getValue();
@@ -88,8 +87,6 @@ using namespace gpu::cuda;
 
         edgeInfo.endEdit();
         d_df.endEdit();
-
-        sofa::helper::AdvancedTimer::stepEnd("addDForceTetraTensorMass");
     }
 
 


### PR DESCRIPTION
By using RAII, `ScopedAdvancedTimer` is less error-prone than `AdvancedTimer::stepBegin/stepEnd`. Let's use it more, in the goal of having only 1 way to define a timer.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
