### PR TITLE
[DetectionOutput] New: added barycentric coords

### DIFF
--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/LocalMinDistance.cpp
@@ -268,6 +268,8 @@ int LocalMinDistance::computeIntersection(Line& e1, Line& e2, OutputVector* cont
     detection->value = detection->normal.norm();
     detection->normal /= detection->value;
     detection->value -= contactDist;
+    detection->barycentricCoords[0] = alpha;
+    detection->barycentricCoords[1] = beta;
 
     return 1;
 }

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/MeshMinProximityIntersection.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/MeshMinProximityIntersection.cpp
@@ -195,6 +195,8 @@ int MeshMinProximityIntersection::computeIntersection(Line& e1, Line& e2, Output
     detection->point[1] = Q;
     detection->normal = PQ;
     detection->value = detection->normal.norm();
+    detection->barycentricCoords[0] = alpha;
+    detection->barycentricCoords[1] = beta;
 
     if(detection->value>1e-15)
     {

--- a/Sofa/framework/Core/src/sofa/core/collision/DetectionOutput.h
+++ b/Sofa/framework/Core/src/sofa/core/collision/DetectionOutput.h
@@ -75,6 +75,8 @@ public:
     double value;
     /// If using a continuous collision detection, estimated of time of contact.
     double deltaT;
+    /// Barycentric coordinates of the intersection (only used in MinProximityIntersection and LocalMinDistance)
+    SReal barycentricCoords[2];
     DetectionOutput()
         : elem( (sofa::core::CollisionModel* )nullptr,
                 (sofa::core::CollisionModel* ) nullptr), id(0), value(0.0), deltaT(0.0)


### PR DESCRIPTION

With this PR, I  suggest to return  barycentric coords to the detection output  members. In my use case , these coordinates are used in cutting simulation to create new vertices from ancestor points when propagating a cut.
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
