### PR TITLE
[LinearAlgebra] Fix segfault when accessing and empty CSR matrix (through iterators)

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
@@ -254,7 +254,14 @@ public :
 
     const VecIndex& getRowIndex() const { return rowIndex; }
     const VecIndex& getRowBegin() const { return rowBegin; }
-    Range getRowRange(Index id) const { return Range(rowBegin[id], rowBegin[id+1]); }
+
+    Range getRowRange(Index id) const
+    {
+        if ((unsigned) id+1 >= rowBegin.size()) return Range();
+
+        return Range(rowBegin[id], rowBegin[id+1]);
+    }
+
     const VecIndex& getColsIndex() const { return colsIndex; }
     const VecBlock& getColsValue() const { return colsValue; }
 


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
