### PR TITLE
[LinearSolver.Direct] Better distribution of tasks among threads

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.h
@@ -80,6 +80,8 @@ protected :
     bool factorize(Matrix& M, InvertData * invertData);
 
     void showInvalidSystemMessage(const std::string& reason) const;
+
+    using Triplet = std::tuple<sofa::SignedIndex, sofa::SignedIndex, Real>;
 };
 
 #if !defined(SOFA_COMPONENT_LINEARSOLVER_SPARSELDLSOLVER_CPP)

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -251,7 +251,7 @@ bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::doAddJMInvJtLocal(ResMat
            });
     }
 
-    const auto nbTriplets = JlocalRowSize * JlocalRowSize / 2;
+    const auto nbTriplets = JlocalRowSize * (JlocalRowSize+1) / 2;
     std::vector<Triplet> tripletsBuffer(nbTriplets);
 
     SCOPED_TIMER("UpperSystem");
@@ -267,8 +267,8 @@ bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::doAddJMInvJtLocal(ResMat
                 for (auto r = range.start; r != range.end; ++r)
                 {
                     //convert a triangular matrix (flat) index to row and column coordinates
-                    const int j = static_cast<int>(std::floor((-1 + std::sqrt(1 + 8 * r)) / 2));
-                    const int i = r - j * (j+1) / 2;
+                    sofa::Index i, j;
+                    linearalgebra::computeRowColumnCoordinateFromIndexInLowerTriangularMatrix(r, i, j);
 
                     auto& [row, col, value] = tripletsBuffer[r];
                     row = Jlocal2global[j];

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolver.inl
@@ -223,58 +223,75 @@ bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::doAddJMInvJtLocal(ResMat
         }
     }
 
-    simulation::forEachRange(execution, *taskScheduler, 0u, JlocalRowSize,
-        [&data, this](const auto& range)
-        {
-            for (auto i = range.start; i != range.end; ++i)
+    {
+        SCOPED_TIMER("LowerSystem");
+        simulation::forEachRange(execution, *taskScheduler, 0u, JlocalRowSize,
+            [&data, this](const auto& range)
             {
-                Real* line = JLinv[i];
-                sofa::linearalgebra::solveLowerUnitriangularSystemCSR(data->n, line, line, data->LT_colptr.data(), data->LT_rowind.data(), data->LT_values.data());
-            }
-        });
-
-    simulation::forEachRange(execution, *taskScheduler, 0u, JlocalRowSize,
-        [&data, this](const auto& range)
-        {
-            for (auto i = range.start; i != range.end; ++i)
-            {
-                Real* lineD = JLinv[i];
-                Real* lineM = JLinvDinv[i];
-                sofa::linearalgebra::solveDiagonalSystemUsingInvertedValues(data->n, lineD, lineM, data->invD.data());
-            }
-        });
-
-    std::mutex mutex;
-    simulation::forEachRange(execution, *taskScheduler, 0u, JlocalRowSize,
-        [&data, this, fact, &mutex, result, JlocalRowSize](const auto& range)
-        {
-            std::vector<std::tuple<sofa::SignedIndex, sofa::SignedIndex, Real> > triplets;
-            triplets.reserve(JlocalRowSize * (range.end - range.start));
-
-            for (auto j = range.start; j != range.end; ++j)
-            {
-                Real* lineJ = JLinvDinv[j];
-                sofa::SignedIndex globalRowJ = Jlocal2global[j];
-                for (unsigned i = j; i < JlocalRowSize; ++i)
+                SCOPED_TIMER("Lower");
+                for (auto i = range.start; i != range.end; ++i)
                 {
+                    Real* line = JLinv[i];
+                    sofa::linearalgebra::solveLowerUnitriangularSystemCSR(data->n, line, line, data->LT_colptr.data(), data->LT_rowind.data(), data->LT_values.data());
+                }
+            });
+    }
+
+    {
+        SCOPED_TIMER("Diagonal");
+        simulation::forEachRange(execution, *taskScheduler, 0u, JlocalRowSize,
+           [&data, this](const auto& range)
+           {
+               for (auto i = range.start; i != range.end; ++i)
+               {
+                   Real* lineD = JLinv[i];
+                   Real* lineM = JLinvDinv[i];
+                   sofa::linearalgebra::solveDiagonalSystemUsingInvertedValues(data->n, lineD, lineM, data->invD.data());
+               }
+           });
+    }
+
+    const auto nbTriplets = JlocalRowSize * JlocalRowSize / 2;
+    std::vector<Triplet> tripletsBuffer(nbTriplets);
+
+    SCOPED_TIMER("UpperSystem");
+    std::mutex mutex;
+
+    // Distribution of the tasks according to the number of triplets, i.e. the
+    // number of elements in a triangular matrix
+    simulation::forEachRange(execution, *taskScheduler, 0u, nbTriplets,
+        [&data, this, fact, &mutex, result, &tripletsBuffer](const auto& range)
+        {
+            {
+                SCOPED_TIMER("UpperRange");
+                for (auto r = range.start; r != range.end; ++r)
+                {
+                    //convert a triangular matrix (flat) index to row and column coordinates
+                    const int j = static_cast<int>(std::floor((-1 + std::sqrt(1 + 8 * r)) / 2));
+                    const int i = r - j * (j+1) / 2;
+
+                    auto& [row, col, value] = tripletsBuffer[r];
+                    row = Jlocal2global[j];
+                    col = Jlocal2global[i];
+
                     Real* lineI = JLinv[i];
-                    int globalRowI = Jlocal2global[i];
+                    Real* lineJ = JLinvDinv[j];
 
-                    Real acc = 0;
-                    for (unsigned k = 0; k < (unsigned)data->n; k++)
+                    value = 0;
+                    for (int k = 0; k < data->n; ++k)
                     {
-                        acc += lineJ[k] * lineI[k];
+                        value += lineJ[k] * lineI[k];
                     }
-                    acc *= fact;
-
-                    triplets.emplace_back(globalRowJ, globalRowI, acc);
+                    value *= fact;
                 }
             }
 
             std::lock_guard guard(mutex);
 
-            for (const auto& [row, col, value] : triplets)
+            SCOPED_TIMER("Assembling");
+            for (auto r = range.start; r != range.end; ++r)
             {
+                const auto& [row, col, value] = tripletsBuffer[r];
                 result->add(row, col, value);
                 if (row != col)
                 {

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/TriangularSystemSolver.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <sofa/config.h>
 #include <cstring>
+#include <cmath>
 
 namespace sofa::linearalgebra
 {
@@ -94,6 +95,30 @@ void solveUpperUnitriangularSystemCSR(
         }
         solutionVector[i] = x_i;
     }
+}
+
+/// A lower triangular matrix can be stored as a linear array. This function
+/// converts the index in this linear array to 2d coordinates (row and column)
+/// of an element in the matrix.
+///
+/// Example of a 6x6 lower triangular matrix:
+/// [ 0               ]
+/// [ 1  2            ]
+/// [ 3  4  5         ]
+/// [ 6  7  8  9      ]
+/// [10 11 12 13 14   ]
+/// [15 16 17 18 19 20]
+///
+/// 0 => (0, 0)
+/// 7 => (3, 1)
+/// 18 => (5, 3)
+inline void computeRowColumnCoordinateFromIndexInLowerTriangularMatrix(
+    const sofa::Index flatIndex,
+    sofa::Index& row,
+    sofa::Index& col)
+{
+    row = std::floor(-0.5 + sqrt(0.25 + 2 * flatIndex));
+    col = flatIndex - row * (row + 1) / 2;
 }
 
 }

--- a/Sofa/framework/LinearAlgebra/test/TriangularSystemSolver_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/TriangularSystemSolver_test.cpp
@@ -125,4 +125,27 @@ TEST(TriangularSystemSolver, upper3x3)
     EXPECT_FLOATINGPOINT_EQ(solution[0], static_cast<SReal>(38))
 }
 
+TEST(TriangularSystemSolver, computeLowerTriangularMatrixCoordinates)
+{
+    for (sofa::Index matrixSize = 2; matrixSize < 50; ++matrixSize)
+    {
+        const auto nbElementsInATriangularMatrix = matrixSize * (matrixSize+1) / 2;
+
+        sofa::Index nbCoordinates {};
+        for (sofa::Index row = 0; row < matrixSize; ++row)
+        {
+            for (sofa::Index col = 0; col <= row; ++col)
+            {
+                sofa::Index r, c;
+                linearalgebra::computeRowColumnCoordinateFromIndexInLowerTriangularMatrix(nbCoordinates, r, c);
+                EXPECT_EQ(r, row) << "index " << nbCoordinates << ", matrix size " << matrixSize;
+                EXPECT_EQ(c, col) << "index " << nbCoordinates << ", matrix size " << matrixSize;
+                ++nbCoordinates;
+            }
+        }
+
+        EXPECT_EQ(nbCoordinates, nbElementsInATriangularMatrix);
+    }
+}
+
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/PipelineImpl.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/PipelineImpl.cpp
@@ -114,6 +114,7 @@ void PipelineImpl::computeCollisionDetection()
 {
     simulation::Node* root = dynamic_cast<simulation::Node*>(getContext());
     if(root == nullptr) return;
+    SCOPED_TIMER("CollisionDetection");
     std::vector<CollisionModel*> collisionModels;
     root->getTreeObjects<CollisionModel>(&collisionModels);
     doCollisionDetection(collisionModels);


### PR DESCRIPTION
I worked with the scene `examples\Demos\fallingBeamLagrangianCollision.scn`


I noticed that the distribution of the work among threads is not uniform:

![image](https://github.com/sofa-framework/sofa/assets/10572752/9145a080-0a7a-4b22-b3dc-501d509aefcf)


Here is the distribution after the changes:

![image](https://github.com/sofa-framework/sofa/assets/10572752/cd047f43-aa7c-49de-a303-7d1945d8dcbd)


Benchmark on 500 time steps:
Before:
```
[INFO]    [BatchGUI] 500 iterations done in 22.9377 s ( 21.7982 FPS).
 LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
   5      14.42    1       0.01   30.28   19.39    6.24   19.39   42.69 .....Get Compliance
```

After
```
[INFO]    [BatchGUI] 500 iterations done in 19.7138 s ( 25.363 FPS).
 LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
  5      13.77    1       0      22.02   15.31    5.07   15.31   39.29 .....Get Compliance
```


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
