### PR TITLE
[SofaCUDA] Fix plugin compilation if Sofa.GUI.Qt is not used

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -319,6 +319,7 @@ sofa_find_package(Sofa.Component.Mapping.NonLinear REQUIRED)
 sofa_find_package(Sofa.Component.Engine.Select REQUIRED)
 sofa_find_package(Sofa.Component.Engine.Transform REQUIRED)
 sofa_find_package(Sofa.Component.MechanicalLoad REQUIRED)
+sofa_find_package(Sofa.GUI.Component REQUIRED)
 
 sofa_find_package(VolumetricRendering QUIET)
 if(VolumetricRendering_FOUND)
@@ -490,6 +491,7 @@ target_link_libraries(${PROJECT_NAME}
     Sofa.Component.Engine.Select
     Sofa.Component.Engine.Transform
     Sofa.Component.MechanicalLoad
+    Sofa.GUI.Component
 )
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)


### PR DESCRIPTION
Sofa.Gui is needed for mouse interactors and was implicitly linked through Sofa.GUI.Qt . Add it by default so SofaCUDA can be compiled even if Qt is not used.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
