### PR TITLE
[MechanicalLoad] Add buildStiffnessMatrix to TrianglePressureForceField

### DIFF
--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.h
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.h
@@ -50,7 +50,9 @@ public:
     using Index = sofa::Index;
 
     Data<Deriv> pressure; ///< pressure is a vector with specified direction
-  	Data<MatSym3> cauchyStress; ///< the Cauchy stress applied on triangles
+
+    SOFA_ATTRIBUTE_DISABLED__TRIANGLE_NON_CONSTANT_FORCEFIELD(cauchyStress)
+    Data<MatSym3> cauchyStress; ///< the Cauchy stress applied on triangles
 
     Data<sofa::type::vector<Index> > triangleList; ///< Indices of triangles separated with commas where a pressure is applied
 
@@ -60,6 +62,8 @@ public:
     Data<Real> dmin; ///< coordinates min of the plane for the vertex selection
     Data<Real> dmax;///< coordinates max of the plane for the vertex selection
     Data<bool> p_showForces; ///< draw triangles which have a given pressure
+
+    SOFA_ATTRIBUTE_DISABLED__TRIANGLE_NON_CONSTANT_FORCEFIELD(p_seConstantForce)
     Data<bool> p_useConstantForce; ///< applied force is computed as the pressure vector times the area at rest
 
     /// Link to be set to the topology container in the component graph.
@@ -121,6 +125,7 @@ public:
     void addKToMatrix(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/ ) override {}
 
     void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override;
     void draw(const core::visual::VisualParams* vparams) override;

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.inl
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/TrianglePressureForceField.inl
@@ -85,7 +85,7 @@ template <class DataTypes> void TrianglePressureForceField<DataTypes>::init()
 
     initTriangleInformation();
 
-    if(p_useConstantForce.m_isSet() || p_useConstantForce.getValue() == false)
+    if(p_useConstantForce.isSet() || p_useConstantForce.getValue() == false)
     {
         msg_deprecated() << "Non constant pressure force field has been removed.";
     }

--- a/Sofa/framework/Config/src/sofa/config.h.in
+++ b/Sofa/framework/Config/src/sofa/config.h.in
@@ -230,6 +230,11 @@ class DeprecatedAndRemoved {};
         "v22.12 (PR#3304)", "v23.06", \
         "Calling ReadX with SingleLink's argument will be removed." msg)
 
+#define SOFA_ATTRIBUTE_DISABLED__TRIANGLE_NON_CONSTANT_FORCEFIELD(type) \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v23.12 (PR#)", "v24.12", \
+        "This type member " sofa_tostring(type) " is now deprecated for removal. Please contact sofa-dev if you need it.")
+
 /**********************************************/
 
 #define SOFA_DECL_CLASS(name) // extern "C" { int sofa_concat(class_,name) = 0; }

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.h
@@ -182,6 +182,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /* mparams */, const DataVecCoord& /* d_x */) const override;
 
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 


### PR DESCRIPTION
Related to #3967

I was not able to not unify a bit the behavior and clean some part of the code. 

The non constant computation of the pressure is not valid as all the derivatives are zero in addDForce, addKtoMatrix... it is also not consistant with QuadPressureForceField.

Moving to the situation with a valid non constant computation on both Triangle and Quad requires more work, so for the moment I prefer to just deprecate the non constant situation.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
