### PR TITLE
[Constraint.Lagrangian.Solver] Another step to factorize both constraint solvers

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -171,7 +171,7 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
     cparams.setV(freeVel);
     cparams.setDx(l_constraintSolver->getDx());
     cparams.setLambda(l_constraintSolver->getLambda());
-    cparams.setOrder(m_solveVelocityConstraintFirst.getValue() ? core::ConstraintParams::ConstOrder::VEL : core::ConstraintParams::ConstOrder::POS_AND_VEL);
+    cparams.setOrder(m_solveVelocityConstraintFirst.getValue() ? core::ConstraintOrder::VEL : core::ConstraintOrder::POS_AND_VEL);
 
     MultiVecDeriv dx(&vop, core::VecDerivId::dx());
     dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
@@ -258,7 +258,7 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
     {
         SCOPED_TIMER("ConstraintSolver");
 
-        if (cparams.constOrder() == core::ConstraintParams::ConstOrder::VEL )
+        if (cparams.constOrder() == core::ConstraintOrder::VEL )
         {
             l_constraintSolver->solveConstraint(&cparams, vel);
             pos.eq(pos, vel, dt); //position += velocity * dt
@@ -391,8 +391,8 @@ void FreeMotionAnimationLoop::computeFreeMotion(const sofa::core::ExecParams* pa
     mop->projectResponse(freeVel);
     mop->propagateDx(freeVel, true);
 
-    if (cparams.constOrder() == sofa::core::ConstraintParams::ConstOrder::POS ||
-        cparams.constOrder() == sofa::core::ConstraintParams::ConstOrder::POS_AND_VEL)
+    if (cparams.constOrder() == sofa::core::ConstraintOrder::POS ||
+        cparams.constOrder() == sofa::core::ConstraintOrder::POS_AND_VEL)
     {
         SCOPED_TIMER("freePosEqPosPlusFreeVelDt");
         MechanicalVOpVisitor freePosEqPosPlusFreeVelDt(params, freePos, pos, freeVel, dt);

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -171,7 +171,7 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
     cparams.setV(freeVel);
     cparams.setDx(l_constraintSolver->getDx());
     cparams.setLambda(l_constraintSolver->getLambda());
-    cparams.setOrder(m_solveVelocityConstraintFirst.getValue() ? core::ConstraintParams::VEL : core::ConstraintParams::POS_AND_VEL);
+    cparams.setOrder(m_solveVelocityConstraintFirst.getValue() ? core::ConstraintParams::ConstOrder::VEL : core::ConstraintParams::ConstOrder::POS_AND_VEL);
 
     MultiVecDeriv dx(&vop, core::VecDerivId::dx());
     dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
@@ -258,7 +258,7 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
     {
         SCOPED_TIMER("ConstraintSolver");
 
-        if (cparams.constOrder() == core::ConstraintParams::VEL )
+        if (cparams.constOrder() == core::ConstraintParams::ConstOrder::VEL )
         {
             l_constraintSolver->solveConstraint(&cparams, vel);
             pos.eq(pos, vel, dt); //position += velocity * dt
@@ -391,8 +391,8 @@ void FreeMotionAnimationLoop::computeFreeMotion(const sofa::core::ExecParams* pa
     mop->projectResponse(freeVel);
     mop->propagateDx(freeVel, true);
 
-    if (cparams.constOrder() == sofa::core::ConstraintParams::POS ||
-        cparams.constOrder() == sofa::core::ConstraintParams::POS_AND_VEL)
+    if (cparams.constOrder() == sofa::core::ConstraintParams::ConstOrder::POS ||
+        cparams.constOrder() == sofa::core::ConstraintParams::ConstOrder::POS_AND_VEL)
     {
         SCOPED_TIMER("freePosEqPosPlusFreeVelDt");
         MechanicalVOpVisitor freePosEqPosPlusFreeVelDt(params, freePos, pos, freeVel, dt);

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/GenericConstraintCorrection.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/GenericConstraintCorrection.cpp
@@ -151,13 +151,13 @@ void GenericConstraintCorrection::addComplianceInConstraintSpace(const Constrain
 
     switch (cparams->constOrder())
     {
-        case ConstraintParams::POS_AND_VEL :
-        case ConstraintParams::POS :
+        case ConstraintParams::ConstOrder::POS_AND_VEL :
+        case ConstraintParams::ConstOrder::POS :
             factor = l_ODESolver.get()->getPositionIntegrationFactor();
             break;
 
-        case ConstraintParams::ACC :
-        case ConstraintParams::VEL :
+        case ConstraintParams::ConstOrder::ACC :
+        case ConstraintParams::ConstOrder::VEL :
             factor = l_ODESolver.get()->getVelocityIntegrationFactor();
             break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/GenericConstraintCorrection.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/GenericConstraintCorrection.cpp
@@ -151,13 +151,13 @@ void GenericConstraintCorrection::addComplianceInConstraintSpace(const Constrain
 
     switch (cparams->constOrder())
     {
-        case ConstraintParams::ConstOrder::POS_AND_VEL :
-        case ConstraintParams::ConstOrder::POS :
+        case sofa::core::ConstraintOrder::POS_AND_VEL :
+        case sofa::core::ConstraintOrder::POS :
             factor = l_ODESolver.get()->getPositionIntegrationFactor();
             break;
 
-        case ConstraintParams::ConstOrder::ACC :
-        case ConstraintParams::ConstOrder::VEL :
+        case sofa::core::ConstraintOrder::ACC :
+        case sofa::core::ConstraintOrder::VEL :
             factor = l_ODESolver.get()->getVelocityIntegrationFactor();
             break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -176,12 +176,12 @@ void LinearSolverConstraintCorrection<DataTypes>::addComplianceInConstraintSpace
     {
     case core::ConstraintParams::ConstOrder::POS_AND_VEL :
     case core::ConstraintParams::ConstOrder::POS :
-        factor = l_ODESolver.get()->getPositionIntegrationFactor();
+        factor = l_ODESolver->getPositionIntegrationFactor();
         break;
 
     case core::ConstraintParams::ConstOrder::ACC :
     case core::ConstraintParams::ConstOrder::VEL :
-        factor = l_ODESolver.get()->getVelocityIntegrationFactor();
+        factor = l_ODESolver->getVelocityIntegrationFactor();
         break;
 
     default :

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -174,13 +174,13 @@ void LinearSolverConstraintCorrection<DataTypes>::addComplianceInConstraintSpace
 
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
-    case core::ConstraintParams::ConstOrder::POS :
+    case core::ConstraintOrder::POS_AND_VEL :
+    case core::ConstraintOrder::POS :
         factor = l_ODESolver->getPositionIntegrationFactor();
         break;
 
-    case core::ConstraintParams::ConstOrder::ACC :
-    case core::ConstraintParams::ConstOrder::VEL :
+    case core::ConstraintOrder::ACC :
+    case core::ConstraintOrder::VEL :
         factor = l_ODESolver->getVelocityIntegrationFactor();
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -174,13 +174,13 @@ void LinearSolverConstraintCorrection<DataTypes>::addComplianceInConstraintSpace
 
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::POS_AND_VEL :
-    case core::ConstraintParams::POS :
+    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
+    case core::ConstraintParams::ConstOrder::POS :
         factor = l_ODESolver.get()->getPositionIntegrationFactor();
         break;
 
-    case core::ConstraintParams::ACC :
-    case core::ConstraintParams::VEL :
+    case core::ConstraintParams::ConstOrder::ACC :
+    case core::ConstraintParams::ConstOrder::VEL :
         factor = l_ODESolver.get()->getVelocityIntegrationFactor();
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -420,12 +420,12 @@ void PrecomputedConstraintCorrection< DataTypes >::addComplianceInConstraintSpac
 
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
-    case core::ConstraintParams::ConstOrder::POS :
+    case core::ConstraintOrder::POS_AND_VEL :
+    case core::ConstraintOrder::POS :
         break;
 
-    case core::ConstraintParams::ConstOrder::ACC :
-    case core::ConstraintParams::ConstOrder::VEL :
+    case core::ConstraintOrder::ACC :
+    case core::ConstraintOrder::VEL :
         factor = 1.0 / this->getContext()->getDt(); // @TODO : Consistency between ODESolver & Compliance and/or Admittance computation
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -420,12 +420,12 @@ void PrecomputedConstraintCorrection< DataTypes >::addComplianceInConstraintSpac
 
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::POS_AND_VEL :
-    case core::ConstraintParams::POS :
+    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
+    case core::ConstraintParams::ConstOrder::POS :
         break;
 
-    case core::ConstraintParams::ACC :
-    case core::ConstraintParams::VEL :
+    case core::ConstraintParams::ConstOrder::ACC :
+    case core::ConstraintParams::ConstOrder::VEL :
         factor = 1.0 / this->getContext()->getDt(); // @TODO : Consistency between ODESolver & Compliance and/or Admittance computation
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.inl
@@ -295,13 +295,13 @@ void UncoupledConstraintCorrection<DataTypes>::addComplianceInConstraintSpace(co
     SReal factor = 1.0;
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
-    case core::ConstraintParams::ConstOrder::POS :
+    case core::ConstraintOrder::POS_AND_VEL :
+    case core::ConstraintOrder::POS :
         factor = useOdeIntegrationFactors ? m_pOdeSolver->getPositionIntegrationFactor() : 1.0;
         break;
 
-    case core::ConstraintParams::ConstOrder::ACC :
-    case core::ConstraintParams::ConstOrder::VEL :
+    case core::ConstraintOrder::ACC :
+    case core::ConstraintOrder::VEL :
         factor = useOdeIntegrationFactors ? m_pOdeSolver->getVelocityIntegrationFactor() : 1.0;
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/UncoupledConstraintCorrection.inl
@@ -295,13 +295,13 @@ void UncoupledConstraintCorrection<DataTypes>::addComplianceInConstraintSpace(co
     SReal factor = 1.0;
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::POS_AND_VEL :
-    case core::ConstraintParams::POS :
+    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
+    case core::ConstraintParams::ConstOrder::POS :
         factor = useOdeIntegrationFactors ? m_pOdeSolver->getPositionIntegrationFactor() : 1.0;
         break;
 
-    case core::ConstraintParams::ACC :
-    case core::ConstraintParams::VEL :
+    case core::ConstraintParams::ConstOrder::ACC :
+    case core::ConstraintParams::ConstOrder::VEL :
         factor = useOdeIntegrationFactors ? m_pOdeSolver->getVelocityIntegrationFactor() : 1.0;
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -182,7 +182,7 @@ void BilateralInteractionConstraint<DataTypes>::getConstraintViolation(const Con
 
     const VecDeriv& restVector = this->restVector.getValue();
 
-    if (cParams->constOrder() == ConstraintParams::VEL)
+    if (cParams->constOrder() == ConstraintParams::ConstOrder::VEL)
     {
         getVelocityViolation(v, d_x1, d_x2, d_v1, d_v2);
         return;

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralInteractionConstraint.inl
@@ -182,7 +182,7 @@ void BilateralInteractionConstraint<DataTypes>::getConstraintViolation(const Con
 
     const VecDeriv& restVector = this->restVector.getValue();
 
-    if (cParams->constOrder() == ConstraintParams::ConstOrder::VEL)
+    if (cParams->constOrder() == sofa::core::ConstraintOrder::VEL)
     {
         getVelocityViolation(v, d_x1, d_x2, d_v1, d_v2);
         return;

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.inl
@@ -88,7 +88,7 @@ void UniformConstraint<DataTypes>::getConstraintViolation(const sofa::core::Cons
     auto pos     = this->getMState()->readPositions();
     auto restPos = this->getMState()->readRestPositions();
 
-    if (cParams->constOrder() == sofa::core::ConstraintParams::VEL)
+    if (cParams->constOrder() == sofa::core::ConstraintParams::ConstOrder::VEL)
     {
         if (d_constraintRestPos.getValue()){
             computeViolation(resV, m_constraintIndex, vfree, Deriv::size(),[&invDt,&pos,&vfree,&restPos](int i, int j)

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UniformConstraint.inl
@@ -88,7 +88,7 @@ void UniformConstraint<DataTypes>::getConstraintViolation(const sofa::core::Cons
     auto pos     = this->getMState()->readPositions();
     auto restPos = this->getMState()->readRestPositions();
 
-    if (cParams->constOrder() == sofa::core::ConstraintParams::ConstOrder::VEL)
+    if (cParams->constOrder() == sofa::core::ConstraintOrder::VEL)
     {
         if (d_constraintRestPos.getValue()){
             computeViolation(resV, m_constraintIndex, vfree, Deriv::size(),[&invDt,&pos,&vfree,&restPos](int i, int j)

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
@@ -295,13 +295,13 @@ void UnilateralInteractionConstraint<DataTypes>::getConstraintViolation(const co
 {
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::POS_AND_VEL :
-    case core::ConstraintParams::POS :
+    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
+    case core::ConstraintParams::ConstOrder::POS :
         getPositionViolation(v);
         break;
 
-    case core::ConstraintParams::ACC :
-    case core::ConstraintParams::VEL :
+    case core::ConstraintParams::ConstOrder::ACC :
+    case core::ConstraintParams::ConstOrder::VEL :
         getVelocityViolation(v);
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.inl
@@ -295,13 +295,13 @@ void UnilateralInteractionConstraint<DataTypes>::getConstraintViolation(const co
 {
     switch (cparams->constOrder())
     {
-    case core::ConstraintParams::ConstOrder::POS_AND_VEL :
-    case core::ConstraintParams::ConstOrder::POS :
+    case core::ConstraintOrder::POS_AND_VEL :
+    case core::ConstraintOrder::POS :
         getPositionViolation(v);
         break;
 
-    case core::ConstraintParams::ConstOrder::ACC :
-    case core::ConstraintParams::ConstOrder::VEL :
+    case core::ConstraintOrder::ACC :
+    case core::ConstraintOrder::VEL :
         getVelocityViolation(v);
         break;
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
@@ -137,5 +137,19 @@ void ConstraintSolverImpl::accumulateMatrixDeriv(const core::ConstraintParams* c
     accumulateMatrixDeriv.execute(getContext());
 }
 
+void ConstraintSolverImpl::accumulateConstraints(const core::ConstraintParams* cparams, unsigned int &constraintId)
+{
+    resetConstraints(cparams);
+    buildConstraintMatrix(cparams, constraintId);
+    accumulateMatrixDeriv(cparams);
+}
+
+void ConstraintSolverImpl::getConstraintViolation(
+    const core::ConstraintParams* cparams, sofa::linearalgebra::BaseVector* v)
+{
+    SCOPED_TIMER("Get Constraint Value");
+    MechanicalGetConstraintViolationVisitor(cparams, v).execute(getContext());
+}
+
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
@@ -21,9 +21,12 @@
 ******************************************************************************/
 
 #include <sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/events/BuildConstraintSystemEndEvent.h>
 #include <sofa/simulation/events/SolveConstraintSystemEndEvent.h>
+#include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
+
 
 namespace sofa::component::constraint::lagrangian::solver
 {
@@ -110,6 +113,12 @@ void ConstraintSolverImpl::clearConstraintCorrections()
         constraintCorrection->removeConstraintSolver(this);
     }
     l_constraintCorrections.clear();
+}
+
+void ConstraintSolverImpl::resetConstraints(const core::ConstraintParams* cParams)
+{
+    SCOPED_TIMER("Reset Constraint");
+    simulation::mechanicalvisitor::MechanicalResetConstraintVisitor(cParams).execute(getContext());
 }
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
@@ -25,6 +25,7 @@
 #include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/events/BuildConstraintSystemEndEvent.h>
 #include <sofa/simulation/events/SolveConstraintSystemEndEvent.h>
+#include <sofa/simulation/mechanicalvisitor/MechanicalBuildConstraintMatrix.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 
 
@@ -119,6 +120,13 @@ void ConstraintSolverImpl::resetConstraints(const core::ConstraintParams* cParam
 {
     SCOPED_TIMER("Reset Constraint");
     simulation::mechanicalvisitor::MechanicalResetConstraintVisitor(cParams).execute(getContext());
+}
+
+void ConstraintSolverImpl::buildConstraintMatrix(const core::ConstraintParams* cparams, unsigned int &constraintId)
+{
+    SCOPED_TIMER("Build Constraint Matrix");
+    simulation::mechanicalvisitor::MechanicalBuildConstraintMatrix buildConstraintMatrix(cparams, cparams->j(), constraintId );
+    buildConstraintMatrix.execute(getContext());
 }
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.cpp
@@ -25,6 +25,7 @@
 #include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/events/BuildConstraintSystemEndEvent.h>
 #include <sofa/simulation/events/SolveConstraintSystemEndEvent.h>
+#include <sofa/simulation/mechanicalvisitor/MechanicalAccumulateMatrixDeriv.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalBuildConstraintMatrix.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 
@@ -127,6 +128,13 @@ void ConstraintSolverImpl::buildConstraintMatrix(const core::ConstraintParams* c
     SCOPED_TIMER("Build Constraint Matrix");
     simulation::mechanicalvisitor::MechanicalBuildConstraintMatrix buildConstraintMatrix(cparams, cparams->j(), constraintId );
     buildConstraintMatrix.execute(getContext());
+}
+
+void ConstraintSolverImpl::accumulateMatrixDeriv(const core::ConstraintParams* cparams)
+{
+    SCOPED_TIMER("Accumulate Matrix Deriv");
+    simulation::mechanicalvisitor::MechanicalAccumulateMatrixDeriv accumulateMatrixDeriv(cparams, cparams->j());
+    accumulateMatrixDeriv.execute(getContext());
 }
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -93,6 +93,9 @@ protected:
         core::behavior::BaseConstraintCorrection,
         BaseLink::FLAG_STOREPATH> l_constraintCorrections;
 
+    /// Call the method resetConstraint on all the mechanical states and BaseConstraintSet
+    void resetConstraints(const core::ConstraintParams* cParams);
+
 };
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -96,6 +96,9 @@ protected:
     /// Call the method resetConstraint on all the mechanical states and BaseConstraintSet
     void resetConstraints(const core::ConstraintParams* cParams);
 
+    /// Call the method buildConstraintMatrix on all the BaseConstraintSet
+    void buildConstraintMatrix(const core::ConstraintParams* cparams, unsigned int &constraintId);
+
 };
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -102,6 +102,10 @@ protected:
     /// Call the method applyJT on all the mappings
     void accumulateMatrixDeriv(const core::ConstraintParams* cparams);
 
+    void accumulateConstraints(const core::ConstraintParams* cparams, unsigned int &constraintId);
+
+    void getConstraintViolation(const core::ConstraintParams* cparams, sofa::linearalgebra::BaseVector *v);
+
 };
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -99,6 +99,9 @@ protected:
     /// Call the method buildConstraintMatrix on all the BaseConstraintSet
     void buildConstraintMatrix(const core::ConstraintParams* cparams, unsigned int &constraintId);
 
+    /// Call the method applyJT on all the mappings
+    void accumulateMatrixDeriv(const core::ConstraintParams* cparams);
+
 };
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h
@@ -93,16 +93,23 @@ protected:
         core::behavior::BaseConstraintCorrection,
         BaseLink::FLAG_STOREPATH> l_constraintCorrections;
 
-    /// Call the method resetConstraint on all the mechanical states and BaseConstraintSet
+    /// Calls the method resetConstraint on all the mechanical states and BaseConstraintSet
+    /// In the case of a MechanicalObject, it clears the constraint jacobian matrix
     void resetConstraints(const core::ConstraintParams* cParams);
 
     /// Call the method buildConstraintMatrix on all the BaseConstraintSet
-    void buildConstraintMatrix(const core::ConstraintParams* cparams, unsigned int &constraintId);
+    void buildLocalConstraintMatrix(const core::ConstraintParams* cparams, unsigned int &constraintId);
 
-    /// Call the method applyJT on all the mappings
+    /// Calls the method applyJT on all the mappings to project the mapped
+    /// constraint matrices on the main constraint matrix
     void accumulateMatrixDeriv(const core::ConstraintParams* cparams);
 
-    void accumulateConstraints(const core::ConstraintParams* cparams, unsigned int &constraintId);
+    /// Reset and build the constraint matrix, including the projection from
+    /// the mapped DoFs
+    /// \return The number of constraints, i.e. the size of the constraint matrix
+    unsigned int buildConstraintMatrix(const core::ConstraintParams* cparams);
+
+    void applyProjectiveConstraintOnConstraintMatrix(const core::ConstraintParams* cparams);
 
     void getConstraintViolation(const core::ConstraintParams* cparams, sofa::linearalgebra::BaseVector *v);
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -520,7 +520,7 @@ void GenericConstraintSolver::applyMotionCorrection(
     }
 }
 
-void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::ConstraintParams* cParams, GenericConstraintSolver::MultiVecId res1, GenericConstraintSolver::MultiVecId res2) const
+void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::ConstraintParams* cParams, MultiVecId res1, MultiVecId res2) const
 {
     SCOPED_TIMER("Compute And Apply Motion Correction");
 
@@ -533,7 +533,7 @@ void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::Constr
     if (std::find(supportedCorrections.begin(), supportedCorrections.end(), cParams->constOrder()) != supportedCorrections.end())
     {
         const core::MultiVecCoordId xId(res1);
-        const core::MultiVecDerivId vId(res2);
+        const core::MultiVecDerivId vId(cParams->constOrder() == ConstraintParams::ConstOrder::VEL ? res1 : res2);
 
         for (const auto& constraintCorrection : filteredConstraintCorrections())
         {

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -216,19 +216,15 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
     // Resolution depending on the method selected
     switch ( d_resolutionMethod.getValue().getSelectedId() )
     {
-        // ProjectedGaussSeidel
-        case 0: {
+        case 0: // ProjectedGaussSeidel
+        case 2: // NonsmoothNonlinearConjugateGradient
+        {
             buildSystem_matrixAssembly(cParams);
             break;
         }
-        // UnbuiltGaussSeidel
-        case 1: {
+        case 1: // UnbuiltGaussSeidel
+        {
             buildSystem_matrixFree(numConstraints);
-            break;
-        }
-        // NonsmoothNonlinearConjugateGradient
-        case 2: {
-            buildSystem_matrixAssembly(cParams);
             break;
         }
         default:

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -500,15 +500,15 @@ void GenericConstraintSolver::applyMotionCorrection(
     const core::MultiVecDerivId vId,
     core::behavior::BaseConstraintCorrection* constraintCorrection) const
 {
-    if (cParams->constOrder() == ConstraintParams::ConstOrder::POS_AND_VEL)
+    if (cParams->constOrder() == sofa::core::ConstraintOrder::POS_AND_VEL)
     {
         constraintCorrection->applyMotionCorrection(cParams, xId, vId, cParams->dx(), this->getDx() );
     }
-    else if (cParams->constOrder() == ConstraintParams::ConstOrder::POS)
+    else if (cParams->constOrder() == sofa::core::ConstraintOrder::POS)
     {
         constraintCorrection->applyPositionCorrection(cParams, xId, cParams->dx(), this->getDx());
     }
-    else if (cParams->constOrder() == ConstraintParams::ConstOrder::VEL)
+    else if (cParams->constOrder() == sofa::core::ConstraintOrder::VEL)
     {
         constraintCorrection->applyVelocityCorrection(cParams, vId, cParams->dx(), this->getDx() );
     }
@@ -519,15 +519,15 @@ void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::Constr
     SCOPED_TIMER("Compute And Apply Motion Correction");
 
     static constexpr auto supportedCorrections = {
-        ConstraintParams::ConstOrder::POS_AND_VEL,
-        ConstraintParams::ConstOrder::POS,
-        ConstraintParams::ConstOrder::VEL
+        sofa::core::ConstraintOrder::POS_AND_VEL,
+        sofa::core::ConstraintOrder::POS,
+        sofa::core::ConstraintOrder::VEL
     };
 
     if (std::find(supportedCorrections.begin(), supportedCorrections.end(), cParams->constOrder()) != supportedCorrections.end())
     {
         const core::MultiVecCoordId xId(res1);
-        const core::MultiVecDerivId vId(cParams->constOrder() == ConstraintParams::ConstOrder::VEL ? res1 : res2);
+        const core::MultiVecDerivId vId(cParams->constOrder() == sofa::core::ConstraintOrder::VEL ? res1 : res2);
 
         for (const auto& constraintCorrection : filteredConstraintCorrections())
         {

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -170,14 +170,11 @@ void GenericConstraintSolver::cleanup()
 
 bool GenericConstraintSolver::prepareStates(const core::ConstraintParams *cParams, MultiVecId /*res1*/, MultiVecId /*res2*/)
 {
-    SCOPED_TIMER_VARNAME(vtimer, "PrepareStates");
-
     last_cp = current_cp;
 
     clearConstraintProblemLocks(); // NOTE: this assumes we solve only one constraint problem per step
 
     simulation::common::VectorOperations vop(cParams, this->getContext());
-
 
     {
         sofa::core::behavior::MultiVecDeriv lambda(&vop, m_lambdaId);
@@ -603,10 +600,7 @@ ConstraintProblem* GenericConstraintSolver::getConstraintProblem()
 
 void GenericConstraintSolver::clearConstraintProblemLocks()
 {
-    for (unsigned int i = 0; i < CP_BUFFER_SIZE; ++i)
-    {
-        m_cpIsLocked[i] = false;
-    }
+    std::fill(m_cpIsLocked.begin(), m_cpIsLocked.end(), false);
 }
 
 void GenericConstraintSolver::lockConstraintProblem(sofa::core::objectmodel::BaseObject* from, ConstraintProblem* p1, ConstraintProblem* p2)

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -515,7 +515,7 @@ bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cPar
     {
         SCOPED_TIMER("Compute And Apply Motion Correction");
 
-        if (cParams->constOrder() == core::ConstraintParams::POS_AND_VEL)
+        if (cParams->constOrder() == core::ConstraintParams::ConstOrder::POS_AND_VEL)
         {
             const core::MultiVecCoordId xId(res1);
             const core::MultiVecDerivId vId(res2);
@@ -536,7 +536,7 @@ bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cPar
                 }
             }
         }
-        else if (cParams->constOrder() == core::ConstraintParams::POS)
+        else if (cParams->constOrder() == core::ConstraintParams::ConstOrder::POS)
         {
             const core::MultiVecCoordId xId(res1);
             for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)
@@ -556,7 +556,7 @@ bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cPar
                 }
             }
         }
-        else if (cParams->constOrder() == core::ConstraintParams::VEL)
+        else if (cParams->constOrder() == core::ConstraintParams::ConstOrder::VEL)
         {
             const core::MultiVecDerivId vId(res1);
             for (unsigned int i = 0; i < l_constraintCorrections.size(); i++)

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -204,8 +204,8 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
 
         auto* context = getContext();
 
-        // mechanical action executed from root node to propagate the constraints
-        MechanicalResetConstraintVisitor(cParams).execute(context);
+        resetConstraints(cParams);
+
         // calling buildConstraintMatrix
         MechanicalBuildConstraintMatrix(cParams, cParams->j(), numConstraints).execute(context);
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -381,41 +381,49 @@ void GenericConstraintSolver::buildSystem_matrixAssembly(const core::ConstraintP
     dmsg_info() << " computeCompliance_done "  ;
 }
 
-void GenericConstraintSolver::rebuildSystem(SReal massFactor, SReal forceFactor)
+void GenericConstraintSolver::rebuildSystem(const SReal massFactor, const SReal forceFactor)
 {
     for (const auto& cc : l_constraintCorrections)
     {
-        if (!cc->isActive()) continue;
-        cc->rebuildSystem(massFactor, forceFactor);
+        if (cc->isActive())
+        {
+            cc->rebuildSystem(massFactor, forceFactor);
+        }
     }
 }
 
 void printLCP(std::ostream& file, SReal *q, SReal **M, SReal *f, int dim, bool printMatrix = true)
 {
     file.precision(9);
-    // affichage de la matrice du LCP
-    if (printMatrix) {
+
+    // print LCP matrix
+    if (printMatrix)
+    {
         file << msgendl << " W = [";
-        for(int compteur=0;compteur<dim;compteur++) {
-            for(int compteur2=0;compteur2<dim;compteur2++) {
-                file << "\t" << M[compteur][compteur2];
+        for (int row = 0; row < dim; row++)
+        {
+            for (int col = 0; col < dim; col++)
+            {
+                file << "\t" << M[row][col];
             }
             file << msgendl;
         }
         file << "      ];" << msgendl << msgendl;
     }
 
-    // affichage de q
+    // print q
     file << " delta = [";
-    for(int compteur=0;compteur<dim;compteur++) {
-        file << "\t" << q[compteur];
+    for (int i = 0; i < dim; i++)
+    {
+        file << "\t" << q[i];
     }
     file << "      ];" << msgendl << msgendl;
 
-    // affichage de f
+    // print f
     file << " lambda = [";
-    for(int compteur=0;compteur<dim;compteur++) {
-        file << "\t" << f[compteur];
+    for (int i = 0; i < dim; i++)
+    {
+        file << "\t" << f[i];
     }
     file << "      ];" << msgendl << msgendl;
 }
@@ -495,7 +503,6 @@ void GenericConstraintSolver::computeResidual(const core::ExecParams* eparam)
         cc->computeResidual(eparam,&current_cp->f);
     }
 }
-
 
 sofa::type::vector<core::behavior::BaseConstraintCorrection*> GenericConstraintSolver::filteredConstraintCorrections() const
 {

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -205,9 +205,7 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
         auto* context = getContext();
 
         resetConstraints(cParams);
-
-        // calling buildConstraintMatrix
-        MechanicalBuildConstraintMatrix(cParams, cParams->j(), numConstraints).execute(context);
+        buildConstraintMatrix(cParams, numConstraints);
 
         MechanicalAccumulateMatrixDeriv(cParams, cParams->j(), reverseAccumulateOrder.getValue()).execute(context);
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -37,15 +37,6 @@
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
 
-#include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
-using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
-
-#include <sofa/simulation/mechanicalvisitor/MechanicalBuildConstraintMatrix.h>
-using sofa::simulation::mechanicalvisitor::MechanicalBuildConstraintMatrix;
-
-#include <sofa/simulation/mechanicalvisitor/MechanicalAccumulateMatrixDeriv.h>
-using sofa::simulation::mechanicalvisitor::MechanicalAccumulateMatrixDeriv;
-
 #include <sofa/simulation/mechanicalvisitor/MechanicalProjectJacobianMatrixVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalProjectJacobianMatrixVisitor;
 
@@ -206,8 +197,7 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
 
         resetConstraints(cParams);
         buildConstraintMatrix(cParams, numConstraints);
-
-        MechanicalAccumulateMatrixDeriv(cParams, cParams->j(), reverseAccumulateOrder.getValue()).execute(context);
+        accumulateMatrixDeriv(cParams);
 
         // suppress the constraints that are on DOFS currently concerned by projective constraint
         core::MechanicalParams mparams = core::MechanicalParams(*cParams);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -109,7 +109,6 @@ protected:
     sofa::type::fixed_array<bool, CP_BUFFER_SIZE> m_cpIsLocked;
     GenericConstraintProblem *current_cp, *last_cp;
     SOFA_ATTRIBUTE_DISABLED__GENERICCONSTRAINTSOLVER_CONSTRAINTCORRECTIONS() DeprecatedAndRemoved constraintCorrections; //use ConstraintSolverImpl::l_constraintCorrections instead
-    type::vector<bool> constraintCorrectionIsActive; // for each constraint correction, a boolean that is false if the parent node is sleeping
 
     sofa::core::MultiVecDerivId m_lambdaId;
     sofa::core::MultiVecDerivId m_dxId;
@@ -132,6 +131,17 @@ private:
         ComplianceMatrixType& m_complianceMatrix;
         std::unique_ptr<ComplianceMatrixType> m_threadMatrix;
     };
+
+
+    sofa::type::vector<core::behavior::BaseConstraintCorrection*> filteredConstraintCorrections() const;
+
+    void computeAndApplyMotionCorrection(const core::ConstraintParams* cParams, GenericConstraintSolver::MultiVecId res1, GenericConstraintSolver::MultiVecId res2) const;
+    void applyMotionCorrection(
+        const core::ConstraintParams* cParams,
+        const core::MultiVecCoordId xId,
+        const core::MultiVecDerivId vId,
+        core::behavior::BaseConstraintCorrection* constraintCorrection) const;
+    void storeConstraintLambdas(const core::ConstraintParams* cParams);
 
 };
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -104,9 +104,9 @@ protected:
 
     void clearConstraintProblemLocks();
 
-    enum { CP_BUFFER_SIZE = 10 };
-    sofa::type::fixed_array<GenericConstraintProblem,CP_BUFFER_SIZE> m_cpBuffer;
-    sofa::type::fixed_array<bool,CP_BUFFER_SIZE> m_cpIsLocked;
+    static constexpr auto CP_BUFFER_SIZE = 10;
+    sofa::type::fixed_array<GenericConstraintProblem, CP_BUFFER_SIZE> m_cpBuffer;
+    sofa::type::fixed_array<bool, CP_BUFFER_SIZE> m_cpIsLocked;
     GenericConstraintProblem *current_cp, *last_cp;
     SOFA_ATTRIBUTE_DISABLED__GENERICCONSTRAINTSOLVER_CONSTRAINTCORRECTIONS() DeprecatedAndRemoved constraintCorrections; //use ConstraintSolverImpl::l_constraintCorrections instead
     type::vector<bool> constraintCorrectionIsActive; // for each constraint correction, a boolean that is false if the parent node is sleeping

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -51,8 +51,6 @@ public:
 
     bool prepareStates(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
     bool buildSystem(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
-    void buildSystem_matrixFree(unsigned int numConstraints);
-    void buildSystem_matrixAssembly(const core::ConstraintParams *cParams);
     void rebuildSystem(SReal massFactor, SReal forceFactor) override;
     bool solveSystem(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
     bool applyCorrection(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
@@ -112,6 +110,11 @@ protected:
 
     sofa::core::MultiVecDerivId m_lambdaId;
     sofa::core::MultiVecDerivId m_dxId;
+
+    void buildSystem_matrixFree(unsigned int numConstraints);
+
+    // Explicitly compute the compliance matrix projected in the constraint space
+    void buildSystem_matrixAssembly(const core::ConstraintParams *cParams);
 
 private:
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -109,16 +109,13 @@ void LCPConstraintProblem::solveTimed(SReal tolerance, int maxIt, SReal timeout)
 
 bool LCPConstraintSolver::prepareStates(const core::ConstraintParams * /*cParams*/, MultiVecId /*res1*/, MultiVecId /*res2*/)
 {
-    sofa::helper::AdvancedTimer::StepVar vtimer("PrepareStates");
-
     last_lcp = lcp;
     MechanicalVOpVisitor(core::execparams::defaultInstance(), (core::VecId)core::VecDerivId::dx()).setMapped(true).execute( getContext()); //dX=0
 
     msg_info() <<" propagate DXn performed - collision called" ;
 
-    SCOPED_TIMER_VARNAME(resetContactForceTimer, "resetContactForce");
-
-    for (const auto cc : l_constraintCorrections)
+    SCOPED_TIMER("resetContactForce");
+    for (const auto& cc : l_constraintCorrections)
     {
         cc->resetContactForce();
     }

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -250,13 +250,6 @@ bool LCPConstraintSolver::applyCorrection(const core::ConstraintParams * /*cPara
     return true;
 }
 
-void LCPConstraintSolver::buildConstraintMatrix(core::ConstraintParams cparams)
-{
-    SCOPED_TIMER("Build Constraint Matrix");
-    MechanicalBuildConstraintMatrix buildConstraintMatrix(&cparams, cparams.j(), _numConstraints );
-    buildConstraintMatrix.execute(getContext());
-}
-
 void LCPConstraintSolver::accumulateMatrixDeriv(core::ConstraintParams cparams)
 {
     SCOPED_TIMER("Accumulate Matrix Deriv");
@@ -634,7 +627,7 @@ void LCPConstraintSolver::buildSystem()
     _numConstraints = 0;
 
     resetConstraints(&cparams);
-    buildConstraintMatrix(cparams);
+    buildConstraintMatrix(&cparams, _numConstraints);
     accumulateMatrixDeriv(cparams);
 
     const auto muValue = mu.getValue();

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -124,13 +124,8 @@ void LCPConstraintSolver::buildSystem()
     cparams.setX(core::ConstVecCoordId::freePosition());
     cparams.setV(core::ConstVecDerivId::freeVelocity());
 
-    _numConstraints = 0;
-
-    {
-        SCOPED_TIMER("Accumulate Constraint");
-        accumulateConstraints(&cparams, _numConstraints);
-        sofa::helper::AdvancedTimer::valSet("numConstraints", _numConstraints);
-    }
+    _numConstraints = buildConstraintMatrix(&cparams);
+    sofa::helper::AdvancedTimer::valSet("numConstraints", _numConstraints);
 
     current_cp->mu = mu.getValue();
     current_cp->clear(_numConstraints);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -31,20 +31,11 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/fwd.h>
 
-#include <sofa/simulation/mechanicalvisitor/MechanicalAccumulateMatrixDeriv.h>
-using sofa::simulation::mechanicalvisitor::MechanicalAccumulateMatrixDeriv;
-
-#include <sofa/simulation/mechanicalvisitor/MechanicalBuildConstraintMatrix.h>
-using sofa::simulation::mechanicalvisitor::MechanicalBuildConstraintMatrix;
-
 #include <sofa/simulation/mechanicalvisitor/MechanicalGetConstraintInfoVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalGetConstraintInfoVisitor;
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
-
-#include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
-using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
 
 using sofa::core::VecId;
 
@@ -248,13 +239,6 @@ bool LCPConstraintSolver::applyCorrection(const core::ConstraintParams * /*cPara
     }
 
     return true;
-}
-
-void LCPConstraintSolver::accumulateMatrixDeriv(core::ConstraintParams cparams)
-{
-    SCOPED_TIMER("Accumulate Matrix Deriv");
-    MechanicalAccumulateMatrixDeriv accumulateMatrixDeriv(&cparams, cparams.j());
-    accumulateMatrixDeriv.execute(getContext());
 }
 
 void LCPConstraintSolver::buildHierarchy()
@@ -628,7 +612,7 @@ void LCPConstraintSolver::buildSystem()
 
     resetConstraints(&cparams);
     buildConstraintMatrix(&cparams, _numConstraints);
-    accumulateMatrixDeriv(cparams);
+    accumulateMatrixDeriv(&cparams);
 
     const auto muValue = mu.getValue();
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -109,8 +109,6 @@ private:
     unsigned int _numConstraints;
     SOFA_ATTRIBUTE_DEPRECATED__LCPCONSTRAINTSOLVERMUMEMBER() DeprecatedAndRemoved _mu;
 
-    /// Call the method buildConstraintMatrix on all the BaseConstraintSet
-    void buildConstraintMatrix(core::ConstraintParams cparams);
     /// Call the method applyJT on all the mappings
     void accumulateMatrixDeriv(core::ConstraintParams cparams);
     /// Multigrid hierarchy is resized and cleared

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -109,8 +109,6 @@ private:
     unsigned int _numConstraints;
     SOFA_ATTRIBUTE_DEPRECATED__LCPCONSTRAINTSOLVERMUMEMBER() DeprecatedAndRemoved _mu;
 
-    /// Call the method applyJT on all the mappings
-    void accumulateMatrixDeriv(core::ConstraintParams cparams);
     /// Multigrid hierarchy is resized and cleared
     void buildHierarchy();
     /// Call the method getConstraintInfo on all the BaseConstraintSet

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -109,8 +109,6 @@ private:
     unsigned int _numConstraints;
     SOFA_ATTRIBUTE_DEPRECATED__LCPCONSTRAINTSOLVERMUMEMBER() DeprecatedAndRemoved _mu;
 
-    /// Call the method resetConstraint on all the mechanical states and BaseConstraintSet
-    void resetConstraints(core::ConstraintParams cparams);
     /// Call the method buildConstraintMatrix on all the BaseConstraintSet
     void buildConstraintMatrix(core::ConstraintParams cparams);
     /// Call the method applyJT on all the mappings

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -65,7 +65,6 @@ protected:
     */
     ~LCPConstraintSolver() override;
 public:
-    void init() override;
 
     bool prepareStates(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
     bool buildSystem(const core::ConstraintParams * /*cParams*/, MultiVecId res1, MultiVecId res2=MultiVecId::null()) override;
@@ -104,7 +103,6 @@ public:
     void lockConstraintProblem(sofa::core::objectmodel::BaseObject* from, ConstraintProblem* p1, ConstraintProblem* p2=nullptr) override; ///< Do not use the following LCPs until the next call to this function. This is used to prevent concurent access to the LCP when using a LCPForceFeedback through an haptic thread
 
 private:
-    type::vector<bool> constraintCorrectionIsActive; // for each constraint correction, a boolean that is false if the parent node is sleeping
     void computeInitialGuess();
     void keepContactForcesValue();
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -123,7 +123,6 @@ private:
     void addComplianceInConstraintSpace(core::ConstraintParams cparams);
 
     /// for built lcp ///
-    void build_LCP();
     LCPConstraintProblem lcp1, lcp2, lcp3; // Triple buffer for LCP.
     LCPConstraintProblem *lcp, *last_lcp; /// use of last_lcp allows several LCPForceFeedback to be used in the same scene
     sofa::linearalgebra::LPtrFullMatrix<SReal>  *_W;
@@ -143,10 +142,10 @@ private:
 
     /// common built-unbuilt
     sofa::linearalgebra::FullVector<SReal> *_dFree, *_result;
+    void buildSystem();
     ///
 
     /// for unbuilt lcp ///
-    void build_problem_info();
     int lcp_gaussseidel_unbuilt(SReal *dfree, SReal *f, std::vector<SReal>* residuals = nullptr);
     int nlcp_gaussseidel_unbuilt(SReal *dfree, SReal *f, std::vector<SReal>* residuals = nullptr);
     int gaussseidel_unbuilt(SReal *dfree, SReal *f, std::vector<SReal>* residuals = nullptr);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h
@@ -39,7 +39,7 @@
 namespace sofa::component::constraint::lagrangian::solver
 {
 
-class LCPConstraintProblem : public ConstraintProblem
+class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API LCPConstraintProblem : public ConstraintProblem
 {
 public:
     SReal mu;
@@ -118,7 +118,7 @@ private:
 
     /// for built lcp ///
     LCPConstraintProblem lcp1, lcp2, lcp3; // Triple buffer for LCP.
-    LCPConstraintProblem *lcp, *last_lcp; /// use of last_lcp allows several LCPForceFeedback to be used in the same scene
+    LCPConstraintProblem *current_cp, *last_cp; /// use of last_lcp allows several LCPForceFeedback to be used in the same scene
     sofa::linearalgebra::LPtrFullMatrix<SReal>  *_W;
 
     /// multi-grid approach ///

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -192,7 +192,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectV");
-            mop.solveConstraint(newVel,core::ConstraintParams::VEL);
+            mop.solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
         }
         SOFATIMER_NEXTSTEP("UpdateX");
 
@@ -201,7 +201,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectX");
-            mop.solveConstraint(newPos,core::ConstraintParams::POS);
+            mop.solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
         }
 #undef SOFATIMER_NEXTSTEP
         sofa::helper::AdvancedTimer::stepEnd  (prevStep);
@@ -218,7 +218,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectV");
-            mop.solveConstraint(newVel,core::ConstraintParams::VEL);
+            mop.solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
         }
         SOFATIMER_NEXTSTEP("UpdateX");
 
@@ -228,7 +228,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectX");
-            mop.solveConstraint(newPos,core::ConstraintParams::POS);
+            mop.solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
         }
 #undef SOFATIMER_NEXTSTEP
         sofa::helper::AdvancedTimer::stepEnd  (prevStep);
@@ -266,11 +266,11 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         {
             {
                 SCOPED_TIMER_VARNAME(correctVTimer, "CorrectV");
-                mop.solveConstraint(newVel,core::ConstraintParams::VEL);
+                mop.solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
             }
             {
                 SCOPED_TIMER_VARNAME(correctXTimer, "CorrectX");
-                mop.solveConstraint(newPos,core::ConstraintParams::POS);
+                mop.solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
             }
         }
     }

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -192,7 +192,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectV");
-            mop.solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
+            mop.solveConstraint(newVel,core::ConstraintOrder::VEL);
         }
         SOFATIMER_NEXTSTEP("UpdateX");
 
@@ -201,7 +201,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectX");
-            mop.solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
+            mop.solveConstraint(newPos,core::ConstraintOrder::POS);
         }
 #undef SOFATIMER_NEXTSTEP
         sofa::helper::AdvancedTimer::stepEnd  (prevStep);
@@ -218,7 +218,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectV");
-            mop.solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
+            mop.solveConstraint(newVel,core::ConstraintOrder::VEL);
         }
         SOFATIMER_NEXTSTEP("UpdateX");
 
@@ -228,7 +228,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         if (solveConstraint)
         {
             SOFATIMER_NEXTSTEP("CorrectX");
-            mop.solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
+            mop.solveConstraint(newPos,core::ConstraintOrder::POS);
         }
 #undef SOFATIMER_NEXTSTEP
         sofa::helper::AdvancedTimer::stepEnd  (prevStep);
@@ -266,11 +266,11 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         {
             {
                 SCOPED_TIMER_VARNAME(correctVTimer, "CorrectV");
-                mop.solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
+                mop.solveConstraint(newVel,core::ConstraintOrder::VEL);
             }
             {
                 SCOPED_TIMER_VARNAME(correctXTimer, "CorrectX");
-                mop.solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
+                mop.solveConstraint(newPos,core::ConstraintOrder::POS);
             }
         }
     }

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/NewmarkImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/NewmarkImplicitSolver.cpp
@@ -138,11 +138,11 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
     b.eq(vel, a, h*(0.5-beta));
     b.peq(aResult, h*beta);
     newPos.eq(pos, b, h);
-    solveConstraint(dt,xResult,core::ConstraintParams::POS);
+    solveConstraint(dt,xResult,core::ConstraintParams::ConstOrder::POS);
     // v_{t+h} = v_t + h ( (1-\gamma) a_t + \gamma a_{t+h} )
     newVel.eq(vel, a, h*(1-gamma));
     newVel.peq(aResult, h*gamma);
-    solveConstraint(dt,vResult,core::ConstraintParams::VEL);
+    solveConstraint(dt,vResult,core::ConstraintParams::ConstOrder::VEL);
 
 #else // single-operation optimization
     typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
@@ -160,8 +160,8 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
     ops[1].second.push_back(std::make_pair(aResult.id(),h*gamma));//v(t+h)=vt+at*h*(1-gamma)+a(t+h)*h*gamma
     vop.v_multiop(ops);
 
-    mop.solveConstraint(vResult,core::ConstraintParams::VEL);
-    mop.solveConstraint(xResult,core::ConstraintParams::POS);
+    mop.solveConstraint(vResult,core::ConstraintParams::ConstOrder::VEL);
+    mop.solveConstraint(xResult,core::ConstraintParams::ConstOrder::POS);
 
 #endif
 

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/NewmarkImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/NewmarkImplicitSolver.cpp
@@ -160,8 +160,8 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
     ops[1].second.push_back(std::make_pair(aResult.id(),h*gamma));//v(t+h)=vt+at*h*(1-gamma)+a(t+h)*h*gamma
     vop.v_multiop(ops);
 
-    mop.solveConstraint(vResult,core::ConstraintParams::ConstOrder::VEL);
-    mop.solveConstraint(xResult,core::ConstraintParams::ConstOrder::POS);
+    mop.solveConstraint(vResult,core::ConstraintOrder::VEL);
+    mop.solveConstraint(xResult,core::ConstraintOrder::POS);
 
 #endif
 

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/StaticSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/StaticSolver.cpp
@@ -240,7 +240,7 @@ void StaticSolver::solve(const sofa::core::ExecParams* params, SReal dt, sofa::c
 
             // Calls "solveConstraint" method of every ConstraintSolver objects found in the current context tree.
             // todo(jnbrunet): Shouldn't this be done AFTER the position propagation of the mapped nodes?
-            mop.solveConstraint(x, sofa::core::ConstraintParams::ConstOrder::POS);
+            mop.solveConstraint(x, sofa::core::ConstraintOrder::POS);
 
             // Propagate positions to mapped mechanical objects, for example, identity mappings, barycentric mappings, ...
             // This will call the methods apply and applyJ on every mechanical mappings.

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/StaticSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/StaticSolver.cpp
@@ -240,7 +240,7 @@ void StaticSolver::solve(const sofa::core::ExecParams* params, SReal dt, sofa::c
 
             // Calls "solveConstraint" method of every ConstraintSolver objects found in the current context tree.
             // todo(jnbrunet): Shouldn't this be done AFTER the position propagation of the mapped nodes?
-            mop.solveConstraint(x, sofa::core::ConstraintParams::POS);
+            mop.solveConstraint(x, sofa::core::ConstraintParams::ConstOrder::POS);
 
             // Propagate positions to mapped mechanical objects, for example, identity mappings, barycentric mappings, ...
             // This will call the methods apply and applyJ on every mechanical mappings.

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
@@ -142,7 +142,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 
 		mop.projectResponse(acc);
 
-		mop.solveConstraint(acc, core::ConstraintParams::ACC);
+		mop.solveConstraint(acc, core::ConstraintParams::ConstOrder::ACC);
 		
         VMultiOp ops;
         ops.resize(2);
@@ -158,7 +158,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 		newp.clear();
 		mop.addMdx(newp,vel_1,1.0);
 
-		mop.solveConstraint(vel_1,core::ConstraintParams::VEL);
+		mop.solveConstraint(vel_1,core::ConstraintParams::ConstOrder::VEL);
 
 	} else {
 
@@ -270,7 +270,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 		vop.v_multiop(opsfin);
 
 		sofa::helper::AdvancedTimer::stepBegin("CorrectV");
-		mop.solveConstraint(vel_1,core::ConstraintParams::VEL);
+		mop.solveConstraint(vel_1,core::ConstraintParams::ConstOrder::VEL);
 
 		// update position
 		VMultiOp opsx;
@@ -341,7 +341,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
     sofa::helper::AdvancedTimer::stepEnd("CorrectV");
     {
         SCOPED_TIMER("CorrectX");
-        mop.solveConstraint(x_1,core::ConstraintParams::POS);
+        mop.solveConstraint(x_1,core::ConstraintParams::ConstOrder::POS);
     }
 
 	// update the previous momemtum as the current one for next step

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
@@ -142,7 +142,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 
 		mop.projectResponse(acc);
 
-		mop.solveConstraint(acc, core::ConstraintParams::ConstOrder::ACC);
+		mop.solveConstraint(acc, core::ConstraintOrder::ACC);
 		
         VMultiOp ops;
         ops.resize(2);
@@ -158,7 +158,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 		newp.clear();
 		mop.addMdx(newp,vel_1,1.0);
 
-		mop.solveConstraint(vel_1,core::ConstraintParams::ConstOrder::VEL);
+		mop.solveConstraint(vel_1,core::ConstraintOrder::VEL);
 
 	} else {
 
@@ -270,7 +270,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 		vop.v_multiop(opsfin);
 
 		sofa::helper::AdvancedTimer::stepBegin("CorrectV");
-		mop.solveConstraint(vel_1,core::ConstraintParams::ConstOrder::VEL);
+		mop.solveConstraint(vel_1,core::ConstraintOrder::VEL);
 
 		// update position
 		VMultiOp opsx;
@@ -341,7 +341,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
     sofa::helper::AdvancedTimer::stepEnd("CorrectV");
     {
         SCOPED_TIMER("CorrectX");
-        mop.solveConstraint(x_1,core::ConstraintParams::ConstOrder::POS);
+        mop.solveConstraint(x_1,core::ConstraintOrder::POS);
     }
 
 	// update the previous momemtum as the current one for next step

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/CentralDifferenceSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/CentralDifferenceSolver.cpp
@@ -97,15 +97,15 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
     mop.accFromF(dx, f);                       // dx = M^{-1} ( P_n - K u_n )
     mop.projectResponse(dx);                    // dx is projected to the constrained space
 
-    mop.solveConstraint(dx, core::ConstraintParams::ACC);
+    mop.solveConstraint(dx, core::ConstraintParams::ConstOrder::ACC);
     // apply the solution
     if (r==0)
     {
 #ifdef SOFA_NO_VMULTIOP // unoptimized version
         vel2.eq( vel, dx, dt );                  // vel = vel + dt M^{-1} ( P_n - K u_n )
-        mop.solveConstraint(vel2, core::ConstraintParams::VEL);
+        mop.solveConstraint(vel2, core::ConstraintParams::ConstOrder::VEL);
         pos2.eq( pos, vel2, dt );                    // pos = pos + h vel
-        mop.solveConstraint(pos2, core::ConstraintParams::POS);
+        mop.solveConstraint(pos2, core::ConstraintParams::ConstOrder::POS);
 
 #else // single-operation optimization
 
@@ -123,8 +123,8 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
 
         vop.v_multiop(ops);
 
-        mop.solveConstraint(vel2,core::ConstraintParams::VEL);
-        mop.solveConstraint(pos2,core::ConstraintParams::POS);
+        mop.solveConstraint(vel2,core::ConstraintParams::ConstOrder::VEL);
+        mop.solveConstraint(pos2,core::ConstraintParams::ConstOrder::POS);
 #endif
     }
     else
@@ -149,8 +149,8 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
 
         vop.v_multiop(ops);
 
-        mop.solveConstraint(vel2,core::ConstraintParams::VEL);
-        mop.solveConstraint(pos2,core::ConstraintParams::POS);
+        mop.solveConstraint(vel2,core::ConstraintParams::ConstOrder::VEL);
+        mop.solveConstraint(pos2,core::ConstraintParams::ConstOrder::POS);
 #endif
     }
 

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/CentralDifferenceSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/CentralDifferenceSolver.cpp
@@ -97,7 +97,7 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
     mop.accFromF(dx, f);                       // dx = M^{-1} ( P_n - K u_n )
     mop.projectResponse(dx);                    // dx is projected to the constrained space
 
-    mop.solveConstraint(dx, core::ConstraintParams::ConstOrder::ACC);
+    mop.solveConstraint(dx, core::ConstraintOrder::ACC);
     // apply the solution
     if (r==0)
     {
@@ -123,8 +123,8 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
 
         vop.v_multiop(ops);
 
-        mop.solveConstraint(vel2,core::ConstraintParams::ConstOrder::VEL);
-        mop.solveConstraint(pos2,core::ConstraintParams::ConstOrder::POS);
+        mop.solveConstraint(vel2,core::ConstraintOrder::VEL);
+        mop.solveConstraint(pos2,core::ConstraintOrder::POS);
 #endif
     }
     else
@@ -149,8 +149,8 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
 
         vop.v_multiop(ops);
 
-        mop.solveConstraint(vel2,core::ConstraintParams::ConstOrder::VEL);
-        mop.solveConstraint(pos2,core::ConstraintParams::ConstOrder::POS);
+        mop.solveConstraint(vel2,core::ConstraintOrder::VEL);
+        mop.solveConstraint(pos2,core::ConstraintOrder::POS);
 #endif
     }
 

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
@@ -204,8 +204,8 @@ void EulerExplicitSolver::updateState(sofa::simulation::common::VectorOperations
         vop->v_multiop(ops);
 
         // Calls "solveConstraint" on every ConstraintSolver objects found in the current context tree.
-        mop->solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
-        mop->solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
+        mop->solveConstraint(newVel,core::ConstraintOrder::VEL);
+        mop->solveConstraint(newPos,core::ConstraintOrder::POS);
     }
 #endif
 }
@@ -307,7 +307,7 @@ void EulerExplicitSolver::solveConstraints(sofa::simulation::common::MechanicalO
     SCOPED_TIMER("solveConstraint");
 
     // Calls "solveConstraint" method of every ConstraintSolver objects found in the current context tree.
-    mop->solveConstraint(acc, core::ConstraintParams::ConstOrder::ACC);
+    mop->solveConstraint(acc, core::ConstraintOrder::ACC);
 }
 
 void EulerExplicitSolver::assembleSystemMatrix(core::behavior::MultiMatrix<simulation::common::MechanicalOperations>* matrix)

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
@@ -135,10 +135,10 @@ void EulerExplicitSolver::updateState(sofa::simulation::common::VectorOperations
         //newPos = pos + newVel * dt
 
         newVel.eq(vel, acc.id(), dt);
-        mop->solveConstraint(newVel, core::ConstraintParams::VEL);
+        mop->solveConstraint(newVel, core::ConstraintParams::ConstOrder::VEL);
 
         newPos.eq(pos, newVel, dt);
-        mop->solveConstraint(newPos, core::ConstraintParams::POS);
+        mop->solveConstraint(newPos, core::ConstraintParams::ConstOrder::POS);
     }
     else
     {
@@ -146,10 +146,10 @@ void EulerExplicitSolver::updateState(sofa::simulation::common::VectorOperations
         //newVel = vel + acc * dt
 
         newPos.eq(pos, vel, dt);
-        mop->solveConstraint(newPos, core::ConstraintParams::POS);
+        mop->solveConstraint(newPos, core::ConstraintParams::ConstOrder::POS);
 
         newVel.eq(vel, acc.id(), dt);
-        mop->solveConstraint(newVel, core::ConstraintParams::VEL);
+        mop->solveConstraint(newVel, core::ConstraintParams::ConstOrder::VEL);
     }
 #else // single-operation optimization
     {
@@ -204,8 +204,8 @@ void EulerExplicitSolver::updateState(sofa::simulation::common::VectorOperations
         vop->v_multiop(ops);
 
         // Calls "solveConstraint" on every ConstraintSolver objects found in the current context tree.
-        mop->solveConstraint(newVel,core::ConstraintParams::VEL);
-        mop->solveConstraint(newPos,core::ConstraintParams::POS);
+        mop->solveConstraint(newVel,core::ConstraintParams::ConstOrder::VEL);
+        mop->solveConstraint(newPos,core::ConstraintParams::ConstOrder::POS);
     }
 #endif
 }
@@ -307,7 +307,7 @@ void EulerExplicitSolver::solveConstraints(sofa::simulation::common::MechanicalO
     SCOPED_TIMER("solveConstraint");
 
     // Calls "solveConstraint" method of every ConstraintSolver objects found in the current context tree.
-    mop->solveConstraint(acc, core::ConstraintParams::ACC);
+    mop->solveConstraint(acc, core::ConstraintParams::ConstOrder::ACC);
 }
 
 void EulerExplicitSolver::assembleSystemMatrix(core::behavior::MultiMatrix<simulation::common::MechanicalOperations>* matrix)

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta2Solver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta2Solver.cpp
@@ -107,8 +107,8 @@ void RungeKutta2Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
         ops[1].second.push_back(std::make_pair(acc.id(),dt));
         vop.v_multiop(ops);
 
-        mop.solveConstraint(vel2,core::ConstraintParams::ConstOrder::VEL);
-        mop.solveConstraint(pos2,core::ConstraintParams::ConstOrder::POS);
+        mop.solveConstraint(vel2,core::ConstraintOrder::VEL);
+        mop.solveConstraint(pos2,core::ConstraintOrder::POS);
     }
 #endif
 

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta2Solver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta2Solver.cpp
@@ -91,9 +91,9 @@ void RungeKutta2Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     // Use the derivative at newX, newV to update the state
 #ifdef SOFA_NO_VMULTIOP // unoptimized version
     pos2.eq(pos,newV,dt);
-    solveConstraint(dt,pos2,core::ConstraintParams::POS);
+    solveConstraint(dt,pos2,core::ConstraintParams::ConstOrder::POS);
     vel2.eq(vel,acc,dt);
-    solveConstraint(dt,vel2,core::ConstraintParams::VEL);
+    solveConstraint(dt,vel2,core::ConstraintParams::ConstOrder::VEL);
 #else // single-operation optimization
     {
         typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
@@ -107,8 +107,8 @@ void RungeKutta2Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
         ops[1].second.push_back(std::make_pair(acc.id(),dt));
         vop.v_multiop(ops);
 
-        mop.solveConstraint(vel2,core::ConstraintParams::VEL);
-        mop.solveConstraint(pos2,core::ConstraintParams::POS);
+        mop.solveConstraint(vel2,core::ConstraintParams::ConstOrder::VEL);
+        mop.solveConstraint(pos2,core::ConstraintParams::ConstOrder::POS);
     }
 #endif
 

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta4Solver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta4Solver.cpp
@@ -160,9 +160,9 @@ void RungeKutta4Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     pos2.peq(k3v,stepBy3);
     vel2.peq(k3a,stepBy3);
     pos2.peq(k4v,stepBy6);
-    solveConstraint(dt, pos2, core::ConstraintParams::POS);
+    solveConstraint(dt, pos2, core::ConstraintParams::ConstOrder::POS);
     vel2.peq(k4a,stepBy6);
-    solveConstraint(dt, vel2, core::ConstraintParams::VEL);
+    solveConstraint(dt, vel2, core::ConstraintParams::ConstOrder::VEL);
 #else // single-operation optimization
     {
         typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
@@ -182,8 +182,8 @@ void RungeKutta4Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
         ops[1].second.push_back(std::make_pair(k4a.id(),stepBy6));
         vop.v_multiop(ops);
 
-        mop.solveConstraint(pos, core::ConstraintParams::POS);
-        mop.solveConstraint(vel, core::ConstraintParams::VEL);
+        mop.solveConstraint(pos, core::ConstraintParams::ConstOrder::POS);
+        mop.solveConstraint(vel, core::ConstraintParams::ConstOrder::VEL);
     }
 #endif
 }

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta4Solver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta4Solver.cpp
@@ -182,8 +182,8 @@ void RungeKutta4Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
         ops[1].second.push_back(std::make_pair(k4a.id(),stepBy6));
         vop.v_multiop(ops);
 
-        mop.solveConstraint(pos, core::ConstraintParams::ConstOrder::POS);
-        mop.solveConstraint(vel, core::ConstraintParams::ConstOrder::VEL);
+        mop.solveConstraint(pos, core::ConstraintOrder::POS);
+        mop.solveConstraint(vel, core::ConstraintOrder::VEL);
     }
 #endif
 }

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -2287,9 +2287,11 @@ void MechanicalObject<DataTypes>::resetAcc(const core::ExecParams* params, core:
 template <class DataTypes>
 void MechanicalObject<DataTypes>::resetConstraint(const core::ConstraintParams* cParams)
 {
+    //reset the constraint jacobian matrix
     Data<MatrixDeriv>& c_data = *this->write(cParams->j().getId(this));
     sofa::helper::getWriteOnlyAccessor(c_data)->clear();
 
+    //reset the mapping jacobian matrix
     Data<MatrixDeriv>& m_data = *this->write(core::MatrixDerivId::mappingJacobian());
     sofa::helper::getWriteOnlyAccessor(m_data)->clear();
 }

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/CollisionModel.h
     ${SRC_ROOT}/ComponentLibrary.h
     ${SRC_ROOT}/ComponentNameHelper.h
+    ${SRC_ROOT}/ConstraintOrder.h
     ${SRC_ROOT}/ConstraintParams.h
     ${SRC_ROOT}/DataEngine.h
     ${SRC_ROOT}/DataTracker.h

--- a/Sofa/framework/Core/src/sofa/core/ConstraintOrder.h
+++ b/Sofa/framework/Core/src/sofa/core/ConstraintOrder.h
@@ -19,52 +19,39 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/simulation/mechanicalvisitor/MechanicalIntegrateConstraintVisitor.h>
-#include <sofa/core/ConstraintParams.h>
-#include <sofa/core/behavior/BaseMechanicalState.h>
-#include <sofa/core/behavior/MultiMatrixAccessor.h>
-namespace sofa::simulation::mechanicalvisitor
+#pragma once
+
+namespace sofa::core
 {
 
-MechanicalIntegrateConstraintsVisitor::MechanicalIntegrateConstraintsVisitor(
-        const core::ConstraintParams* cparams,
-        double pf, double vf,
-        sofa::core::ConstMultiVecDerivId correction,
-        sofa::core::MultiVecDerivId dx,
-        sofa::core::MultiVecCoordId x,
-        sofa::core::MultiVecDerivId v)
-    :BaseMechanicalVisitor(cparams)
-    ,cparams(cparams)
-    ,positionFactor(pf)
-    ,velocityFactor(vf)
-    ,correctionId(correction)
-    ,dxId(dx)
-    ,xId(x)
-    ,vId(v)
-    ,offset(0)
-{}
-
-MechanicalIntegrateConstraintsVisitor::Result MechanicalIntegrateConstraintsVisitor::fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms)
+/// Description of the order of the constraint
+enum class ConstraintOrder
 {
-    if (positionFactor != 0)
+    POS = 0,
+    VEL,
+    ACC,
+    POS_AND_VEL
+};
+
+constexpr static std::string_view constOrderToString(ConstraintOrder order)
+{
+    if (order == sofa::core::ConstraintOrder::POS)
     {
-        //x = x_free + correction * positionFactor;
-        ms->vOp(params, xId.getId(ms), cparams->x().getId(ms), correctionId.getId(ms), positionFactor);
+        return "POSITION";
     }
-
-    if (velocityFactor != 0)
+    if (order == sofa::core::ConstraintOrder::VEL)
     {
-        //v = v_free + correction * velocityFactor;
-        ms->vOp(params, vId.getId(ms), cparams->v().getId(ms), correctionId.getId(ms), velocityFactor);
+        return "VELOCITY";
     }
-
-    const double correctionFactor = cparams->constOrder() == sofa::core::ConstraintOrder::VEL ? velocityFactor : positionFactor;
-
-    //dx *= correctionFactor;
-    ms->vOp(params,dxId.getId(ms),core::VecDerivId::null(), correctionId.getId(ms), correctionFactor);
-
-    return RESULT_CONTINUE;
+    if (order == sofa::core::ConstraintOrder::ACC)
+    {
+        return "ACCELERATION";
+    }
+    if (order == sofa::core::ConstraintOrder::POS_AND_VEL)
+    {
+        return "POSITION AND VELOCITY";
+    }
+    return {};
 }
 
-} // namespace sofa::simulation::mechanicalvisitor
-
+}

--- a/Sofa/framework/Core/src/sofa/core/ConstraintParams.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ConstraintParams.cpp
@@ -38,7 +38,7 @@ ConstraintParams::ConstraintParams(const sofa::core::ExecParams& p)
     , m_j(MatrixDerivId::constraintJacobian())
     , m_dx(VecDerivId::dx())
     , m_lambda(VecDerivId::externalForce())
-    , m_constOrder (ConstOrder::POS_AND_VEL)
+    , m_constOrder (ConstraintOrder::POS_AND_VEL)
     , m_smoothFactor (1)
 {
 }

--- a/Sofa/framework/Core/src/sofa/core/ConstraintParams.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ConstraintParams.cpp
@@ -38,7 +38,7 @@ ConstraintParams::ConstraintParams(const sofa::core::ExecParams& p)
     , m_j(MatrixDerivId::constraintJacobian())
     , m_dx(VecDerivId::dx())
     , m_lambda(VecDerivId::externalForce())
-    , m_constOrder (POS_AND_VEL)
+    , m_constOrder (ConstOrder::POS_AND_VEL)
     , m_smoothFactor (1)
 {
 }

--- a/Sofa/framework/Core/src/sofa/core/ConstraintParams.h
+++ b/Sofa/framework/Core/src/sofa/core/ConstraintParams.h
@@ -254,25 +254,3 @@ protected:
 };
 
 } // namespace sofa::core
-
-#define CONSTORDER_TIMER_STRINGIZE(x) #x
-
-/// Tracy only allows constant strings for naming a zone.
-/// The following macro is a trick to allow dynamic names based on a finite
-/// number of enumerations.
-#ifdef TRACY_ENABLE
-    #define CONSTORDER_TIMER(prefix, varname, constOrder) \
-        static constexpr tracy::SourceLocationData sofaConstOrderSourceLocationDataPos { CONSTORDER_TIMER_STRINGIZE(prefix ## : POSITION), TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 };\
-        static constexpr tracy::SourceLocationData sofaConstOrderSourceLocationDataVel { CONSTORDER_TIMER_STRINGIZE(prefix ## : VELOCITY), TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 };\
-        static constexpr tracy::SourceLocationData sofaConstOrderSourceLocationDataAcc { CONSTORDER_TIMER_STRINGIZE(prefix ## : ACCELERATION), TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 };\
-        static constexpr tracy::SourceLocationData sofaConstOrderSourceLocationDataPosAndVel { CONSTORDER_TIMER_STRINGIZE(prefix ## : POSITION AND VELOCITY), TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 };\
-        const tracy::SourceLocationData* data { nullptr };\
-        if ((constOrder) == sofa::core::ConstraintParams::ConstOrder::POS) data = &sofaConstOrderSourceLocationDataPos;\
-        if ((constOrder) == sofa::core::ConstraintParams::ConstOrder::VEL) data = &sofaConstOrderSourceLocationDataVel;\
-        if ((constOrder) == sofa::core::ConstraintParams::ConstOrder::ACC) data = &sofaConstOrderSourceLocationDataAcc;\
-        if ((constOrder) == sofa::core::ConstraintParams::ConstOrder::POS_AND_VEL) data = &sofaConstOrderSourceLocationDataPosAndVel;\
-        tracy::ScopedZone varname( data, true );
-#else
-    #define CONSTORDER_TIMER(prefix, varname, constOrder) \
-        sofa::helper::ScopedAdvancedTimer varname(CONSTORDER_TIMER_STRINGIZE(prefix) + std::string(": ") + std::string(sofa::core::ConstraintParams::constOrderToString(constOrder)));
-#endif

--- a/Sofa/framework/Core/src/sofa/core/ConstraintParams.h
+++ b/Sofa/framework/Core/src/sofa/core/ConstraintParams.h
@@ -23,6 +23,7 @@
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/core/objectmodel/Data.h>
+#include <sofa/core/ConstraintOrder.h>
 
 namespace sofa::core
 {
@@ -34,47 +35,17 @@ class SOFA_CORE_API ConstraintParams : public sofa::core::ExecParams
 {
 public:
 
-    /// Description of the order of the constraint
-    enum class ConstOrder
-    {
-        POS = 0,
-        VEL,
-        ACC,
-        POS_AND_VEL
-    };
-
-    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto POS = ConstOrder::POS;
-    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto VEL = ConstOrder::VEL;
-    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto ACC = ConstOrder::ACC;
-    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto POS_AND_VEL = ConstOrder::POS_AND_VEL;
-
-    constexpr static std::string_view constOrderToString(ConstOrder order)
-    {
-        if (order == ConstOrder::POS)
-        {
-            return "POSITION";
-        }
-        if (order == ConstOrder::VEL)
-        {
-            return "VELOCITY";
-        }
-        if (order == ConstOrder::ACC)
-        {
-            return "ACCELERATION";
-        }
-        if (order == ConstOrder::POS_AND_VEL)
-        {
-            return "POSITION AND VELOCITY";
-        }
-        return {};
-    }
+    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto POS = sofa::core::ConstraintOrder::POS;
+    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto VEL = sofa::core::ConstraintOrder::VEL;
+    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto ACC = sofa::core::ConstraintOrder::ACC;
+    SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() static constexpr auto POS_AND_VEL = sofa::core::ConstraintOrder::POS_AND_VEL;
 
     /// @name Flags and parameters getters
     /// @{
 
-    ConstOrder constOrder() const { return m_constOrder; }
+    ConstraintOrder constOrder() const { return m_constOrder; }
 
-    ConstraintParams& setOrder(ConstOrder o) { m_constOrder = o;   return *this; }
+    ConstraintParams& setOrder(ConstraintOrder o) { m_constOrder = o;   return *this; }
 
 	/// Smooth contribution factor (for smooth constraints resolution)
     double smoothFactor() const { return m_smoothFactor; }
@@ -257,7 +228,7 @@ protected:
     MultiVecDerivId      m_lambda;
 
     /// Description of the order of the constraint
-    ConstOrder m_constOrder;
+    ConstraintOrder m_constOrder;
 
 	/// Smooth contribution factor (for smooth constraints resolution)
     double m_smoothFactor;

--- a/Sofa/framework/Core/src/sofa/core/ConstraintParams.h
+++ b/Sofa/framework/Core/src/sofa/core/ConstraintParams.h
@@ -174,19 +174,29 @@ public:
 	/// Set smooth contribution factor (for smooth constraints resolution)
     ConstraintParams& setSmoothFactor(double v) { m_smoothFactor = v; return *this; }
 
+    /// Returns ids of the position vectors
     const ConstMultiVecCoordId& x() const { return m_x; }
+    /// Returns ids of the position vectors
     ConstMultiVecCoordId& x()       { return m_x; }
 
+    /// Returns ids of the velocity vectors
     const ConstMultiVecDerivId& v() const { return m_v; }
+    /// Returns ids of the velocity vectors
     ConstMultiVecDerivId& v()       { return m_v; }
 
+    /// Returns ids of the constraint jacobian matrices
     const MultiMatrixDerivId&  j() const { return m_j; }
+    /// Returns ids of the constraint jacobian matrices
     MultiMatrixDerivId& j()              { return m_j; }
 
+    /// Returns ids of the contraint correction vectors
     const MultiVecDerivId& dx() const { return m_dx;  }
+    /// Returns ids of the contraint correction vectors
     MultiVecDerivId&  dx()            { return m_dx;  }
 
+    /// Returns ids of the constraint lambda vectors
     const MultiVecDerivId& lambda() const { return m_lambda; }
+    /// Returns ids of the constraint lambda vectors
     MultiVecDerivId&  lambda()            { return m_lambda; }
 
     /// Set the IDs where to read the free position vector

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintCorrection.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintCorrection.h
@@ -112,11 +112,8 @@ public:
     /// the result is accumulated in Vecid::force()
     virtual void computeResidual(const core::ExecParams* /*params*/, linearalgebra::BaseVector * /*lambda*/) ;
 
-    /// @name Deprecated API
-    /// @{
     virtual void applyContactForce(const linearalgebra::BaseVector *f) = 0;
     virtual void resetContactForce() = 0;
-    /// @}
 
     /// @name Unbuilt constraint system during resolution
     /// @{

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
@@ -33,17 +33,17 @@ ConstraintSolver::~ConstraintSolver() = default;
 
 void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVecId res1, MultiVecId res2)
 {
-    CONSTORDER_TIMER(SolveConstraint, solveConstraintTimer, cParams->constOrder())
+    SCOPED_TIMER("SolveConstraint");
 
     bool continueSolving = true;
     {
-        CONSTORDER_TIMER(PrepareState, prepareStateTimer, cParams->constOrder())
+        SCOPED_TIMER("PrepareState");
         continueSolving = prepareStates(cParams, res1, res2);
     }
 
     if (continueSolving)
     {
-        CONSTORDER_TIMER(BuildSystem, buildSystemTimer, cParams->constOrder())
+        SCOPED_TIMER("BuildSystem");
         continueSolving = buildSystem(cParams, res1, res2);
 
         postBuildSystem(cParams);
@@ -51,7 +51,7 @@ void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVe
 
     if (continueSolving)
     {
-        CONSTORDER_TIMER(SolveSystem, solveSystemTimer, cParams->constOrder())
+        SCOPED_TIMER("SolveSystem");
         continueSolving = solveSystem(cParams, res1, res2);
 
         postSolveSystem(cParams);
@@ -59,7 +59,7 @@ void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVe
 
     if (continueSolving)
     {
-        CONSTORDER_TIMER(ApplyCorrection, applyCorrectionTimer, cParams->constOrder())
+        SCOPED_TIMER("ApplyCorrection");
         applyCorrection(cParams, res1, res2);
     }
 }

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
@@ -33,18 +33,17 @@ ConstraintSolver::~ConstraintSolver() = default;
 
 void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVecId res1, MultiVecId res2)
 {
-    const std::string className = "SolveConstraint: " + cParams->getName();
-    sofa::helper::ScopedAdvancedTimer solveConstraintTimer(className);
+    CONSTORDER_TIMER(SolveConstraint, solveConstraintTimer, cParams->constOrder())
 
     bool continueSolving = true;
     {
-        helper::ScopedAdvancedTimer timer(className + " - PrepareState");
+        CONSTORDER_TIMER(PrepareState, prepareStateTimer, cParams->constOrder())
         continueSolving = prepareStates(cParams, res1, res2);
     }
 
     if (continueSolving)
     {
-        helper::ScopedAdvancedTimer timer(className + " - BuildSystem");
+        CONSTORDER_TIMER(BuildSystem, buildSystemTimer, cParams->constOrder())
         continueSolving = buildSystem(cParams, res1, res2);
 
         postBuildSystem(cParams);
@@ -52,7 +51,7 @@ void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVe
 
     if (continueSolving)
     {
-        helper::ScopedAdvancedTimer timer(className + " - SolveSystem");
+        CONSTORDER_TIMER(SolveSystem, solveSystemTimer, cParams->constOrder())
         continueSolving = solveSystem(cParams, res1, res2);
 
         postSolveSystem(cParams);
@@ -60,7 +59,7 @@ void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVe
 
     if (continueSolving)
     {
-        helper::ScopedAdvancedTimer timer(className + " - ApplyCorrection");
+        CONSTORDER_TIMER(ApplyCorrection, applyCorrectionTimer, cParams->constOrder())
         applyCorrection(cParams, res1, res2);
     }
 }

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.cpp
@@ -34,34 +34,10 @@ ConstraintSolver::~ConstraintSolver() = default;
 void ConstraintSolver::solveConstraint(const ConstraintParams * cParams, MultiVecId res1, MultiVecId res2)
 {
     SCOPED_TIMER("SolveConstraint");
-
-    bool continueSolving = true;
-    {
-        SCOPED_TIMER("PrepareState");
-        continueSolving = prepareStates(cParams, res1, res2);
-    }
-
-    if (continueSolving)
-    {
-        SCOPED_TIMER("BuildSystem");
-        continueSolving = buildSystem(cParams, res1, res2);
-
-        postBuildSystem(cParams);
-    }
-
-    if (continueSolving)
-    {
-        SCOPED_TIMER("SolveSystem");
-        continueSolving = solveSystem(cParams, res1, res2);
-
-        postSolveSystem(cParams);
-    }
-
-    if (continueSolving)
-    {
-        SCOPED_TIMER("ApplyCorrection");
-        applyCorrection(cParams, res1, res2);
-    }
+    prepareStatesTask(cParams, res1, res2) &&
+    buildSystemTask(cParams, res1, res2) &&
+    solveSystemTask(cParams, res1, res2) &&
+    applyCorrectionTask(cParams, res1, res2);
 }
 
 bool ConstraintSolver::insertInNode( objectmodel::BaseNode* node )
@@ -76,6 +52,34 @@ bool ConstraintSolver::removeInNode( objectmodel::BaseNode* node )
     node->removeConstraintSolver(this);
     Inherit1::removeInNode(node);
     return true;
+}
+
+bool ConstraintSolver::prepareStatesTask(const ConstraintParams* cParams, MultiVecId res1, MultiVecId res2)
+{
+    SCOPED_TIMER("PrepareState");
+    return prepareStates(cParams, res1, res2);
+}
+
+bool ConstraintSolver::buildSystemTask(const ConstraintParams* cParams, MultiVecId res1, MultiVecId res2)
+{
+    SCOPED_TIMER("BuildSystem");
+    const auto success = buildSystem(cParams, res1, res2);
+    postBuildSystem(cParams);
+    return success;
+}
+
+bool ConstraintSolver::solveSystemTask(const ConstraintParams* cParams, MultiVecId res1, MultiVecId res2)
+{
+    SCOPED_TIMER("SolveSystem");
+    const auto success = solveSystem(cParams, res1, res2);
+    postSolveSystem(cParams);
+    return success;
+}
+
+bool ConstraintSolver::applyCorrectionTask(const ConstraintParams* cParams, MultiVecId res1, MultiVecId res2)
+{
+    SCOPED_TIMER("ApplyCorrection");
+    return applyCorrection(cParams, res1, res2);
 }
 
 } // namespace sofa::core::behavior

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintSolver.h
@@ -120,6 +120,12 @@ protected:
 
     virtual void postBuildSystem(const ConstraintParams* constraint_params) { SOFA_UNUSED(constraint_params); }
     virtual void postSolveSystem(const ConstraintParams* constraint_params) { SOFA_UNUSED(constraint_params); }
+
+    bool prepareStatesTask(const ConstraintParams*, MultiVecId res1, MultiVecId res2);
+    bool buildSystemTask(const ConstraintParams *, MultiVecId res1, MultiVecId res2);
+    bool solveSystemTask(const ConstraintParams *, MultiVecId res1, MultiVecId res2);
+    bool applyCorrectionTask(const ConstraintParams *, MultiVecId res1, MultiVecId res2);
+
 };
 
 } // namespace sofa::core::behavior

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -53,3 +53,10 @@
     SOFA_ATTRIBUTE_DEPRECATED("v23.12 (PR#3861)", "v24.06", msg)
 
 #endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() \
+    SOFA_ATTRIBUTE_DEPRECATED("v23.12", "v24.06", "ConstOrder is now a scoped enumeration. It must be used to access the values.")
+#endif

--- a/Sofa/framework/Helper/src/sofa/helper/LCPcalc.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/LCPcalc.cpp
@@ -1629,11 +1629,11 @@ int nlcp_gaussseidel(int dim, SReal *dfree, SReal**W, SReal *f, SReal mu, SReal 
         for (c1=0; c1<numContacts; c1++)
         {
             // index of contact
-            int index1 = c1;
+            const int index1 = c1;
 
             // put the previous value of the contact force in a buffer and put the current value to 0
             f_1[0] = f[3*index1]; f_1[1] = f[3*index1+1]; f_1[2] = f[3*index1+2];
-            set3Dof(f,index1,0.0,0.0,0.0); //		f[3*index] = 0.0; f[3*index+1] = 0.0; f[3*index+2] = 0.0;
+            set3Dof(f,index1, 0, 0, 0); //		f[3*index] = 0.0; f[3*index+1] = 0.0; f[3*index+2] = 0.0;
 
             // computation of actual d due to contribution of other contacts
             dn=dfree[3*index1]; dt=dfree[3*index1+1]; ds=dfree[3*index1+2];
@@ -1649,7 +1649,8 @@ int nlcp_gaussseidel(int dim, SReal *dfree, SReal**W, SReal *f, SReal mu, SReal 
             if (minW != 0.0 && fabs(W[3*index1  ][3*index1  ]) <= minW)
             {
                 // constraint compliance is too small
-                if(it==0){
+                if(it==0)
+                {
                     std::stringstream tmpmsg;
                     tmpmsg << "Compliance too small for contact " << index1 << ": |" << std::scientific << W[3*index1  ][3*index1  ] << "| < " << minW << std::fixed ;
                     dmsg_warning("LCPcalc") << tmpmsg.str() ;
@@ -1740,19 +1741,17 @@ int nlcp_gaussseidel(int dim, SReal *dfree, SReal**W, SReal *f, SReal mu, SReal 
 
 int nlcp_gaussseidelTimed(int dim, SReal *dfree, SReal**W, SReal*f, SReal mu, SReal tol, int numItMax, bool useInitialF, SReal timeout, bool verbose)
 {
-    SReal test = dim/3;
-    const SReal zero = 0.0;
-    const int numContacts =  (int) floor(test);
-    test = dim/3 - numContacts;
+    const int numContacts =  dim/3;
+
+    if (dim % 3)
+    {
+        dmsg_info("LCPcalc") << "dim should be dividable by 3 in nlcp_gaussseidelTimed" ;
+        return 0;
+    }
 
     const ctime_t t0 = CTime::getTime();
     const ctime_t tdiff = (ctime_t)(timeout*CTime::getTicksPerSec());
 
-    if (test>0.01)
-    {
-        printf("\n WARNING dim should be dividable by 3 in nlcp_gaussseidel");
-        return 0;
-    }
     // iterators
     int it,c1,i;
 
@@ -1772,17 +1771,6 @@ int nlcp_gaussseidelTimed(int dim, SReal *dfree, SReal**W, SReal*f, SReal mu, SR
     W33 = (LocalBlock33 **) malloc (dim*sizeof(LocalBlock33));
     for (c1=0; c1<numContacts; c1++)
         W33[c1] = new LocalBlock33();
-    /*
-    std::vector<listElem> sortedList;
-    listElem buf;
-    sortedList.clear();
-    for (c1=0; c1<numContacts; c1++)
-    {
-        buf.value = dfree[3*c1];
-        buf.index = c1;
-        sortedList.push_back(buf);
-    }
-    */
 
     //////////////
     // Beginning of iterative computations
@@ -1800,7 +1788,7 @@ int nlcp_gaussseidelTimed(int dim, SReal *dfree, SReal**W, SReal*f, SReal mu, SR
 
             // put the previous value of the contact force in a buffer and put the current value to 0
             f_1[0] = f[3*index1]; f_1[1] = f[3*index1+1]; f_1[2] = f[3*index1+2];
-            set3Dof(f,index1,zero,zero,zero); //		f[3*index] = 0.0; f[3*index+1] = 0.0; f[3*index+2] = 0.0;
+            set3Dof(f,index1, 0, 0, 0); //		f[3*index] = 0.0; f[3*index+1] = 0.0; f[3*index+2] = 0.0;
 
             // computation of actual d due to contribution of other contacts
             dn=dfree[3*index1]; dt=dfree[3*index1+1]; ds=dfree[3*index1+2];

--- a/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
+++ b/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
@@ -41,7 +41,6 @@ namespace sofa::helper
  * selected.
  *
  */
-
 class SOFA_HELPER_API OptionsGroup
 {
 public :

--- a/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -68,6 +68,6 @@ ScopedAdvancedTimer::ScopedAdvancedTimer(const char* message, T* obj)
     #define SCOPED_TIMER(name) ZoneScopedN(name)
     #define SCOPED_TIMER_VARNAME(varname, name) ZoneNamedN(varname, name, true)
 #else
-    #define SCOPED_TIMER(name) sofa::helper::ScopedAdvancedTimer timer(name)
+    #define SCOPED_TIMER(name) sofa::helper::ScopedAdvancedTimer sofaScopedTimer(name)
     #define SCOPED_TIMER_VARNAME(varname, name) sofa::helper::ScopedAdvancedTimer varname(name)
 #endif

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
@@ -415,7 +415,7 @@ void MechanicalOperations::solveConstraint(SReal dt, MultiVecCoordId id, core::C
 }
 */
 
-void MechanicalOperations::solveConstraint(MultiVecId id, core::ConstraintParams::ConstOrder order)
+void MechanicalOperations::solveConstraint(MultiVecId id, core::ConstraintOrder order)
 {
     cparams.setOrder(order);
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
@@ -400,7 +400,7 @@ void MechanicalOperations::solveConstraint(SReal dt, MultiVecDerivId id, core::C
 {
   core::ConstraintParams cparams(mparams    // PARAMS FIRST //, order);
   mparams.setDt(dt);
-  assert( order == core::ConstraintParams::VEL || order == core::ConstraintParams::ACC);
+  assert( order == core::ConstraintParams::ConstOrder::VEL || order == core::ConstraintParams::ConstOrder::ACC);
   cparams.setV( id);
   solveConstraint(&cparams    // PARAMS FIRST //, id);
 }
@@ -409,7 +409,7 @@ void MechanicalOperations::solveConstraint(SReal dt, MultiVecCoordId id, core::C
 {
   core::ConstraintParams cparams(mparams    // PARAMS FIRST //, order);
   mparams.setDt(dt);
-  assert( order == core::ConstraintParams::POS);
+  assert( order == core::ConstraintParams::ConstOrder::POS);
   cparams.setX( id);
   solveConstraint(&cparams    // PARAMS FIRST //, id);
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
@@ -111,7 +111,7 @@ public:
 
     /** Find all the Constraint present in the scene graph, build the constraint equation system, solve and apply the correction
 **/
-    void solveConstraint(sofa::core::MultiVecId id, core::ConstraintParams::ConstOrder order);
+    void solveConstraint(sofa::core::MultiVecId id, core::ConstraintOrder order);
 
 
 


### PR DESCRIPTION
Some methods are moved into a base class. They were exactly doing the same thing in both solvers. The result is that `buildSystem` now looks very similar in both classes. It allows to better understand that both solvers do some similar things. It could be factorized again in the future.

A lot of cosmetic changes

`applyCorrection` has been split into smaller functions

`build_LCP` and `build_problem_info` are factorized

`ConstraintSolver::solveConstraint` is condensed




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
