### PR TITLE
[Config] CMake: Dont check for IPO at every configure step

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -119,11 +119,19 @@ set(SOFACONFIG_LINK_OPTIONS "")
 set(SOFACONFIG_LINK_OPTIONS_DEBUG "")
 set(SOFACONFIG_LINK_OPTIONS_RELEASE "")
 
-include(CheckIPOSupported)
-check_ipo_supported(RESULT IS_IPO_SUPPORTED OUTPUT IPO_ERROR)
-
 ## Link-time optimization
-if (IS_IPO_SUPPORTED)
+if(NOT IPO_CHECK_DONE)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT IS_IPO_SUPPORTED OUTPUT IPO_ERROR)
+    set(IPO_CHECK_DONE ON CACHE INTERNAL "IPO check has been done" FORCE)
+    if (IS_IPO_SUPPORTED)
+        set(IPO_SUPPORTED ON CACHE INTERNAL "IPO can be activated" FORCE)
+    else()
+        message(STATUS "IPO / LTO not supported: <${IPO_ERROR}>")
+    endif()
+endif()
+
+if (IPO_SUPPORTED)
     # Focus on max speed with link-time optimization
     option(SOFA_ENABLE_LINK_TIME_OPTIMIZATION "Enable interprocedural optimization" OFF)
     if (SOFA_ENABLE_LINK_TIME_OPTIMIZATION)


### PR DESCRIPTION
IPO state wont change anyway so it is useless to do the test every time.

On Windows, this test takes 2sec (for a total of 7sec for a minimal SOFA configuration), so it is quite appreciable without it.
On linux (Ubuntu) it takes 200ms on my setup so barely perceptible...



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
