### PR TITLE
 [GitHub] Add an action closing old discussion topics (using js)

### DIFF
--- a/.github/workflows/close_old_discussion_topics.yml
+++ b/.github/workflows/close_old_discussion_topics.yml
@@ -1,0 +1,22 @@
+name: Close Old Discussion Topics
+on:
+  schedule:
+    # Schedule this action to run periodically (e.g., daily)
+    - cron: "0 0 * * 1" # Run every week on Monday at midnight
+  workflow_dispatch:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  check_title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger remote action to close topics
+        uses: hugtalbot/close-old-discussion-topics@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          owner: sofa-framework
+          repository: sofa
+        uses: ./

--- a/.github/workflows/close_old_discussion_topics.yml
+++ b/.github/workflows/close_old_discussion_topics.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger remote action to close topics
-        uses: hugtalbot/close-old-discussion-topics@master
+        uses: hugtalbot/close-old-discussion-topics@v0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           owner: sofa-framework

--- a/.github/workflows/close_old_discussion_topics.yml
+++ b/.github/workflows/close_old_discussion_topics.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger remote action to close topics
-        uses: hugtalbot/close-old-discussion-topics@v0.1
+        uses: hugtalbot/close-old-discussion-topics@master
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           owner: sofa-framework

--- a/.github/workflows/close_old_discussion_topics.yml
+++ b/.github/workflows/close_old_discussion_topics.yml
@@ -10,7 +10,7 @@ on:
       - unlabeled
 
 jobs:
-  check_title:
+  close_old_discussion_topics:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger remote action to close topics

--- a/.github/workflows/close_old_discussion_topics.yml
+++ b/.github/workflows/close_old_discussion_topics.yml
@@ -19,4 +19,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           owner: sofa-framework
           repository: sofa
-        uses: ./

--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -1,4 +1,3 @@
----
 name: Label Checker
 on:
   pull_request:


### PR DESCRIPTION
New action implemented here: https://github.com/hugtalbot/close-old-discussion-topics
We use this action in this new script.

Note the action is not yet active and only creates logs.

Close and replace #4096 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
