### PR TITLE
[LinearAlgebra] Speedup accumulation on BTDMatrix

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BTDMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BTDMatrix.h
@@ -255,7 +255,7 @@ void BTDMatrix<N, T>::add(Index row, Index col,
         {
             for (sofa::Index j = 0; j < BSIZE; ++j)
             {
-                this->add(row + i, row + j, v(i, j));
+                this->add(row + i, col + j, v(i, j));
             }
         }
     }

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BTDMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BTDMatrix.h
@@ -185,6 +185,12 @@ public:
 
     void add(Index i, Index j, double v) override;
 
+    /**
+     * Accumulation specialized on contributions of the same size than the blocks.
+     */
+    template <std::size_t M = N, std::enable_if_t<(M > 3), int> = 0>
+    void add(Index row, Index col, const type::Mat<BSIZE, BSIZE, Real>& v);
+
     void clear(Index i, Index j) override;
 
     void clearRow(Index i) override;
@@ -225,6 +231,36 @@ public:
         return name.c_str();
     }
 };
+
+
+template <std::size_t N, typename T>
+template <std::size_t M, std::enable_if_t<(M > 3), int>>
+void BTDMatrix<N, T>::add(Index row, Index col,
+    const type::Mat<BSIZE, BSIZE, Real>& v)
+{
+    if (row % BSIZE == 0 && col % BSIZE == 0)
+    {
+        const Index bi = row / BSIZE;
+        const Index bj = col / BSIZE;
+        const Index bindex = bj - bi + 1;
+        if (bindex >= 3)
+        {
+            return;
+        }
+        data[bi * 3 + bindex] += v;
+    }
+    else
+    {
+        for (sofa::Index i = 0; i < BSIZE; ++i)
+        {
+            for (sofa::Index j = 0; j < BSIZE; ++j)
+            {
+                this->add(row + i, row + j, v(i, j));
+            }
+        }
+    }
+}
+
 
 #if !defined(SOFA_LINEARALGEBRA_BTDMATRIX_CPP)
 extern template class SOFA_LINEARALGEBRA_API linearalgebra::BTDMatrix<6, SReal>;


### PR DESCRIPTION

Validated with the following benchmark. The benchmark `BM_BTDMatrix_addBlock` uses the new implemented accumulation function and must be compared to `BM_BTDMatrix_add`.

```
-------------------------------------------------------------------------------
Benchmark                                     Time             CPU   Iterations
-------------------------------------------------------------------------------
BM_BTDMatrix_add<6, SReal>/64              6212 ns         3069 ns       224000
BM_BTDMatrix_add<6, SReal>/512            49857 ns        32087 ns        22400
BM_BTDMatrix_add<6, SReal>/1024          103536 ns        54408 ns        11200
BM_BTDMatrix_addBlock<6, SReal>/64          602 ns          391 ns      1600000
BM_BTDMatrix_addBlock<6, SReal>/512        5607 ns         3432 ns       186667
BM_BTDMatrix_addBlock<6, SReal>/1024      12176 ns         6417 ns       112000

```

https://github.com/alxbilger/SofaBenchmark/pull/36


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
