### PR TITLE
[Core] POC introduction of iterators on scene graph

### DIFF
--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -81,6 +81,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/SceneCheck.h
     ${SRC_ROOT}/SceneCheckRegistry.h
     ${SRC_ROOT}/SceneCheckMainRegistry.h
+    ${SRC_ROOT}/SceneGraphObjectTraversal.h
     ${SRC_ROOT}/WorkerThread.h
     ${SRC_ROOT}/events/BuildConstraintSystemEndEvent.h
     ${SRC_ROOT}/events/SimulationInitDoneEvent.h
@@ -177,6 +178,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/MechanicalVisitor.cpp
     ${SRC_ROOT}/MutationListener.cpp
     ${SRC_ROOT}/Node.cpp
+    ${SRC_ROOT}/NodeIterator.cpp
     ${SRC_ROOT}/ParallelVisitorScheduler.cpp
     ${SRC_ROOT}/PauseEvent.cpp
     ${SRC_ROOT}/PipelineImpl.cpp
@@ -188,6 +190,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/SceneLoaderFactory.cpp
     ${SRC_ROOT}/SceneCheck.cpp
     ${SRC_ROOT}/SceneCheckRegistry.cpp
+    ${SRC_ROOT}/SceneGraphObjectTraversal.cpp
     ${SRC_ROOT}/SceneCheckMainRegistry.cpp
     ${SRC_ROOT}/Simulation.cpp
     ${SRC_ROOT}/SolveVisitor.cpp

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/MutationListener.h
     ${SRC_ROOT}/Node.h
     ${SRC_ROOT}/Node.inl
+    ${SRC_ROOT}/NodeIterator.h
     ${SRC_ROOT}/ParallelForEach.h
     ${SRC_ROOT}/ParallelVisitorScheduler.h
     ${SRC_ROOT}/PauseEvent.h

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.cpp
@@ -1,0 +1,57 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFA_SIMULATION_NODEITERATOR_CPP
+
+#include <sofa/simulation/NodeIterator.h>
+#include <sofa/core/collision/Pipeline.h>
+
+namespace sofa::simulation
+{
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::objectmodel::BaseObject>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BehaviorModel>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BaseMapping>;
+
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::OdeSolver>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::ConstraintSolver>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseLinearSolver>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::topology::BaseTopologyObject>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseForceField>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseInteractionForceField>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseProjectiveConstraintSet>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseConstraintSet>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::objectmodel::ContextObject>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::objectmodel::ConfigurationSetting>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::Shader>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::VisualModel>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::VisualManager>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::CollisionModel>;
+
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseAnimationLoop>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::VisualLoop>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::topology::Topology>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::topology::BaseMeshTopology>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BaseState>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseMechanicalState>;
+// template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BaseMapping>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseMass>;
+template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::collision::Pipeline>;
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -139,6 +139,7 @@ class NodeIterator
         {
             for (auto& node : current->child)
             {
+                SOFA_UNUSED(node);
                 findFirstObject();
             }
         }
@@ -179,7 +180,7 @@ public:
     ObjectType* operator*() { return *m_currentDataIterator; }
     const ObjectType* operator*() const { return *m_currentDataIterator; }
 
-    [[nodiscard]] ObjectType* const ptr() const
+    [[nodiscard]] ObjectType* ptr() const
     {
         if (m_rootNode == nullptr)
         {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -1,0 +1,256 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/simulation/Node.h>
+
+namespace sofa::simulation
+{
+
+namespace trait
+{
+template<class T> struct is_strong : std::false_type {};
+template<> struct is_strong<sofa::core::objectmodel::BaseObject> : std::true_type {};
+
+template< class T >
+inline constexpr bool is_strong_v = is_strong<T>::value;
+
+template<class T> struct is_single : std::false_type {};
+template<> struct is_single<sofa::core::behavior::BaseAnimationLoop> : std::true_type {};
+template<> struct is_single<sofa::core::visual::VisualLoop> : std::true_type {};
+template<> struct is_single<sofa::core::topology::Topology> : std::true_type {};
+template<> struct is_single<sofa::core::topology::BaseMeshTopology> : std::true_type {};
+template<> struct is_single<sofa::core::BaseState> : std::true_type {};
+template<> struct is_single<sofa::core::behavior::BaseMechanicalState> : std::true_type {};
+// template<> struct is_single<sofa::core::BaseMapping> : std::true_type {};
+template<> struct is_single<sofa::core::behavior::BaseMass> : std::true_type {};
+template<> struct is_single<sofa::core::collision::Pipeline> : std::true_type {};
+
+template< class T >
+inline constexpr bool is_single_v = is_single<T>::value;
+}
+
+template<class ObjectType>
+std::conditional_t<trait::is_single_v<ObjectType>,
+    NodeSingle<ObjectType>,
+    NodeSequence<ObjectType, trait::is_strong_v<ObjectType>>
+>&
+getLocalObjects(sofa::simulation::Node& node)
+{
+    static_assert(false, "Object type is not known");
+    return {};
+}
+
+#define GETLOCALOBJECTS(type, name) \
+template<> \
+inline std::conditional_t<trait::is_single_v<type>,\
+    NodeSingle<type>,\
+    NodeSequence<type, trait::is_strong_v<type>>\
+>& getLocalObjects<type>(sofa::simulation::Node& node) \
+{\
+    return node.name;\
+}
+
+GETLOCALOBJECTS(sofa::core::objectmodel::BaseObject, object)
+GETLOCALOBJECTS(sofa::core::BehaviorModel, behaviorModel)
+GETLOCALOBJECTS(sofa::core::BaseMapping, mapping)
+
+GETLOCALOBJECTS(sofa::core::behavior::OdeSolver, solver)
+GETLOCALOBJECTS(sofa::core::behavior::ConstraintSolver, constraintSolver)
+GETLOCALOBJECTS(sofa::core::behavior::BaseLinearSolver, linearSolver)
+GETLOCALOBJECTS(sofa::core::topology::BaseTopologyObject, topologyObject)
+GETLOCALOBJECTS(sofa::core::behavior::BaseForceField, forceField)
+GETLOCALOBJECTS(sofa::core::behavior::BaseInteractionForceField, interactionForceField)
+GETLOCALOBJECTS(sofa::core::behavior::BaseProjectiveConstraintSet, projectiveConstraintSet)
+GETLOCALOBJECTS(sofa::core::behavior::BaseConstraintSet, constraintSet)
+GETLOCALOBJECTS(sofa::core::objectmodel::ContextObject, contextObject)
+GETLOCALOBJECTS(sofa::core::objectmodel::ConfigurationSetting, configurationSetting)
+GETLOCALOBJECTS(sofa::core::visual::Shader, shaders)
+GETLOCALOBJECTS(sofa::core::visual::VisualModel, visualModel)
+GETLOCALOBJECTS(sofa::core::visual::VisualManager, visualManager)
+GETLOCALOBJECTS(sofa::core::CollisionModel, collisionModel)
+
+GETLOCALOBJECTS(sofa::core::behavior::BaseAnimationLoop, animationManager)
+GETLOCALOBJECTS(sofa::core::visual::VisualLoop, visualLoop)
+GETLOCALOBJECTS(sofa::core::topology::Topology, topology)
+GETLOCALOBJECTS(sofa::core::topology::BaseMeshTopology, meshTopology)
+GETLOCALOBJECTS(sofa::core::BaseState, state)
+GETLOCALOBJECTS(sofa::core::behavior::BaseMechanicalState, mechanicalState)
+// GETLOCALOBJECTS(sofa::core::BaseMapping, mechanicalMapping)
+GETLOCALOBJECTS(sofa::core::behavior::BaseMass, mass)
+GETLOCALOBJECTS(sofa::core::collision::Pipeline, collisionPipeline)
+
+#undef GETLOCALOBJECTS
+
+template<class ObjectType>
+class NodeIterator
+{
+    using container = std::conditional_t<trait::is_single_v<ObjectType>,
+                                         NodeSingle<ObjectType>,
+                                         NodeSequence<ObjectType, trait::is_strong_v<ObjectType>>>;
+
+    using data_iterator = typename container::iterator;
+    using const_data_iterator = typename container::iterator;
+
+    sofa::simulation::Node* m_rootNode { nullptr };
+    std::stack<sofa::simulation::Node*> m_stack;
+
+    data_iterator m_currentDataIterator;
+    data_iterator m_currentDataEndIterator;
+    bool m_isNull { false };
+
+    void findFirstObject()
+    {
+        auto* current = m_stack.top();
+        m_stack.pop();
+
+        for (auto& node : current->child)
+        {
+            m_stack.push(node.get());
+        }
+
+        if (auto& objects = getLocalObjects<ObjectType>(*current); !objects.empty())
+        {
+            m_currentDataIterator = objects.begin();
+            m_currentDataEndIterator = objects.end();
+            m_isNull = false;
+        }
+        else
+        {
+            for (auto& node : current->child)
+            {
+                findFirstObject();
+            }
+        }
+    }
+
+    void increment()
+    {
+        if (m_rootNode == nullptr)
+            return;
+
+        ++m_currentDataIterator;
+        if (m_currentDataIterator == m_currentDataEndIterator)
+        {
+            if (m_stack.empty())
+            {
+                m_currentDataIterator = data_iterator{};
+                m_currentDataEndIterator = data_iterator{};
+                m_isNull = true;
+                return;
+            }
+
+            findFirstObject();
+        }
+    }
+
+public:
+
+    explicit NodeIterator(sofa::simulation::Node* current)
+        : m_rootNode{current}, m_isNull(true)
+    {
+        if (current != nullptr)
+        {
+            m_stack.push(current);
+            findFirstObject();
+        }
+    }
+
+    ObjectType* operator*() { return *m_currentDataIterator; }
+    const ObjectType* operator*() const { return *m_currentDataIterator; }
+
+    [[nodiscard]] ObjectType* const ptr() const
+    {
+        if (m_rootNode == nullptr)
+        {
+            return nullptr;
+        }
+        if (m_currentDataIterator == data_iterator{})
+        {
+            return nullptr;
+        }
+        if constexpr (trait::is_single_v<ObjectType>)
+        {
+            return *m_currentDataIterator;
+        }
+        else
+        {
+            return m_currentDataIterator->get();
+        }
+    }
+
+    /// post-increment
+    NodeIterator operator++(int)
+    {
+        NodeIterator it = *this;
+        increment();
+        return it;
+
+    }
+
+    /// pre-increment
+    NodeIterator& operator++()
+    {
+        increment();
+        return *this;
+    }
+
+    bool operator==(const NodeIterator& it)
+    {
+        if (m_isNull && it.m_isNull)
+        {
+            return true;
+        }
+        return m_isNull == it.m_isNull && m_currentDataIterator == it.m_currentDataIterator;
+    }
+    bool operator!=(const NodeIterator& it)
+    {
+        return !operator==(it);
+    }
+};
+
+template<class ObjectType>
+struct SceneGraphObjectTraversal
+{
+    using iterator = NodeIterator<ObjectType>;
+
+    explicit SceneGraphObjectTraversal(sofa::simulation::Node* root)
+        : m_root{root}
+    {}
+
+    SceneGraphObjectTraversal() = delete;
+
+    iterator begin() const
+    {
+        return iterator{m_root};
+    }
+
+    iterator end() const
+    {
+        return iterator{nullptr};
+    }
+
+private:
+    sofa::simulation::Node* m_root { nullptr };
+};
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -56,6 +56,7 @@ std::conditional_t<trait::is_single_v<ObjectType>,
 >&
 getLocalObjects(sofa::simulation::Node& node)
 {
+    SOFA_UNUSED(node);
     static_assert(false, "Object type is not known");
     return {};
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -54,12 +54,7 @@ std::conditional_t<trait::is_single_v<ObjectType>,
     NodeSingle<ObjectType>,
     NodeSequence<ObjectType, trait::is_strong_v<ObjectType>>
 >&
-getLocalObjects(sofa::simulation::Node& node)
-{
-    SOFA_UNUSED(node);
-    static_assert(false, "Object type is not known");
-    return {};
-}
+getLocalObjects(sofa::simulation::Node& node);
 
 #define GETLOCALOBJECTS(type, name) \
 template<> \

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -112,7 +112,11 @@ public:
     using container = std::conditional_t<trait::is_single_v<ObjectType>,
                                          NodeSingle<ObjectType>,
                                          NodeSequence<ObjectType, trait::is_strong_v<ObjectType>>>;
-    using value_type = ObjectType*;
+    using value_type = ObjectType;
+    using difference_type = std::size_t;
+    using reference = ObjectType&;
+    using pointer = ObjectType*;
+    using iterator_category = std::input_iterator_tag;
 
     using data_iterator = typename container::iterator;
     using const_data_iterator = typename container::iterator;
@@ -186,10 +190,9 @@ public:
         }
     }
 
-    value_type operator*() { return ptr(); }
-    value_type operator*() const { return ptr(); }
+    reference operator*() const { return *ptr(); }
 
-    [[nodiscard]] value_type ptr() const
+    [[nodiscard]] pointer ptr() const
     {
         if (m_rootNode == nullptr)
         {
@@ -199,20 +202,13 @@ public:
         {
             return nullptr;
         }
-        if constexpr (trait::is_single_v<ObjectType>)
+        if constexpr (trait::is_strong_v<ObjectType>)
         {
-            return *m_currentDataIterator;
+            return m_currentDataIterator->get();
         }
         else
         {
-            if constexpr (trait::is_strong_v<ObjectType>)
-            {
-                return m_currentDataIterator->get();
-            }
-            else
-            {
-                return *m_currentDataIterator;
-            }
+            return *m_currentDataIterator;
         }
     }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -97,15 +97,27 @@ GETLOCALOBJECTS(sofa::core::collision::Pipeline, collisionPipeline)
 
 #undef GETLOCALOBJECTS
 
+/**
+ * @brief Iterator for traversing nodes in a scene graph containing objects of a specific type.
+ *
+ * This iterator is designed to be used with the `SceneGraphObjectTraversal` class to iterate through nodes
+ * in a scene graph that contain objects of a specified type (`ObjectType`).
+ *
+ * @tparam ObjectType The type of objects to traverse in the scene graph.
+ */
 template<class ObjectType>
 class NodeIterator
 {
+public:
     using container = std::conditional_t<trait::is_single_v<ObjectType>,
                                          NodeSingle<ObjectType>,
                                          NodeSequence<ObjectType, trait::is_strong_v<ObjectType>>>;
+    using value_type = ObjectType*;
 
     using data_iterator = typename container::iterator;
     using const_data_iterator = typename container::iterator;
+
+private:
 
     sofa::simulation::Node* m_rootNode { nullptr };
     std::stack<sofa::simulation::Node*> m_stack;
@@ -114,6 +126,8 @@ class NodeIterator
     data_iterator m_currentDataEndIterator;
     bool m_isNull { false };
 
+    /// Recursive function traversing the graph, searching for an object of
+    /// type ObjectType
     void findFirstObject()
     {
         auto* current = m_stack.top();
@@ -172,10 +186,10 @@ public:
         }
     }
 
-    ObjectType* operator*() { return ptr(); }
-    const ObjectType* operator*() const { return ptr(); }
+    value_type operator*() { return ptr(); }
+    value_type operator*() const { return ptr(); }
 
-    [[nodiscard]] ObjectType* ptr() const
+    [[nodiscard]] value_type ptr() const
     {
         if (m_rootNode == nullptr)
         {
@@ -208,7 +222,6 @@ public:
         NodeIterator it = *this;
         increment();
         return it;
-
     }
 
     /// pre-increment

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -172,8 +172,8 @@ public:
         }
     }
 
-    ObjectType* operator*() { return *m_currentDataIterator; }
-    const ObjectType* operator*() const { return *m_currentDataIterator; }
+    ObjectType* operator*() { return ptr(); }
+    const ObjectType* operator*() const { return ptr(); }
 
     [[nodiscard]] ObjectType* ptr() const
     {
@@ -191,7 +191,14 @@ public:
         }
         else
         {
-            return m_currentDataIterator->get();
+            if constexpr (trait::is_strong_v<ObjectType>)
+            {
+                return m_currentDataIterator->get();
+            }
+            else
+            {
+                return *m_currentDataIterator;
+            }
         }
     }
 
@@ -225,29 +232,34 @@ public:
     }
 };
 
-template<class ObjectType>
-struct SceneGraphObjectTraversal
-{
-    using iterator = NodeIterator<ObjectType>;
+#if !defined(SOFA_SIMULATION_NODEITERATOR_CPP)
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::objectmodel::BaseObject>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BehaviorModel>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BaseMapping>;
 
-    explicit SceneGraphObjectTraversal(sofa::simulation::Node* root)
-        : m_root{root}
-    {}
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::OdeSolver>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::ConstraintSolver>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseLinearSolver>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::topology::BaseTopologyObject>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseForceField>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseInteractionForceField>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseProjectiveConstraintSet>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseConstraintSet>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::objectmodel::ContextObject>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::objectmodel::ConfigurationSetting>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::Shader>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::VisualModel>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::VisualManager>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::CollisionModel>;
 
-    SceneGraphObjectTraversal() = delete;
-
-    iterator begin() const
-    {
-        return iterator{m_root};
-    }
-
-    iterator end() const
-    {
-        return iterator{nullptr};
-    }
-
-private:
-    sofa::simulation::Node* m_root { nullptr };
-};
-
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseAnimationLoop>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::visual::VisualLoop>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::topology::Topology>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::topology::BaseMeshTopology>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BaseState>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseMechanicalState>;
+// extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::BaseMapping>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::behavior::BaseMass>;
+extern template class SOFA_SIMULATION_CORE_API NodeIterator<sofa::core::collision::Pipeline>;
+#endif
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/NodeIterator.h
@@ -98,7 +98,7 @@ GETLOCALOBJECTS(sofa::core::collision::Pipeline, collisionPipeline)
 #undef GETLOCALOBJECTS
 
 /**
- * @brief Iterator for traversing nodes in a scene graph containing objects of a specific type.
+ * @brief Iterator for preorder traversing nodes in a scene graph containing objects of a specific type.
  *
  * This iterator is designed to be used with the `SceneGraphObjectTraversal` class to iterate through nodes
  * in a scene graph that contain objects of a specified type (`ObjectType`).
@@ -133,9 +133,9 @@ private:
         auto* current = m_stack.top();
         m_stack.pop();
 
-        for (auto& node : current->child)
+        for (auto it = current->child.rbegin(); it != current->child.rend(); ++it)
         {
-            m_stack.push(node.get());
+            m_stack.push(it->get());
         }
 
         if (auto& objects = getLocalObjects<ObjectType>(*current); !objects.empty())

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.cpp
@@ -1,0 +1,57 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFA_SIMULATION_SCENEGRAPHOBJECTTRAVERSAL_CPP
+#include <sofa/simulation/SceneGraphObjectTraversal.h>
+
+namespace sofa::simulation
+{
+
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::objectmodel::BaseObject>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BehaviorModel>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BaseMapping>;
+
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::OdeSolver>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::ConstraintSolver>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseLinearSolver>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::topology::BaseTopologyObject>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseForceField>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseInteractionForceField>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseProjectiveConstraintSet>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseConstraintSet>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::objectmodel::ContextObject>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::objectmodel::ConfigurationSetting>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::Shader>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::VisualModel>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::VisualManager>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::CollisionModel>;
+
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseAnimationLoop>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::VisualLoop>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::topology::Topology>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::topology::BaseMeshTopology>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BaseState>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>;
+// template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BaseMapping>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseMass>;
+template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::collision::Pipeline>;
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.h
@@ -26,10 +26,19 @@
 namespace sofa::simulation
 {
 
+/**
+ * @brief Represents a traversal of a scene graph for a specific object type.
+ *
+ * This class provides a convenient way to traverse a scene graph for objects of a specific type.
+ * It uses an iterator, `NodeIterator`, to iterate through the nodes containing objects of the specified type.
+ *
+ * @tparam ObjectType The type of objects to traverse in the scene graph.
+ */
 template<class ObjectType>
 struct SceneGraphObjectTraversal
 {
     using iterator = NodeIterator<ObjectType>;
+    using value_type = ObjectType*;
 
     explicit SceneGraphObjectTraversal(sofa::simulation::Node* root)
         : m_root{root}
@@ -37,12 +46,12 @@ struct SceneGraphObjectTraversal
 
     SceneGraphObjectTraversal() = delete;
 
-    iterator begin() const
+    [[nodiscard]] iterator begin() const
     {
         return iterator{m_root};
     }
 
-    iterator end() const
+    [[nodiscard]] iterator end() const
     {
         return iterator{nullptr};
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.h
@@ -56,6 +56,11 @@ struct SceneGraphObjectTraversal
         return iterator{nullptr};
     }
 
+    [[nodiscard]] typename iterator::difference_type size() const
+    {
+        return std::distance(begin(), end());
+    }
+
 private:
     sofa::simulation::Node* m_root { nullptr };
 };

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneGraphObjectTraversal.h
@@ -1,0 +1,85 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/simulation/NodeIterator.h>
+
+namespace sofa::simulation
+{
+
+template<class ObjectType>
+struct SceneGraphObjectTraversal
+{
+    using iterator = NodeIterator<ObjectType>;
+
+    explicit SceneGraphObjectTraversal(sofa::simulation::Node* root)
+        : m_root{root}
+    {}
+
+    SceneGraphObjectTraversal() = delete;
+
+    iterator begin() const
+    {
+        return iterator{m_root};
+    }
+
+    iterator end() const
+    {
+        return iterator{nullptr};
+    }
+
+private:
+    sofa::simulation::Node* m_root { nullptr };
+};
+
+#if !defined(SOFA_SIMULATION_SCENEGRAPHOBJECTTRAVERSAL_CPP)
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::objectmodel::BaseObject>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BehaviorModel>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BaseMapping>;
+
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::OdeSolver>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::ConstraintSolver>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseLinearSolver>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::topology::BaseTopologyObject>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseForceField>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseInteractionForceField>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseProjectiveConstraintSet>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseConstraintSet>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::objectmodel::ContextObject>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::objectmodel::ConfigurationSetting>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::Shader>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::VisualModel>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::VisualManager>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::CollisionModel>;
+
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseAnimationLoop>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::visual::VisualLoop>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::topology::Topology>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::topology::BaseMeshTopology>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BaseState>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>;
+// extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::BaseMapping>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::behavior::BaseMass>;
+extern template struct SOFA_SIMULATION_CORE_API SceneGraphObjectTraversal<sofa::core::collision::Pipeline>;
+#endif
+
+}

--- a/Sofa/framework/Simulation/Graph/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Graph/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE_FILES
     DAGNode_test.cpp
     MutationListener_test.cpp
     Node_test.cpp
+    NodeIterator_test.cpp
     SimpleApi_test.cpp
     Simulation_test.cpp
     Link_test.cpp

--- a/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
@@ -69,6 +69,7 @@ TEST(NodeIterator, oneElementInRoot)
         std::size_t counter {};
         for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
         {
+            SOFA_UNUSED(state);
             ++counter;
         }
 
@@ -92,6 +93,7 @@ TEST(NodeIterator, oneElementInRootAndOneElementInAChild)
         std::size_t counter {};
         for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
         {
+            SOFA_UNUSED(state);
             ++counter;
         }
 
@@ -128,14 +130,11 @@ TEST(NodeIterator, oneElementInRootAndOneElementInEachChild)
         std::size_t counter {};
         for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
         {
+            SOFA_UNUSED(state);
             ++counter;
         }
 
         EXPECT_EQ(counter, 4);
-    }
-
-    for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
-    {
     }
 }
 

--- a/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <variant>
-#include <sofa/simulation/NodeIterator.h>
+#include <sofa/simulation/SceneGraphObjectTraversal.h>
 #include <gtest/gtest.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
 #include <sofa/simulation/graph/DAGNode.h>

--- a/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
@@ -1,0 +1,142 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <variant>
+#include <sofa/simulation/NodeIterator.h>
+#include <gtest/gtest.h>
+#include <sofa/component/statecontainer/MechanicalObject.h>
+#include <sofa/simulation/graph/DAGNode.h>
+
+
+namespace sofa
+{
+
+using simulation::graph::DAGNode;
+using simulation::NodeIterator;
+TEST(NodeIterator, constructor)
+{
+    {
+        const simulation::NodeIterator<core::objectmodel::BaseObject> begin(nullptr);
+        EXPECT_EQ(begin.ptr(), nullptr);
+    }
+
+    {
+        const simulation::NodeIterator<sofa::core::behavior::BaseMechanicalState> begin(nullptr);
+        EXPECT_EQ(begin.ptr(), nullptr);
+    }
+
+    const DAGNode::SPtr root = core::objectmodel::New<DAGNode>("root");
+    {
+        const simulation::NodeIterator<core::objectmodel::BaseObject> begin(root.get());
+        EXPECT_EQ(begin.ptr(), nullptr);
+    }
+}
+
+TEST(NodeIterator, oneElementInRoot)
+{
+    const DAGNode::SPtr root = core::objectmodel::New<DAGNode>("root");
+
+    const auto dofs = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    root->addObject(dofs);
+
+    {
+        simulation::NodeIterator<sofa::core::behavior::BaseMechanicalState> begin(root.get());
+        EXPECT_EQ(begin.ptr(), dofs.get());
+
+        begin++;
+        EXPECT_EQ(begin.ptr(), nullptr);
+    }
+
+    {
+        std::size_t counter {};
+        for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
+        {
+            ++counter;
+        }
+
+        EXPECT_EQ(counter, 1);
+    }
+}
+
+TEST(NodeIterator, oneElementInRootAndOneElementInAChild)
+{
+    const DAGNode::SPtr root = core::objectmodel::New<DAGNode>("root");
+
+    const auto dofs = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    root->addObject(dofs);
+
+    const DAGNode::SPtr child = core::objectmodel::New<DAGNode>("child");
+    root->addChild(child);
+
+    const auto dofsChild = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    child->addObject(dofsChild);
+    {
+        std::size_t counter {};
+        for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
+        {
+            ++counter;
+        }
+
+        EXPECT_EQ(counter, 2);
+    }
+}
+
+TEST(NodeIterator, oneElementInRootAndOneElementInEachChild)
+{
+    const DAGNode::SPtr root = core::objectmodel::New<DAGNode>("root");
+
+    const auto dofs = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    root->addObject(dofs);
+
+    const DAGNode::SPtr child = core::objectmodel::New<DAGNode>("child");
+    root->addChild(child);
+
+    const auto dofsChild = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    child->addObject(dofsChild);
+
+    const DAGNode::SPtr child2 = core::objectmodel::New<DAGNode>("child2");
+    child->addChild(child2);
+
+    const auto dofsChild2 = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    child2->addObject(dofsChild2);
+
+    const DAGNode::SPtr child3 = core::objectmodel::New<DAGNode>("child3");
+    root->addChild(child3);
+
+    const auto dofsChild3 = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    child3->addObject(dofsChild3);
+
+    {
+        std::size_t counter {};
+        for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
+        {
+            ++counter;
+        }
+
+        EXPECT_EQ(counter, 4);
+    }
+
+    for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
+    {
+    }
+}
+
+}

--- a/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/NodeIterator_test.cpp
@@ -247,4 +247,58 @@ TEST(NodeIterator, diamond)
     }
 }
 
+TEST(NodeIterator, preOrderTraversal)
+{
+    const DAGNode::SPtr root = core::objectmodel::New<DAGNode>("root");
+    const auto dofsRoot = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    root->addObject(dofsRoot);
+
+    const DAGNode::SPtr childA = core::objectmodel::New<DAGNode>("A");
+    root->addChild(childA);
+    const auto dofsA = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    childA->addObject(dofsA);
+
+    const DAGNode::SPtr childB = core::objectmodel::New<DAGNode>("B");
+    root->addChild(childB);
+    const auto dofsB = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    childB->addObject(dofsB);
+
+    const DAGNode::SPtr childC = core::objectmodel::New<DAGNode>("C");
+    childA->addChild(childC);
+    const auto dofsC = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    childC->addObject(dofsC);
+
+    const DAGNode::SPtr childD = core::objectmodel::New<DAGNode>("D");
+    childA->addChild(childD);
+    const auto dofsD = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    childD->addObject(dofsD);
+
+    const DAGNode::SPtr childE = core::objectmodel::New<DAGNode>("E");
+    childD->addChild(childE);
+    const auto dofsE = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    childE->addObject(dofsE);
+
+    const DAGNode::SPtr childF = core::objectmodel::New<DAGNode>("F");
+    childD->addChild(childF);
+    const auto dofsF = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    childF->addObject(dofsF);
+
+    sofa::type::vector<const sofa::core::behavior::BaseMechanicalState*> visitedStates;
+    for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
+    {
+        visitedStates.push_back(state);
+    }
+
+    const sofa::type::vector<const sofa::core::behavior::BaseMechanicalState*> expectedOrder{
+        dofsRoot.get(),
+        dofsA.get(),
+        dofsC.get(),
+        dofsD.get(),
+        dofsE.get(),
+        dofsF.get(),
+        dofsB.get()
+    };
+    EXPECT_EQ(visitedStates, expectedOrder);
+}
+
 }


### PR DESCRIPTION
This could be a step toward the removal of some visitors. The goal is to write something like the following instead of going through visitors:

```C++
//simple counter of BaseMechanicalState
std::size_t counter {};
for (const auto* state : simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMechanicalState>(root.get()))
{
    ++counter;
}

// The following replaces the visitor MechanicalGetNonDiagonalMassesCountVisitor
const auto massTraversal = simulation::SceneGraphObjectTraversal<sofa::core::behavior::BaseMass>(this->getContext());
const std::size_t nbNonDiagonalMasses = std::count_if(massTraversal.begin(), massTraversal.end(), 
    [](auto* mass){ return !mass->isDiagonal();});
//note that these lines don't compile yet because this->getContext() does not give a Node*
```


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
