### PR TITLE
[CollisionModel] New: added collision layer property

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/CollisionModel.cpp
+++ b/Sofa/framework/Core/src/sofa/core/CollisionModel.cpp
@@ -165,6 +165,9 @@ bool CollisionModel::canCollideWith(CollisionModel* model)
     if (model->getContext() == this->getContext()) // models are in the Node -> is self collision activated?
         return bSelfCollision.getValue();
 
+    if (model->layer.getValue() != this->layer.getValue()) // no collisions between models in different layers
+        return false;
+
     const auto& myGroups = this->group.getValue();
     if (myGroups.empty()) // a collision model without any group always collides
         return true;

--- a/Sofa/framework/Core/src/sofa/core/CollisionModel.h
+++ b/Sofa/framework/Core/src/sofa/core/CollisionModel.h
@@ -407,6 +407,9 @@ protected:
     /// models included in a common group (i.e. sharing a common id)
     Data< std::set<int> > group;
 
+    // No collision can occur between collision models in different layers
+    Data<int> layer;
+
     /// Number of collision elements
     Size size;
 


### PR DESCRIPTION
This PR introduces  collision layers, a collision filtering algorithm similar to the one used in [Unity's collsion pipeline](https://docs.unity3d.com/Manual/LayerBasedCollision.html). The overall idea is to omit collision detection for models that are in different layers.  This way, each layer can be used for different functionality, e.g. cutting simulation.
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
