### PR TITLE
[All] ColorMap uses RGBAColor

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -224,7 +224,7 @@ public:
     Data<int> _computeVonMisesStress; ///< compute and display von Mises stress: 0: no computations, 1: using corotational strain, 2: using full Green strain
     Data<type::vector<Real> > _vonMisesPerElement; ///< von Mises Stress per element
     Data<type::vector<Real> > _vonMisesPerNode; ///< von Mises Stress per node
-    Data<type::vector<type::Vec4f> > _vonMisesStressColors; ///< Vector of colors describing the VonMises stress
+    Data<type::vector<type::RGBAColor> > _vonMisesStressColors; ///< Vector of colors describing the VonMises stress
 
     Real m_minVonMisesPerNode;
     Real m_maxVonMisesPerNode;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -1900,7 +1900,7 @@ void TetrahedronFEMForceField<DataTypes>::drawTrianglesFromRangeOfTetrahedra(
                 else
                 {
                     sofa::helper::ColorMap::evaluator<Real> evalColor = this->m_VonMisesColorMap->getEvaluator(minVM, maxVM);
-                    auto col = sofa::type::RGBAColor::fromVec4(evalColor(vM[elementId]));
+                    auto col = evalColor(vM[elementId]);
                     col[3] = 1.0f;
                     color[0] = col;
                     color[1] = col;
@@ -2542,7 +2542,7 @@ void TetrahedronFEMForceField<DataTypes>::computeVonMisesStress()
 
     updateVonMisesStress=false;
 
-    helper::WriteAccessor<Data<type::vector<type::Vec4f> > > vonMisesStressColors(_vonMisesStressColors);
+    helper::WriteAccessor<Data<type::vector<type::RGBAColor> > > vonMisesStressColors(_vonMisesStressColors);
     vonMisesStressColors.clear();
     type::vector<unsigned int> vonMisesStressColorsCoeff;
 
@@ -2565,12 +2565,12 @@ void TetrahedronFEMForceField<DataTypes>::computeVonMisesStress()
     for(it = _indexedElements->begin() ; it != _indexedElements->end() ; ++it, ++i)
     {
         helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(minVM, maxVM);
-        const type::Vec4f col = evalColor(vME[i]);
+        const auto col = evalColor(vME[i]);
         Tetrahedron tetra = (*_indexedElements)[i];
 
         for(unsigned int j=0 ; j<4 ; j++)
         {
-            vonMisesStressColors[tetra[j]] += (col);
+            vonMisesStressColors[tetra[j]] = vonMisesStressColors[tetra[j]]+(col);
             vonMisesStressColorsCoeff[tetra[j]] ++;
         }
     }
@@ -2579,7 +2579,7 @@ void TetrahedronFEMForceField<DataTypes>::computeVonMisesStress()
     {
         if(vonMisesStressColorsCoeff[i] != 0)
         {
-            vonMisesStressColors[i] /= vonMisesStressColorsCoeff[i];
+            vonMisesStressColors[i] = vonMisesStressColors[i] / vonMisesStressColorsCoeff[i];
         }
     }
 }

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
@@ -252,7 +252,7 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
             {
                 RGBAColor color = std::isnan(triData[i])
                     ? f_colorNaN.getValue()
-                    : RGBAColor::fromVec4(eval(triData[i]));
+                    : eval(triData[i]);
                 color[3] = transparency;
                 const Triangle& t = m_topology->getTriangle(i);
                 vparams->drawTool()->drawTriangle(
@@ -272,15 +272,15 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
             {
                 RGBAColor color0 = std::isnan(pointTriData[i*3])
                     ? f_colorNaN.getValue()
-                    : RGBAColor::fromVec4(eval(pointTriData[i*3]));
+                    : eval(pointTriData[i*3]);
                 color0[3] = transparency;
                 RGBAColor color1 = std::isnan(pointTriData[i*3+1])
                         ? f_colorNaN.getValue()
-                        : RGBAColor::fromVec4(eval(pointTriData[i*3+1]));
+                        : eval(pointTriData[i*3+1]);
                 color1[3] = transparency;
                 RGBAColor color2 = std::isnan(pointTriData[i*3+2])
                     ? f_colorNaN.getValue()
-                    : RGBAColor::fromVec4(eval(pointTriData[i*3+2]));
+                    : eval(pointTriData[i*3+2]);
                 color2[3] = transparency;
                 const Triangle& t = m_topology->getTriangle(i);
 
@@ -308,7 +308,7 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
             {
                 RGBAColor color = std::isnan(quadData[i])
                     ? f_colorNaN.getValue()
-                    : RGBAColor::fromVec4(eval(quadData[i]));
+                    : eval(quadData[i]);
                 color[3] = transparency;
                 const Quad& t = m_topology->getQuad(i);
                 vparams->drawTool()->drawQuad(
@@ -326,18 +326,18 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
             {
                 RGBAColor color0 = std::isnan(pointQuadData[i*4])
                     ? f_colorNaN.getValue()
-                    : RGBAColor::fromVec4(eval(pointQuadData[i*4]));
+                    : eval(pointQuadData[i*4]);
                 RGBAColor color1 = std::isnan(pointQuadData[i*4+1])
                         ? f_colorNaN.getValue()
-                        : RGBAColor::fromVec4(eval(pointQuadData[i*4+1]));
+                        : eval(pointQuadData[i*4+1]);
                 color1[3] = transparency;
                 RGBAColor color2 = std::isnan(pointQuadData[i*4+2])
                     ? f_colorNaN.getValue()
-                    : RGBAColor::fromVec4(eval(pointQuadData[i*4+2]));
+                    : eval(pointQuadData[i*4+2]);
                 color2[3] = transparency;
                 RGBAColor color3 = std::isnan(pointQuadData[i*4+3])
                     ? f_colorNaN.getValue()
-                    : RGBAColor::fromVec4(eval(pointQuadData[i*4+3]));
+                    : eval(pointQuadData[i*4+3]);
                 color1[3] = transparency;
                 const Quad& q = m_topology->getQuad(i);
 
@@ -370,7 +370,7 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
         {
             RGBAColor color = std::isnan(ptData[i])
                 ? f_colorNaN.getValue()
-                : RGBAColor::fromVec4(eval(ptData[i]));
+                : eval(ptData[i]);
             color[3] = transparency;
             vparams->drawTool()->drawPoint(x[i], color);
         }
@@ -388,7 +388,7 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
             for (int j=0; j<3; j++) {
                 color[j] = std::isnan(ptData[t[j]])
                         ? f_colorNaN.getValue()
-                        : RGBAColor::fromVec4(eval(ptData[t[j]]));
+                        : eval(ptData[t[j]]);
                 color[j][3] = transparency;
             }
             glNormal3fv(m_normals[t[0]].ptr());
@@ -416,7 +416,7 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
             {
                 color[j] = std::isnan(ptData[q[j]])
                 ? f_colorNaN.getValue()
-                : RGBAColor::fromVec4(eval(ptData[q[j]]));
+                : eval(ptData[q[j]]);
                 color[j][3] = transparency;
             }
 

--- a/Sofa/framework/Helper/src/sofa/helper/ColorMap.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ColorMap.cpp
@@ -174,136 +174,136 @@ void ColorMap::reinit()
         const float step = (2.0f/3.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(hsv2rgb(Color3(i*step, 1.0f, 1.0f)), 1.0f));
+            entries.push_back(type::RGBAColor::fromHSVA(i*step, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Blue to Red") {
         // List the colors
         const float step = (2.0f/3.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(hsv2rgb(Color3(2.0f/3.0f - i*step, 1.0f, 1.0f)), 1.0f));
+            entries.push_back(type::RGBAColor::fromHSVA(2.0f/3.0f - i*step, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Yellow to Cyan") {
         // List the colors
         const float step = (0.5f - 1.0f/6.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(hsv2rgb(Color3(1.0f/6.0f + i*step, 1.0f, 1.0f)), 1.0f));
+            entries.push_back(type::RGBAColor::fromHSVA(1.0f/6.0f + i*step, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Cyan to Yellow") {
         // List the colors
         const float step = (0.5f - 1.0f/6.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(hsv2rgb(Color3(0.5f-i*step, 1.0f, 1.0f)), 1.0f));
+            entries.push_back(type::RGBAColor::fromHSVA(0.5f-i*step, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Red to Yellow") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(1.0f, i*step, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(1.0f, i*step, 0.0f, 1.0f));
         }
     } else if (scheme == "Yellow to Red") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(1.0f, 1.0f-i*step, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(1.0f, 1.0f-i*step, 0.0f, 1.0f));
         }
     } else if (scheme == "Yellow to Green") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(1.0f-i*step, 1.0f, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(1.0f-i*step, 1.0f, 0.0f, 1.0f));
         }
     } else if (scheme == "Green to Yellow") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(i*step, 1.0f, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(i*step, 1.0f, 0.0f, 1.0f));
         }
     } else if (scheme == "Green to Cyan") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(0.0f, 1.0f, i*step, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, 1.0f, i*step, 1.0f));
         }
     } else if (scheme == "Cyan to Green") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(0.0f, 1.0f, 1.0f-i*step, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, 1.0f, 1.0f-i*step, 1.0f));
         }
     } else if (scheme == "Cyan to Blue") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(0.0f, 1.0f-i*step, 1.0f, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, 1.0f-i*step, 1.0f, 1.0f));
         }
     } else if (scheme == "Blue to Cyan") {
         const float step = 1.0f/(nColors);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(Color(0.0f, i*step, 1.0f, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, i*step, 1.0f, 1.0f));
         }
     } else if (scheme == "Red") {
         const float step = 1.4f/(nColors);
         for (unsigned int i=0; i<nColors/2; i++)
         {
-            entries.push_back(Color(0.3f + i*step, 0.0f, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(0.3f + i*step, 0.0f, 0.0f, 1.0f));
         }
         for (unsigned int i=0; i<(nColors - nColors/2); i++)
         {
-            entries.push_back(Color(1.0f, i*step, i*step, 1.0f));
+            entries.push_back(type::RGBAColor(1.0f, i*step, i*step, 1.0f));
         }
     } else if (scheme == "RedInv") {
         const float step = 1.4f/(nColors);
         for (unsigned int i=0; i<(nColors - nColors/2); i++)
         {
-            entries.push_back(Color(1.0f, 0.7f-i*step, 0.7f-i*step, 1.0f));
+            entries.push_back(type::RGBAColor(1.0f, 0.7f-i*step, 0.7f-i*step, 1.0f));
         }
         for (unsigned int i=0; i<nColors/2; i++)
         {
-            entries.push_back(Color(1.0f-i*step, 0.0f, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(1.0f-i*step, 0.0f, 0.0f, 1.0f));
         }
     } else if (scheme == "Green") {
         const float step = 1.4f/(nColors);
         for (unsigned int i=0; i<nColors/2; i++)
         {
-            entries.push_back(Color(0.0f, 0.3f + i*step, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, 0.3f + i*step, 0.0f, 1.0f));
         }
         for (unsigned int i=0; i<(nColors - nColors/2); i++)
         {
-            entries.push_back(Color(i*step, 1.0f, i*step, 1.0f));
+            entries.push_back(type::RGBAColor(i*step, 1.0f, i*step, 1.0f));
         }
     } else if (scheme == "GreenInv") {
         const float step = 1.4f/(nColors);
         for (unsigned int i=0; i<(nColors - nColors/2); i++)
         {
-            entries.push_back(Color(0.7f-i*step, 1.0f, 0.7f-i*step, 1.0f));
+            entries.push_back(type::RGBAColor(0.7f-i*step, 1.0f, 0.7f-i*step, 1.0f));
         }
         for (unsigned int i=0; i<nColors/2; i++)
         {
-            entries.push_back(Color(0.0f, 1.0f - i*step, 0.0f, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, 1.0f - i*step, 0.0f, 1.0f));
         }
     } else if (scheme == "Blue") {
         const float step = 1.4f/(nColors);
         for (unsigned int i=0; i<nColors/2; i++)
         {
-            entries.push_back(Color(0.0f, 0.0f, 0.3f + i*step, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, 0.0f, 0.3f + i*step, 1.0f));
         }
         for (unsigned int i=0; i<(nColors - nColors/2); i++)
         {
-            entries.push_back(Color(i*step, i*step, 1.0f, 1.0f));
+            entries.push_back(type::RGBAColor(i*step, i*step, 1.0f, 1.0f));
         }
     } else if (scheme == "BlueInv") {
         const float step = 1.4f/(nColors);
         for (unsigned int i=0; i<(nColors - nColors/2); i++)
         {
-            entries.push_back(Color(0.7f-i*step, 0.7f-i*step, 1.0f, 1.0f));
+            entries.push_back(type::RGBAColor(0.7f-i*step, 0.7f-i*step, 1.0f, 1.0f));
         }
         for (unsigned int i=0; i<nColors/2; i++)
         {
-            entries.push_back(Color(0.0f, 0.0f, 1.0f - i*step, 1.0f));
+            entries.push_back(type::RGBAColor(0.0f, 0.0f, 1.0f - i*step, 1.0f));
         }
     } else {
         // HSV is the default
@@ -315,7 +315,7 @@ void ColorMap::reinit()
         const float step = 1.0f/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.emplace_back(hsv2rgb(Color3(i*step,1.f,1.f)), 1.0f);
+            entries.emplace_back(type::RGBAColor::fromHSVA(i*step,1.f,1.f, 1.0f));
         }
     }
 }
@@ -326,9 +326,9 @@ void ColorMap::reinit()
 // h,s,v ∈ [0,1]
 // r,g,b ∈ [0,1]
 // Ref: Alvy Ray Smith, Color Gamut Transform Pairs, SIGGRAPH '78
-ColorMap::Color3 ColorMap::hsv2rgb(const Color3 &hsv)
+type::Vec3f ColorMap::hsv2rgb(const type::Vec3f&hsv)
 {
-    Color3 rgb(0.0f, 0.0f, 0.0f);
+    /*Color3 rgb(0.0f, 0.0f, 0.0f);
 
     float i, f;
     f = modff(hsv[0] * 6.0f, &i);
@@ -346,7 +346,10 @@ ColorMap::Color3 ColorMap::hsv2rgb(const Color3 &hsv)
         case 5: rgb = Color3(hsv[2],      x,      y); break;
     }
 
-    return rgb;
+    return rgb;*/
+    auto rgba = type::RGBAColor::fromHSVA( hsv[0], hsv[1],hsv[2], 1.0f );
+
+    return { rgba[0], rgba[1], rgba[2] };
 }
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/ColorMap.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ColorMap.h
@@ -25,6 +25,7 @@
 #include <sofa/helper/config.h>
 
 #include <sofa/type/vector.h>
+#include <sofa/type/RGBAColor.h>
 #include <sofa/helper/rmath.h>
 #include <sofa/type/Vec.h>
 #include <string>
@@ -40,10 +41,7 @@ namespace helper
 class SOFA_HELPER_API ColorMap 
 {
 public:
-
-    typedef type::Vec3f Color3;  // Color tripplet
-    typedef type::Vec4f Color;   // ... with alpha value
-    typedef sofa::type::vector<Color> VecColor;
+    typedef sofa::type::vector<type::RGBAColor> VecColor;
     
     ColorMap(unsigned int paletteSize = 256, const std::string& colorScheme = "HSV");
     virtual ~ColorMap();
@@ -59,7 +57,7 @@ public:
         evaluator(const ColorMap* map, Real vmin, Real vmax)
             : map(map), vmin(vmin), vmax(vmax), vscale((vmax == vmin) ? (Real)0 : (map->entries.size()-1)/(vmax-vmin)) {}
 
-        Color operator()(Real r) const
+        auto operator()(Real r) const
         {
             Real e = (r-vmin)*vscale;
             if (e<0) return map->entries.front();
@@ -67,8 +65,8 @@ public:
             unsigned int i = (unsigned int)(e);
             if (i>=map->entries.size()-1) return map->entries.back();
 
-            Color c1 = map->entries[i];
-            const Color c2 = map->entries[i+1];
+            const auto& c1 = map->entries[i];
+            const auto& c2 = map->entries[i+1];
             return c1+(c2-c1)*(e-i);
         }
     protected:
@@ -93,9 +91,9 @@ public:
     void setColorScheme(const std::string& colorScheme) { m_colorScheme = colorScheme; }
 
     unsigned int getNbColors() const { return (unsigned int) entries.size(); }
-    Color getColor(unsigned int i) {
+    type::RGBAColor getColor(unsigned int i) {
         if (i < entries.size()) return entries[i];
-        return Color(0.f, 0.f, 0.f, 0.f);
+        return type::RGBAColor(0.f, 0.f, 0.f, 0.f);
     }
 
     static ColorMap* getDefault();
@@ -110,7 +108,8 @@ public:
         }
     }
 
-    Color3 hsv2rgb(const Color3 &hsv);
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    type::Vec3f hsv2rgb(const type::Vec3f& hsv);
 
     inline friend std::ostream& operator << (std::ostream& out, const ColorMap& m )
     {

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -26,6 +26,7 @@
 
 #include <sofa/type/fixed_array.h>
 #include <sofa/type/fixed_array_algorithms.h>
+#include <sofa/type/Vec.h>
 
 using namespace sofa::type::pairwise;
 
@@ -174,6 +175,16 @@ RGBAColor RGBAColor::fromVec4(const type::fixed_array<float, 4>& color)
 }
 
 RGBAColor RGBAColor::fromVec4(const type::fixed_array<double, 4>& color)
+{
+    return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
+}
+
+RGBAColor RGBAColor::fromVec4(const type::Vec4f& color)
+{
+    return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
+}
+
+RGBAColor RGBAColor::fromVec4(const type::Vec4d& color)
 {
     return RGBAColor(float(color[0]), float(color[1]), float(color[2]), float(color[3]));
 }

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -209,6 +209,17 @@ constexpr RGBAColor operator+(const RGBAColor& l, const RGBAColor& r)
     return sofa::type::pairwise::operator+(l, r);
 }
 
+constexpr RGBAColor operator/(const RGBAColor& l, const float div)
+{
+    RGBAColor result{};
+    for (std::size_t i = 0; i < 4; ++i)
+    {
+        result[i] = l[i] / div;
+    }
+    return result;
+}
+
+
 constexpr RGBAColor g_white     {1.0f,1.0f,1.0f,1.0f};
 constexpr RGBAColor g_black     {0.0f,0.0f,0.0f,1.0f};
 constexpr RGBAColor g_red       {1.0f,0.0f,0.0f,1.0f};

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.h
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.h
@@ -65,6 +65,10 @@ public:
     static RGBAColor fromVec4(const type::fixed_array<float, 4>& color);
     SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
     static RGBAColor fromVec4(const type::fixed_array<double, 4>& color);
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    static RGBAColor fromVec4(const Vec4f& color);
+    SOFA_ATTRIBUTE_DEPRECATED__RGBACOLOR_AS_FIXEDARRAY()
+    static RGBAColor fromVec4(const Vec4d& color);
 
     static RGBAColor fromString(const std::string& str);
     static RGBAColor fromFloat(float r, float g, float b, float a);


### PR DESCRIPTION
Based on
- #4263 

Part of the task to use std container and also just it felt dumb that ColorMap was not using the standard RGBAColor class
Mostly breaking because people needed to convert the result of ColorMap::eval() to RGBAColor


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
