### PR TITLE
[SolidMechanics.Springs] Cleaning of QuadularBendingSprings

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.h
@@ -85,8 +85,8 @@ protected:
 
         sofa::type::fixed_array<Spring, 2> springs;
 
-        SReal  ks;      /// spring stiffness (initialized to the default value)
-        SReal  kd;      /// damping factor (initialized to the default value)
+        SReal  ks {};      /// spring stiffness
+        SReal  kd {};      /// damping factor
 
         bool is_activated;
 
@@ -114,8 +114,6 @@ protected:
         }
     };
 
-
-
 public:
     /// Searches quad topology and creates the bending springs
     void init() override;
@@ -126,19 +124,6 @@ public:
     void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
 
     SReal getPotentialEnergy(const core::MechanicalParams* /* mparams */, const DataVecCoord& /* d_x */) const override;
-
-
-    struct Force
-    {
-        Deriv force;
-        Real forceIntensity;
-        Real inverseLength;
-    };
-    Force computeForce(const VecDeriv& v, const EdgeInformation& einfo, const typename EdgeInformation::Spring& spring, Coord direction, Real distance);
-    Mat computeLocalJacobian(EdgeInformation& einfo, const Coord& direction, const Force& force);
-    void computeSpringForce(VecDeriv& f, const VecCoord& x, const VecDeriv& v,
-                          EdgeInformation& einfo,
-                          typename EdgeInformation::Spring& spring);
 
     virtual SReal getKs() const { return f_ks.getValue();}
     virtual SReal getKd() const { return f_kd.getValue();}
@@ -152,10 +137,7 @@ public:
         f_kd.setValue((SReal)kd);
     }
 
-    // -- VisualModel interface
     void draw(const core::visual::VisualParams* vparams) override;
-    void initTextures() { }
-    void update() { }
 
     sofa::core::topology::EdgeData<sofa::type::vector<EdgeInformation> > &getEdgeInfo() {return edgeInfo;}
 
@@ -197,6 +179,19 @@ public:
 
 protected:
     sofa::core::topology::EdgeData<sofa::type::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
+
+    struct ForceOutput
+    {
+        Deriv force;
+        Real forceIntensity;
+        Real inverseLength;
+    };
+
+    ForceOutput computeForce(const VecDeriv& v, const EdgeInformation& einfo, const typename EdgeInformation::Spring& spring, Coord direction, Real distance);
+    Mat computeLocalJacobian(EdgeInformation& einfo, const Coord& direction, const ForceOutput& force);
+    void computeSpringForce(VecDeriv& f, const VecCoord& x, const VecDeriv& v,
+                          EdgeInformation& einfo,
+                          typename EdgeInformation::Spring& spring);
 
     /// Pointer to the current topology
     sofa::core::topology::BaseMeshTopology* m_topology;

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.h
@@ -75,12 +75,12 @@ protected:
     class EdgeInformation
     {
     public:
-        Mat DfDx; /// the edge stiffness matrix
 
         struct Spring
         {
             sofa::topology::Edge edge;
             Real restLength;
+            Mat DfDx; /// the edge stiffness matrix
         };
 
         sofa::type::fixed_array<Spring, 2> springs;
@@ -138,7 +138,7 @@ public:
     Mat computeLocalJacobian(EdgeInformation& einfo, const Coord& direction, const Force& force);
     void computeSpringForce(VecDeriv& f, const VecCoord& x, const VecDeriv& v,
                           EdgeInformation& einfo,
-                          const typename EdgeInformation::Spring& spring);
+                          typename EdgeInformation::Spring& spring);
 
     virtual SReal getKs() const { return f_ks.getValue();}
     virtual SReal getKd() const { return f_kd.getValue();}

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadularBendingSprings.inl
@@ -448,9 +448,9 @@ auto QuadularBendingSprings<DataTypes>::computeForce(
     const VecDeriv& v,
     const EdgeInformation& einfo, const typename EdgeInformation::Spring& spring,
     Coord direction,
-    Real distance) -> Force
+    Real distance) -> ForceOutput
 {
-    Force force;
+    ForceOutput force;
 
     force.inverseLength = 1 / distance;
     direction *= force.inverseLength;
@@ -466,7 +466,7 @@ auto QuadularBendingSprings<DataTypes>::computeForce(
 }
 
 template <class DataTypes>
-auto QuadularBendingSprings<DataTypes>::computeLocalJacobian(EdgeInformation& einfo, const Coord& direction, const Force& force)
+auto QuadularBendingSprings<DataTypes>::computeLocalJacobian(EdgeInformation& einfo, const Coord& direction, const ForceOutput& force)
 -> Mat
 {
     const Real tgt = force.forceIntensity * force.inverseLength;
@@ -490,7 +490,7 @@ void QuadularBendingSprings<DataTypes>::computeSpringForce(VecDeriv& f, const Ve
 
     if (distance > 1.0e-4)
     {
-        const Force force = computeForce(v, einfo, spring, difference, distance);
+        const ForceOutput force = computeForce(v, einfo, spring, difference, distance);
 
         f[e0] += force.force;
         f[e1] -= force.force;

--- a/examples/Component/SolidMechanics/Spring/QuadularBendingSprings.scn
+++ b/examples/Component/SolidMechanics/Spring/QuadularBendingSprings.scn
@@ -1,49 +1,31 @@
-<!-- Mechanical MassSpring Group Basic Example -->
 <Node name="root" dt="0.005" showBoundingTree="0" gravity="0 -9.81 0">
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
-    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
-    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
-    <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->
-    <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
-    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
-    <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
-    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TriangularFEMForceField] -->
-    <RequiredPlugin name="Sofa.Component.SolidMechanics.Spring"/> <!-- Needed to use components [QuadularBendingSprings] -->
-    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [QuadSetGeometryAlgorithms QuadSetTopologyContainer QuadSetTopologyModifier TriangleSetGeometryAlgorithms TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
-    <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Quad2TriangleTopologicalMapping] -->
-    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
-    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+    <Node name="plugins">
+    </Node>
 
     <DefaultAnimationLoop/>
-    <VisualStyle displayFlags="showBehaviorModels" />
-    <CollisionPipeline verbose="0" />
-    <BruteForceBroadPhase/>
-    <BVHNarrowPhase/>
-    <CollisionResponse response="PenalityContactForceField" />
-    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
+    <VisualStyle displayFlags="showBehaviorModels showWireframe showForceFields" />
     <Node name="QuadularSprings">
-        <!-- <StaticSolver iterations="140" /> -->
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshGmshLoader filename="mesh/nine_quads.msh" name="loader" />
-        <MechanicalObject src="@loader" name="Quads" />
-        <include href="Objects/QuadSetTopology.xml" src="@loader" />
-        <QuadularBendingSprings name="FEM-Bend" stiffness="3000" damping="1.0" />
-        <DiagonalMass massDensity="0.5" />
-        <FixedConstraint indices="12 15" />
+<!--        <ShewchukPCGLinearSolver preconditioner="@preconditioner"/>-->
+<!--        <AsyncSparseLDLSolver name="preconditioner" template="CompressedRowSparseMatrixMat3x3"/>-->
+<!--        <SparseLDLSolver name="preconditioner" template="CompressedRowSparseMatrixMat3x3"/>-->
+        <CGLinearSolver iterations="5000" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <RegularGridTopology min="0 0 0" max="1 0 1" nx="10" ny="1" nz="10" name="grid" />
+        <MechanicalObject name="Quads" />
+        <QuadSetTopologyContainer name="Container" quads="@grid.quads"/>
+        <QuadularBendingSprings name="FEM-Bend" stiffness="3000" damping="1.0" topology="@Container" draw="true"/>
+        <DiagonalMass massDensity="1.5" />
+        <BoxROI box="-0.0001 -0.0001 -0.0001 0.0001 0.0001 0.0001  0.999 -0.0001 -0.0001 1.0001 0.0001 0.0001" name="box"/>
+        <FixedConstraint indices="@box.indices" />
+        <Node name="Surf">
+            <TriangleSetTopologyContainer  name="Container"/>
+            <TriangleSetTopologyModifier   name="Modifier" />
+            <Quad2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <TriangularFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.3" method="large" />
+        </Node>
         <Node name="Visu">
             <OglModel name="Visual" color="yellow" />
             <IdentityMapping input="@../Quads" output="@Visual" />
-        </Node>
-        <Node name="Surf">
-            <include href="Objects/TriangleSetTopology.xml" src="@../Container"/>
-            <Quad2TriangleTopologicalMapping input="@../Container" output="@Container" />
-            <TriangularFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.3" method="large" />
-            <TriangleCollisionModel />
         </Node>
     </Node>
 </Node>

--- a/examples/Component/SolidMechanics/Spring/QuadularBendingSprings.scn
+++ b/examples/Component/SolidMechanics/Spring/QuadularBendingSprings.scn
@@ -1,16 +1,27 @@
 <Node name="root" dt="0.005" showBoundingTree="0" gravity="0 -9.81 0">
     <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [EigenSimplicialLDLT] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TriangularFEMForceField] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.Spring"/> <!-- Needed to use components [QuadularBendingSprings] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [QuadSetTopologyContainer,TriangleSetTopologyContainer,TriangleSetTopologyModifier] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Quad2TriangleTopologicalMapping] -->
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     </Node>
 
     <DefaultAnimationLoop/>
-    <VisualStyle displayFlags="showBehaviorModels showWireframe showForceFields" />
+    <VisualStyle displayFlags="showBehaviorModels showWireframe" />
     <Node name="QuadularSprings">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-<!--        <ShewchukPCGLinearSolver preconditioner="@preconditioner"/>-->
-<!--        <AsyncSparseLDLSolver name="preconditioner" template="CompressedRowSparseMatrixMat3x3"/>-->
-<!--        <SparseLDLSolver name="preconditioner" template="CompressedRowSparseMatrixMat3x3"/>-->
-        <CGLinearSolver iterations="5000" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <RegularGridTopology min="0 0 0" max="1 0 1" nx="10" ny="1" nz="10" name="grid" />
+        <EigenSimplicialLDLT name="linearSolver" template="CompressedRowSparseMatrixMat3x3"/>
+        <RegularGridTopology min="0 0 0" max="1 0 1" nx="20" ny="1" nz="20" name="grid" />
         <MechanicalObject name="Quads" />
         <QuadSetTopologyContainer name="Container" quads="@grid.quads"/>
         <QuadularBendingSprings name="FEM-Bend" stiffness="3000" damping="1.0" topology="@Container" draw="true"/>
@@ -18,8 +29,8 @@
         <BoxROI box="-0.0001 -0.0001 -0.0001 0.0001 0.0001 0.0001  0.999 -0.0001 -0.0001 1.0001 0.0001 0.0001" name="box"/>
         <FixedConstraint indices="@box.indices" />
         <Node name="Surf">
-            <TriangleSetTopologyContainer  name="Container"/>
-            <TriangleSetTopologyModifier   name="Modifier" />
+            <TriangleSetTopologyContainer name="Container"/>
+            <TriangleSetTopologyModifier name="Modifier" />
             <Quad2TriangleTopologicalMapping input="@../Container" output="@Container" />
             <TriangularFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.3" method="large" />
         </Node>


### PR DESCRIPTION
- Massive cleaning
- Factorize duplicated code
- Fix storage of the local jacobian matrix. There was only one jacobian matrix for two springs, and the second spring always overwrote the values of the first jacobian matrix. There are now one jacobian matrix by spring.
- Implementation of `buildStiffnessMatrix` (a task from https://github.com/sofa-framework/sofa/issues/3967)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
