### PR TITLE
[Core] Refactor VMultiOpEntry

### DIFF
--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.cpp
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/CGLinearSolver.cpp
@@ -50,15 +50,16 @@ inline void CGLinearSolver<component::linearsolver::GraphScatteredMatrix,compone
     x.peq(p,alpha);                 // x = x + alpha p
     r.peq(q,-alpha);                // r = r - alpha q
 #else // single-operation optimization
-    typedef sofa::core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-    VMultiOp ops;
-    ops.resize(2);
-    ops[0].first = (MultiVecDerivId)x;
-    ops[0].second.push_back(std::make_pair((MultiVecDerivId)x,1.0));
-    ops[0].second.push_back(std::make_pair((MultiVecDerivId)p,alpha));
-    ops[1].first = (MultiVecDerivId)r;
-    ops[1].second.push_back(std::make_pair((MultiVecDerivId)r,1.0));
-    ops[1].second.push_back(std::make_pair((MultiVecDerivId)q,-alpha));
+    using core::behavior::ScaledConstMultiVecId;
+
+    sofa::core::behavior::VMultiOp ops(2);
+    ops[0] = core::behavior::VMultiOpEntry{(MultiVecDerivId)x,
+        ScaledConstMultiVecId{x, 1_sreal} + ScaledConstMultiVecId{p, alpha}
+    };
+    ops[1] = core::behavior::VMultiOpEntry{(MultiVecDerivId)r,
+            ScaledConstMultiVecId{r, 1_sreal} + ScaledConstMultiVecId{q, -alpha}
+    };
+
     this->executeVisitor(MechanicalVMultiOpVisitor(params, ops));
 #endif
 }

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -238,27 +238,20 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
 #ifndef SOFA_NO_VMULTIOP
     else
     {
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
+        typedef core::behavior::VMultiOp VMultiOp;
+        VMultiOp ops(2);
         if (firstOrder)
         {
-            ops.resize(2);
-            ops[0].first = newVel;
-            ops[0].second.push_back(std::make_pair(x.id(),1.0));
-            ops[1].first = newPos;
-            ops[1].second.push_back(std::make_pair(pos.id(),1.0));
-            ops[1].second.push_back(std::make_pair(newVel.id(),h));
+            ops[0] = VMultiOpEntry{newVel,
+                ScaledConstMultiVecId{x.id(), 1._sreal}};
         }
         else
         {
-            ops.resize(2);
-            ops[0].first = newVel;
-            ops[0].second.push_back(std::make_pair(vel.id(),1.0));
-            ops[0].second.push_back(std::make_pair(x.id(),1.0));
-            ops[1].first = newPos;
-            ops[1].second.push_back(std::make_pair(pos.id(),1.0));
-            ops[1].second.push_back(std::make_pair(newVel.id(),h));
+            ops[0] = VMultiOpEntry{newVel,
+                ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{x.id(), 1._sreal}};
         }
+        ops[1] = VMultiOpEntry{newPos,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{newVel.id(), h}};
 
         SCOPED_TIMER_VARNAME(updateVAndXTimer, "UpdateVAndX");
         vop.v_multiop(ops);

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/NewmarkImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/NewmarkImplicitSolver.cpp
@@ -145,19 +145,21 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
     solveConstraint(dt,vResult,core::ConstraintParams::ConstOrder::VEL);
 
 #else // single-operation optimization
-    typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
+    typedef core::behavior::VMultiOp VMultiOp;
 
-    VMultiOp ops;
-    ops.resize(2);
-    ops[0].first = newPos;
-    ops[0].second.push_back(std::make_pair(pos.id(),1.0));
-    ops[0].second.push_back(std::make_pair(vel.id(), h));
-    ops[0].second.push_back(std::make_pair(a.id(), h*h*(0.5-beta)));
-    ops[0].second.push_back(std::make_pair(aResult.id(),h*h*beta));//b=vt+at*h/2(1-2*beta)+a(t+h)*h*beta
-    ops[1].first = newVel;
-    ops[1].second.push_back(std::make_pair(vel.id(),1.0));
-    ops[1].second.push_back(std::make_pair(a.id(), h*(1-gamma)));
-    ops[1].second.push_back(std::make_pair(aResult.id(),h*gamma));//v(t+h)=vt+at*h*(1-gamma)+a(t+h)*h*gamma
+    VMultiOp ops(2);
+    ops[0] = VMultiOpEntry{ newPos,
+        ScaledConstMultiVecId{pos.id(), 1._sreal} +
+        ScaledConstMultiVecId{vel.id(), h} +
+        ScaledConstMultiVecId{a.id(), h*h*(0.5-beta)} +
+        ScaledConstMultiVecId{aResult.id(), h*h*beta}
+    };
+    ops[1] = VMultiOpEntry{ newVel,
+        ScaledConstMultiVecId{vel.id(), 1._sreal} +
+        ScaledConstMultiVecId{a.id(),  h*(1-gamma)} +
+        ScaledConstMultiVecId{aResult.id(), h*gamma}
+    };
+
     vop.v_multiop(ops);
 
     mop.solveConstraint(vResult,core::ConstraintOrder::VEL);

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/VariationalSymplecticSolver.cpp
@@ -115,7 +115,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
     MultiVecDeriv pPrevious(&vop, pID); // get previous momemtum value
     p.eq(pPrevious); // set p to previous momemtum
 
-    typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
+    typedef core::behavior::VMultiOp VMultiOp;
  
 	if (f_explicit.getValue()) {
 		mop->setImplicit(false); // this solver is explicit only
@@ -144,14 +144,12 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 
 		mop.solveConstraint(acc, core::ConstraintOrder::ACC);
 		
-        VMultiOp ops;
-        ops.resize(2);
-        // change order of operations depending on the symplectic flag
-        ops[0].first = vel_1;
-        ops[0].second.push_back(std::make_pair(acc.id(),h)); // v(k+1) = 1/m (h*f(q(k)+p(k))
-        ops[1].first = x_1; // q(k+1)=q(k)+h*v(k+1)
-        ops[1].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[1].second.push_back(std::make_pair(vel_1.id(),h));
+        VMultiOp ops(2);
+	    ops[0] = VMultiOpEntry{ vel_1,
+            ScaledConstMultiVecId{acc.id(), h}};
+	    ops[1] = VMultiOpEntry{ x_1,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{vel_1.id(), h}};
+
 		vop.v_multiop(ops);
 
 		// p(k+1)=M v(k+1)
@@ -226,20 +224,14 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
             }
 
 			/// Updates of q(k,i) ///
-			VMultiOp ops;
-			ops.resize(3);
+		    VMultiOp ops(3);
+		    ops[0] = VMultiOpEntry{ x_1,
+                ScaledConstMultiVecId{oldpos.id(), 1._sreal} + ScaledConstMultiVecId{res.id(), 1._sreal}};
+		    ops[1] = VMultiOpEntry{ resi,
+                ScaledConstMultiVecId{x_1.id(), 1._sreal} + ScaledConstMultiVecId{x_0.id(), -1._sreal}};
+		    ops[2] = VMultiOpEntry{ x_0,
+                ScaledConstMultiVecId{x_1.id(), 1._sreal}};
 
-			//x_1=q(k,i)=res(i)+q(k,0)=res(i)+oldpos
-			ops[0].first = x_1;
-			ops[0].second.push_back(std::make_pair(oldpos.id(),1.0));
-			ops[0].second.push_back(std::make_pair(res.id(),1.0));
-			// resi=q(k,i)-q(k,i-1)  save the residual as a stopping criterion
-			ops[1].first = resi;
-			ops[1].second.push_back(std::make_pair(x_1.id(),1.0));
-			ops[1].second.push_back(std::make_pair(x_0.id(),-1.0));
-			// q(k,i)=q(k,i-1) 
-			ops[2].first = x_0; 
-			ops[2].second.push_back(std::make_pair(x_1.id(),1.0));
 			vop.v_multiop(ops);
 
 			mop.propagateX(x_1);
@@ -263,24 +255,18 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 
         /// Updates of v, p and final position ///
 		//v(k+1,0)=(2/h)(q(k,i_end)-q(k,0))
-		VMultiOp opsfin;
-		opsfin.resize(1);
-		opsfin[0].first = vel_1;
-		opsfin[0].second.push_back(std::make_pair(res.id(),2.0/h));
-		vop.v_multiop(opsfin);
+	    vop.v_multiop({VMultiOpEntry{ vel_1,
+            ScaledConstMultiVecId{res.id(), 2.0/h} }});
 
 		sofa::helper::AdvancedTimer::stepBegin("CorrectV");
 		mop.solveConstraint(vel_1,core::ConstraintOrder::VEL);
 
 		// update position
-		VMultiOp opsx;
+	    VMultiOp opsx{VMultiOpEntry{ x_1,
+            ScaledConstMultiVecId{oldpos.id(), 1._sreal} + ScaledConstMultiVecId{vel_1.id(), h/2}}};
 
 		// here x_1=q(k,0)+(h/2)v(k+1,0)
-		opsx.resize(1);
-		opsx[0].first = x_1;
-		opsx[0].second.push_back(std::make_pair(oldpos.id(),1.0));
-		opsx[0].second.push_back(std::make_pair(vel_1.id(),h/2));
-		vop.v_multiop(opsx);
+	    vop.v_multiop(opsx);
 
 		// get p(k+1)= f(q(k,0)+(h/2)v(k+1,0))*h/2 + M*v(k+1)
 		mop.computeForce(f);
@@ -290,7 +276,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 		mop.addMdx(newp,vel_1,1.0);
 
 		// adding (h/2)v(k+1,0) so that x_1=q(k+1,0)=q(k,0)+h*v(k+1,0)
-		opsx[0].second.push_back(std::make_pair(vel_1.id(),h/2));
+		opsx[0].getLinearCombination().emplace_back(vel_1.id(), h/2);
 		vop.v_multiop(opsx);
 
         // Compute hamiltonian energy

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/CentralDifferenceSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/CentralDifferenceSolver.cpp
@@ -99,7 +99,7 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
 
     mop.solveConstraint(dx, core::ConstraintOrder::ACC);
     // apply the solution
-    if (r==0)
+    if (r == 0)
     {
 #ifdef SOFA_NO_VMULTIOP // unoptimized version
         vel2.eq( vel, dx, dt );                  // vel = vel + dt M^{-1} ( P_n - K u_n )
@@ -109,17 +109,16 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
 
 #else // single-operation optimization
 
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
+        typedef core::behavior::VMultiOp VMultiOp;
+        VMultiOp ops(2);
+
         // vel += dx * dt
-        ops[0].first = vel2;
-        ops[0].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[0].second.push_back(std::make_pair(dx.id(),dt));
+        ops[0] = VMultiOpEntry{ vel2,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{dx.id(), dt}};
+
         // pos += vel * dt
-        ops[1].first = pos2;
-        ops[1].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[1].second.push_back(std::make_pair(vel2.id(),dt));
+        ops[1] = VMultiOpEntry{ pos2,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{vel2.id(), dt}};
 
         vop.v_multiop(ops);
 
@@ -134,18 +133,17 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
         vel2.peq( dx, 1/(1/dt + r/2) );     // vel = \frac{\frac{1}{dt} - \frac{r}{2}}{\frac{1}{dt} + \frac{r}{2}} vel + \frac{1}{\frac{1}{dt} + \frac{r}{2}} M^{-1} ( P_n - K u_n )
         pos2.eq( pos, vel2, dt );                    // pos = pos + h vel
 #else // single-operation optimization
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
-        // vel += dx * dt
-        ops[0].first = vel2;
-        ops[0].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[0].second.push_back(std::make_pair(vel.id(),-1.0 + (1/dt - r/2)/(1/dt + r/2)));
-        ops[0].second.push_back(std::make_pair(dx.id(),1/(1/dt + r/2)));
-        // pos += vel * dt
-        ops[1].first = pos2;
-        ops[1].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[1].second.push_back(std::make_pair(vel2.id(),dt));
+        typedef core::behavior::VMultiOp VMultiOp;
+        VMultiOp ops(2);
+
+        ops[0] = VMultiOpEntry{ vel2,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} +
+            ScaledConstMultiVecId{vel.id(), -1.0 + (1/dt - r/2)/(1/dt + r/2)} +
+            ScaledConstMultiVecId{dx.id(), 1/(1/dt + r/2)}
+        };
+
+        ops[1] = VMultiOpEntry{ pos2,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{vel2.id(), dt}};
 
         vop.v_multiop(ops);
 

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerSolver.cpp
@@ -153,7 +153,7 @@ void EulerExplicitSolver::updateState(sofa::simulation::common::VectorOperations
     }
 #else // single-operation optimization
     {
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
+        typedef core::behavior::VMultiOp VMultiOp;
 
         // Create a set of linear operations that will be executed on two vectors
         // In our case, the operations will be executed to compute the new velocity vector,
@@ -165,34 +165,15 @@ void EulerExplicitSolver::updateState(sofa::simulation::common::VectorOperations
         const VMultiOp::size_type posId = d_symplectic.getValue(); // 1 if symplectic, 0 otherwise
         const VMultiOp::size_type velId = 1 - posId; // 0 if symplectic, 1 otherwise
 
-        // Access the set of operations corresponding to the velocity vector
-        // In case of symplectic solver, these operations are executed first.
-        auto& ops_vel = ops[velId];
+        const auto previousVelId = d_symplectic.getValue() ? newVel.id() : vel.id();
 
-        // Associate the new velocity vector as the result to this set of operations
-        ops_vel.first = newVel;
+        // Define the following operation: newPos = pos + dt * v
+        ops[posId] = VMultiOpEntry{ newPos,
+            ScaledConstMultiVecId{pos.id(), 1_sreal} + ScaledConstMultiVecId{previousVelId, dt}};
 
-        // The two following operations are actually a unique operation: newVel = vel + dt * acc
-        // The value 1.0 indicates that the first operation is based on the values
-        // in the second pair and, therefore, the second operation is discarded.
-        ops_vel.second.emplace_back(vel.id(), 1.0);
-        ops_vel.second.emplace_back(acc.id(), dt);
-
-        // Access the set of operations corresponding to the position vector
-        // In case of symplectic solver, these operations are executed second.
-        auto& ops_pos = ops[posId];
-
-        // Associate the new position vector as the result to this set of operations
-        ops_pos.first = newPos;
-
-        // The two following operations are actually a unique operation: newPos = pos + dt * v
-        // where v is "newVel" in case of a symplectic solver, and "vel" otherwise.
-        // If symplectic: newPos = pos + dt * newVel, executed after newVel has been computed
-        // If not symplectic: newPos = pos + dt * vel
-        // The value 1.0 indicates that the first operation is based on the values
-        // in the second pair and, therefore, the second operation is discarded.
-        ops_pos.second.emplace_back(pos.id(), 1.0);
-        ops_pos.second.emplace_back(d_symplectic.getValue() ? newVel.id() : vel.id(), dt);
+        // Define the following operation: newVel = vel + dt * acc
+        ops[velId] = VMultiOpEntry{ newVel,
+            ScaledConstMultiVecId{vel.id(), 1_sreal} + ScaledConstMultiVecId{acc.id(), dt}};
 
         // Execute the defined operations to compute the new velocity vector and
         // the new position vector.

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta2Solver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta2Solver.cpp
@@ -70,16 +70,12 @@ void RungeKutta2Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     newV.peq(acc, dt/2.); // newV = vel + acc dt/2
 #else // single-operation optimization
     {
+        core::behavior::VMultiOp ops(2);
 
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
-        ops[0].first = newX;
-        ops[0].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[0].second.push_back(std::make_pair(vel.id(),dt/2));
-        ops[1].first = newV;
-        ops[1].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[1].second.push_back(std::make_pair(acc.id(),dt/2));
+        ops[0] = VMultiOpEntry{newX,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{vel.id(), dt/2}};
+        ops[1] = VMultiOpEntry{newV,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{acc.id(), dt/2}};
 
         vop.v_multiop(ops);
     }
@@ -96,15 +92,13 @@ void RungeKutta2Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     solveConstraint(dt,vel2,core::ConstraintParams::ConstOrder::VEL);
 #else // single-operation optimization
     {
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
-        ops[0].first = pos2;
-        ops[0].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[0].second.push_back(std::make_pair(newV.id(),dt));
-        ops[1].first = vel2;
-        ops[1].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[1].second.push_back(std::make_pair(acc.id(),dt));
+        core::behavior::VMultiOp ops(2);
+
+        ops[0] = VMultiOpEntry{pos2,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{newV.id(), dt}};
+        ops[1] = VMultiOpEntry{vel2,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{acc.id(), dt}};
+
         vop.v_multiop(ops);
 
         mop.solveConstraint(vel2,core::ConstraintOrder::VEL);

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta4Solver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/RungeKutta4Solver.cpp
@@ -87,15 +87,13 @@ void RungeKutta4Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     k2v.peq(k1a, stepBy2);
 #else // single-operation optimization
     {
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
-        ops[0].first = newX;
-        ops[0].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[0].second.push_back(std::make_pair(k1v.id(),stepBy2));
-        ops[1].first = k2v;
-        ops[1].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[1].second.push_back(std::make_pair(k1a.id(),stepBy2));
+        core::behavior::VMultiOp ops(2);
+
+        ops[0] = VMultiOpEntry{newX,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{k1v.id(), stepBy2}};
+        ops[1] = VMultiOpEntry{k2v,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{k1a.id(), stepBy2}};
+
         vop.v_multiop(ops);
     }
 #endif
@@ -111,15 +109,13 @@ void RungeKutta4Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     k3v.peq(k2a, stepBy2);
 #else // single-operation optimization
     {
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
-        ops[0].first = newX;
-        ops[0].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[0].second.push_back(std::make_pair(k2v.id(),stepBy2));
-        ops[1].first = k3v;
-        ops[1].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[1].second.push_back(std::make_pair(k2a.id(),stepBy2));
+        core::behavior::VMultiOp ops(2);
+
+        ops[0] = VMultiOpEntry{newX,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{k2v.id(), stepBy2}};
+        ops[1] = VMultiOpEntry{k3v,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{k2a.id(), stepBy2}};
+
         vop.v_multiop(ops);
     }
 #endif
@@ -135,15 +131,13 @@ void RungeKutta4Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     k4v.peq(k3a, dt);
 #else // single-operation optimization
     {
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
-        ops[0].first = newX;
-        ops[0].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[0].second.push_back(std::make_pair(k3v.id(),dt));
-        ops[1].first = k4v;
-        ops[1].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[1].second.push_back(std::make_pair(k3a.id(),dt));
+        core::behavior::VMultiOp ops(2);
+
+        ops[0] = VMultiOpEntry{newX,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{k3v.id(), dt}};
+        ops[1] = VMultiOpEntry{k4v,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{k3a.id(), dt}};
+
         vop.v_multiop(ops);
     }
 #endif
@@ -165,21 +159,23 @@ void RungeKutta4Solver::solve(const core::ExecParams* params, SReal dt, sofa::co
     solveConstraint(dt, vel2, core::ConstraintParams::ConstOrder::VEL);
 #else // single-operation optimization
     {
-        typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
-        VMultiOp ops;
-        ops.resize(2);
-        ops[0].first = pos2;
-        ops[0].second.push_back(std::make_pair(pos.id(),1.0));
-        ops[0].second.push_back(std::make_pair(k1v.id(),stepBy6));
-        ops[0].second.push_back(std::make_pair(k2v.id(),stepBy3));
-        ops[0].second.push_back(std::make_pair(k3v.id(),stepBy3));
-        ops[0].second.push_back(std::make_pair(k4v.id(),stepBy6));
-        ops[1].first = vel2;
-        ops[1].second.push_back(std::make_pair(vel.id(),1.0));
-        ops[1].second.push_back(std::make_pair(k1a.id(),stepBy6));
-        ops[1].second.push_back(std::make_pair(k2a.id(),stepBy3));
-        ops[1].second.push_back(std::make_pair(k3a.id(),stepBy3));
-        ops[1].second.push_back(std::make_pair(k4a.id(),stepBy6));
+        core::behavior::VMultiOp ops(2);
+
+        ops[0] = VMultiOpEntry{pos2,
+            ScaledConstMultiVecId{pos.id(), 1._sreal} +
+            ScaledConstMultiVecId{k1v.id(), stepBy6} +
+            ScaledConstMultiVecId{k2v.id(), stepBy3} +
+            ScaledConstMultiVecId{k3v.id(), stepBy3} +
+            ScaledConstMultiVecId{k4v.id(), stepBy6}
+        };
+        ops[1] = VMultiOpEntry{vel2,
+            ScaledConstMultiVecId{vel.id(), 1._sreal} +
+            ScaledConstMultiVecId{k1a.id(), stepBy6} +
+            ScaledConstMultiVecId{k2a.id(), stepBy3} +
+            ScaledConstMultiVecId{k3a.id(), stepBy3} +
+            ScaledConstMultiVecId{k4a.id(), stepBy6}
+        };
+
         vop.v_multiop(ops);
 
         mop.solveConstraint(pos, core::ConstraintOrder::POS);

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -1976,24 +1976,24 @@ void MechanicalObject<DataTypes>::vMultiOp(const core::ExecParams* params, const
 {
     // optimize common integration case: v += a*dt, x += v*dt
     if (ops.size() == 2
-            && ops[0].second.size() == 2
-            && ops[0].first.getId(this) == ops[0].second[0].first.getId(this)
-            && ops[0].first.getId(this).type == sofa::core::V_DERIV
-            && ops[0].second[1].first.getId(this).type == sofa::core::V_DERIV
-            && ops[1].second.size() == 2
-            && ops[1].first.getId(this) == ops[1].second[0].first.getId(this)
-            && ops[0].first.getId(this) == ops[1].second[1].first.getId(this)
-            && ops[1].first.getId(this).type == sofa::core::V_COORD)
+            && ops[0].getLinearCombination().size() == 2
+            && ops[0].getOutput().getId(this) == ops[0].getLinearCombination()[0].id.getId(this)
+            && ops[0].getOutput().getId(this).type == sofa::core::V_DERIV
+            && ops[0].getLinearCombination()[1].id.getId(this).type == sofa::core::V_DERIV
+            && ops[1].getLinearCombination().size() == 2
+            && ops[1].getOutput().getId(this) == ops[1].getLinearCombination()[0].id.getId(this)
+            && ops[0].getOutput().getId(this) == ops[1].getLinearCombination()[1].id.getId(this)
+            && ops[1].getOutput().getId(this).type == sofa::core::V_COORD)
     {
-        auto va = getReadAccessor<core::V_DERIV>(ops[0].second[1].first.getId(this));
-        auto vv = getWriteAccessor<core::V_DERIV>(ops[0].first.getId(this));
-        auto vx = getWriteAccessor<core::V_COORD>(ops[1].first.getId(this));
+        auto va = getReadAccessor<core::V_DERIV>(ops[0].getLinearCombination()[1].id.getId(this));
+        auto vv = getWriteAccessor<core::V_DERIV>(ops[0].getOutput().getId(this));
+        auto vx = getWriteAccessor<core::V_COORD>(ops[1].getOutput().getId(this));
 
         const auto n = vx.size();
-        const Real f_v_v = (Real)(ops[0].second[0].second);
-        const Real f_v_a = (Real)(ops[0].second[1].second);
-        const Real f_x_x = (Real)(ops[1].second[0].second);
-        const Real f_x_v = (Real)(ops[1].second[1].second);
+        const Real f_v_v = (Real)(ops[0].getLinearCombination()[0].factor);
+        const Real f_v_a = (Real)(ops[0].getLinearCombination()[1].factor);
+        const Real f_x_x = (Real)(ops[1].getLinearCombination()[0].factor);
+        const Real f_x_v = (Real)(ops[1].getLinearCombination()[1].factor);
 
         if (f_v_v == 1.0 && f_x_x == 1.0) // very common case
         {
@@ -2035,23 +2035,23 @@ void MechanicalObject<DataTypes>::vMultiOp(const core::ExecParams* params, const
         }
     }
     else if(ops.size()==2 //used in the ExplicitBDF solver only (Electrophysiology)
-            && ops[0].second.size()==1
-            && ops[0].second[0].second == 1.0
-            && ops[1].second.size()==3
+            && ops[0].getLinearCombination().size()==1
+            && ops[0].getLinearCombination()[0].factor == 1.0
+            && ops[1].getLinearCombination().size()==3
             )
     {
-        auto v11 = getReadAccessor<core::V_COORD>(ops[0].second[0].first.getId(this));
-        auto v21 = getReadAccessor<core::V_COORD>(ops[1].second[0].first.getId(this));
-        auto v22 = getReadAccessor<core::V_COORD>(ops[1].second[1].first.getId(this));
-        auto v23 = getReadAccessor<core::V_DERIV>(ops[1].second[2].first.getId(this));
+        auto v11 = getReadAccessor<core::V_COORD>(ops[0].getLinearCombination()[0].id.getId(this));
+        auto v21 = getReadAccessor<core::V_COORD>(ops[1].getLinearCombination()[0].id.getId(this));
+        auto v22 = getReadAccessor<core::V_COORD>(ops[1].getLinearCombination()[1].id.getId(this));
+        auto v23 = getReadAccessor<core::V_DERIV>(ops[1].getLinearCombination()[2].id.getId(this));
 
-        auto previousPos = getWriteAccessor<core::V_COORD>(ops[0].first.getId(this));
-        auto newPos = getWriteAccessor<core::V_COORD>(ops[1].first.getId(this));
+        auto previousPos = getWriteAccessor<core::V_COORD>(ops[0].getOutput().getId(this));
+        auto newPos = getWriteAccessor<core::V_COORD>(ops[1].getOutput().getId(this));
 
         const auto n = v11.size();
-        const Real f_1 = (Real)(ops[1].second[0].second);
-        const Real f_2 = (Real)(ops[1].second[1].second);
-        const Real f_3 = (Real)(ops[1].second[2].second);
+        const Real f_1 = (Real)(ops[1].getLinearCombination()[0].factor);
+        const Real f_2 = (Real)(ops[1].getLinearCombination()[1].factor);
+        const Real f_3 = (Real)(ops[1].getLinearCombination()[2].factor);
 
         for (unsigned int i=0; i<n; ++i)
         {

--- a/Sofa/framework/Config/src/sofa/config.h.in
+++ b/Sofa/framework/Config/src/sofa/config.h.in
@@ -197,8 +197,8 @@ class DeprecatedAndRemoved {};
         "It is still usable but has been DEPRECATED since " deprecateDate ". " \
         "You have until " removeDate " to fix your code. " toFixMsg)]]
 
-// The following macro is empty because it is supposed to be used in conjonction
-// when an attribute of type DeprecatedAndRemoved. It should not contain a [[deprecated]]
+// The following macro is empty because it is supposed to be used in conjunction
+// with an attribute of type DeprecatedAndRemoved. It should not contain a [[deprecated]]
 // attribute, because if it does, the "deprecated" warning is showed in every constructor's
 // for every disabled attribute.
 #define SOFA_ATTRIBUTE_DISABLED(deprecateDate, disableDate, toFixMsg)

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -103,6 +103,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/behavior/StateAccessor.h
     ${SRC_ROOT}/behavior/SingleMatrixAccessor.h
     ${SRC_ROOT}/behavior/SingleStateAccessor.h
+    ${SRC_ROOT}/behavior/VMultiOpEntry.h
     ${SRC_ROOT}/behavior/fwd.h
     ${SRC_ROOT}/collision/BroadPhaseDetection.h
     ${SRC_ROOT}/collision/CollisionAlgorithm.h

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMechanicalState.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMechanicalState.cpp
@@ -43,8 +43,8 @@ void BaseMechanicalState::vMultiOp(const ExecParams* params, const VMultiOp& ops
 {
     for (const auto& op : ops)
     {
-        VecId r = op.first.getId(this);
-        const type::vector< std::pair< ConstMultiVecId, SReal > >& operands = op.second;
+        VecId r = op.getOutput().getId(this);
+        const auto& operands = op.getLinearCombination();
         const size_t nop = operands.size();
         if (nop==0)
         {
@@ -52,27 +52,27 @@ void BaseMechanicalState::vMultiOp(const ExecParams* params, const VMultiOp& ops
         }
         else if (nop==1)
         {
-            if (operands[0].second == 1.0)
-                vOp( params, r, operands[0].first.getId(this));
+            if (operands[0].factor == 1._sreal)
+                vOp( params, r, operands[0].id.getId(this));
             else
-                vOp( params, r, ConstVecId::null(), operands[0].first.getId(this), operands[0].second);
+                vOp( params, r, ConstVecId::null(), operands[0].id.getId(this), operands[0].factor);
         }
         else
         {
             size_t i;
-            if (operands[0].second == 1.0)
+            if (operands[0].factor == 1._sreal)
             {
-                vOp( params, r, operands[0].first.getId(this), operands[1].first.getId(this), operands[1].second);
+                vOp( params, r, operands[0].id.getId(this), operands[1].id.getId(this), operands[1].factor);
                 i = 2;
             }
             else
             {
-                vOp( params, r, ConstVecId::null(), operands[0].first.getId(this), operands[0].second);
+                vOp( params, r, ConstVecId::null(), operands[0].id.getId(this), operands[0].factor);
                 i = 1;
             }
             for (; i<nop; ++i)
             {
-                vOp(params, r, r, operands[i].first.getId(this), operands[i].second);
+                vOp(params, r, r, operands[i].id.getId(this), operands[i].factor);
             }
         }
     }

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMechanicalState.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMechanicalState.h
@@ -27,6 +27,7 @@
 #include <sofa/type/Vec.h>
 #include <sofa/type/Quat.h>
 #include <sofa/linearalgebra/fwd.h> /// For BaseMatrix
+#include <sofa/core/behavior/VMultiOpEntry.h>
 
 namespace sofa::core::behavior
 {
@@ -130,25 +131,7 @@ public:
                      ConstVecId b = ConstVecId::null(),
                      SReal f = 1.0 ) = 0;
 
-    /// Data structure describing a set of linear operation on vectors
-    /// \see vMultiOp
-    class VMultiOpEntry : public std::pair< MultiVecId, type::vector< std::pair< ConstMultiVecId, SReal > > >
-    {
-    public:
-        typedef std::pair< ConstMultiVecId, SReal > Fact;
-        typedef type::vector< Fact > VecFact;
-        typedef std::pair< MultiVecId, VecFact > Inherit;
-        VMultiOpEntry() : Inherit(MultiVecId::null(), VecFact()) {}
-        VMultiOpEntry(MultiVecId v) : Inherit(v, VecFact()) {}
-        VMultiOpEntry(MultiVecId v, ConstMultiVecId a, SReal af = 1.0) : Inherit(v, VecFact())
-        { this->second.push_back(Fact(a, af)); }
-        VMultiOpEntry(MultiVecId v, ConstMultiVecId a, ConstMultiVecId b, SReal bf = 1.0) : Inherit(v, VecFact())
-        { this->second.push_back(Fact(a,1.0));  this->second.push_back(Fact(b, bf)); }
-        VMultiOpEntry(MultiVecId v, ConstMultiVecId a, SReal af, ConstMultiVecId b, SReal bf = 1.0) : Inherit(v, VecFact())
-        { this->second.push_back(Fact(a, af));  this->second.push_back(Fact(b, bf)); }
-    };
-
-    typedef type::vector< VMultiOpEntry > VMultiOp;
+    using VMultiOp = sofa::core::behavior::VMultiOp;
 
     /// \brief Perform a sequence of linear vector accumulation operation $r_i = sum_j (v_j*f_{ij})$
     ///

--- a/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
@@ -35,6 +35,12 @@ struct ScaledMultiVecId
 
     explicit ScaledMultiVecId(TMultiVecId<vtype, vaccess> _id, SReal _factor = 1._sreal)
         : id{_id}, factor(_factor) {}
+
+    SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_ID()
+    DeprecatedAndRemoved first;
+
+    SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_FACTOR()
+    DeprecatedAndRemoved second;
 };
 
 using ScaledConstMultiVecId = ScaledMultiVecId<V_ALL, V_READ>;
@@ -89,6 +95,12 @@ public:
 
     Output& getOutput() { return m_output; }
     LinearCombinationConstMultiVecId& getLinearCombination() { return m_linearCombination; }
+
+    SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_OUTPUT()
+    DeprecatedAndRemoved first;
+
+    SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_LIST()
+    DeprecatedAndRemoved second;
 
 private:
     Output m_output;

--- a/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
@@ -80,14 +80,14 @@ public:
     using Output = MultiVecId;
     using LinearCombinationConstMultiVecId = LinearCombinationMultiVecId<V_ALL, V_READ>; //corresponds to ConstMultiVecId
 
-    explicit VMultiOpEntry(const Output& id = MultiVecId::null(),
+    explicit VMultiOpEntry(const Output& outputId = MultiVecId::null(),
                            LinearCombinationConstMultiVecId linearCombination = {})
-        : m_output(id)
+        : m_output(outputId)
         , m_linearCombination(std::move(linearCombination))
     {}
 
-    VMultiOpEntry(const Output& id, ScaledConstMultiVecId scaledId)
-        : VMultiOpEntry(id, LinearCombinationConstMultiVecId{std::move(scaledId)})
+    VMultiOpEntry(const Output& outputId, ScaledConstMultiVecId scaledId)
+        : VMultiOpEntry(outputId, LinearCombinationConstMultiVecId{std::move(scaledId)})
     {}
 
     [[nodiscard]] const Output& getOutput() const { return m_output; }

--- a/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
@@ -1,0 +1,99 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/core/MultiVecId.h>
+
+
+namespace sofa::core::behavior
+{
+
+/// The composition of a TMultiVecId and a scalar representing a scaled vector
+template <VecType vtype, VecAccess vaccess>
+struct ScaledMultiVecId
+{
+    TMultiVecId<vtype, vaccess> id;
+    SReal factor{ 1._sreal};
+
+    explicit ScaledMultiVecId(TMultiVecId<vtype, vaccess> _id, SReal _factor = 1._sreal)
+        : id{_id}, factor(_factor) {}
+};
+
+using ScaledConstMultiVecId = ScaledMultiVecId<V_ALL, V_READ>;
+
+/// A linear combination represented by a list of scaled vectors
+template <VecType vtype, VecAccess vaccess>
+using LinearCombinationMultiVecId = type::vector< ScaledMultiVecId<vtype, vaccess> >;
+
+template <VecType vtype, VecAccess vaccess>
+LinearCombinationMultiVecId<vtype, vaccess> operator+(const ScaledMultiVecId<vtype, vaccess>& a, const ScaledMultiVecId<vtype, vaccess>& b)
+{
+    return {a, b};
+}
+
+template <VecType vtype, VecAccess vaccess>
+LinearCombinationMultiVecId<vtype, vaccess> operator+(const ScaledMultiVecId<vtype, vaccess>& a, const LinearCombinationMultiVecId<vtype, vaccess>& b)
+{
+    LinearCombinationMultiVecId<vtype, vaccess> result { a };
+    result.insert(result.end(), b.result.begin(), b.result.end());
+    return result;
+}
+
+template <VecType vtype, VecAccess vaccess>
+LinearCombinationMultiVecId<vtype, vaccess> operator+(const LinearCombinationMultiVecId<vtype, vaccess>& a, const ScaledMultiVecId<vtype, vaccess>& b)
+{
+    LinearCombinationMultiVecId<vtype, vaccess> result { a };
+    result.push_back(b);
+    return result;
+}
+
+/// Data structure describing a set of linear operation on vectors to move
+/// into an output vector
+/// \see vMultiOp
+class VMultiOpEntry
+{
+public:
+    using Output = MultiVecId;
+    using LinearCombinationConstMultiVecId = LinearCombinationMultiVecId<V_ALL, V_READ>; //corresponds to ConstMultiVecId
+
+    explicit VMultiOpEntry(const Output& id = MultiVecId::null(),
+                           LinearCombinationConstMultiVecId linearCombination = {})
+        : m_output(id)
+        , m_linearCombination(std::move(linearCombination))
+    {}
+
+    VMultiOpEntry(const Output& id, ScaledConstMultiVecId scaledId)
+        : VMultiOpEntry(id, LinearCombinationConstMultiVecId{std::move(scaledId)})
+    {}
+
+    [[nodiscard]] const Output& getOutput() const { return m_output; }
+    [[nodiscard]] const LinearCombinationConstMultiVecId& getLinearCombination() const { return m_linearCombination; }
+
+    Output& getOutput() { return m_output; }
+    LinearCombinationConstMultiVecId& getLinearCombination() { return m_linearCombination; }
+
+private:
+    Output m_output;
+    LinearCombinationConstMultiVecId m_linearCombination;
+};
+
+using VMultiOp = type::vector< VMultiOpEntry >;
+}

--- a/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/VMultiOpEntry.h
@@ -103,7 +103,10 @@ public:
     DeprecatedAndRemoved second;
 
 private:
+    /// The linear combination will be written in this MultiVecId
     Output m_output;
+
+    /// Definition of the operation to perform as a linear combination
     LinearCombinationConstMultiVecId m_linearCombination;
 };
 

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -60,3 +60,31 @@
 #define SOFA_ATTRIBUTE_DEPRECATED__CONSTORDER() \
     SOFA_ATTRIBUTE_DEPRECATED("v23.12", "v24.06", "ConstOrder is now a scoped enumeration. It must be used to access the values.")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_ID()
+#else
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_ID() \
+    SOFA_ATTRIBUTE_DISABLED("", "v24.06", "The attribute 'first' (from std::pair) has been replaced by the attribute 'id'.")
+#endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_FACTOR()
+#else
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_FACTOR() \
+    SOFA_ATTRIBUTE_DISABLED("", "v24.06", "The attribute 'second' (from std::pair) has been replaced by the attribute 'factor'.")
+#endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_OUTPUT()
+#else
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_OUTPUT() \
+    SOFA_ATTRIBUTE_DISABLED("", "v24.06", "The attribute 'first' (from std::pair) has been removed. Use 'getOutput()' instead.")
+#endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_LIST()
+#else
+#define SOFA_ATTRIBUTE_DISABLED_VMULTIOPENTRY_LINEARCOMBINATION_LIST() \
+    SOFA_ATTRIBUTE_DISABLED("", "v24.06", "The attribute 'second' (from std::pair) has been removed. Use 'getLinearCombination()' instead.")
+#endif

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVMultiOpVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVMultiOpVisitor.h
@@ -36,7 +36,7 @@ namespace sofa::simulation::mechanicalvisitor
 class SOFA_SIMULATION_CORE_API MechanicalVMultiOpVisitor : public BaseMechanicalVisitor
 {
 public:
-    typedef sofa::core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
+    typedef sofa::core::behavior::VMultiOp VMultiOp;
     bool mapped;
     MechanicalVMultiOpVisitor(const sofa::core::ExecParams* params, const VMultiOp& o)
             : BaseMechanicalVisitor(params), mapped(false), ops(o)


### PR DESCRIPTION
My goal was to simplify the writing of vector operations in ODE solvers.

Before

```C++
VMultiOp ops;
ops.resize(2);
// vel += dx * dt
ops[0].first = vel2;                                   // <-- What is first???
ops[0].second.push_back(std::make_pair(vel.id(),1.0)); // <-- What does a pair represent? What does this list represent?
ops[0].second.push_back(std::make_pair(dx.id(),dt));
// pos += vel * dt
ops[1].first = pos2;
ops[1].second.push_back(std::make_pair(pos.id(),1.0));
ops[1].second.push_back(std::make_pair(vel2.id(),dt));
```

to 

```C++
VMultiOp ops(2);

// vel += dx * dt
ops[0] = VMultiOpEntry{ vel2,
    ScaledConstMultiVecId{vel.id(), 1._sreal} + ScaledConstMultiVecId{dx.id(), dt}};
// ok, now we know that the scalar and the MultiVecId are multiplied together.
// there is also an operator +, suggesting that the whole operation is a linear combination

// pos += vel * dt
ops[1] = VMultiOpEntry{ pos2,
    ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{vel2.id(), dt}};
```

Note that in C++20, we can write something like:
```C++
ops[1] = VMultiOpEntry{ .outputId = pos2,
    ScaledConstMultiVecId{pos.id(), 1._sreal} + ScaledConstMultiVecId{vel2.id(), dt}};
```
which is IMO clearer.



**NOT IMPLEMENTED**:
I wanted to go even further (but there are problems of type conversion, so it's not yet ready):

```C++
VMultiOp ops(2);

// vel += dx * dt
ops[0] = VMultiOpEntry{ vel2, vel.id() + dx.id() * dt};

// pos += vel * dt
ops[1] = VMultiOpEntry{ pos2, pos.id() + vel2.id() * dt};
```


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
