### PR TITLE
[Topology] Check indices out-of-bound in TriangleSetTopologyContainer

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
@@ -122,7 +122,7 @@ void EdgeSetTopologyContainer::createEdgesAroundVertexArray()
         
         if (edge[0] >= unsigned(nbPoints) || edge[1] >= unsigned(nbPoints))
         {
-            msg_warning() << "EdgesAroundVertex creation failed, Edge buffer is not concistent with number of points: Edge: " << edge << " for: " << nbPoints << " points.";
+            msg_warning() << "EdgesAroundVertex creation failed, Edge buffer is not consistent with number of points, Edge: " << edge << " for: " << nbPoints << " points.";
             continue;
         }
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
@@ -125,6 +125,13 @@ void TriangleSetTopologyContainer::createTrianglesAroundVertexArray()
     m_trianglesAroundVertex.resize(getNbPoints());
     for (size_t i = 0; i < m_triangle.size(); ++i)
     {
+        if (m_triangle[i][0] >= getNbPoints() || m_triangle[i][1] >= getNbPoints() || m_triangle[i][2] >= getNbPoints())
+        {
+            msg_warning() << "trianglesAroundVertex creation failed, Triangle buffer is not concistent with number of points: Triangle: " << m_triangle[i] << " for: " << getNbPoints() << " points.";
+            continue;
+        }
+
+
         // adding edge i in the edge shell of both points
         for (unsigned int j=0; j<3; ++j)
             m_trianglesAroundVertex[ m_triangle[i][j]  ].push_back( (TriangleID)i );

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
@@ -127,7 +127,7 @@ void TriangleSetTopologyContainer::createTrianglesAroundVertexArray()
     {
         if (m_triangle[i][0] >= getNbPoints() || m_triangle[i][1] >= getNbPoints() || m_triangle[i][2] >= getNbPoints())
         {
-            msg_warning() << "trianglesAroundVertex creation failed, Triangle buffer is not concistent with number of points: Triangle: " << m_triangle[i] << " for: " << getNbPoints() << " points.";
+            msg_warning() << "trianglesAroundVertex creation failed, Triangle buffer is not consistent with number of points, Triangle: " << m_triangle[i] << " for: " << getNbPoints() << " points.";
             continue;
         }
 


### PR DESCRIPTION
Check that triangles index match the size of the triangleAroundVertexArray (Like it is done in EdgeSetTopologyContainer for EdgeAroundVertexArray)






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
