### PR TITLE
[Core] Minor clean of DefaultAnimationLoop 

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -170,14 +170,6 @@ void DefaultAnimationLoop::propagateAnimateBeginEvent(const core::ExecParams* pa
     m_node->execute(act);
 }
 
-void DefaultAnimationLoop::resetConstraint(const core::ExecParams* params) const
-{
-    SCOPED_TIMER("resetConstraint");
-    const sofa::core::ConstraintParams cparams(*params);
-    sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor resetConstraint(&cparams);
-    m_node->execute(&resetConstraint);
-}
-
 void DefaultAnimationLoop::beginIntegration(const core::ExecParams* params, SReal dt) const
 {
     propagateIntegrateBeginEvent(params);
@@ -193,14 +185,6 @@ void DefaultAnimationLoop::propagateIntegrateBeginEvent(const core::ExecParams* 
     IntegrateBeginEvent evBegin;
     PropagateEventVisitor eventPropagation( params, &evBegin);
     eventPropagation.execute(m_node);
-}
-
-void DefaultAnimationLoop::buildConstraintMatrix(core::ConstraintParams cparams) const
-{
-    SCOPED_TIMER("buildConstraintMatrix");
-    unsigned int constraintId = 0;
-    mechanicalvisitor::MechanicalBuildConstraintMatrix buildConstraintMatrix(&cparams, core::MatrixDerivId::constraintJacobian(), constraintId );
-    buildConstraintMatrix.execute(m_node);
 }
 
 void DefaultAnimationLoop::accumulateMatrixDeriv(const core::ConstraintParams cparams) const

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -292,14 +292,11 @@ void DefaultAnimationLoop::animate(const core::ExecParams* params, SReal dt) con
     behaviorUpdatePosition(params, dt);
     updateInternalData(params);
 
-    resetConstraint(params);
-
     collisionDetection(params);
 
     beginIntegration(params, dt);
     {
         const core::ConstraintParams cparams;
-        buildConstraintMatrix(cparams);
         accumulateMatrixDeriv(cparams);
 
         solve(params, dt);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.h
@@ -69,10 +69,8 @@ protected :
 
     void behaviorUpdatePosition(const sofa::core::ExecParams* params, SReal dt) const;
     void updateInternalData(const sofa::core::ExecParams* params) const;
-    void resetConstraint(const sofa::core::ExecParams* params) const;
     void beginIntegration(const sofa::core::ExecParams* params, SReal dt) const;
     void propagateIntegrateBeginEvent(const sofa::core::ExecParams* params) const;
-    void buildConstraintMatrix(sofa::core::ConstraintParams cparams) const;
     void accumulateMatrixDeriv(sofa::core::ConstraintParams cparams) const;
     void solve(const sofa::core::ExecParams* params, SReal dt) const;
     void propagateIntegrateEndEvent(const sofa::core::ExecParams* params) const;


### PR DESCRIPTION
The use of those two step where not logical because:

1. It only acted either on object inherited from `BaseConstraintSet` (in `buildConstraintMatrix`)
2. It was using part of the mechanical state code dedicated to Lagrangian based constraints (in `resetConstraint`)

Tested the diff with ` AttachConstraint.scn`: nearly no performance change but still working.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
