### PR TITLE
Add a cmake option to disable build of runSofa app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,9 @@ sofa_add_subdirectory(plugin applications/plugins/SceneCreator SceneCreator OFF
     WHEN_TO_SHOW "NOT SOFA_BUILD_SCENECREATOR AND NOT SOFA_BUILD_TESTS AND NOT SOFA_BUILD_TUTORIALS AND NOT SOFA_BUILD_RELEASE_PACKAGE"
     VALUE_IF_HIDDEN "ON")
 
+## runSofa application option
+option(SOFA_APPLICATION_RUNSOFA "Build runSofa application." ON)
+
 ## Plugins
 add_subdirectory(applications/plugins)
 

--- a/applications/projects/CMakeLists.txt
+++ b/applications/projects/CMakeLists.txt
@@ -10,7 +10,10 @@ sofa_add_subdirectory(application GenerateRigid GenerateRigid)
 sofa_add_subdirectory(application SofaPhysicsAPI SofaPhysicsAPI)
 sofa_add_subdirectory(application SofaGuiGlut SofaGuiGlut OFF)
 
-sofa_add_subdirectory(application runSofa runSofa ON)
+if(SOFA_APPLICATION_RUNSOFA)
+  sofa_add_subdirectory(application runSofa runSofa ON)
+endif()
+
 sofa_add_subdirectory(application sofaOPENCL sofaOPENCL OFF)
 
 sofa_add_subdirectory(directory Regression Regression EXTERNAL)


### PR DESCRIPTION
Title is self-explanatory.
Follows discussion about redefining CI minimal scope.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
