### PR TITLE
[LinearAlgera, Core] Fix linking with LTO on MacOS/Clang

### DIFF
--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -306,6 +306,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/topology/Topology.cpp
     ${SRC_ROOT}/topology/TopologyChange.cpp
     ${SRC_ROOT}/topology/TopologyHandler.cpp
+    ${SRC_ROOT}/topology/TopologyData.cpp
     ${SRC_ROOT}/topology/TopologySubsetIndices.cpp
     ${SRC_ROOT}/visual/Data[DisplayFlags].cpp
     ${SRC_ROOT}/visual/DisplayFlags.cpp

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyData.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyData.cpp
@@ -19,16 +19,14 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_LINEARALGEBRA_FULLVECTOR_DEFINITION
-#include <sofa/linearalgebra/FullVector.inl>
+#define SOFA_CORE_TOPOLOGY_TOPOLOGYDATA_DEFINITION
 
-namespace sofa::linearalgebra
+#include <sofa/core/topology/TopologyData.inl>
+
+
+namespace sofa::core::topology
 {
+    
+template class SOFA_CORE_API sofa::core::topology::TopologyData < core::topology::BaseMeshTopology::Point, type::vector<Index> >;
 
-std::ostream& operator <<(std::ostream& out, const FullVector<float>& v){ return readFromStream(out, v); }
-std::ostream& operator <<(std::ostream& out, const FullVector<double>& v){ return readFromStream(out, v); }
-
-template class SOFA_LINEARALGEBRA_API FullVector<float>;
-template class SOFA_LINEARALGEBRA_API FullVector<double>;
-
-} /// namespace sofa::linearalgebra
+} //namespace sofa::core::topology

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologyData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologyData.h
@@ -164,5 +164,9 @@ template< class VecT > using QuadData        = TopologyData<core::topology::Base
 template< class VecT > using TetrahedronData = TopologyData<core::topology::BaseMeshTopology::Tetrahedron, VecT>;
 template< class VecT > using HexahedronData  = TopologyData<core::topology::BaseMeshTopology::Hexahedron, VecT>;
 
+#if !defined(SOFA_CORE_TOPOLOGY_TOPOLOGYDATA_DEFINITION)
+extern template class SOFA_CORE_API sofa::core::topology::TopologyData < core::topology::BaseMeshTopology::Point, type::vector<Index> >;
+#endif
+
 
 } //namespace sofa::core::topology

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
@@ -85,7 +85,6 @@ void TopologySubsetIndices::updateLastIndex(Index posLastIndex, Index newGlobalI
 }
 
 template class SOFA_CORE_API sofa::core::topology::TopologyDataHandler < core::topology::BaseMeshTopology::Point, type::vector<Index> >;
-template class SOFA_CORE_API sofa::core::topology::TopologyData < core::topology::BaseMeshTopology::Point, type::vector<Index> >;
 //template class SOFA_CORE_API sofa::core::topology::BaseTopologyData < type::vector<Index> >;
 
 } //namespace sofa::core::topology

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/FullVector.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/FullVector.h
@@ -220,7 +220,7 @@ public:
 SOFA_LINEARALGEBRA_API std::ostream& operator <<(std::ostream& out, const FullVector<float>& v);
 SOFA_LINEARALGEBRA_API std::ostream& operator <<(std::ostream& out, const FullVector<double>& v);
 
-#if !defined(SOFABASELINEARSOLVER_FULLMATRIX_DEFINITION)
+#if !defined(SOFA_LINEARALGEBRA_FULLVECTOR_DEFINITION)
 extern template class SOFA_LINEARALGEBRA_API FullVector<float>;
 extern template class SOFA_LINEARALGEBRA_API FullVector<double>;
 #endif


### PR DESCRIPTION
Apparently clang-mac is very picky about location of the symbols with LTO enabled, and this fact could expose some problem for explicit instanciations (typos, wrong location)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
