### PR TITLE
[MultiThreading] Avoid Static Initialization Order Fiasco

### DIFF
--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.cpp
@@ -25,7 +25,11 @@
 namespace multithreading
 {
 
-sofa::type::vector<ParallelImplementationsRegistry::Implementation> ParallelImplementationsRegistry::s_implementations;
+sofa::type::vector<ParallelImplementationsRegistry::Implementation>& getStaticImplementations()
+{
+    static sofa::type::vector<ParallelImplementationsRegistry::Implementation> s_implementations;
+    return s_implementations;
+}
 
 bool ParallelImplementationsRegistry::addEquivalentImplementations(
     const std::string& sequentialImplementation, const std::string& parallelImplementation)
@@ -34,9 +38,9 @@ bool ParallelImplementationsRegistry::addEquivalentImplementations(
 
     const auto it = findParallelImplementationImpl(sequentialImplementation);
 
-    if (it == s_implementations.end())
+    if (it == getStaticImplementations().end())
     {
-        s_implementations.push_back(implementation);
+        getStaticImplementations().push_back(implementation);
         return true;
     }
 
@@ -62,7 +66,7 @@ std::string ParallelImplementationsRegistry::findParallelImplementation(
 {
     const auto it = findParallelImplementationImpl(sequentialImplementation);
 
-    if (it != s_implementations.end())
+    if (it != getImplementations().end())
     {
         return it->parallel;
     }
@@ -72,14 +76,14 @@ std::string ParallelImplementationsRegistry::findParallelImplementation(
 const sofa::type::vector<ParallelImplementationsRegistry::Implementation>&
 ParallelImplementationsRegistry::getImplementations()
 {
-    return s_implementations;
+    return getStaticImplementations();
 }
 
 sofa::type::vector<ParallelImplementationsRegistry::Implementation>::const_iterator
 ParallelImplementationsRegistry::findParallelImplementationImpl(
     const std::string& sequentialImplementation)
 {
-    return std::find_if(s_implementations.begin(), s_implementations.end(),
+    return std::find_if(getStaticImplementations().begin(), getStaticImplementations().end(),
         [&sequentialImplementation](const Implementation& i)
         {
             return i.sequential == sequentialImplementation;

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelImplementationsRegistry.h
@@ -44,7 +44,6 @@ public:
     static const sofa::type::vector<Implementation>& getImplementations();
 
 private:
-    static sofa::type::vector<Implementation> s_implementations;
 
     static sofa::type::vector<Implementation>::const_iterator findParallelImplementationImpl(const std::string& sequentialImplementation);
 };


### PR DESCRIPTION
It happened to me in debug mode



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
