### PR TITLE
[LinearSystem] MatrixLinearSystem: add registration in the factory for BTDMatrix6

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/MatrixLinearSystem[BTDMatrix].cpp
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/MatrixLinearSystem[BTDMatrix].cpp
@@ -23,7 +23,14 @@
 #include <sofa/component/linearsolver/direct/MatrixLinearSystem[BTDMatrix].h>
 #include <sofa/component/linearsystem/MatrixLinearSystem.inl>
 
+#include <sofa/core/ObjectFactory.h>
+
 namespace sofa::component::linearsystem
 {
 template class SOFA_COMPONENT_LINEARSOLVER_DIRECT_API MatrixLinearSystem< linearalgebra::BTDMatrix<6, SReal>, linearalgebra::BlockVector<6, SReal> >;
+
+int AssemblingMatrixLinearSystemBTDClass = core::RegisterObject("Linear system")
+.add<MatrixLinearSystem< linearalgebra::BTDMatrix<6, SReal>, linearalgebra::BlockVector<6, SReal> > >();
+;
+
 }

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.cpp
@@ -29,8 +29,6 @@
 #include <sofa/linearalgebra/RotationMatrix.h>
 #include <sofa/linearalgebra/FullMatrix.h>
 #include <sofa/linearalgebra/BlockDiagonalMatrix.h>
-#include <sofa/linearalgebra/BTDMatrix.h>
-#include <sofa/linearalgebra/BlockVector.h>
 
 namespace sofa::component::linearsystem
 {
@@ -42,8 +40,6 @@ using sofa::linearalgebra::BlockDiagonalMatrix;
 using sofa::linearalgebra::RotationMatrix;
 using sofa::linearalgebra::FullMatrix;
 using sofa::linearalgebra::FullVector;
-using sofa::linearalgebra::BTDMatrix;
-using sofa::linearalgebra::BlockVector;
 
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< FullMatrix<SReal>, FullVector<SReal> >;
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< SparseMatrix<SReal>, FullVector<SReal> >;
@@ -56,7 +52,6 @@ template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRow
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< DiagonalMatrix<SReal>, FullVector<SReal> >;
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< BlockDiagonalMatrix<3,SReal>, FullVector<SReal> >;
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< RotationMatrix<SReal>, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< BTDMatrix<6, SReal>, BlockVector<6, SReal>  >;
 
 int AssemblingMatrixLinearSystemClass = core::RegisterObject("Linear system")
         .add<MatrixLinearSystem< FullMatrix<SReal>, FullVector<SReal> > >()
@@ -67,7 +62,6 @@ int AssemblingMatrixLinearSystemClass = core::RegisterObject("Linear system")
         .add<MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,SReal> >, FullVector<SReal> > >()
         .add<MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,SReal> >, FullVector<SReal> > >()
         .add<MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,SReal> >, FullVector<SReal> > >()
-        .add<MatrixLinearSystem< BTDMatrix<6, SReal>, BlockVector<6, SReal> > >()
         ;
 
 } //namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.cpp
@@ -29,6 +29,8 @@
 #include <sofa/linearalgebra/RotationMatrix.h>
 #include <sofa/linearalgebra/FullMatrix.h>
 #include <sofa/linearalgebra/BlockDiagonalMatrix.h>
+#include <sofa/linearalgebra/BTDMatrix.h>
+#include <sofa/linearalgebra/BlockVector.h>
 
 namespace sofa::component::linearsystem
 {
@@ -40,6 +42,8 @@ using sofa::linearalgebra::BlockDiagonalMatrix;
 using sofa::linearalgebra::RotationMatrix;
 using sofa::linearalgebra::FullMatrix;
 using sofa::linearalgebra::FullVector;
+using sofa::linearalgebra::BTDMatrix;
+using sofa::linearalgebra::BlockVector;
 
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< FullMatrix<SReal>, FullVector<SReal> >;
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< SparseMatrix<SReal>, FullVector<SReal> >;
@@ -52,6 +56,7 @@ template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRow
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< DiagonalMatrix<SReal>, FullVector<SReal> >;
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< BlockDiagonalMatrix<3,SReal>, FullVector<SReal> >;
 template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< RotationMatrix<SReal>, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< BTDMatrix<6, SReal>, BlockVector<6, SReal>  >;
 
 int AssemblingMatrixLinearSystemClass = core::RegisterObject("Linear system")
         .add<MatrixLinearSystem< FullMatrix<SReal>, FullVector<SReal> > >()
@@ -62,6 +67,7 @@ int AssemblingMatrixLinearSystemClass = core::RegisterObject("Linear system")
         .add<MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,SReal> >, FullVector<SReal> > >()
         .add<MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,SReal> >, FullVector<SReal> > >()
         .add<MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,SReal> >, FullVector<SReal> > >()
+        .add<MatrixLinearSystem< BTDMatrix<6, SReal>, BlockVector<6, SReal> > >()
         ;
 
 } //namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
@@ -26,7 +26,6 @@
 #include <sofa/core/behavior/BaseLocalForceFieldMatrix.h>
 #include <sofa/core/behavior/BaseLocalMassMatrix.h>
 #include <sofa/core/BaseLocalMappingMatrix.h>
-#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
 #include <sofa/component/linearsystem/MappingGraph.h>
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
 #include <sofa/component/linearsystem/matrixaccumulators/AssemblingMappedMatrixAccumulator.h>


### PR DESCRIPTION
For scenes with `BTDLinearSolver`, as it is a linear solver only templated on `BTDMatrix<6,Sreal>`

MatrixLinearSystem<BTDMatrix6> is not present in the factory.

Interestingly, it will still create a MatrixLinearSystem templated on BTDMatrix6 and set it as slave, so this PR is mainly to avoid the error/warning due to the object creation/factory.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
