### PR TITLE
[Simulation.Core] BaseMechanicalVisitor: Deprecate rootData

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
@@ -201,14 +201,14 @@ Visitor::Result BaseMechanicalVisitor::fwdInteractionConstraint(VisitorContext* 
 Visitor::Result BaseMechanicalVisitor::processNodeTopDown(simulation::Node* node, LocalStorage* stack)
 {
     SOFA_UNUSED(stack);
-    processNodeTopDown(node);
+    return processNodeTopDown(node);
 }
 
 
 void BaseMechanicalVisitor::processNodeBottomUp(simulation::Node* node, LocalStorage* stack)
 {
     SOFA_UNUSED(stack);
-    processNodeBottomUp(node);
+    return processNodeBottomUp(node);
 }
 
 
@@ -365,25 +365,6 @@ void BaseMechanicalVisitor::end(simulation::Node* node, core::objectmodel::BaseO
 //    return dynamic_cast<const sofa::core::ConstraintParams*>(params);
 //}
 
-
-/// Return true if this visitor need to read the node-specific data if given
-bool BaseMechanicalVisitor::readNodeData() const
-{ return false; }
-
-/// Return true if this visitor need to write to the node-specific data if given
-bool BaseMechanicalVisitor::writeNodeData() const
-{ return false; }
-
-void BaseMechanicalVisitor::setNodeData(simulation::Node* /*node*/, SReal* nodeData, const SReal* parentData)
-{
-    *nodeData = (parentData == nullptr) ? 0.0 : *parentData;
-}
-
-void BaseMechanicalVisitor::addNodeData(simulation::Node* /*node*/, SReal* parentData, const SReal* nodeData)
-{
-    if (parentData)
-        *parentData += *nodeData;
-}
 
 /// Return a class name for this visitor
 /// Only used for debugging / profiling purposes

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
@@ -200,57 +200,15 @@ Visitor::Result BaseMechanicalVisitor::fwdInteractionConstraint(VisitorContext* 
 
 Visitor::Result BaseMechanicalVisitor::processNodeTopDown(simulation::Node* node, LocalStorage* stack)
 {
-    if (root == nullptr)
-    {
-        root = node;
-    }
-
-    VisitorContext ctx;
-    ctx.root = root;
-    ctx.node = node;
-    ctx.nodeData = rootData;
-
-    const bool writeData = writeNodeData();
-    if (writeData)
-    {
-        // create temporary accumulation buffer for parallel reductions (dot products)
-        if (node != root)
-        {
-            const SReal* parentData = stack->empty() ? rootData : (SReal*)stack->top();
-            ctx.nodeData = new SReal(0.0);
-            setNodeData(node, ctx.nodeData, parentData);
-            stack->push(ctx.nodeData);
-        }
-    }
-
-    return processNodeTopDown(node, &ctx);
+    SOFA_UNUSED(stack);
+    processNodeTopDown(node);
 }
 
 
 void BaseMechanicalVisitor::processNodeBottomUp(simulation::Node* node, LocalStorage* stack)
 {
-    VisitorContext ctx;
-    ctx.root = root;
-    ctx.node = node;
-    ctx.nodeData = rootData;
-    SReal* parentData = rootData;
-
-    const bool writeData = writeNodeData();
-
-    if (writeData)
-    {
-        // use temporary accumulation buffer for parallel reductions (dot products)
-        if (node != root)
-        {
-            ctx.nodeData = (SReal*)stack->pop();
-            parentData = stack->empty() ? rootData : (SReal*)stack->top();
-        }
-    }
-
-    processNodeBottomUp(node, &ctx);
-
-    if (writeData && parentData != ctx.nodeData)
-        addNodeData(node, parentData, ctx.nodeData);
+    SOFA_UNUSED(stack);
+    processNodeBottomUp(node);
 }
 
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.h
@@ -45,7 +45,9 @@ class SOFA_SIMULATION_CORE_API BaseMechanicalVisitor : public Visitor
 
 protected:
     simulation::Node* root; ///< root node from which the visitor was executed
-    SReal* rootData; ///< data for root node
+
+    SOFA_ATTRIBUTE_DEPRECATED_NODEDATA()
+    SReal* rootData { nullptr }; ///< data for root node
 
     virtual Result processNodeTopDown(simulation::Node* node, VisitorContext* ctx);
     virtual void processNodeBottomUp(simulation::Node* node, VisitorContext* ctx);
@@ -53,14 +55,17 @@ protected:
 public:
     BaseMechanicalVisitor(const sofa::core::ExecParams* params);
 
-    /// Return true if this visitor need to read the node-specific data if given
-    virtual bool readNodeData() const;
+    SOFA_ATTRIBUTE_DEPRECATED_NODEDATA()
+    virtual bool readNodeData() const { return false; };
 
-    /// Return true if this visitor need to write to the node-specific data if given
-    virtual bool writeNodeData() const;
+    SOFA_ATTRIBUTE_DEPRECATED_NODEDATA()
+    virtual bool writeNodeData() const { return false; };
 
-    virtual void setNodeData(simulation::Node* /*node*/, SReal* nodeData, const SReal* parentData);
-    virtual void addNodeData(simulation::Node* /*node*/, SReal* parentData, const SReal* nodeData);
+    SOFA_ATTRIBUTE_DEPRECATED_NODEDATA()
+    virtual void setNodeData(simulation::Node* /*node*/, SReal* /*nodeData*/, const SReal* /*parentData*/) {};
+
+    SOFA_ATTRIBUTE_DEPRECATED_NODEDATA()
+    virtual void addNodeData(simulation::Node* /*node*/, SReal* /*parentData*/, const SReal* /*nodeData*/) {};
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/config.h.in
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/config.h.in
@@ -253,5 +253,5 @@ SOFA_ATTRIBUTE_DEPRECATED( \
 #define SOFA_ATTRIBUTE_DEPRECATED_NODEDATA()
 #else
 #define SOFA_ATTRIBUTE_DEPRECATED_NODEDATA() \
-SOFA_ATTRIBUTE_DEPRECATED("v23.12", "v24.06", "rootdata/nodedata feature was never really used so it has been deprecated. All the related functions/members/variables wont do anything.")
+SOFA_ATTRIBUTE_DEPRECATED("v23.12", "v24.06", "rootdata/nodedata feature was never really used so it has been deprecated. All the related functions/members/variables won't do anything.")
 #endif // SOFA_BUILD_SOFA_SIMULATION_CORE

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/config.h.in
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/config.h.in
@@ -248,3 +248,10 @@ SOFA_ATTRIBUTE_DEPRECATED( \
 #define SOFA_ATTRIBUTE_DEPRECATED_LOCALSTORAGE() \
     SOFA_ATTRIBUTE_DEPRECATED("v23.12", "v24.06", "LocalStorage feature was seemingly not used so it has been deprecated.")
 #endif // SOFA_BUILD_SOFA_SIMULATION_CORE
+
+#ifdef SOFA_BUILD_SOFA_SIMULATION_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED_NODEDATA()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED_NODEDATA() \
+SOFA_ATTRIBUTE_DEPRECATED("v23.12", "v24.06", "rootdata/nodedata feature was never really used so it has been deprecated. All the related functions/members/variables wont do anything.")
+#endif // SOFA_BUILD_SOFA_SIMULATION_CORE

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h
@@ -45,11 +45,6 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalGetNonDiagonalMassesCountVisitor";}
-
-    bool writeNodeData() const override
-    {
-        return true;
-    }
 };
 
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVDotVisitor.h
@@ -53,10 +53,6 @@ public:
     {
         return true;
     }
-    bool writeNodeData() const override
-    {
-        return true;
-    }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
     void setReadWriteVectors() override

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVMultiOpVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVMultiOpVisitor.h
@@ -59,10 +59,6 @@ public:
     {
         return true;
     }
-    bool readNodeData() const override
-    {
-        return true;
-    }
 #ifdef SOFA_DUMP_VISITOR_INFO
     void setReadWriteVectors() override
     {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVNormVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVNormVisitor.h
@@ -58,10 +58,6 @@ public:
     {
         return true;
     }
-    bool writeNodeData() const override
-    {
-        return true;
-    }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
     void setReadWriteVectors() override

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h
@@ -64,10 +64,6 @@ public:
     {
         return true;
     }
-    bool readNodeData() const override
-    {
-        return true;
-    }
 #ifdef SOFA_DUMP_VISITOR_INFO
     void setReadWriteVectors() override
     {


### PR DESCRIPTION
It was only used if a "LocalStorage" stack was provided but #4327  showed that it was not used actually.
(and  #4328 showed it was used it in a wrong way)

So this PR makes all the related stuff (nodedata member, readNodeData and writeNodeData) non-functional at all 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
