### PR TITLE
[Helper] Update ComponentChange for MechanicalMatrixMapper

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -470,7 +470,6 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     { "VoidMapping", Moved("v22.06", "SofaMiscMapping", "Sofa.Component.Mapping.Linear") },
 
     // SofaConstraint was deprecated in #2635, #2790, #2796, #2813 and ...
-    { "MappingGeometricStiffnessForceField", Moved("v22.06", "SofaConstraint", "Sofa.Component.Mapping.MappedMatrix") },
     { "BilateralInteractionConstraint", Moved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Model") },
     { "GenericConstraintCorrection", Moved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Correction") },
     { "GenericConstraintSolver", Moved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Solver") },
@@ -487,7 +486,6 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     { "LocalMinDistance", Moved("v22.06", "SofaConstraint", "Sofa.Component.Collision.Detection.Intersection") },
 
     // SofaGeneralAnimationLoop was deprecated in #2635 and #2796
-    { "MechanicalMatrixMapper", Moved("v22.06", "SofaGeneralAnimationLoop", "Sofa.Component.Mapping.MappedMatrix") },
     { "MultiStepAnimationLoop", Moved("v22.06", "SofaGeneralAnimationLoop", "Sofa.Component.AnimationLoop") },
     { "MultiTagAnimationLoop", Moved("v22.06", "SofaGeneralAnimationLoop", "Sofa.Component.AnimationLoop") },
 
@@ -718,6 +716,10 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     // SofaValidation was deprecated in #3039
     { "CompareState", Moved("v22.06", "SofaValidation", "Sofa.Component.Playback") },
     { "CompareTopology", Moved("v22.06", "SofaValidation", "Sofa.Component.Playback") },
+
+    // Removed in #4040, deprecated in #2777
+    { "MechanicalMatrixMapper", Removed("v23.06", "v23.12") },
+    { "MappingGeometricStiffnessForceField", Removed("v23.06", "v23.12") },
 };
 
 } // namespace sofa::helper::lifecycle


### PR DESCRIPTION
and MappingGeometricStiffnessForceField

The message goes from:
```
Object type MechanicalMatrixMapper<Vec3d,Vec3d> was not created
The object 'MechanicalMatrixMapper' is not in the factory.
This component has been MOVED from SofaGeneralAnimationLoop to Sofa.Component.Mapping.MappedMatrix since SOFA v22.06.
To continue using this component you may need to update your scene by adding
<RequiredPlugin name='Sofa.Component.Mapping.MappedMatrix'/>
```

to:

```
The object 'MechanicalMatrixMapper' is not in the factory.
This component has been REMOVED since SOFA v23.06 (deprecated since v23.12).
Please consider updating your scene. If this component is crucial to you please report in a GitHub issue in order to reconsider this component for future re-integration.
```






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
