### PR TITLE
[Collections] Remove reference to non-existing SofaSimulation

### DIFF
--- a/applications/collections/deprecated/CMakeLists.txt
+++ b/applications/collections/deprecated/CMakeLists.txt
@@ -1,7 +1,6 @@
 # meta-modules (SofaKernel)
 
 sofa_add_subdirectory(collection SofaFramework SofaFramework ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
-sofa_add_subdirectory(collection SofaSimulation SofaSimulation ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 sofa_add_subdirectory(collection SofaBase SofaBase ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 
 


### PR DESCRIPTION
Finally decided to remove the warning
`The collection SofaSimulation (/home/fred/sofa/src/current/applications/collections/deprecated/SofaSimulation) does not exist and will be ignored.` at every cmake config step.

I guess this collection thingy should be deleted in the future anyway



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
