### PR TITLE
[Simulation.Core] Remove usage of ill-used nodeData in MechanicalGetNonDiagonalMassesCountVisitor and MechanicalVDotVisitor

### DIFF
--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
@@ -76,7 +76,7 @@ void EulerExplicitSolver::solve(const core::ExecParams* params,
     addSeparateGravity(&mop, dt, vResult);
     computeForce(&mop, f);
 
-    SReal nbNonDiagonalMasses = 0;
+    sofa::Size nbNonDiagonalMasses = 0;
     MechanicalGetNonDiagonalMassesCountVisitor(&mop.mparams, &nbNonDiagonalMasses).execute(this->getContext());
 
     // Mass matrix is diagonal, solution can thus be found by computing acc = f/m

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.cpp
@@ -27,7 +27,11 @@ namespace sofa::simulation::mechanicalvisitor
 
 Visitor::Result MechanicalGetNonDiagonalMassesCountVisitor::fwdMass(VisitorContext* ctx, core::behavior::BaseMass* mass)
 {
-    *ctx->nodeData += !mass->isDiagonal();
+    SOFA_UNUSED(ctx);
+
+    if(this->m_nbNonDiagonalMassesPtr && !mass->isDiagonal())
+        (*m_nbNonDiagonalMassesPtr)++;
+
     return RESULT_CONTINUE;
 }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
@@ -30,9 +30,12 @@ namespace sofa::simulation::mechanicalvisitor
 class SOFA_SIMULATION_CORE_API MechanicalGetNonDiagonalMassesCountVisitor : public MechanicalVisitor
 {
 public:
-    SReal* const m_nbNonDiagonalMassesPtr { nullptr };
+    sofa::Size* const m_nbNonDiagonalMassesPtr { nullptr };
 
-    MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, SReal* result)
+    // given result is not a Real anymore since https://github.com/sofa-framework/sofa/pull/4328
+    MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, SReal* result) = delete;
+
+    MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, sofa::Size* result)
         : MechanicalVisitor(mparams), m_nbNonDiagonalMassesPtr(result)
     {
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
@@ -30,7 +30,7 @@ namespace sofa::simulation::mechanicalvisitor
 class SOFA_SIMULATION_CORE_API MechanicalGetNonDiagonalMassesCountVisitor : public MechanicalVisitor
 {
 public:
-    SReal* m_nbNonDiagonalMassesPtr { nullptr };
+    SReal* const m_nbNonDiagonalMassesPtr { nullptr };
 
     MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, SReal* result)
         : MechanicalVisitor(mparams), m_nbNonDiagonalMassesPtr(result)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
@@ -30,10 +30,11 @@ namespace sofa::simulation::mechanicalvisitor
 class SOFA_SIMULATION_CORE_API MechanicalGetNonDiagonalMassesCountVisitor : public MechanicalVisitor
 {
 public:
+    SReal* m_nbNonDiagonalMassesPtr {nullptr};
+
     MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, SReal* result)
-            : MechanicalVisitor(mparams)
+        : MechanicalVisitor(mparams), m_nbNonDiagonalMassesPtr(result)
     {
-        rootData = result;
     }
 
     Result fwdMass(VisitorContext* ctx, sofa::core::behavior::BaseMass* mass) override;
@@ -46,7 +47,6 @@ public:
     {
         return true;
     }
-
 };
 
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
@@ -32,7 +32,7 @@ class SOFA_SIMULATION_CORE_API MechanicalGetNonDiagonalMassesCountVisitor : publ
 public:
     sofa::Size* const m_nbNonDiagonalMassesPtr { nullptr };
 
-    // given result is not a Real anymore since https://github.com/sofa-framework/sofa/pull/4328
+    // SOFA_ATTRIBUTE_DISABLED("v24.06", "v24.12", "given result is not a Real anymore since https://github.com/sofa-framework/sofa/pull/4328")
     MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, SReal* result) = delete;
 
     MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, sofa::Size* result)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
@@ -30,7 +30,7 @@ namespace sofa::simulation::mechanicalvisitor
 class SOFA_SIMULATION_CORE_API MechanicalGetNonDiagonalMassesCountVisitor : public MechanicalVisitor
 {
 public:
-    SReal* m_nbNonDiagonalMassesPtr {nullptr};
+    SReal* m_nbNonDiagonalMassesPtr { nullptr };
 
     MechanicalGetNonDiagonalMassesCountVisitor(const sofa::core::MechanicalParams* mparams, SReal* result)
         : MechanicalVisitor(mparams), m_nbNonDiagonalMassesPtr(result)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.cpp
@@ -29,7 +29,9 @@ namespace sofa::simulation::mechanicalvisitor
 
 Visitor::Result MechanicalVDotVisitor::fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm)
 {
-    *ctx->nodeData += mm->vDot(this->params, a.getId(mm),b.getId(mm) );
+    if(m_total)
+        *m_total += mm->vDot(this->params, a.getId(mm),b.getId(mm) );
+
     return RESULT_CONTINUE;
 }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.h
@@ -32,7 +32,7 @@ class SOFA_SIMULATION_CORE_API MechanicalVDotVisitor : public BaseMechanicalVisi
 public:
     sofa::core::ConstMultiVecId a;
     sofa::core::ConstMultiVecId b;
-    SReal* m_total { nullptr };
+    SReal* const m_total { nullptr };
 
     MechanicalVDotVisitor(const sofa::core::ExecParams* params, sofa::core::ConstMultiVecId a, sofa::core::ConstMultiVecId b, SReal* t)
             : BaseMechanicalVisitor(params) , a(a), b(b), m_total(t)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.h
@@ -32,13 +32,14 @@ class SOFA_SIMULATION_CORE_API MechanicalVDotVisitor : public BaseMechanicalVisi
 public:
     sofa::core::ConstMultiVecId a;
     sofa::core::ConstMultiVecId b;
+    SReal* m_total { nullptr };
+
     MechanicalVDotVisitor(const sofa::core::ExecParams* params, sofa::core::ConstMultiVecId a, sofa::core::ConstMultiVecId b, SReal* t)
-            : BaseMechanicalVisitor(params) , a(a), b(b) //, total(t)
+            : BaseMechanicalVisitor(params) , a(a), b(b), m_total(t)
     {
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
-        rootData = t;
     }
 
     Result fwdMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm) override;


### PR DESCRIPTION
First task of removing(deprecating) the usage of nodeData (noticed in #4327)

Those two visitors are using the pointer nodeData for local computations so It was changed to local (weak) stored pointers. 
Not fan of pointers but it does not break API. (a SReal to count is weird btw)




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
