### PR TITLE
[Type] RGBAColor: remove inheritance from type::fixed_array and use std::array to store its components

### DIFF
--- a/Sofa/GL/src/sofa/gl/Axis.cpp
+++ b/Sofa/GL/src/sofa/gl/Axis.cpp
@@ -389,4 +389,39 @@ void Axis::draw(const type::Vec3& p1, const type::Vec3& p2, const double& r1, co
 
 }
 
+void Axis::draw(const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+{
+    draw(type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+}
+
+void Axis::draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+{
+    draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+}
+
+void Axis::draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+{
+    draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+}
+
+void Axis::draw(const double* mat, const type::Vec3& length, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+{
+    draw(mat, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+}
+
+void Axis::draw(const type::Vec3& center, const Quaternion& orient, SReal length, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+{
+    draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+}
+
+void Axis::draw(const type::Vec3& center, const double orient[4][4], SReal length, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+{
+    draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+}
+
+void Axis::draw(const double* mat, SReal length, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+{
+    draw(mat, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+}
+
 } // namespace sofa::gl

--- a/Sofa/GL/src/sofa/gl/Axis.cpp
+++ b/Sofa/GL/src/sofa/gl/Axis.cpp
@@ -130,7 +130,7 @@ void Axis::initDraw()
     glEndList();
 }
 
-void Axis::draw( const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ )
+void Axis::draw( const type::RGBAColor& colorX, const type::RGBAColor& colorY, const type::RGBAColor& colorZ )
 {
     initDraw();
 
@@ -263,42 +263,42 @@ Axis::AxisSPtr Axis::get(const type::Vec3& len)
     return a;
 }
 
-void Axis::draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ )
+void Axis::draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& len, const type::RGBAColor& colorX, const type::RGBAColor& colorY, const type::RGBAColor& colorZ )
 {
     const auto a = get(len);
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
-void Axis::draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+void Axis::draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& len, const type::RGBAColor& colorX, const type::RGBAColor& colorY, const type::RGBAColor& colorZ)
 {
     const auto a = get(len);
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
-void Axis::draw(const double *mat, const type::Vec3& len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+void Axis::draw(const double *mat, const type::Vec3& len, const type::RGBAColor& colorX, const type::RGBAColor& colorY, const type::RGBAColor& colorZ)
 {
     const auto a = get(len);
     a->update(mat);
     a->draw( colorX, colorY, colorZ );
 }
 
-void Axis::draw(const type::Vec3& center, const Quaternion& orient, SReal len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+void Axis::draw(const type::Vec3& center, const Quaternion& orient, SReal len, const type::RGBAColor& colorX, const type::RGBAColor& colorY, const type::RGBAColor& colorZ)
 {
     const auto a = get(type::Vec3(len,len,len));
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
-void Axis::draw(const type::Vec3& center, const double orient[4][4], SReal len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+void Axis::draw(const type::Vec3& center, const double orient[4][4], SReal len, const type::RGBAColor& colorX, const type::RGBAColor& colorY, const type::RGBAColor& colorZ)
 {
     const auto a = get(type::Vec3(len,len,len));
     a->update(center, orient);
     a->draw( colorX, colorY, colorZ );
 }
 
-void Axis::draw(const double *mat, SReal len, const type::Vec4f& colorX, const type::Vec4f& colorY, const type::Vec4f& colorZ)
+void Axis::draw(const double *mat, SReal len, const type::RGBAColor& colorX, const type::RGBAColor& colorY, const type::RGBAColor& colorZ)
 {
     const auto a = get(type::Vec3(len,len,len));
     a->update(mat);

--- a/Sofa/GL/src/sofa/gl/Axis.h
+++ b/Sofa/GL/src/sofa/gl/Axis.h
@@ -58,51 +58,28 @@ public:
     void update(const type::Vec3& center, const double orient[4][4]);
     void update(const double *mat);
 
-    void draw(const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
-    static void draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
-    static void draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
-    static void draw(const double* mat, const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
-    static void draw(const type::Vec3& center, const Quaternion& orient, SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
-    static void draw(const type::Vec3& center, const double orient[4][4], SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
-    static void draw(const double* mat, SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
+    void draw(const type::RGBAColor& colorX = type::RGBAColor::red(), const type::RGBAColor& colorY = type::RGBAColor::green(), const type::RGBAColor& colorZ = type::RGBAColor::red());
+    static void draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor::red(), const type::RGBAColor& colorY = type::RGBAColor::green(), const type::RGBAColor& colorZ = type::RGBAColor::red());
+    static void draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor::red(), const type::RGBAColor& colorY = type::RGBAColor::green(), const type::RGBAColor& colorZ = type::RGBAColor::red());
+    static void draw(const double* mat, const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor::red(), const type::RGBAColor& colorY = type::RGBAColor::green(), const type::RGBAColor& colorZ = type::RGBAColor::red());
+    static void draw(const type::Vec3& center, const Quaternion& orient, SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor::red(), const type::RGBAColor& colorY = type::RGBAColor::green(), const type::RGBAColor& colorZ = type::RGBAColor::red());
+    static void draw(const type::Vec3& center, const double orient[4][4], SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor::red(), const type::RGBAColor& colorY = type::RGBAColor::green(), const type::RGBAColor& colorZ = type::RGBAColor::red());
+    static void draw(const double* mat, SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor::red(), const type::RGBAColor& colorY = type::RGBAColor::green(), const type::RGBAColor& colorZ = type::RGBAColor::red());
 
-    [[deprecated]] 
-    void draw(const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
-    {
-        draw(type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
-    }
-
-    [[deprecated]] 
-    static void draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
-    {
-        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
-    }
-
-    [[deprecated]] 
-    static void draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
-    {
-        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
-    }
-    [[deprecated]] 
-    static void draw(const double* mat, const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
-    {
-        draw(mat, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
-    }
-    [[deprecated]] 
-    static void draw(const type::Vec3& center, const Quaternion& orient, SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
-    {
-        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
-    }
-    [[deprecated]] 
-    static void draw(const type::Vec3& center, const double orient[4][4], SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
-    {
-        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
-    }
-    [[deprecated]] 
-    static void draw(const double* mat, SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
-    {
-        draw(mat, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
-    }
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    void draw(const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1));
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    static void draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1));
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    static void draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1));
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    void draw(const double* mat, const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1));
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    static void draw(const type::Vec3& center, const Quaternion& orient, SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1));
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    static void draw(const type::Vec3& center, const double orient[4][4], SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1));
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    static void draw(const double* mat, SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1));
 
 
     //Draw a nice vector (cylinder + cone) given 2 points and a radius (used to draw the cylinder)

--- a/Sofa/GL/src/sofa/gl/Axis.h
+++ b/Sofa/GL/src/sofa/gl/Axis.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <sofa/type/Vec.h>
 #include <sofa/type/Quat.h>
+#include <sofa/type/RGBAColor.h>
 
 #include <sofa/gl/gl.h>
 #include <sofa/gl/glu.h>
@@ -57,14 +58,52 @@ public:
     void update(const type::Vec3& center, const double orient[4][4]);
     void update(const double *mat);
 
-    void draw( const type::Vec4f& colorX=type::Vec4f(1,0,0,1), const type::Vec4f& colorY=type::Vec4f(0,1,0,1), const type::Vec4f& colorZ=type::Vec4f(0,0,1,1) );
+    void draw(const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
+    static void draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
+    static void draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
+    static void draw(const double* mat, const type::Vec3& length, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
+    static void draw(const type::Vec3& center, const Quaternion& orient, SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
+    static void draw(const type::Vec3& center, const double orient[4][4], SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
+    static void draw(const double* mat, SReal length = 1.0_sreal, const type::RGBAColor& colorX = type::RGBAColor(1, 0, 0, 1), const type::RGBAColor& colorY = type::RGBAColor(0, 1, 0, 1), const type::RGBAColor& colorZ = type::RGBAColor(0, 0, 1, 1));
 
-    static void draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::Vec4f& colorX=type::Vec4f(1,0,0,1), const type::Vec4f& colorY=type::Vec4f(0,1,0,1), const type::Vec4f& colorZ=type::Vec4f(0,0,1,1) );
-    static void draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::Vec4f& colorX=type::Vec4f(1,0,0,1), const type::Vec4f& colorY=type::Vec4f(0,1,0,1), const type::Vec4f& colorZ=type::Vec4f(0,0,1,1) );
-    static void draw(const double *mat, const type::Vec3& length, const type::Vec4f& colorX=type::Vec4f(1,0,0,1), const type::Vec4f& colorY=type::Vec4f(0,1,0,1), const type::Vec4f& colorZ=type::Vec4f(0,0,1,1) );
-    static void draw(const type::Vec3& center, const Quaternion& orient, SReal length=1.0_sreal, const type::Vec4f& colorX=type::Vec4f(1,0,0,1), const type::Vec4f& colorY=type::Vec4f(0,1,0,1), const type::Vec4f& colorZ=type::Vec4f(0,0,1,1) );
-    static void draw(const type::Vec3& center, const double orient[4][4], SReal length=1.0_sreal, const type::Vec4f& colorX=type::Vec4f(1,0,0,1), const type::Vec4f& colorY=type::Vec4f(0,1,0,1), const type::Vec4f& colorZ=type::Vec4f(0,0,1,1) );
-    static void draw(const double *mat, SReal length=1.0_sreal, const type::Vec4f& colorX=type::Vec4f(1,0,0,1), const type::Vec4f& colorY=type::Vec4f(0,1,0,1), const type::Vec4f& colorZ=type::Vec4f(0,0,1,1) );
+    [[deprecated]] 
+    void draw(const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
+    {
+        draw(type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+    }
+
+    [[deprecated]] 
+    static void draw(const type::Vec3& center, const Quaternion& orient, const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
+    {
+        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+    }
+
+    [[deprecated]] 
+    static void draw(const type::Vec3& center, const double orient[4][4], const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
+    {
+        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+    }
+    [[deprecated]] 
+    static void draw(const double* mat, const type::Vec3& length, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
+    {
+        draw(mat, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+    }
+    [[deprecated]] 
+    static void draw(const type::Vec3& center, const Quaternion& orient, SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
+    {
+        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+    }
+    [[deprecated]] 
+    static void draw(const type::Vec3& center, const double orient[4][4], SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
+    {
+        draw(center, orient, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+    }
+    [[deprecated]] 
+    static void draw(const double* mat, SReal length = 1.0_sreal, const type::Vec4f& colorX = type::Vec4f(1, 0, 0, 1), const type::Vec4f& colorY = type::Vec4f(0, 1, 0, 1), const type::Vec4f& colorZ = type::Vec4f(0, 0, 1, 1))
+    {
+        draw(mat, length, type::RGBAColor::fromVec4(colorX), type::RGBAColor::fromVec4(colorY), type::RGBAColor::fromVec4(colorZ));
+    }
+
 
     //Draw a nice vector (cylinder + cone) given 2 points and a radius (used to draw the cylinder)
     static void draw(const type::Vec3& center, const type::Vec3& ext, const double& radius );

--- a/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
+++ b/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
@@ -442,7 +442,7 @@ void DrawToolGL::drawFrame(const Vec3& position, const Quaternion &orientation, 
 void DrawToolGL::drawFrame(const Vec3& position, const Quaternion &orientation, const Vec<3,float> &size, const type::RGBAColor &color)
 {
     setPolygonMode(0,false);
-    gl::Axis::draw(position, orientation, size, color.array(), color.array(), color.array());
+    gl::Axis::draw(position, orientation, size, color, color, color);
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
+++ b/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
@@ -437,12 +437,12 @@ void DrawToolGL::drawTriangleFan(const std::vector<Vec3> &points,
 void DrawToolGL::drawFrame(const Vec3& position, const Quaternion &orientation, const Vec<3,float> &size)
 {
     setPolygonMode(0,false);
-    gl::Axis::draw(position, orientation, size);
+    gl::Axis::draw(position, orientation, size, type::RGBAColor::red(), type::RGBAColor::green(), type::RGBAColor::blue());
 }
 void DrawToolGL::drawFrame(const Vec3& position, const Quaternion &orientation, const Vec<3,float> &size, const type::RGBAColor &color)
 {
     setPolygonMode(0,false);
-    gl::Axis::draw(position, orientation, size, color, color, color);
+    gl::Axis::draw(position, orientation, size, color.array(), color.array(), color.array());
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -748,11 +748,11 @@ void DrawToolGL::internalDrawTriangle(const Vec3 &p1,const Vec3 &p2,const Vec3 &
         const type::RGBAColor &c1, const type::RGBAColor &c2, const type::RGBAColor &c3)
 {
     glNormalT(normal);
-    glColor4fv(c1.array());
+    glColor4fv(c1.data());
     glVertexNv<3>(p1.ptr());
-    glColor4fv(c2.array());
+    glColor4fv(c2.data());
     glVertexNv<3>(p2.ptr());
-    glColor4fv(c3.array());
+    glColor4fv(c3.data());
     glVertexNv<3>(p3.ptr());
 }
 
@@ -762,13 +762,13 @@ void DrawToolGL::internalDrawTriangle(const Vec3 &p1,const Vec3 &p2,const Vec3 &
         const type::RGBAColor &c1, const type::RGBAColor &c2, const type::RGBAColor &c3)
 {
     glNormalT(normal1);
-    glColor4fv(c1.array());
+    glColor4fv(c1.data());
     glVertexNv<3>(p1.ptr());
     glNormalT(normal2);
-    glColor4fv(c2.array());
+    glColor4fv(c2.data());
     glVertexNv<3>(p2.ptr());
     glNormalT(normal3);
-    glColor4fv(c3.array());
+    glColor4fv(c3.data());
     glVertexNv<3>(p3.ptr());
 }
 
@@ -777,7 +777,7 @@ void DrawToolGL::internalDrawTriangle( const Vec3 &p1, const Vec3 &p2, const Vec
         const Vec3 &normal, const  type::RGBAColor &c)
 {
     glNormalT(normal);
-    glColor4fv(c.array());
+    glColor4fv(c.data());
     glVertexNv<3>(p1.ptr());
     glVertexNv<3>(p2.ptr());
     glVertexNv<3>(p3.ptr());
@@ -845,7 +845,7 @@ void DrawToolGL::internalDrawQuad(const Vec3 &p1,const Vec3 &p2,const Vec3 &p3,c
         const Vec3 &normal, const type::RGBAColor &c)
 {
     glNormalT(normal);
-    glColor4fv(c.array());
+    glColor4fv(c.data());
     glVertexNv<3>(p1.ptr());
     glVertexNv<3>(p2.ptr());
     glVertexNv<3>(p3.ptr());
@@ -857,13 +857,13 @@ void DrawToolGL::internalDrawQuad(const Vec3 &p1,const Vec3 &p2,const Vec3 &p3,c
         const type::RGBAColor &c1, const type::RGBAColor &c2, const type::RGBAColor &c3, const type::RGBAColor &c4)
 {
     glNormalT(normal);
-    glColor4fv(c1.array());
+    glColor4fv(c1.data());
     glVertexNv<3>(p1.ptr());
-    glColor4fv(c2.array());
+    glColor4fv(c2.data());
     glVertexNv<3>(p2.ptr());
-    glColor4fv(c3.array());
+    glColor4fv(c3.data());
     glVertexNv<3>(p3.ptr());
-    glColor4fv(c4.array());
+    glColor4fv(c4.data());
     glVertexNv<3>(p4.ptr());
 }
 
@@ -872,16 +872,16 @@ void DrawToolGL::internalDrawQuad(const Vec3 &p1,const Vec3 &p2,const Vec3 &p3,c
         const type::RGBAColor &c1, const type::RGBAColor &c2, const type::RGBAColor &c3, const type::RGBAColor &c4)
 {
     glNormalT(normal1);
-    glColor4fv(c1.array());
+    glColor4fv(c1.data());
     glVertexNv<3>(p1.ptr());
     glNormalT(normal2);
-    glColor4fv(c2.array());
+    glColor4fv(c2.data());
     glVertexNv<3>(p2.ptr());
     glNormalT(normal3);
-    glColor4fv(c3.array());
+    glColor4fv(c3.data());
     glVertexNv<3>(p3.ptr());
     glNormalT(normal4);
-    glColor4fv(c4.array());
+    glColor4fv(c4.data());
     glVertexNv<3>(p4.ptr());
 }
 
@@ -1411,7 +1411,7 @@ void DrawToolGL::disableDepthTest()
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void DrawToolGL::draw3DText(const Vec3 &p, float scale, const type::RGBAColor &color, const char* text)
 {
-    glColor4fv(color.array());
+    glColor4fv(color.data());
 
     sofa::gl::GlText::draw(text, p, (double)scale);
 }

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.cpp
@@ -94,10 +94,15 @@ void QRGBAColorPicker::updateRGBAColor()
     redrawColorButton();
 }
 
+void QRGBAColorPicker::setColor(const type::RGBAColor& color)
+{
+    setColor(Vec4f{ color[0], color[1] , color[2] ,color[3] });
+}
+
 void QRGBAColorPicker::setColor(const Vec4f& color)
 {
     typedef unsigned char uchar;
-    const uchar max = std::numeric_limits<uchar>::max();
+    constexpr uchar max = std::numeric_limits<uchar>::max();
     const uchar r = uchar(  max * color[0] );
     const uchar g = uchar(  max * color[1] );
     const uchar b = uchar(  max * color[2] );

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.cpp
@@ -64,7 +64,7 @@ QRGBAColorPicker::QRGBAColorPicker(QWidget* parent) : QWidget(parent)
 Vec4f QRGBAColorPicker::getColor() const
 {
     typedef unsigned char uchar;
-    const uchar max = std::numeric_limits<uchar>::max();
+    constexpr uchar max = std::numeric_limits<uchar>::max();
     Vec4f color;
     float r = _r->text().toFloat();
     float g = _g->text().toFloat();
@@ -96,17 +96,12 @@ void QRGBAColorPicker::updateRGBAColor()
 
 void QRGBAColorPicker::setColor(const type::RGBAColor& color)
 {
-    setColor(Vec4f{ color[0], color[1] , color[2] ,color[3] });
-}
-
-void QRGBAColorPicker::setColor(const Vec4f& color)
-{
     typedef unsigned char uchar;
     constexpr uchar max = std::numeric_limits<uchar>::max();
-    const uchar r = uchar(  max * color[0] );
-    const uchar g = uchar(  max * color[1] );
-    const uchar b = uchar(  max * color[2] );
-    const uchar a = uchar(  max * color[3] );
+    const uchar r = uchar(max * color[0]);
+    const uchar g = uchar(max * color[1]);
+    const uchar b = uchar(max * color[2]);
+    const uchar a = uchar(max * color[3]);
     QString str;
     str.setNum(r);
     _r->setText(str);
@@ -116,9 +111,14 @@ void QRGBAColorPicker::setColor(const Vec4f& color)
     _b->setText(str);
     str.setNum(a);
     _a->setText(str);
-    _rgba = qRgba(r,g,b,a);
+    _rgba = qRgba(r, g, b, a);
 
     redrawColorButton();
+}
+
+void QRGBAColorPicker::setColor(const Vec4f& color)
+{
+    setColor(type::RGBAColor{color[0], color[1] , color[2] ,color[3]});
 }
 
 void QRGBAColorPicker::redrawColorButton()

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.h
@@ -58,7 +58,9 @@ signals:
 
 public:
     QRGBAColorPicker(QWidget* parent);
-    void setColor( const Vec4f& color );
+    void setColor(const type::RGBAColor& color);
+
+    [[deprecated]] void setColor( const Vec4f& color );
     Vec4f getColor() const;
 
 protected:

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QRGBAColorPicker.h
@@ -60,7 +60,7 @@ public:
     QRGBAColorPicker(QWidget* parent);
     void setColor(const type::RGBAColor& color);
 
-    [[deprecated]] void setColor( const Vec4f& color );
+    void setColor( const Vec4f& color );
     Vec4f getColor() const;
 
 protected:

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
@@ -609,7 +609,7 @@ void QtGLViewer::DisplayOBJs()
                                                   , this->camera()->orientation()[1]
                                                   , this->camera()->orientation()[2]
                                                   , this->camera()->orientation()[3]);
-            gl::Axis::draw(sofa::type::Vec3(30.0_sreal,30.0_sreal,0.0_sreal),sofaQuat.inverse(), 25.0);
+            gl::Axis::draw(sofa::type::Vec3(30.0_sreal,30.0_sreal,0.0_sreal),sofaQuat.inverse(), 25.0, sofa::type::RGBAColor::red(), sofa::type::RGBAColor::green(), sofa::type::RGBAColor::blue());
 
             glMatrixMode(GL_PROJECTION);
             glPopMatrix();

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -599,7 +599,7 @@ void QtViewer::DisplayOBJs()
             glMatrixMode(GL_MODELVIEW);
             glPushMatrix();
             glLoadIdentity();
-            gl::Axis::draw(sofa::type::Vec3(30.0,30.0,0.0),currentCamera->getOrientation().inverse(), 25.0);
+            gl::Axis::draw(sofa::type::Vec3(30.0,30.0,0.0),currentCamera->getOrientation().inverse(), 25.0, sofa::type::RGBAColor::red(), sofa::type::RGBAColor::green(), sofa::type::RGBAColor::blue());
             glMatrixMode(GL_PROJECTION);
             glPopMatrix();
             glMatrixMode(GL_MODELVIEW);

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_RGBAColor.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_RGBAColor.h
@@ -29,7 +29,7 @@ namespace sofa::defaulttype
 {
 
 template<>
-class DataTypeInfo< sofa::type::RGBAColor > : public FixedArrayTypeInfo<sofa::type::fixed_array<float,4>>
+class DataTypeInfo< sofa::type::RGBAColor > : public FixedArrayTypeInfo<sofa::type::RGBAColor>
 {
     public:
         static std::string name() { return "RGBAColor"; }

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -24,7 +24,9 @@
 #include <sstream>
 #include <locale>
 
+#include <sofa/type/fixed_array.h>
 #include <sofa/type/fixed_array_algorithms.h>
+
 using namespace sofa::type::pairwise;
 
 namespace // anonymous
@@ -80,6 +82,12 @@ static void extractValidatedHexaString(std::istream& in, std::string& s)
     /// we need to reset the failbit because it is set by the get function
     /// on the last character.
     in.clear(in.rdstate() & ~std::ios_base::failbit) ;
+}
+
+
+RGBAColor::RGBAColor(const type::fixed_array<float, NumberOfComponents>& c)
+    : m_components{ c[0], c[1], c[2], c[3] }
+{
 }
 
 bool RGBAColor::read(const std::string& str, RGBAColor& color)

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -160,7 +160,6 @@ RGBAColor RGBAColor::fromHSVA(const float h, const float s, const float v, const
     return rgba;
 }
 
-// compat
 RGBAColor RGBAColor::fromVec4(const type::fixed_array<float, 4>& color)
 {
     return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
@@ -170,7 +169,6 @@ RGBAColor RGBAColor::fromVec4(const type::fixed_array<double, 4>& color)
 {
     return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
 }
-
 
 /// This function remove the leading space in the stream.
 static std::istream& trimInitialSpaces(std::istream& in)
@@ -275,9 +273,7 @@ SOFA_TYPE_API std::ostream& operator << ( std::ostream& out, const RGBAColor& t 
 /// @brief enlight a color by a given factor.
 RGBAColor RGBAColor::lighten(const RGBAColor& in, const SReal factor)
 {
-    auto cc = RGBAColor::white() - RGBAColor::clamp(in, 0.0f, 1.0f);
-
-    RGBAColor c = in + ( cc * rclamp(float(factor), 0.0f, 1.0f));
+    RGBAColor c = in + ( (RGBAColor::white() - RGBAColor::clamp(in, 0.0f, 1.0f)) * rclamp(float(factor), 0.0f, 1.0f));
 
     c.a() = 1.0;
     return c ;

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -29,6 +29,7 @@ using namespace sofa::type::pairwise;
 
 namespace // anonymous
 {
+
     template<class T>
     T rclamp(const T& value, const T& low, const T& high)
     {
@@ -93,10 +94,10 @@ bool RGBAColor::read(const std::string& str, RGBAColor& color)
 
 void RGBAColor::set(const float r, const float g, const float b, const float a)
 {
-    this->elems[0] = r;
-    this->elems[1] = g;
-    this->elems[2] = b;
-    this->elems[3] = a;
+    this->m_components[0] = r;
+    this->m_components[1] = g;
+    this->m_components[2] = b;
+    this->m_components[3] = a;
 }
 
 
@@ -117,13 +118,13 @@ RGBAColor RGBAColor::fromFloat(const float r, const float g, const float b, cons
 }
 
 
-RGBAColor RGBAColor::fromVec4(const fixed_array<float, 4>& color)
+RGBAColor RGBAColor::fromStdArray(const std::array<float, 4>& color)
 {
     return RGBAColor(color) ;
 }
 
 
-RGBAColor RGBAColor::fromVec4(const fixed_array<double, 4>& color)
+RGBAColor RGBAColor::fromStdArray(const std::array<double, 4>& color)
 {
     return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
 }
@@ -157,6 +158,17 @@ RGBAColor RGBAColor::fromHSVA(const float h, const float s, const float v, const
     }
 
     return rgba;
+}
+
+// compat
+RGBAColor RGBAColor::fromVec4(const type::fixed_array<float, 4>& color)
+{
+    return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
+}
+
+RGBAColor RGBAColor::fromVec4(const type::fixed_array<double, 4>& color)
+{
+    return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
 }
 
 
@@ -263,8 +275,11 @@ SOFA_TYPE_API std::ostream& operator << ( std::ostream& out, const RGBAColor& t 
 /// @brief enlight a color by a given factor.
 RGBAColor RGBAColor::lighten(const RGBAColor& in, const SReal factor)
 {
-    RGBAColor c = in + ( (RGBAColor::white() - clamp(in, 0.0f, 1.0f)) * rclamp(float(factor), 0.0f, 1.0f));
-    c.a()=1.0;
+    auto cc = RGBAColor::white() - RGBAColor::clamp(in, 0.0f, 1.0f);
+
+    RGBAColor c = in + ( cc * rclamp(float(factor), 0.0f, 1.0f));
+
+    c.a() = 1.0;
     return c ;
 }
 

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -198,6 +198,10 @@ public:
     {
         return m_components.end();
     }
+
+    static constexpr std::size_t static_size = NumberOfComponents;
+    static constexpr std::size_t size() { return static_size; }
+    using value_type = float;
 };
 
 constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -52,7 +52,7 @@ public:
     constexpr RGBAColor()
         : m_components{ 1.f, 1.f, 1.f, 1.f } {}
 
-    constexpr RGBAColor(const std::array<float, NumberOfComponents>& c)
+    constexpr explicit RGBAColor(const std::array<float, NumberOfComponents>& c)
         : m_components(c) {}
 
     constexpr RGBAColor(float r, float g, float b, float a)
@@ -60,7 +60,7 @@ public:
 
     // compat
     SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
-    constexpr RGBAColor(const type::fixed_array<float, NumberOfComponents>& c)
+    constexpr explicit RGBAColor(const type::fixed_array<float, NumberOfComponents>& c)
         : m_components{ c[0], c[1], c[2], c[3] } {}
 
     SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
@@ -115,9 +115,7 @@ public:
     }
     constexpr const float& operator[](std::size_t i) const
     {
-#ifndef NDEBUG
         assert(i < N && "index in RGBAColor must be smaller than 4");
-#endif
         return m_components[i];
     }
 
@@ -204,7 +202,7 @@ public:
 constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)
 {
     RGBAColor result{};
-    for (sofa::Size i = 0; i < 4; ++i)
+    for (sofa::Size i = 0; i < NumberOfComponents; ++i)
     {
         result[i] = l[i] - r[i];
     }
@@ -214,7 +212,7 @@ constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)
 constexpr RGBAColor operator+(const RGBAColor& l, const RGBAColor& r)
 {
     RGBAColor result{};
-    for (sofa::Size i = 0; i < 4; ++i)
+    for (sofa::Size i = 0; i < NumberOfComponents; ++i)
     {
         result[i] = l[i] + r[i];
     }

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -22,14 +22,15 @@
 #pragma once
 #include <sofa/type/config.h>
 
+#include <sofa/type/fwd.h>
+
 #include <ostream>
 #include <istream>
 #include <string>
 #include <cmath>
 #include <array>
 #include <algorithm>
-
-#include <sofa/type/fixed_array.h>
+#include <cassert>
 
 namespace sofa::type
 {
@@ -41,14 +42,10 @@ namespace sofa::type
  */
 class SOFA_TYPE_API RGBAColor
 {
-private:
+public:
     static constexpr sofa::Size NumberOfComponents = 4;
-
     using ComponentArray = std::array<float, NumberOfComponents>;
 
-    ComponentArray m_components;
-
-public:
     constexpr RGBAColor()
         : m_components{ 1.f, 1.f, 1.f, 1.f } {}
 
@@ -60,8 +57,7 @@ public:
 
     // compat
     SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
-    constexpr explicit RGBAColor(const type::fixed_array<float, NumberOfComponents>& c)
-        : m_components{ c[0], c[1], c[2], c[3] } {}
+    RGBAColor(const type::fixed_array<float, NumberOfComponents>& c);
 
     SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
     static RGBAColor fromVec4(const type::fixed_array<float, 4>& color);
@@ -108,14 +104,12 @@ public:
     // operator[]
     constexpr float& operator[](std::size_t i)
     {
-#ifndef NDEBUG
-        assert(i < N && "index in RGBAColor must be smaller than 4");
-#endif
+        assert(i < NumberOfComponents && "index in RGBAColor must be smaller than 4");
         return m_components[i];
     }
     constexpr const float& operator[](std::size_t i) const
     {
-        assert(i < N && "index in RGBAColor must be smaller than 4");
+        assert(i < NumberOfComponents && "index in RGBAColor must be smaller than 4");
         return m_components[i];
     }
 
@@ -197,12 +191,15 @@ public:
     static constexpr sofa::Size static_size = NumberOfComponents;
     static constexpr sofa::Size size() { return static_size; }
     using value_type = float;
+
+private:
+    ComponentArray m_components;
 };
 
 constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)
 {
     RGBAColor result{};
-    for (sofa::Size i = 0; i < NumberOfComponents; ++i)
+    for (sofa::Size i = 0; i < RGBAColor::NumberOfComponents; ++i)
     {
         result[i] = l[i] - r[i];
     }
@@ -212,7 +209,7 @@ constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)
 constexpr RGBAColor operator+(const RGBAColor& l, const RGBAColor& r)
 {
     RGBAColor result{};
-    for (sofa::Size i = 0; i < NumberOfComponents; ++i)
+    for (sofa::Size i = 0; i < RGBAColor::NumberOfComponents; ++i)
     {
         result[i] = l[i] + r[i];
     }

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -59,17 +59,14 @@ public:
         : m_components{ r, g, b, a } {}
 
     // compat
-    [[deprecated]]
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
     constexpr RGBAColor(const type::fixed_array<float, NumberOfComponents>& c)
         : m_components{ c[0], c[1], c[2], c[3] } {}
 
-    [[deprecated]] 
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
     static RGBAColor fromVec4(const type::fixed_array<float, 4>& color);
-    [[deprecated]] 
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
     static RGBAColor fromVec4(const type::fixed_array<double, 4>& color);
-    [[deprecated]]
-    operator type::fixed_array<float, 4>() const { return type::fixed_array<float, 4>{m_components[0], m_components[1], m_components[2], m_components[3]}; }
-
 
     static RGBAColor fromString(const std::string& str);
     static RGBAColor fromFloat(float r, float g, float b, float a);

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -42,7 +42,7 @@ namespace sofa::type
 class SOFA_TYPE_API RGBAColor
 {
 private:
-    static constexpr std::size_t NumberOfComponents = 4;
+    static constexpr sofa::Size NumberOfComponents = 4;
 
     using ComponentArray = std::array<float, NumberOfComponents>;
 
@@ -171,7 +171,7 @@ public:
     {
         RGBAColor result{};
 
-        for(std::size_t i = 0 ; i < NumberOfComponents; ++i)
+        for(sofa::Size i = 0 ; i < NumberOfComponents; ++i)
         {
             result[i] = std::clamp(color[i], min, max);
         }
@@ -196,15 +196,15 @@ public:
         return m_components.end();
     }
 
-    static constexpr std::size_t static_size = NumberOfComponents;
-    static constexpr std::size_t size() { return static_size; }
+    static constexpr sofa::Size static_size = NumberOfComponents;
+    static constexpr sofa::Size size() { return static_size; }
     using value_type = float;
 };
 
 constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)
 {
     RGBAColor result{};
-    for (std::size_t i = 0; i < 4; ++i)
+    for (sofa::Size i = 0; i < 4; ++i)
     {
         result[i] = l[i] - r[i];
     }
@@ -214,7 +214,7 @@ constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)
 constexpr RGBAColor operator+(const RGBAColor& l, const RGBAColor& r)
 {
     RGBAColor result{};
-    for (std::size_t i = 0; i < 4; ++i)
+    for (sofa::Size i = 0; i < 4; ++i)
     {
         result[i] = l[i] + r[i];
     }

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -32,6 +32,8 @@
 #include <algorithm>
 #include <cassert>
 
+#include <sofa/type/fixed_array_algorithms.h>
+
 namespace sofa::type
 {
 
@@ -191,6 +193,7 @@ public:
     static constexpr sofa::Size static_size = NumberOfComponents;
     static constexpr sofa::Size size() { return static_size; }
     using value_type = float;
+    using size_type = sofa::Size;
 
 private:
     ComponentArray m_components;
@@ -198,22 +201,12 @@ private:
 
 constexpr RGBAColor operator-(const RGBAColor& l, const RGBAColor& r)
 {
-    RGBAColor result{};
-    for (sofa::Size i = 0; i < RGBAColor::NumberOfComponents; ++i)
-    {
-        result[i] = l[i] - r[i];
-    }
-    return result;
+    return sofa::type::pairwise::operator-(l, r);
 }
 
 constexpr RGBAColor operator+(const RGBAColor& l, const RGBAColor& r)
 {
-    RGBAColor result{};
-    for (sofa::Size i = 0; i < RGBAColor::NumberOfComponents; ++i)
-    {
-        result[i] = l[i] + r[i];
-    }
-    return result;
+    return sofa::type::pairwise::operator+(l, r);
 }
 
 constexpr RGBAColor g_white     {1.0f,1.0f,1.0f,1.0f};

--- a/Sofa/framework/Type/src/sofa/type/config.h.in
+++ b/Sofa/framework/Type/src/sofa/type/config.h.in
@@ -47,6 +47,6 @@
 #else
 #define SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY() \
     SOFA_ATTRIBUTE_DEPRECATED( \
-        "v23.06", "v23.12", \
+        "v23.12", "v24.06", \
         "RGBAColor does not inherit anymore from sofa::type::fixed_array. Use respective functions accordingly.")
 #endif

--- a/Sofa/framework/Type/src/sofa/type/config.h.in
+++ b/Sofa/framework/Type/src/sofa/type/config.h.in
@@ -41,3 +41,12 @@
         "v22.12", "v23.06", \
         "As an alternative, use sofa::type::Mat<L,C,real>::Identity().")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_TYPE
+#define SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v23.06", "v23.12", \
+        "RGBAColor does not inherit anymore from sofa::type::fixed_array. Use respective functions accordingly.")
+#endif

--- a/Sofa/framework/Type/src/sofa/type/fixed_array_algorithms.h
+++ b/Sofa/framework/Type/src/sofa/type/fixed_array_algorithms.h
@@ -46,7 +46,7 @@ T clamp(const T& in, const TT& minValue, const TT& maxValue)
 
 /// @brief pairwise add of two fixed_array
 template<class T, class TT=typename T::value_type, size_t TN=T::static_size>
-T operator+(const T& l, const T& r)
+constexpr T operator+(const T& l, const T& r)
 {
     T result {};
     for(typename T::size_type i=0; i < typename T::size_type(TN); ++i)
@@ -58,7 +58,7 @@ T operator+(const T& l, const T& r)
 
 /// @brief pairwise subtract of two fixed_array
 template<class T, class TT=typename T::value_type, size_t TN=T::static_size>
-T operator-(const T& l, const T& r)
+constexpr T operator-(const T& l, const T& r)
 {
     T result {};
     for(typename T::size_type i=0; i < typename T::size_type(TN); ++i)

--- a/Sofa/framework/Type/test/Color_test.cpp
+++ b/Sofa/framework/Type/test/Color_test.cpp
@@ -134,12 +134,16 @@ void Color_Test::checkCreateFromDouble()
 
     const Vec4d tt(2,3,4,5) ;
     EXPECT_EQ( RGBAColor::fromVec4(tt), RGBAColor(2,3,4,5)) ;
+
+    const std::array<double, 4> stdarrtt{ 2, 3, 4, 5 };
+    EXPECT_EQ(RGBAColor::fromStdArray(stdarrtt), RGBAColor(2, 3, 4, 5));
 }
 
 
 void Color_Test::checkConstructors()
 {
-    EXPECT_EQ( RGBAColor(sofa::type::Vec<4,float>(1,2,3,4)), RGBAColor(1,2,3,4) ) ;
+    EXPECT_EQ(RGBAColor(std::array<float, 4>{1, 2, 3, 4}), RGBAColor(1, 2, 3, 4));
+    EXPECT_EQ( RGBAColor(sofa::type::Vec<4, float>(1, 2, 3, 4)), RGBAColor(1, 2, 3, 4));
 }
 
 

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/mass/CudaUniformMass.inl
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/mass/CudaUniformMass.inl
@@ -241,7 +241,7 @@ void UniformMass<gpu::cuda::CudaRigid3fTypes>::draw(const core::visual::VisualPa
 
     for (unsigned int i=0; i<x.size(); i++)
     {
-        sofa::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len);
+        sofa::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len, sofa::type::RGBAColor::red(), sofa::type::RGBAColor::green(), sofa::type::RGBAColor::blue());
     }
 #endif // SOFACUDA_HAVE_SOFA_GL == 1
 }
@@ -409,7 +409,7 @@ void UniformMass<gpu::cuda::CudaRigid3dTypes>::draw(const core::visual::VisualPa
 
     for (unsigned int i=0; i<x.size(); i++)
     {
-        sofa::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len);
+        sofa::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len, sofa::type::RGBAColor::red(), sofa::type::RGBAColor::green(), sofa::type::RGBAColor::blue());
     }
 }
 


### PR DESCRIPTION
Task for #4217 

As less breaking as possible, but as I did not re-implement all functions from fixed_array, it is bound to break if one used a function not present (+some technicalities like array() which was returning a ref to a c-array[], which could be implicitly casted as pointer, or some functions which was taking a fixed_array as a parameter)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
