### PR TITLE
[LinearAlgebra] Use class template argument deduction with MatrixExpr

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
@@ -1311,7 +1311,7 @@ public:
     template<class TBlock2, class TPolicy2>
     void operator-=(const CompressedRowSparseMatrixMechanical<TBlock2, TPolicy2>& m)
     {
-        equal(MatrixExpr< MatrixNegative< CompressedRowSparseMatrixMechanical<TBlock2, TPolicy2> > >(MatrixNegative< CompressedRowSparseMatrixMechanical<TBlock2, TPolicy2> >(m)), true);
+        equal(MatrixExpr { MatrixNegative< CompressedRowSparseMatrixMechanical<TBlock2, TPolicy2> >(m) }, true);
     }
 
     template<class Expr2>
@@ -1329,23 +1329,23 @@ public:
     template<class Expr2>
     void operator-=(const MatrixExpr< Expr2 >& m)
     {
-        addEqual(MatrixExpr< MatrixNegative< Expr2 > >(MatrixNegative< Expr2 >(m)));
+        addEqual(MatrixExpr{ MatrixNegative< Expr2 >(m) } );
     }
 
     MatrixExpr< MatrixTranspose< Matrix > > t() const
     {
-        return MatrixExpr< MatrixTranspose< Matrix > >(MatrixTranspose< Matrix >(*this));
+        return MatrixExpr{ MatrixTranspose< Matrix >{*this} };
     }
 
 
     MatrixExpr< MatrixNegative< Matrix > > operator-() const
     {
-        return MatrixExpr< MatrixNegative< Matrix > >(MatrixNegative< Matrix >(*this));
+        return MatrixExpr{ MatrixNegative< Matrix >(*this) };
     }
 
     MatrixExpr< MatrixScale< Matrix, double > > operator*(const double& r) const
     {
-        return MatrixExpr< MatrixScale< Matrix, double > >(MatrixScale< Matrix, double >(*this, r));
+        return MatrixExpr{ MatrixScale< Matrix, double >(*this, r) };
     }
 
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/DiagonalMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/DiagonalMatrix.h
@@ -283,27 +283,27 @@ public:
     template<class Expr2>
     void operator-=(const MatrixExpr< Expr2 >& m)
     {
-        addEqual(MatrixExpr< MatrixNegative< Expr2 > >(MatrixNegative< Expr2 >(m)));
+        addEqual(MatrixExpr { MatrixNegative< Expr2 >(m) } );
     }
 
     MatrixExpr< MatrixTranspose< DiagonalMatrix<T> > > t() const
     {
-        return MatrixExpr< MatrixTranspose< DiagonalMatrix<T> > >(MatrixTranspose< DiagonalMatrix<T> >(*this));
+        return MatrixExpr { MatrixTranspose< DiagonalMatrix<T> >(*this) };
     }
 
     MatrixExpr< MatrixInverse< DiagonalMatrix<T> > > i() const
     {
-        return MatrixExpr< MatrixInverse< DiagonalMatrix<T> > >(MatrixInverse< DiagonalMatrix<T> >(*this));
+        return MatrixExpr { MatrixInverse< DiagonalMatrix<T> >(*this) };
     }
 
     MatrixExpr< MatrixNegative< DiagonalMatrix<T> > > operator-() const
     {
-        return MatrixExpr< MatrixNegative< DiagonalMatrix<T> > >(MatrixNegative< DiagonalMatrix<T> >(*this));
+        return MatrixExpr { MatrixNegative< DiagonalMatrix<T> >(*this) };
     }
 
     MatrixExpr< MatrixScale< DiagonalMatrix<T>, double > > operator*(const double& r) const
     {
-        return MatrixExpr< MatrixScale< DiagonalMatrix<T>, double > >(MatrixScale< DiagonalMatrix<T>, double >(*this, r));
+        return MatrixExpr { MatrixScale< DiagonalMatrix<T>, double >(*this, r) };
     }
 
     friend std::ostream& operator << (std::ostream& out, const DiagonalMatrix<T>& v )

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/MatrixExpr.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/MatrixExpr.h
@@ -45,60 +45,62 @@ class MatrixNegative;
 template<class M1, class R2>
 class MatrixScale;
 
+/// Data structure representing an operation on matrices. Used in the context of
+/// the expression templates pattern.
 template<class T>
 class MatrixExpr : public T
 {
 public:
     typedef T Expr;
 
-    MatrixExpr(const Expr& e) : Expr(e) {}
+    explicit MatrixExpr(const Expr& e) : Expr(e) {}
 
     template<class M2>
     MatrixExpr< MatrixProduct< Expr, typename M2::Expr > > operator*(const M2& m) const
     {
-        return MatrixExpr< MatrixProduct< Expr, typename M2::Expr > >(MatrixProduct< Expr, typename M2::Expr >(*this, m));
+        return MatrixExpr { MatrixProduct< Expr, typename M2::Expr >(*this, m) };
     }
     template<class M2>
     MatrixExpr< MatrixAddition< Expr, typename M2::Expr > > operator+(const M2& m) const
     {
-        return MatrixExpr< MatrixAddition< Expr, typename M2::Expr > >(MatrixAddition< Expr, typename M2::Expr >(*this, m));
+        return MatrixExpr { MatrixAddition< Expr, typename M2::Expr >(*this, m) };
     }
     template<class M2>
     MatrixExpr< MatrixSubstraction< Expr, typename M2::Expr > > operator-(const M2& m) const
     {
-        return MatrixExpr< MatrixSubstraction< Expr, typename M2::Expr > >(MatrixSubstraction< Expr, typename M2::Expr >(*this, m));
+        return MatrixExpr { MatrixSubstraction< Expr, typename M2::Expr >(*this, m) };
     }
     MatrixExpr< MatrixNegative< Expr > > operator-() const
     {
-        return MatrixExpr< MatrixNegative< Expr > >(MatrixNegative< Expr >(*this));
+        return MatrixExpr { MatrixNegative< Expr >(*this) };
     }
     MatrixExpr< MatrixTranspose< Expr > > t() const
     {
-        return MatrixExpr< MatrixTranspose< Expr > >(MatrixTranspose< Expr >(*this));
+        return MatrixExpr { MatrixTranspose< Expr >(*this) };
     }
 
     MatrixExpr< MatrixScale< Expr, double > > operator*(double d) const
     {
-        return MatrixExpr< MatrixScale< Expr, double > >(MatrixScale< Expr, double >(*this, d));
+        return MatrixExpr { MatrixScale< Expr, double >(*this, d) };
     }
     friend MatrixExpr< MatrixScale< Expr, double > > operator*(double d, const MatrixExpr<Expr>& m)
     {
-        return MatrixExpr< MatrixScale< Expr, double > >(MatrixScale< Expr, double >(m, d));
+        return MatrixExpr { MatrixScale< Expr, double >(m, d) };
     }
     template<class M1>
     friend MatrixExpr< MatrixProduct< typename M1::Expr, Expr > > operator*(const M1& m1, const MatrixExpr<Expr>& m2)
     {
-        return MatrixExpr< MatrixProduct< typename M1::Expr, Expr > >(MatrixProduct< typename M1::Expr, Expr >(m1,m2));
+        return MatrixExpr { MatrixProduct< typename M1::Expr, Expr >(m1,m2) };
     }
     template<class M1>
     friend MatrixExpr< MatrixAddition< typename M1::Expr, Expr > > operator+(const M1& m1, const MatrixExpr<Expr>& m2)
     {
-        return MatrixExpr< MatrixAddition< typename M1::Expr, Expr > >(MatrixAddition< typename M1::Expr, Expr >(m1,m2));
+        return MatrixExpr { MatrixAddition< typename M1::Expr, Expr >(m1,m2) };
     }
     template<class M1>
     friend MatrixExpr< MatrixSubstraction< typename M1::Expr, Expr > > operator-(const M1& m1, const MatrixExpr<Expr>& m2)
     {
-        return MatrixExpr< MatrixSubstraction< typename M1::Expr, Expr > >(MatrixSubstraction< typename M1::Expr, Expr >(m1,m2));
+        return MatrixExpr { MatrixSubstraction< typename M1::Expr, Expr >(m1,m2) };
     }
 };
 
@@ -216,7 +218,8 @@ public:
     typedef typename M1::matrix_type matrix_type;
 
     const M1& m1;
-    MatrixNegative(const M1& m1) : m1(m1)
+
+    explicit MatrixNegative(const M1& m1) : m1(m1)
     {}
 
     bool valid() const
@@ -274,7 +277,8 @@ public:
     typedef typename M1::matrix_type matrix_type;
 
     const M1& m1;
-    MatrixTranspose(const M1& m1) : m1(m1)
+
+    explicit MatrixTranspose(const M1& m1) : m1(m1)
     {}
 
     bool valid() const
@@ -556,7 +560,8 @@ public:
     enum { operand = 0 };
 
     const M1& m1;
-    MatrixInverse(const M1& m1) : m1(m1)
+
+    explicit MatrixInverse(const M1& m1) : m1(m1)
     {}
 
     bool valid() const

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/SparseMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/SparseMatrix.h
@@ -331,35 +331,35 @@ public:
 
     MatrixExpr< MatrixTranspose< SparseMatrix<T> > > t() const
     {
-        return MatrixExpr< MatrixTranspose< SparseMatrix<T> > >(MatrixTranspose< SparseMatrix<T> >(*this));
+        return MatrixExpr { MatrixTranspose< SparseMatrix<T> >(*this) };
     }
 
     MatrixExpr< MatrixNegative< SparseMatrix<T> > > operator-() const
     {
-        return MatrixExpr< MatrixNegative< SparseMatrix<T> > >(MatrixNegative< SparseMatrix<T> >(*this));
+        return MatrixExpr { MatrixNegative< SparseMatrix<T> >(*this) };
     }
 
     template<class Real2>
     MatrixExpr< MatrixProduct< SparseMatrix<T>, SparseMatrix<Real2> > > operator*(const SparseMatrix<Real2>& m) const
     {
-        return MatrixExpr< MatrixProduct< SparseMatrix<T>, SparseMatrix<Real2> > >(MatrixProduct< SparseMatrix<T>, SparseMatrix<Real2> >(*this, m));
+        return MatrixExpr { MatrixProduct< SparseMatrix<T>, SparseMatrix<Real2> >(*this, m) };
     }
 
     MatrixExpr< MatrixScale< SparseMatrix<T>, double > > operator*(const double& r) const
     {
-        return MatrixExpr< MatrixScale< SparseMatrix<T>, double > >(MatrixScale< SparseMatrix<T>, double >(*this, r));
+        return MatrixExpr { MatrixScale< SparseMatrix<T>, double >(*this, r) };
     }
 
     template<class Real2>
     MatrixExpr< MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> > > operator+(const SparseMatrix<Real2>& m) const
     {
-        return MatrixExpr< MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> > >(MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> >(*this, m));
+        return MatrixExpr { MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> >(*this, m) };
     }
 
     template<class Real2>
     MatrixExpr< MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> > > operator-(const SparseMatrix<Real2>& m) const
     {
-        return MatrixExpr< MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> > >(MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> >(*this, m));
+        return MatrixExpr { MatrixAddition< SparseMatrix<T>, SparseMatrix<Real2> >(*this, m) };
     }
 
     void swap(SparseMatrix<T>& m)


### PR DESCRIPTION
This is allowed since C++17: https://en.cppreference.com/w/cpp/language/class_template_argument_deduction. And it is, in my opinion, easier to read.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
