### PR TITLE
[SofaCUDA] FIX compilation SofaCUDA along with SparseGrid with Cuda12

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.cu
@@ -85,7 +85,7 @@ __global__ void SubsetContactMapperCuda3f_setPoints1_kernel(unsigned int nbPoint
     GPUContact c = contacts[curTestEntry.firstIndex + threadIdx.x];
     if (threadIdx.x < curTestEntry.curSize)
     {
-        map[curTestEntry.newIndex + threadIdx.x] = __umul24(curTestEntry.elem1,nbPointsPerElem) + c.p1;
+        map[curTestEntry.newIndex + threadIdx.x] = curTestEntry.elem1 * nbPointsPerElem + c.p1;
     }
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.cu
@@ -85,7 +85,7 @@ __global__ void SubsetContactMapperCuda3f_setPoints1_kernel(unsigned int nbPoint
     GPUContact c = contacts[curTestEntry.firstIndex + threadIdx.x];
     if (threadIdx.x < curTestEntry.curSize)
     {
-        map[curTestEntry.newIndex + threadIdx.x] = umul24(curTestEntry.elem1,nbPointsPerElem) + c.p1;
+        map[curTestEntry.newIndex + threadIdx.x] = __umul24(curTestEntry.elem1,nbPointsPerElem) + c.p1;
     }
 }
 


### PR DESCRIPTION
The method `umul24` disappeared fromt eh header `crt/device_functions.hpp` in cuda 12. It originally was just a wrapper for a call to `__umul24`, therefore the change. 

This wrapper disappearing might indicate a deprecation, so this solution will maybe not be one with the next cuda release.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
