### PR TITLE
[Config] Integrate Tracy profiler

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -55,11 +55,9 @@
 #include <sofa/component/visual/VisualStyle.h>
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
+#include <sofa/simulation/SimulationLoop.h>
 
 #include <sofa/helper/system/SetDirectory.h>
-#ifdef TRACY_ENABLE
-#include <tracy/Tracy.hpp>
-#endif
 using sofa::helper::system::SetDirectory;
 
 #include <sofa/helper/system/FileSystem.h>
@@ -1915,6 +1913,7 @@ void RealGUI::interactionGUI ( bool )
 //called at each step of the rendering
 void RealGUI::step()
 {
+    SIMULATION_LOOP_SCOPE
     sofa::helper::AdvancedTimer::begin("Animate");
 
     Node* root = currentSimulation();
@@ -1979,9 +1978,6 @@ void RealGUI::step()
 #endif
 
     sofa::helper::AdvancedTimer::end("Animate");
-#ifdef TRACY_ENABLE
-    FrameMark;
-#endif
 }
 
 //------------------------------------

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -57,6 +57,9 @@
 #include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <sofa/helper/system/SetDirectory.h>
+#ifdef TRACY_ENABLE
+#include <tracy/Tracy.hpp>
+#endif
 using sofa::helper::system::SetDirectory;
 
 #include <sofa/helper/system/FileSystem.h>
@@ -1976,6 +1979,9 @@ void RealGUI::step()
 #endif
 
     sofa::helper::AdvancedTimer::end("Animate");
+#ifdef TRACY_ENABLE
+    FrameMark;
+#endif
 }
 
 //------------------------------------

--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -236,17 +236,19 @@ endif()
 ## Tracy
 option(SOFA_TRACY "Compile SOFA with the Tracy profiler client")
 if (SOFA_TRACY)
+    set(SOFA_TRACY_VERSION v0.9.1)
     include(FetchContent)
     option(TRACY_STATIC "Whether to build Tracy as a static library" OFF)
     FetchContent_Declare (
         tracy
         GIT_REPOSITORY https://github.com/wolfpld/tracy.git
-        GIT_TAG v0.9.1
+        GIT_TAG ${SOFA_TRACY_VERSION}
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
     )
     FetchContent_MakeAvailable (tracy)
     target_link_libraries(${PROJECT_NAME} PUBLIC TracyClient )
+    message(STATUS "SOFA is compiled with the Tracy profiler client. Use the Tracy server ${SOFA_TRACY_VERSION}.")
 endif()
 
 # An important C++11 feature may be not enabled due to

--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -233,6 +233,22 @@ if(SOFA_OPENMP)
     endif()
 endif()
 
+## Tracy
+option(SOFA_TRACY "Compile SOFA with the Tracy profiler client")
+if (SOFA_TRACY)
+    include(FetchContent)
+    option(TRACY_STATIC "Whether to build Tracy as a static library" OFF)
+    FetchContent_Declare (
+        tracy
+        GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+        GIT_TAG v0.9.1
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+    )
+    FetchContent_MakeAvailable (tracy)
+    target_link_libraries(${PROJECT_NAME} PUBLIC TracyClient )
+endif()
+
 # An important C++11 feature may be not enabled due to
 # the compiler being built without the --enable-libstdcxx-time option.
 if(CMAKE_COMPILER_IS_GNUCXX)

--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -198,6 +198,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
     list(APPEND SOURCE_FILES  ${SRC_ROOT}/system/FileMonitor_windows.cpp)
 endif()
 
+if (SOFA_TRACY)
+    list(APPEND HEADER_FILES ${SRC_ROOT}/logging/TracyMessageHandler.h)
+    list(APPEND SOURCE_FILES ${SRC_ROOT}/logging/TracyMessageHandler.cpp)
+endif()
+
 sofa_find_package(Sofa.Config REQUIRED)
 sofa_find_package(Sofa.Type REQUIRED)
 sofa_find_package(Sofa.Topology REQUIRED)

--- a/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -48,3 +48,11 @@ struct SOFA_HELPER_API ScopedAdvancedTimer
 
 } /// sofa::helper
 
+#ifdef TRACY_ENABLE
+    #include <tracy/Tracy.hpp>
+    #define SCOPED_TIMER(name) ZoneScopedN(name)
+    #define SCOPED_TIMER_VARNAME(varname, name) ZoneNamedN(varname, name, true)
+#else
+    #define SCOPED_TIMER(name) sofa::helper::ScopedAdvancedTimer timer(name)
+    #define SCOPED_TIMER_VARNAME(varname, name) sofa::helper::ScopedAdvancedTimer varname(name)
+#endif

--- a/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.cpp
@@ -1,0 +1,57 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/helper/logging/TracyMessageHandler.h>
+#include <sofa/helper/logging/MessageFormatter.h>
+#ifdef TRACY_ENABLE
+#include <tracy/Tracy.hpp>
+#endif
+
+
+namespace sofa::helper::logging
+{
+
+TracyMessageHandler::TracyMessageHandler(MessageFormatter* formatter)
+    : m_formatter(formatter)
+{}
+
+void TracyMessageHandler::process(Message& m)
+{
+#ifdef TRACY_ENABLE
+    std::stringstream ss;
+    m_formatter->formatMessage(m, ss) ;
+    TracyMessage(ss.str().c_str(), ss.str().size());
+#endif
+}
+
+void TracyMessageHandler::setMessageFormatter(MessageFormatter* formatter)
+{
+    m_formatter = formatter;
+}
+
+TracyMessageHandler& MainTracyMessageHandler::getInstance()
+{
+    static TracyMessageHandler s_instance;
+    return s_instance;
+}
+
+}

--- a/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <sofa/helper/logging/DefaultStyleMessageFormatter.h>
 #include <sofa/helper/logging/TracyMessageHandler.h>
 #include <sofa/helper/logging/MessageFormatter.h>
 #ifdef TRACY_ENABLE
@@ -32,7 +33,12 @@ namespace sofa::helper::logging
 
 TracyMessageHandler::TracyMessageHandler(MessageFormatter* formatter)
     : m_formatter(formatter)
-{}
+{
+    if (m_formatter == nullptr)
+    {
+        m_formatter = &DefaultStyleMessageFormatter::getInstance();
+    }
+}
 
 void TracyMessageHandler::process(Message& m)
 {

--- a/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.h
@@ -1,0 +1,63 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/*****************************************************************************
+* User of this library should read the documentation
+* in the messaging.h file.
+******************************************************************************/
+#pragma once
+
+#include <sofa/helper/logging/MessageHandler.h>
+#include <sofa/helper/config.h>
+
+namespace sofa::helper::logging
+{
+
+class MessageFormatter;
+
+/// Send the message to the Tracy profiler
+class SOFA_HELPER_API TracyMessageHandler : public MessageHandler
+{
+public:
+    /// Create a new ConsoleMessageHandler. By default the handler is using the
+    /// DefaultStyleMessageFormatter object to format the message.
+    TracyMessageHandler(MessageFormatter* formatter = nullptr);
+    void process(Message &m) override ;
+    void setMessageFormatter( MessageFormatter* formatter );
+
+private:
+    MessageFormatter *m_formatter { nullptr };
+
+};
+
+///
+/// \brief The MainTracyMessageHandler class contains a singleton to TracyMessageHandler
+/// and offer static version of TracyMessageHandler API
+///
+/// \see TracyMessageHandler
+///
+class SOFA_HELPER_API MainTracyMessageHandler
+{
+public:
+    static TracyMessageHandler& getInstance() ;
+};
+} // namespace sofa::helper::logging
+

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -48,6 +48,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/ResetVisitor.h
     ${SRC_ROOT}/SceneLoaderFactory.h
     ${SRC_ROOT}/Simulation.h
+    ${SRC_ROOT}/SimulationLoop.h
     ${SRC_ROOT}/SolveVisitor.h
     ${SRC_ROOT}/StateChangeVisitor.h
     ${SRC_ROOT}/TopologyChangeVisitor.h

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SimulationLoop.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SimulationLoop.h
@@ -1,0 +1,29 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#ifdef TRACY_ENABLE
+#include <tracy/Tracy.hpp>
+#define SIMULATION_LOOP_SCOPE FrameMark;
+#else
+#define SIMULATION_LOOP_SCOPE
+#endif

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -95,6 +95,10 @@ using sofa::helper::logging::ClangMessageHandler ;
 #include <sofa/helper/logging/ExceptionMessageHandler.h>
 using sofa::helper::logging::ExceptionMessageHandler;
 
+#ifdef TRACY_ENABLE
+#include <sofa/helper/logging/TracyMessageHandler.h>
+#endif
+
 #include <sofa/gui/common/ArgumentParser.h>
 
 
@@ -375,6 +379,9 @@ int main(int argc, char** argv)
         msg_warning("") << "Invalid argument '" << messageHandler << "' for '--formatting'";
     }
     MessageDispatcher::addHandler(&MainPerComponentLoggingMessageHandler::getInstance()) ;
+#ifdef TRACY_ENABLE
+    MessageDispatcher::addHandler(&sofa::helper::logging::MainTracyMessageHandler::getInstance());
+#endif
 
     // Output FileRepositories
     msg_info("runSofa") << "PluginRepository paths = " << PluginRepository.getPathsJoined();


### PR DESCRIPTION
I integrated the Tracy profiler (https://github.com/wolfpld/tracy). It adds a ton of new feature to our internal profiler. In particular, I like:
- Multithreaded timeline
- Statistics
- Messages
- Memory management (need more work, I could not test it)
- See context switching
- Mutex profiling (not tested yet)

I tried not to be invasive, but it will require a change on the way we define timers such as in https://github.com/sofa-framework/sofa/compare/master...alxbilger:sofa:scoped_timer (the demo runs with this branch).

TODO: a dedicated MessageHandler

![peek (1)](https://github.com/sofa-framework/sofa/assets/10572752/17714b7d-337e-43b2-9701-3ae20dd5f262)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
