### PR TITLE
[Mapping] Add scale to rigid mapping to scale the initial mapping

### DIFF
--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.h
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.h
@@ -112,6 +112,8 @@ public:
     Data<bool> d_globalToLocalCoords; ///< are the output DOFs initially expressed in global coordinates
     SOFA_ATTRIBUTE_DISABLED("v23.06", "v23.12", "Use d_globalToLocalCoords instead") DeprecatedAndRemoved globalToLocalCoords;
 
+    Data<double> d_scale;
+
     SOFA_ATTRIBUTE_DISABLED("v23.06", "v23.06", "Use d_geometricStiffness instead") DeprecatedAndRemoved geometricStiffness;
 
 protected:

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
@@ -124,6 +124,7 @@ RigidMapping<TIn, TOut>::RigidMapping()
     , d_indexFromEnd(initData(&d_indexFromEnd, false, "indexFromEnd", "input DOF index starts from the end of input DOFs vector"))
     , d_rigidIndexPerPoint(initData(&d_rigidIndexPerPoint, "rigidIndexPerPoint", "For each mapped point, the index of the Rigid it is mapped from"))
     , d_globalToLocalCoords(initData(&d_globalToLocalCoords, "globalToLocalCoords", "are the output DOFs initially expressed in global coordinates"))
+    , d_scale(initData(&d_scale, 1.0, "scale","Scale the output point's position with respect to their first position in the rigid frame"))
     , m_matrixJ()
     , m_updateJ(false)
 {
@@ -320,8 +321,8 @@ void RigidMapping<TIn, TOut>::apply(const core::MechanicalParams * /*mparams*/, 
     {
         sofa::Index rigidIndex = getRigidIndex(i);
 
-        m_rotatedPoints[i] = in[rigidIndex].rotate( Out::getCPos(pts[i]) );
-        out[i] = in[rigidIndex].mult( pts[i]) ;
+        m_rotatedPoints[i] = in[rigidIndex].rotate( Out::getCPos(pts[i] * d_scale.getValue()) );
+        out[i] = in[rigidIndex].mult( pts[i] * d_scale.getValue()) ;
     }
 }
 


### PR DESCRIPTION
While trying to provide a complete answer to the discussion #4218 I wondered if it was that difficult to do this. In fact, it only requires to scale the stored data `d_position` while calling apply and modifying the attribute `m_rotatedPoints` because this is used to compute every ohter step (applyJ, JT etc...). 

I've tried it in a simple scene with lagrangian constraint to see if it works, and after changing the scale factor in the middle of the simulation its maps correctly the forces (you can se the torque scaled) and the lambda are computed accordingly. 

``` xml
<?xml version="1.0"?>

<Node name="root" dt="0.01" gravity="0 0 0" >
    <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
    <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [LinearSolverConstraintCorrection] -->
    <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Model"/> <!-- Needed to use components [BilateralInteractionConstraint] -->
    <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Solver"/> <!-- Needed to use components [GenericConstraintSolver] -->
    <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
    <RequiredPlugin name="Sofa.Component.Mapping.NonLinear"/> <!-- Needed to use components [RigidMapping] -->
    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
    <RequiredPlugin name="Sofa.Component.MechanicalLoad"/> <!-- Needed to use components [ConstantForceField] -->
    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
    <RequiredPlugin name="Sofa.Component.Setting"/> <!-- Needed to use components [BackgroundSetting] -->
    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->

    <VisualStyle displayFlags="showVisualModels" />
    <BackgroundSetting color="0.8 0.8 0.8 1" />

    <FreeMotionAnimationLoop name="FreeMotionAnimationLoop" />
    <GenericConstraintSolver maxIterations="10" tolerance="1.0e-3"/>

    <Node name="Mesh" >
        <EulerImplicitSolver firstOrder="false" rayleighMass="0.1" rayleighStiffness="0.1" />
        <SparseLDLSolver name="precond" template="CompressedRowSparseMatrixd"  />

        <MechanicalObject name="mstate" position="0 0 0 0 0 0 1" template="Rigid3d" />
        <UniformMass totalMass="1"/>

        <Node name="AttachPoint">
            <MechanicalObject name="points" template="Vec3" position="0 0 0 1 0 0 0 1 0 0 0 1"  />
            <ConstantForceField indices="1" forces="0.0 0.0 1.0" showArrowSize="0.2"/>
            <RigidMapping />
        </Node>
        <LinearSolverConstraintCorrection linearSolver="@precond"/>
    </Node>

    <Node name="Mesh2" >
        <MechanicalObject name="mstate" position="0 0 0 0 0 0 1" template="Rigid3d" />
    </Node>

    <BilateralInteractionConstraint template="Rigid3d"
                                    object1="@Mesh/mstate"
                                    object2="@Mesh2/mstate"
                                    first_point="0" second_point="0" />
</Node >
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
