### PR TITLE
[Constraint.Lagrangian.Solver] GenericConstraintSolver: avoid repeated allocation in loops

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintProblem.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintProblem.cpp
@@ -317,10 +317,9 @@ void GenericConstraintProblem::unbuiltGaussSeidel(SReal timeout, GenericConstrai
 
     tabErrors.resize(dimension);
 
-    // pre-allocated buffers
-    constexpr std::size_t bufferSize = 10;
-    std::vector<SReal> errF(bufferSize);
-    std::vector<SReal> tempF(bufferSize);
+    // temporary buffers
+    std::vector<SReal> errF;
+    std::vector<SReal> tempF;
 
     for(iter=0; iter < static_cast<unsigned int>(maxIterations); iter++)
     {
@@ -339,7 +338,7 @@ void GenericConstraintProblem::unbuiltGaussSeidel(SReal timeout, GenericConstrai
 
             //2. for each line we compute the actual value of d
             //   (a)d is set to dfree
-            if(nb > bufferSize)
+            if(nb > errF.size())
             {
                 errF.resize(nb);
             }
@@ -399,7 +398,7 @@ void GenericConstraintProblem::unbuiltGaussSeidel(SReal timeout, GenericConstrai
 
             if(update)
             {
-                if (nb > bufferSize)
+                if (nb > tempF.size())
                 {
                     tempF.resize(nb);
                 }


### PR DESCRIPTION
Use pre-allocated buffers instead of creating new vectors + allocations at every step of the loops.

Same benchs as 
 - https://github.com/sofa-framework/sofa/pull/4132

```
(mu=0.1)
LCP :       5000 iterations done in 58.1724 s ( 85.9514 FPS)
GCS before: 5000 iterations done in 83.4733 s ( 59.8994 FPS)
GCS after:  5000 iterations done in 69.2669 s ( 72.1846 FPS)
```
```
(mu=0.0)
LCP :       5000 iterations done in 44.0637 s ( 113.472 FPS)
GCS before: 5000 iterations done in 69.1173 s ( 72.3408 FPS)
GCS after:  5000 iterations done in 53.8957 s ( 92.7719 FPS)
```

Speedup of ~20-30% but still slower than LCP (but much less though ).
But this improvement should be felt whenever the GCS is using the unbuilt method (contrary to #4132 which was specialized for LinearConstraintCorrection with wire optimization)


Other bench on caduceus (5000 steps)
```
LCP
LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
4       1.11    1       0       0.69    0.14    0.04    0.14    9.10 ....SolveConstraint: POSITION AND VELOCITY - SolveSystem
```
```
GCSunbuilt before
LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
4       1.28    1       0      33.01    0.24    1.45    0.24   13.24 ....SolveConstraint: POSITION AND VELOCITY - SolveSystem
```
```
GCSunbuilt   after
LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
4       1.28    1       0      19.89    0.16    0.98    0.16    9.38 ....SolveConstraint: POSITION AND VELOCITY - SolveSystem
```
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
