### PR TITLE
[Topology.Mapping] SimpleTesselatedHexaTopologicalMapping: use correct type for Index

### DIFF
--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SimpleTesselatedHexaTopologicalMapping.cpp
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SimpleTesselatedHexaTopologicalMapping.cpp
@@ -39,7 +39,6 @@ using namespace sofa::type;
 using namespace sofa::defaulttype;
 using namespace sofa::component::mapping::linear;
 using namespace sofa::core::topology;
-using sofa::type::fixed_array;
 
 // Register in the Factory
 int SimpleTesselatedHexaTopologicalMappingClass = core::RegisterObject ( "Special case of mapping where HexahedronSetTopology is converted into a finer HexahedronSetTopology" )
@@ -72,7 +71,7 @@ void SimpleTesselatedHexaTopologicalMapping::init()
         toModel->addPoint(fromModel->getPX(i), fromModel->getPY(i), fromModel->getPZ(i));
     }
 
-    size_t pointIndex = pointMappedFromPoint.size();
+    sofa::Index pointIndex = static_cast<sofa::Index>(pointMappedFromPoint.size());
     Vec3 p;
 
     for (std::size_t i=0; i<fromModel->getNbHexahedra(); ++i)
@@ -89,97 +88,96 @@ void SimpleTesselatedHexaTopologicalMapping::init()
         Vec3 p7(fromModel->getPX(h[7]), fromModel->getPY(h[7]), fromModel->getPZ(h[7]));
 
         // points mapped from edges
-        std::pair<std::map<fixed_array<int,2>, int>::iterator, bool> insert_result;
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[0],h[1]),pointIndex));
-        if(insert_result.second)
+        bool insertResultSuccessful = pointMappedFromEdge.insert({ {h[0],h[1]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p0+p1)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[1],h[(2)]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[1],h[(2)]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p1+p2)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[3],h[2]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[3],h[2]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p3+p2)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[0],h[3]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[0],h[3]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p0+p3)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[0],h[4]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[0],h[4]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p0+p4)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[1],h[5]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[1],h[5]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p1+p5)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[2],h[6]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[2],h[6]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p2+p6)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[3],h[7]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[3],h[7]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p3+p7)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[4],h[5]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[4],h[5]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p4+p5)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[5],h[6]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[5],h[6]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p5+p6)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[7],h[6]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[7],h[6]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p7+p6)/2;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_result = pointMappedFromEdge.insert(std::make_pair(fixed_array<int,2>(h[4],h[7]),pointIndex));
-        if(insert_result.second)
+        insertResultSuccessful = pointMappedFromEdge.insert({{h[4],h[7]},pointIndex }).second;
+        if(insertResultSuccessful)
         {
             p = (p4+p7)/2;
             toModel->addPoint(p[0], p[1], p[2]);
@@ -187,49 +185,48 @@ void SimpleTesselatedHexaTopologicalMapping::init()
         }
 
         // points mapped from facets
-        std::pair<std::map<fixed_array<int,4>, int>::iterator, bool> insert_facets_result;
-        insert_facets_result = pointMappedFromFacet.insert(std::make_pair(fixed_array<int,4>(h[0], h[1], h[2], h[3]), pointIndex));
-        if (insert_facets_result.second)
+        bool insertFacetsResultSuccessful = pointMappedFromFacet.insert({ {h[0], h[1], h[2], h[3]}, pointIndex }).second;
+        if (insertFacetsResultSuccessful)
         {
             p = (p0+p1+p2+p3)/4;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_facets_result = pointMappedFromFacet.insert(std::make_pair(fixed_array<int,4>(h[0], h[1], h[5], h[4]), pointIndex));
-        if (insert_facets_result.second)
+        insertFacetsResultSuccessful = pointMappedFromFacet.insert({ {h[0], h[1], h[5], h[4] }, pointIndex }).second;
+        if (insertFacetsResultSuccessful)
         {
             p = (p0+p1+p5+p4)/4;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_facets_result = pointMappedFromFacet.insert(std::make_pair(fixed_array<int,4>(h[1], h[2], h[6], h[5]), pointIndex));
-        if (insert_facets_result.second)
+        insertFacetsResultSuccessful = pointMappedFromFacet.insert({ {h[1], h[2], h[6], h[5]}, pointIndex }).second;
+        if (insertFacetsResultSuccessful)
         {
             p = (p1+p2+p6+p5)/4;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_facets_result = pointMappedFromFacet.insert(std::make_pair(fixed_array<int,4>(h[3], h[2], h[6], h[7]), pointIndex));
-        if (insert_facets_result.second)
+        insertFacetsResultSuccessful = pointMappedFromFacet.insert({ {h[3], h[2], h[6], h[7]}, pointIndex }).second;
+        if (insertFacetsResultSuccessful)
         {
             p = (p3+p2+p6+p7)/4;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_facets_result = pointMappedFromFacet.insert(std::make_pair(fixed_array<int,4>(h[0], h[3], h[7], h[4]), pointIndex));
-        if (insert_facets_result.second)
+        insertFacetsResultSuccessful = pointMappedFromFacet.insert({ {h[0], h[3], h[7], h[4]}, pointIndex }).second;
+        if (insertFacetsResultSuccessful)
         {
             p = (p0+p4+p7+p3)/4;
             toModel->addPoint(p[0], p[1], p[2]);
             pointIndex++;
         }
 
-        insert_facets_result = pointMappedFromFacet.insert(std::make_pair(fixed_array<int,4>(h[4], h[5], h[6], h[7]), pointIndex));
-        if (insert_facets_result.second)
+        insertFacetsResultSuccessful = pointMappedFromFacet.insert({ {h[4], h[5], h[6], h[7]}, pointIndex }).second;
+        if (insertFacetsResultSuccessful)
         {
             p = (p4+p5+p6+p7)/4;
             toModel->addPoint(p[0], p[1], p[2]);
@@ -257,75 +254,75 @@ void SimpleTesselatedHexaTopologicalMapping::init()
         Vec3d p7(fromModel->getPX(h[7]), fromModel->getPY(h[7]), fromModel->getPZ(h[7]));
 
         toModel->addHexa(h[0],
-                pointMappedFromEdge[fixed_array<int,2>(h[0],h[1])],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[2],h[3])],
-                pointMappedFromEdge[fixed_array<int,2>(h[0],h[3])],
-                pointMappedFromEdge[fixed_array<int,2>(h[0],h[4])],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[5],h[4])],
+                pointMappedFromEdge[{h[0],h[1]}],
+                pointMappedFromFacet[{h[0],h[1],h[2],h[3]}],
+                pointMappedFromEdge[{h[0],h[3]}],
+                pointMappedFromEdge[{h[0],h[4]}],
+                pointMappedFromFacet[{h[0],h[1],h[5],h[4]}],
                 pointMappedFromHexa[i],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[3],h[7],h[4])]);
+                pointMappedFromFacet[{h[0],h[3],h[7],h[4]}]);
 
-        toModel->addHexa(pointMappedFromEdge[fixed_array<int,2>(h[0],h[1])],
+        toModel->addHexa(pointMappedFromEdge[{h[0],h[1]}],
                 h[1],
-                pointMappedFromEdge[fixed_array<int,2>(h[1],h[2])],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[2],h[3])],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[5],h[4])],
-                pointMappedFromEdge[fixed_array<int,2>(h[1],h[5])],
-                pointMappedFromFacet[fixed_array<int,4>(h[1],h[2],h[6],h[5])],
+                pointMappedFromEdge[{h[1],h[2]}],
+                pointMappedFromFacet[{h[0],h[1],h[2],h[3]}],
+                pointMappedFromFacet[{h[0],h[1],h[5],h[4]}],
+                pointMappedFromEdge[{h[1],h[5]}],
+                pointMappedFromFacet[{h[1],h[2],h[6],h[5]}],
                 pointMappedFromHexa[i]);
 
-        toModel->addHexa(pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[2],h[3])],
-                pointMappedFromEdge[fixed_array<int,2>(h[1],h[2])],
+        toModel->addHexa(pointMappedFromFacet[{h[0],h[1],h[2],h[3]}],
+                pointMappedFromEdge[{h[1],h[2]}],
                 h[2],
-                pointMappedFromEdge[fixed_array<int,2>(h[3],h[2])],
+                pointMappedFromEdge[{h[3],h[2]}],
                 pointMappedFromHexa[i],
-                pointMappedFromFacet[fixed_array<int,4>(h[1],h[2],h[6],h[5])],
-                pointMappedFromEdge[fixed_array<int,2>(h[2],h[6])],
-                pointMappedFromFacet[fixed_array<int,4>(h[3],h[2],h[6],h[7])]);
+                pointMappedFromFacet[{h[1],h[2],h[6],h[5]}],
+                pointMappedFromEdge[{h[2],h[6]}],
+                pointMappedFromFacet[{h[3],h[2],h[6],h[7]}]);
 
-        toModel->addHexa(pointMappedFromEdge[fixed_array<int,2>(h[0],h[3])],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[2],h[3])],
-                pointMappedFromEdge[fixed_array<int,2>(h[3],h[2])],
+        toModel->addHexa(pointMappedFromEdge[{h[0],h[3]}],
+                pointMappedFromFacet[{h[0],h[1],h[2],h[3]}],
+                pointMappedFromEdge[{h[3],h[2]}],
                 h[3],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[3],h[7],h[4])],
+                pointMappedFromFacet[{h[0],h[3],h[7],h[4]}],
                 pointMappedFromHexa[i],
-                pointMappedFromFacet[fixed_array<int,4>(h[3],h[2],h[6],h[7])],
-                pointMappedFromEdge[fixed_array<int,2>(h[3],h[7])]);
+                pointMappedFromFacet[{h[3],h[2],h[6],h[7]}],
+                pointMappedFromEdge[{h[3],h[7]}]);
 
-        toModel->addHexa(pointMappedFromEdge[fixed_array<int,2>(h[0],h[4])],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[5],h[4])],
+        toModel->addHexa(pointMappedFromEdge[{h[0],h[4]}],
+                pointMappedFromFacet[{h[0],h[1],h[5],h[4]}],
                 pointMappedFromHexa[i],
-                pointMappedFromFacet[fixed_array<int,4>(h[0],h[3],h[7],h[4])],
+                pointMappedFromFacet[{h[0],h[3],h[7],h[4]}],
                 h[4],
-                pointMappedFromEdge[fixed_array<int,2>(h[4],h[5])],
-                pointMappedFromFacet[fixed_array<int,4>(h[4],h[5],h[6],h[7])],
-                pointMappedFromEdge[fixed_array<int,2>(h[4],h[7])]);
+                pointMappedFromEdge[{h[4],h[5]}],
+                pointMappedFromFacet[{h[4],h[5],h[6],h[7]}],
+                pointMappedFromEdge[{h[4],h[7]}]);
 
-        toModel->addHexa(pointMappedFromFacet[fixed_array<int,4>(h[0],h[1],h[5],h[4])],
-                pointMappedFromEdge[fixed_array<int,2>(h[1],h[5])],
-                pointMappedFromFacet[fixed_array<int,4>(h[1],h[2],h[6],h[5])],
+        toModel->addHexa(pointMappedFromFacet[{h[0],h[1],h[5],h[4]}],
+                pointMappedFromEdge[{h[1],h[5]}],
+                pointMappedFromFacet[{h[1],h[2],h[6],h[5]}],
                 pointMappedFromHexa[i],
-                pointMappedFromEdge[fixed_array<int,2>(h[4],h[5])],
+                pointMappedFromEdge[{h[4],h[5]}],
                 h[5],
-                pointMappedFromEdge[fixed_array<int,2>(h[5],h[6])],
-                pointMappedFromFacet[fixed_array<int,4>(h[4],h[5],h[6],h[7])]);
+                pointMappedFromEdge[{h[5],h[6]}],
+                pointMappedFromFacet[{h[4],h[5],h[6],h[7]}]);
 
         toModel->addHexa(pointMappedFromHexa[i],
-                pointMappedFromFacet[fixed_array<int,4>(h[1],h[2],h[6],h[5])],
-                pointMappedFromEdge[fixed_array<int,2>(h[2],h[6])],
-                pointMappedFromFacet[fixed_array<int,4>(h[3],h[2],h[6],h[7])],
-                pointMappedFromFacet[fixed_array<int,4>(h[4],h[5],h[6],h[7])],
-                pointMappedFromEdge[fixed_array<int,2>(h[5],h[6])],
+                pointMappedFromFacet[{h[1],h[2],h[6],h[5]}],
+                pointMappedFromEdge[{h[2],h[6]}],
+                pointMappedFromFacet[{h[3],h[2],h[6],h[7]}],
+                pointMappedFromFacet[{h[4],h[5],h[6],h[7]}],
+                pointMappedFromEdge[{h[5],h[6]}],
                 h[6],
-                pointMappedFromEdge[fixed_array<int,2>(h[7],h[6])]);
+                pointMappedFromEdge[{h[7],h[6]}]);
 
-        toModel->addHexa(pointMappedFromFacet[fixed_array<int,4>(h[0],h[3],h[7],h[4])],
+        toModel->addHexa(pointMappedFromFacet[{h[0],h[3],h[7],h[4]}],
                 pointMappedFromHexa[i],
-                pointMappedFromFacet[fixed_array<int,4>(h[3],h[2],h[6],h[7])],
-                pointMappedFromEdge[fixed_array<int,2>(h[3],h[7])],
-                pointMappedFromEdge[fixed_array<int,2>(h[4],h[7])],
-                pointMappedFromFacet[fixed_array<int,4>(h[4],h[5],h[6],h[7])],
-                pointMappedFromEdge[fixed_array<int,2>(h[7],h[6])],
+                pointMappedFromFacet[{h[3],h[2],h[6],h[7]}],
+                pointMappedFromEdge[{h[3],h[7]}],
+                pointMappedFromEdge[{h[4],h[7]}],
+                pointMappedFromFacet[{h[4],h[5],h[6],h[7]}],
+                pointMappedFromEdge[{h[7],h[6]}],
                 h[7]);
     }
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SimpleTesselatedHexaTopologicalMapping.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SimpleTesselatedHexaTopologicalMapping.h
@@ -81,10 +81,10 @@ public:
      *
      */
 protected:
-    type::vector<int> pointMappedFromPoint;
-    std::map<type::fixed_array<int,2>, int> pointMappedFromEdge;
-    std::map<type::fixed_array<int,4>, int> pointMappedFromFacet;
-    type::vector<int> pointMappedFromHexa;
+    type::vector<sofa::Index> pointMappedFromPoint;
+    std::map<type::fixed_array<sofa::Index,2>, sofa::Index> pointMappedFromEdge;
+    std::map<type::fixed_array<sofa::Index,4>, sofa::Index> pointMappedFromFacet;
+    type::vector<sofa::Index> pointMappedFromHexa;
 };
 
 } //namespace sofa::component::mapping::linear


### PR DESCRIPTION
Using sofa::Index instead of int.

\+ removing verbose types and using aggreg. contructions



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
