### PR TITLE
[LinearAlgebra] Support 6x6 matrices accumulation in BaseMatrix

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/AssemblingMatrixAccumulator.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/AssemblingMatrixAccumulator.h
@@ -76,6 +76,8 @@ protected:
     void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, double value) override;
     void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<3, 3, float>& value) override;
     void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<3, 3, double>& value) override;
+    void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<6, 6, float>& value) override;
+    void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<6, 6, double>& value) override;
 };
 
 
@@ -103,6 +105,20 @@ void AssemblingMatrixAccumulator<c, TStrategy>::add(const core::matrixaccumulato
 }
 template<sofa::core::matrixaccumulator::Contribution c, class TStrategy>
 void AssemblingMatrixAccumulator<c, TStrategy>::add(const core::matrixaccumulator::no_check_policy&, const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<3, 3, double>& value)
+{
+    m_globalMatrix->add(row + m_cachedPositionInGlobalMatrix[0],
+                              col + m_cachedPositionInGlobalMatrix[1],
+                              value * static_cast<double>(m_cachedFactor));
+}
+template<sofa::core::matrixaccumulator::Contribution c, class TStrategy>
+void AssemblingMatrixAccumulator<c, TStrategy>::add(const core::matrixaccumulator::no_check_policy&, const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<6, 6, float>& value)
+{
+    m_globalMatrix->add(row + m_cachedPositionInGlobalMatrix[0],
+                              col + m_cachedPositionInGlobalMatrix[1],
+                              value * static_cast<float>(m_cachedFactor));
+}
+template<sofa::core::matrixaccumulator::Contribution c, class TStrategy>
+void AssemblingMatrixAccumulator<c, TStrategy>::add(const core::matrixaccumulator::no_check_policy&, const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<6, 6, double>& value)
 {
     m_globalMatrix->add(row + m_cachedPositionInGlobalMatrix[0],
                               col + m_cachedPositionInGlobalMatrix[1],

--- a/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
+++ b/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
@@ -125,82 +125,44 @@ public:
     [[maybe_unused]]
     std::shared_ptr<TStrategy> indexVerificationStrategy;
 
-    void add(sofa::SignedIndex row, sofa::SignedIndex col, float value) override final
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const float value) override final
     {
-        if constexpr (TStrategy::verify_index::value)
-        {
-            if (indexVerificationStrategy)
-            {
-                indexVerificationStrategy->checkRowIndex(row);
-                indexVerificationStrategy->checkColIndex(col);
-            }
-        }
-        add(matrixaccumulator::no_check, row, col, value);
+        indexCheckedAdd(row, col, value);
     }
 
-    void add(sofa::SignedIndex row, sofa::SignedIndex col, double value) override final
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, double value) override final
     {
-        if constexpr (TStrategy::verify_index::value)
-        {
-            if (indexVerificationStrategy)
-            {
-                indexVerificationStrategy->checkRowIndex(row);
-                indexVerificationStrategy->checkColIndex(col);
-            }
-        }
-        add(matrixaccumulator::no_check, row, col, value);
+        indexCheckedAdd(row, col, value);
     }
 
-    void add(sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<2, 2, float>& value) override final
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<2, 2, float>& value) override final
     {
-        if constexpr (TStrategy::verify_index::value)
-        {
-            if (indexVerificationStrategy)
-            {
-                indexVerificationStrategy->checkRowIndex(row);
-                indexVerificationStrategy->checkColIndex(col);
-            }
-        }
-        add(matrixaccumulator::no_check, row, col, value);
+        indexCheckedAdd(row, col, value);
     }
 
-    void add(sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<2, 2, double>& value) override final
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<2, 2, double>& value) override final
     {
-        if constexpr (TStrategy::verify_index::value)
-        {
-            if (indexVerificationStrategy)
-            {
-                indexVerificationStrategy->checkRowIndex(row);
-                indexVerificationStrategy->checkColIndex(col);
-            }
-        }
-        add(matrixaccumulator::no_check, row, col, value);
+        indexCheckedAdd(row, col, value);
     }
 
-    void add(sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<3, 3, float>& value) override final
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<3, 3, float>& value) override final
     {
-        if constexpr (TStrategy::verify_index::value)
-        {
-            if (indexVerificationStrategy)
-            {
-                indexVerificationStrategy->checkRowIndex(row);
-                indexVerificationStrategy->checkColIndex(col);
-            }
-        }
-        add(matrixaccumulator::no_check, row, col, value);
+        indexCheckedAdd(row, col, value);
     }
 
-    void add(sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<3, 3, double>& value) override final
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<3, 3, double>& value) override final
     {
-        if constexpr (TStrategy::verify_index::value)
-        {
-            if (indexVerificationStrategy)
-            {
-                indexVerificationStrategy->checkRowIndex(row);
-                indexVerificationStrategy->checkColIndex(col);
-            }
-        }
-        add(matrixaccumulator::no_check, row, col, value);
+        indexCheckedAdd(row, col, value);
+    }
+
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<6, 6, float>& value) override final
+    {
+        indexCheckedAdd(row, col, value);
+    }
+
+    void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const sofa::type::Mat<6, 6, double>& value) override final
+    {
+        indexCheckedAdd(row, col, value);
     }
 
 protected:
@@ -231,6 +193,29 @@ protected:
     virtual void add(const matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<2, 2, double>& value)
     {
         TBaseMatrixAccumulator::add(row, col, value);
+    }
+
+    virtual void add(const matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<6, 6, float>& value)
+    {
+        TBaseMatrixAccumulator::add(row, col, value);
+    }
+    virtual void add(const matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<6, 6, double>& value)
+    {
+        TBaseMatrixAccumulator::add(row, col, value);
+    }
+
+    template <typename T>
+    void indexCheckedAdd(sofa::SignedIndex row, sofa::SignedIndex col, const T& value)
+    {
+        if constexpr (TStrategy::verify_index::value)
+        {
+            if (indexVerificationStrategy)
+            {
+                indexVerificationStrategy->checkRowIndex(row);
+                indexVerificationStrategy->checkColIndex(col);
+            }
+        }
+        add(matrixaccumulator::no_check, row, col, value);
     }
 };
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
@@ -106,32 +106,50 @@ struct BaseMatrixLinearOpMV_BlockDiagonal
     }
 };
 
+template <sofa::Size L, sofa::Size C, class real>
+void matrixAdd(BaseMatrix* self, const Index row, const Index col, const sofa::type::Mat<L, C, real>& M)
+{
+    for (unsigned int r = 0; r < L; ++r)
+    {
+        for (unsigned int c = 0; c < C; ++c)
+        {
+            self->add(row + r, col + c, M[r][c]);
+        }
+    }
+}
+
 ///Adding values from a 3x3d matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index row, Index col, const type::Mat3x3d & _M) {
-    for (unsigned i=0;i<3;i++)
-        for (unsigned j=0;j<3;j++)
-            add(row + i, col + j, _M[i][j]);
+void BaseMatrix::add(const Index row, const Index col, const type::Mat3x3d & _M)
+{
+    matrixAdd(this, row, col, _M);
 }
 
 ///Adding values from a 3x3f matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index row, Index col, const type::Mat3x3f & _M) {
-    for (unsigned i=0;i<3;i++)
-        for (unsigned j=0;j<3;j++)
-            add(row + i, col + j, _M[i][j]);
+void BaseMatrix::add(const Index row, const Index col, const type::Mat3x3f & _M)
+{
+    matrixAdd(this, row, col, _M);
 }
 
 ///Adding values from a 2x2d matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index row, Index col, const type::Mat2x2d & _M) {
-    for (unsigned i=0;i<2;i++)
-        for (unsigned j=0;j<2;j++)
-            add(row + i, col + j, _M[i][j]);
+void BaseMatrix::add(const Index row, const Index col, const type::Mat2x2d & _M)
+{
+    matrixAdd(this, row, col, _M);
 }
 
 ///Adding values from a 2x2f matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index row, Index col, const type::Mat2x2f & _M) {
-    for (unsigned i=0;i<2;i++)
-        for (unsigned j=0;j<2;j++)
-            add(row + i, col + j, _M[i][j]);
+void BaseMatrix::add(const Index row, const Index col, const type::Mat2x2f & _M)
+{
+    matrixAdd(this, row, col, _M);
+}
+
+void BaseMatrix::add(const Index row, const Index col, const type::Mat6x6d& _M)
+{
+    matrixAdd(this, row, col, _M);
+}
+
+void BaseMatrix::add(const Index row, const Index col, const type::Mat6x6f& _M)
+{
+    matrixAdd(this, row, col, _M);
 }
 
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.h
@@ -78,6 +78,12 @@ public:
     ///Adding values from a 2x2f matrix. This function may be overload to obtain better performances
     virtual void add(Index row, Index col, const type::Mat2x2f & _M);
 
+    ///Adding values from a 6x6d matrix. This function may be overload to obtain better performances
+    virtual void add(Index row, Index col, const type::Mat6x6d & _M);
+
+    ///Adding values from a 6x6f matrix. This function may be overload to obtain better performances
+    virtual void add(Index row, Index col, const type::Mat6x6f & _M);
+
     /*    /// Write the value of the element at row i, column j (using 0-based indices)
         virtual void set(Index i, Index j, float v) { set(i,j,(double)v); }
         /// Add v to the existing value of the element at row i, column j (using 0-based indices)

--- a/Sofa/framework/Type/src/sofa/type/fwd.h
+++ b/Sofa/framework/Type/src/sofa/type/fwd.h
@@ -97,9 +97,13 @@ typedef Mat<3,4,double> Mat3x4d;
 typedef Mat<4,4,float> Mat4x4f;
 typedef Mat<4,4,double> Mat4x4d;
 
+typedef Mat<6, 6, float> Mat6x6f;
+typedef Mat<6, 6, double> Mat6x6d;
+
 typedef Mat<2,2,SReal> Mat2x2;
 typedef Mat<3,3,SReal> Mat3x3;
 typedef Mat<4,4,SReal> Mat4x4;
+typedef Mat<6,6,SReal> Mat6x6;
 
 typedef Mat<2,2,SReal> Matrix2;
 typedef Mat<3,3,SReal> Matrix3;


### PR DESCRIPTION
Since beams simulation is an important feature of SOFA






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
