### PR TITLE
[Topology.Container] Remove method writeMSHfile in GeometryAlgorithms components

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.h
@@ -134,7 +134,6 @@ public:
     bool computeEdgePlaneIntersection (EdgeID edgeID, sofa::type::Vec<3,Real> pointOnPlane, sofa::type::Vec<3,Real> normalOfPlane, sofa::type::Vec<3,Real>& intersection);
     bool computeRestEdgePlaneIntersection (EdgeID edgeID, sofa::type::Vec<3,Real> pointOnPlane, sofa::type::Vec<3,Real> normalOfPlane, sofa::type::Vec<3,Real>& intersection);
 
-    void writeMSHfile(const char *filename) const;
 
     /** Computes weights allowing to compute the deformation gradient (deformed basis)  at each vertex during the simulation, for a volumetric object.
       For each vertex, computes the weights associated with each edge around the vertex, so that the weighted sum of the edges corresponds to the identity.
@@ -162,6 +161,8 @@ public:
         const sofa::type::Vec<3, Real>& b,
         Real &baryCoef);
 
+    SOFA_ATTRIBUTE_DISABLED("v23.12", "v23.12", "Method writeMSHfile has been disabled. To export the topology as .gmsh file, use the sofa::component::io::mesh::MeshExporter.")
+    void writeMSHfile(const char *filename) const {msg_deprecated() << "Method writeMSHfile has been disabled. To export the topology as " << filename << " file, use the sofa::component::io::mesh::MeshExporter."; }
 protected:
     Data<bool> showEdgeIndices; ///< Debug : view Edge indices.
     Data<bool>  d_drawEdges; ///< if true, draw the edges in the topology.

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.inl
@@ -402,45 +402,6 @@ auto EdgeSetGeometryAlgorithms<DataTypes>::compute2PointsBarycoefs(
 }
 
 
-/// Write the current mesh into a msh file
-template <typename DataTypes>
-void EdgeSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) const
-{
-    std::ofstream myfile;
-    myfile.open (filename);
-
-    const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
-
-    const size_t numVertices = vect_c.size();
-
-    myfile << "$NOD\n";
-    myfile << numVertices <<"\n";
-
-    for (size_t i=0; i<numVertices; ++i)
-    {
-        Real x=0,y=0,z=0; DataTypes::get(x,y,z, vect_c[i]);
-
-        myfile << i+1 << " " << x << " " << y << " " << z <<"\n";
-    }
-
-    myfile << "$ENDNOD\n";
-    myfile << "$ELM\n";
-
-    const sofa::type::vector<Edge> &edge = this->m_topology->getEdges();
-
-    myfile << edge.size() <<"\n";
-
-    for (size_t i=0; i<edge.size(); ++i)
-    {
-        myfile << i+1 << " 1 1 1 2 " << edge[i][0]+1 << " " << edge[i][1]+1 <<"\n";
-    }
-
-    myfile << "$ENDELM\n";
-
-    myfile.close();
-}
-
-
 template<class Vec>
 bool is_point_on_edge(const Vec& p, const Vec& a, const Vec& b)
 {

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.h
@@ -145,11 +145,10 @@ public:
 	/// return a pointer to the container of cubature points
 	NumericalIntegrationDescriptor<Real,3> &getHexahedronNumericalIntegrationDescriptor();
 
-    /** \brief Write the current mesh into a msh file
-    */
-    void writeMSHfile(const char *filename) const;
-
     void draw(const core::visual::VisualParams* vparams) override;
+
+    SOFA_ATTRIBUTE_DISABLED("v23.12", "v23.12", "Method writeMSHfile has been disabled. To export the topology as .gmsh file, use the sofa::component::io::mesh::MeshExporter.")
+    void writeMSHfile(const char *filename) const {msg_deprecated() << "Method writeMSHfile has been disabled. To export the topology as " << filename << " file, use the sofa::component::io::mesh::MeshExporter."; }
 
 protected:
     Data<bool> d_showHexaIndices; ///< Debug : view Hexa indices

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetGeometryAlgorithms.inl
@@ -781,48 +781,6 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::computeHexahedronVolume( BasicA
     }
 }
 
-/// Write the current mesh into a msh file
-template <typename DataTypes>
-void HexahedronSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) const
-{
-    std::ofstream myfile;
-    myfile.open (filename);
-
-    const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
-
-    const size_t numVertices = vect_c.size();
-
-    myfile << "$NOD\n";
-    myfile << numVertices <<"\n";
-
-    for(size_t i=0; i<numVertices; ++i)
-    {
-        const double x = (double) vect_c[i][0];
-        const double y = (double) vect_c[i][1];
-        const double z = (double) vect_c[i][2];
-
-        myfile << i+1 << " " << x << " " << y << " " << z <<"\n";
-    }
-
-    myfile << "$ENDNOD\n";
-    myfile << "$ELM\n";
-
-    const sofa::type::vector<Hexahedron>& hea = this->m_topology->getHexahedra();
-
-    myfile << hea.size() <<"\n";
-
-    for(size_t i=0; i<hea.size(); ++i)
-    {
-        myfile << i+1 << " 5 1 1 8 " << hea[i][4]+1 << " " << hea[i][5]+1 << " "
-                << hea[i][1]+1 << " " << hea[i][0]+1 << " "
-                << hea[i][7]+1 << " " << hea[i][6]+1 << " "
-                << hea[i][2]+1 << " " << hea[i][3]+1 << "\n";
-    }
-
-    myfile << "$ENDELM\n";
-
-    myfile.close();
-}
 
 template<class DataTypes>
 void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.h
@@ -99,11 +99,10 @@ public:
 
     bool isPointInQuad(const QuadID ind_q, const sofa::type::Vec<3,Real>& p) const;
 
-    /** \brief Write the current mesh into a msh file
-    */
-    void writeMSHfile(const char *filename) const;
-
     void draw(const core::visual::VisualParams* vparams) override;
+
+    SOFA_ATTRIBUTE_DISABLED("v23.12", "v23.12", "Method writeMSHfile has been disabled. To export the topology as .gmsh file, use the sofa::component::io::mesh::MeshExporter.")
+    void writeMSHfile(const char *filename) const {msg_deprecated() << "Method writeMSHfile has been disabled. To export the topology as " << filename << " file, use the sofa::component::io::mesh::MeshExporter."; }
 
 protected:
     Data<bool> showQuadIndices; ///< Debug : view Quad indices

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetGeometryAlgorithms.inl
@@ -246,45 +246,6 @@ bool QuadSetGeometryAlgorithms< DataTypes >::isPointInQuad(const QuadID ind_q, c
     return false;
 }
 
-/// Write the current mesh into a msh file
-template <typename DataTypes>
-void QuadSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) const
-{
-    std::ofstream myfile;
-    myfile.open (filename);
-
-    const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
-
-    const size_t numVertices = vect_c.size();
-
-    myfile << "$NOD\n";
-    myfile << numVertices <<"\n";
-
-    for(size_t i=0; i<numVertices; ++i)
-    {
-        const double x = (double) vect_c[i][0];
-        const double y = (double) vect_c[i][1];
-        const double z = (double) vect_c[i][2];
-
-        myfile << i+1 << " " << x << " " << y << " " << z <<"\n";
-    }
-
-    myfile << "$ENDNOD\n";
-    myfile << "$ELM\n";
-
-    const sofa::type::vector<Quad>& qa = this->m_topology->getQuads();
-
-    myfile << qa.size() <<"\n";
-
-    for(size_t i=0; i<qa.size(); ++i)
-    {
-        myfile << i+1 << " 3 1 1 4 " << qa[i][0]+1 << " " << qa[i][1]+1 << " " << qa[i][2]+1 << " " << qa[i][3]+1 << "\n";
-    }
-
-    myfile << "$ENDELM\n";
-
-    myfile.close();
-}
 
 template <class DataTypes>
 bool QuadSetGeometryAlgorithms<DataTypes>::mustComputeBBox() const

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.h
@@ -121,9 +121,6 @@ public:
             sofa::type::vector<TetrahedronID> &indices) const;
     void getTetraInBall(const Coord& c, Real r,
             sofa::type::vector<TetrahedronID> &indices) const;
-    /** \brief Write the current mesh into a msh file
-    */
-    void writeMSHfile(const char *filename) const;
 
     /// finds the intersection point with plane which is defined by c and normal
     void getIntersectionPointWithPlane(const TetraID ind_ta, const sofa::type::Vec<3,Real>& planP0, const sofa::type::Vec<3,Real>& normal, sofa::type::vector< sofa::type::Vec<3,Real> >& intersectedPoint, SeqEdges& intersectedEdge);
@@ -166,6 +163,9 @@ public:
     void subDivideRestTetrahedronsWithPlane(sofa::type::vector< sofa::type::vector<SReal> >& coefs, sofa::type::vector<EdgeID>& intersectedEdgeID, Coord /*planePos*/, Coord planeNormal);
     void subDivideRestTetrahedronsWithPlane(sofa::type::vector<Coord>& intersectedPoints, sofa::type::vector<EdgeID>& intersectedEdgeID, Coord planePos, Coord planeNormal);
     int subDivideRestTetrahedronWithPlane(TetraID tetraIdx, sofa::type::vector<EdgeID>& intersectedEdgeID, sofa::type::vector<PointID>& intersectedPointID, Coord planeNormal, sofa::type::vector<Tetra>& toBeAddedTetra);
+
+    SOFA_ATTRIBUTE_DISABLED("v23.12", "v23.12", "Method writeMSHfile has been disabled. To export the topology as .gmsh file, use the sofa::component::io::mesh::MeshExporter.")
+    void writeMSHfile(const char *filename) const {msg_deprecated() << "Method writeMSHfile has been disabled. To export the topology as " << filename << " file, use the sofa::component::io::mesh::MeshExporter."; }
 
 protected:
     Data<bool> d_showTetrahedraIndices; ///< Debug : view Tetrahedrons indices

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.inl
@@ -1011,48 +1011,6 @@ const sofa::type::vector<BaseMeshTopology::TetraID>& TetrahedronSetGeometryAlgor
 }
 
 
-/// Write the current mesh into a msh file
-template <typename DataTypes>
-void TetrahedronSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) const
-{
-    std::ofstream myfile;
-    myfile.open (filename);
-
-    const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
-
-    const size_t numVertices = vect_c.size();
-
-    myfile << "$NOD\n";
-    myfile << numVertices <<"\n";
-
-    for (size_t i=0; i<numVertices; ++i)
-    {
-        Real x = (Real) vect_c[i][0];
-        Real y = (Real) vect_c[i][1];
-        Real z = (Real) vect_c[i][2];
-
-        myfile << i+1 << " " << x << " " << y << " " << z <<"\n";
-    }
-
-    myfile << "$ENDNOD\n";
-    myfile << "$ELM\n";
-
-    const sofa::type::vector<Tetrahedron> &tea = this->m_topology->getTetrahedra();
-
-    myfile << tea.size() <<"\n";
-
-    for (size_t i=0; i<tea.size(); ++i)
-    {
-        myfile << i+1 << " 4 1 1 4 " << tea[i][0]+1 << " " << tea[i][1]+1 << " " << tea[i][2]+1 << " " << tea[i][3]+1 <<"\n";
-    }
-
-    myfile << "$ENDELM\n";
-
-    myfile.close();
-}
-
-
-
 template<class DataTypes>
 void TetrahedronSetGeometryAlgorithms<DataTypes>::subDivideTetrahedronsWithPlane(sofa::type::vector< sofa::type::vector<SReal> >& coefs, sofa::type::vector<EdgeID>& intersectedEdgeID, Coord /*planePos*/, Coord planeNormal)
 {

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
@@ -284,10 +284,6 @@ public:
     int getTriangleInDirection(PointID p, const sofa::type::Vec<3,Real>& dir) const;
 
 
-    /** \brief Write the current mesh into a msh file
-     */
-    void writeMSHfile(const char *filename) const;
-
     /** \brief This function will changed vertex index in triangles if normal from one to another triangle are in opposite direction.
       First triangle index is used as ground truth. Use option flipNormals if first triangle direction is wrong.
       */
@@ -354,7 +350,8 @@ public:
     virtual bool InciseAlongEdgeList(const sofa::type::vector<EdgeID>& edges, sofa::type::vector<PointID>& new_points, sofa::type::vector<PointID>& end_points, bool& reachBorder);
 
 
-
+    SOFA_ATTRIBUTE_DISABLED("v23.12", "v23.12", "Method writeMSHfile has been disabled. To export the topology as .gmsh file, use the sofa::component::io::mesh::MeshExporter.")
+    void writeMSHfile(const char *filename) const {msg_deprecated() << "Method writeMSHfile has been disabled. To export the topology as " << filename << " file, use the sofa::component::io::mesh::MeshExporter."; }
 
 protected:
     Data<bool> showTriangleIndices; ///< Debug : view Triangle indices

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
@@ -2402,46 +2402,6 @@ int TriangleSetGeometryAlgorithms<DataTypes>::getTriangleInDirection(PointID p, 
     return -1;
 }
 
-/// Write the current mesh into a msh file
-template <typename DataTypes>
-void TriangleSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) const
-{
-    std::ofstream myfile;
-    myfile.open (filename);
-
-    const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
-
-    const size_t numVertices = vect_c.size();
-
-    myfile << "$NOD\n";
-    myfile << numVertices <<"\n";
-
-    for (size_t i=0; i<numVertices; ++i)
-    {
-        Real x = (Real) vect_c[i][0];
-        Real y = (Real) vect_c[i][1];
-        Real z = (Real) vect_c[i][2];
-
-        myfile << i+1 << " " << x << " " << y << " " << z <<"\n";
-    }
-
-    myfile << "$ENDNOD\n";
-    myfile << "$ELM\n";
-
-    const sofa::type::vector<Triangle> &ta=this->m_topology->getTriangles();
-
-    myfile << ta.size() <<"\n";
-
-    for (size_t i=0; i<ta.size(); ++i)
-    {
-        myfile << i+1 << " 2 6 6 3 " << ta[i][0]+1 << " " << ta[i][1]+1 << " " << ta[i][2]+1 <<"\n";
-    }
-
-    myfile << "$ENDELM\n";
-
-    myfile.close();
-}
-
 
 template <typename DataTypes>
 void TriangleSetGeometryAlgorithms<DataTypes>::reorderTrianglesOrientationFromNormals()


### PR DESCRIPTION
I found those methods while digging into the code. I'm pretty sure no one is using it and not sure it even work.

As mentioned in the disabled warning, the `MeshExporter `do that in a better way. 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
