### PR TITLE
[LinearAlgebra] constexpr if statement when possible

### DIFF
--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
@@ -29,7 +29,7 @@
 namespace sofa::linearalgebra
 {
 
-BaseMatrix::BaseMatrix() {}
+BaseMatrix::BaseMatrix() = default;
 
 BaseMatrix::~BaseMatrix()
 {}
@@ -64,11 +64,20 @@ struct BaseMatrixLinearOpMV_BlockDiagonal
         const Index colSize = mat->colSize();
         BlockData buffer;
 
-        if (!add)
-            opVresize(result, (transpose ? colSize : rowSize));
+        if constexpr (!add)
+        {
+            if constexpr (transpose)
+            {
+                opVresize(result, colSize);
+            }
+            else
+            {
+                opVresize(result, rowSize);
+            }
+        }
         for (std::pair<RowBlockConstIterator, RowBlockConstIterator> rowRange = mat->bRowsRange();
-                rowRange.first != rowRange.second;
-                ++rowRange.first)
+             rowRange.first != rowRange.second;
+             ++rowRange.first)
         {
             std::pair<ColBlockConstIterator,ColBlockConstIterator> colRange = rowRange.first.range();
             if (colRange.first != colRange.second) // diagonal block exists
@@ -77,7 +86,7 @@ struct BaseMatrixLinearOpMV_BlockDiagonal
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index i = block.getRow() * NL;
                 const Index j = block.getCol() * NC;
-                if (!transpose)
+                if constexpr (!transpose)
                 {
                     type::VecNoInit<NC,Real> vj;
                     for (int bj = 0; bj < NC; ++bj)
@@ -162,8 +171,17 @@ struct BaseMatrixLinearOpMV_BlockDiagonal<Real, 1, 1, add, transpose, M, V1, V2>
     {
         const Index rowSize = mat->rowSize();
         const Index colSize = mat->colSize();
-        if (!add)
-            opVresize(result, (transpose ? colSize : rowSize));
+        if constexpr (!add)
+        {
+            if constexpr (transpose)
+            {
+                opVresize(result, colSize);
+            }
+            else
+            {
+                opVresize(result, rowSize);
+            }
+        }
         const Index size = (rowSize < colSize) ? rowSize : colSize;
         for (Index i=0; i<size; ++i)
         {
@@ -188,14 +206,16 @@ struct BaseMatrixLinearOpMV_BlockSparse
         BlockData buffer;
         type::Vec<NC,Real> vtmpj;
         type::Vec<NL,Real> vtmpi;
-        if (!add)
+        if constexpr (!add)
+        {
             opVresize(result, (transpose ? colSize : rowSize));
+        }
         for (std::pair<RowBlockConstIterator, RowBlockConstIterator> rowRange = mat->bRowsRange();
-                rowRange.first != rowRange.second;
-                ++rowRange.first)
+             rowRange.first != rowRange.second;
+             ++rowRange.first)
         {
             const Index i = rowRange.first.row() * NL;
-            if (!transpose)
+            if constexpr (!transpose)
             {
                 for (int bi = 0; bi < NL; ++bi)
                     vtmpi[bi] = (Real)0;
@@ -212,7 +232,7 @@ struct BaseMatrixLinearOpMV_BlockSparse
                 BlockConstAccessor block = colRange.first.bloc();
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index j = block.getCol() * NC;
-                if (!transpose)
+                if constexpr (!transpose)
                 {
                     for (int bj = 0; bj < NC; ++bj)
                         vtmpj[bj] = (Real)opVget(v, j+bj);
@@ -231,13 +251,10 @@ struct BaseMatrixLinearOpMV_BlockSparse
                         opVadd(result, j+bj, vtmpj[bj]);
                 }
             }
-            if (!transpose)
+            if constexpr (!transpose)
             {
                 for (int bi = 0; bi < NL; ++bi)
                     opVadd(result, i+bi, vtmpi[bi]);
-            }
-            else
-            {
             }
         }
     }
@@ -253,9 +270,18 @@ public:
     {
         const Index rowSize = mat->rowSize();
         const Index colSize = mat->colSize();
-        if (!add)
-            opVresize(result, (transpose ? colSize : rowSize));
-        if (!transpose)
+        if constexpr (!add)
+        {
+            if constexpr (transpose)
+            {
+                opVresize(result, colSize);
+            }
+            else
+            {
+                opVresize(result, rowSize);
+            }
+        }
+        if constexpr (!transpose)
         {
             for (Index i=0; i<rowSize; ++i)
             {
@@ -285,8 +311,17 @@ public:
     {
         const Index rowSize = mat->rowSize();
         const Index colSize = mat->colSize();
-        if (!add)
-            opVresize(result, (transpose ? colSize : rowSize));
+        if constexpr (!add)
+        {
+            if constexpr (transpose)
+            {
+                opVresize(result, colSize);
+            }
+            else
+            {
+                opVresize(result, rowSize);
+            }
+        }
         const Index size = (rowSize < colSize) ? rowSize : colSize;
         for (Index i=0; i<size; ++i)
         {
@@ -300,8 +335,17 @@ public:
     {
         const Index rowSize = mat->rowSize();
         const Index colSize = mat->colSize();
-        if (!add)
-            opVresize(result, (transpose ? colSize : rowSize));
+        if constexpr (!add)
+        {
+            if (transpose)
+            {
+                opVresize(result, colSize);
+            }
+            else
+            {
+                opVresize(result, rowSize);
+            }
+        }
         const Index size = (rowSize < colSize) ? rowSize : colSize;
         for (Index i=0; i<size; ++i)
         {
@@ -513,7 +557,7 @@ struct BaseMatrixLinearOpAM_BlockSparse
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index j = block.getCol() * NC;
 
-                if (!transpose)
+                if constexpr (!transpose)
                 {
                     for (int bi = 0; bi < NL; ++bi)
                         for (int bj = 0; bj < NC; ++bj)
@@ -558,7 +602,7 @@ struct BaseMatrixLinearOpAMS_BlockSparse
                 BlockConstAccessor block = colRange.first.bloc();
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index j = block.getCol() * NC;
-                if (!transpose)
+                if constexpr (!transpose)
                 {
                     for (int bi = 0; bi < NL; ++bi)
                         for (int bj = 0; bj < NC; ++bj)
@@ -603,7 +647,7 @@ struct BaseMatrixLinearOpAM1_BlockSparse
                 const BlockData& bdata = *(const BlockData*)block.elements(&buffer);
                 const Index j = block.getCol();
 
-                if (!transpose)
+                if constexpr (!transpose)
                 {
                     m2->add(i,j,bdata * fact);
                 }
@@ -626,7 +670,7 @@ public:
     {
         const Index rowSize = m1->rowSize();
         const Index colSize = m2->colSize();
-        if (!transpose)
+        if constexpr (!transpose)
         {
             for (Index j=0; j<rowSize; ++j)
             {

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
@@ -75,14 +75,12 @@ struct BaseMatrixLinearOpMV_BlockDiagonal
                 opVresize(result, rowSize);
             }
         }
-        for (std::pair<RowBlockConstIterator, RowBlockConstIterator> rowRange = mat->bRowsRange();
-             rowRange.first != rowRange.second;
-             ++rowRange.first)
+        for (auto [rowIt, rowEnd] = mat->bRowsRange(); rowIt != rowEnd; ++rowIt)
         {
-            std::pair<ColBlockConstIterator,ColBlockConstIterator> colRange = rowRange.first.range();
-            if (colRange.first != colRange.second) // diagonal block exists
+            auto [colBegin, colEnd] = rowIt.range();
+            if (colBegin != colEnd) // diagonal block exists
             {
-                BlockConstAccessor block = colRange.first.bloc();
+                BlockConstAccessor block = colBegin.bloc();
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index i = block.getRow() * NL;
                 const Index j = block.getCol() * NC;
@@ -210,11 +208,9 @@ struct BaseMatrixLinearOpMV_BlockSparse
         {
             opVresize(result, (transpose ? colSize : rowSize));
         }
-        for (std::pair<RowBlockConstIterator, RowBlockConstIterator> rowRange = mat->bRowsRange();
-             rowRange.first != rowRange.second;
-             ++rowRange.first)
+        for (auto [rowIt, rowEnd] = mat->bRowsRange(); rowIt != rowEnd; ++rowIt)
         {
-            const Index i = rowRange.first.row() * NL;
+            const Index i = rowIt.row() * NL;
             if constexpr (!transpose)
             {
                 for (int bi = 0; bi < NL; ++bi)
@@ -225,11 +221,9 @@ struct BaseMatrixLinearOpMV_BlockSparse
                 for (int bi = 0; bi < NL; ++bi)
                     vtmpi[bi] = (Real)opVget(v, i+bi);
             }
-            for (std::pair<ColBlockConstIterator,ColBlockConstIterator> colRange = rowRange.first.range();
-                    colRange.first != colRange.second;
-                    ++colRange.first)
+            for (auto [colIt, colEnd] = rowIt.range(); colIt != colEnd; ++colIt)
             {
-                BlockConstAccessor block = colRange.first.bloc();
+                BlockConstAccessor block = colIt.bloc();
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index j = block.getCol() * NC;
                 if constexpr (!transpose)
@@ -542,18 +536,14 @@ struct BaseMatrixLinearOpAM_BlockSparse
     {
         BlockData buffer;
 
-        for (std::pair<RowBlockConstIterator, RowBlockConstIterator> rowRange = m1->bRowsRange();
-                rowRange.first != rowRange.second;
-                ++rowRange.first)
+        for (auto [rowIt, rowEnd] = m1->bRowsRange(); rowIt != rowEnd; ++rowIt)
         {
-            const Index i = rowRange.first.row() * NL;
+            const Index i = rowIt.row() * NL;
 
-            for (std::pair<ColBlockConstIterator,ColBlockConstIterator> colRange = rowRange.first.range();
-                    colRange.first != colRange.second;
-                    ++colRange.first)
+            for (auto [colIt, colEnd] = rowIt.range(); colIt != colEnd; ++colIt)
             {
 
-                BlockConstAccessor block = colRange.first.bloc();
+                BlockConstAccessor block = colIt.bloc();
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index j = block.getCol() * NC;
 
@@ -588,18 +578,13 @@ struct BaseMatrixLinearOpAMS_BlockSparse
     {
         BlockData buffer;
 
-        for (std::pair<RowBlockConstIterator, RowBlockConstIterator> rowRange = m1->bRowsRange();
-                rowRange.first != rowRange.second;
-                ++rowRange.first)
+        for (auto [rowIt, rowEnd] = m1->bRowsRange(); rowIt != rowEnd; ++rowIt)
         {
-            const Index i = rowRange.first.row() * NL;
+            const Index i = rowIt.row() * NL;
 
-            for (std::pair<ColBlockConstIterator,ColBlockConstIterator> colRange = rowRange.first.range();
-                    colRange.first != colRange.second;
-                    ++colRange.first)
+            for (auto [colIt, colEnd] = rowIt.range(); colIt != colEnd; ++colIt)
             {
-
-                BlockConstAccessor block = colRange.first.bloc();
+                BlockConstAccessor block = colIt.bloc();
                 const BlockData& bdata = *(const BlockData*)block.elements(buffer.ptr());
                 const Index j = block.getCol() * NC;
                 if constexpr (!transpose)
@@ -632,18 +617,13 @@ struct BaseMatrixLinearOpAM1_BlockSparse
     {
         BlockData buffer;
 
-        for (std::pair<RowBlockConstIterator, RowBlockConstIterator> rowRange = m1->bRowsRange();
-                rowRange.first != rowRange.second;
-                ++rowRange.first)
+        for (auto [rowIt, rowEnd] = m1->bRowsRange(); rowIt != rowEnd; ++rowIt)
         {
-            const Index i = rowRange.first.row();
+            const Index i = rowIt.row();
 
-            for (std::pair<ColBlockConstIterator,ColBlockConstIterator> colRange = rowRange.first.range();
-                    colRange.first != colRange.second;
-                    ++colRange.first)
+            for (auto [colIt, colEnd] = rowIt.range(); colIt != colEnd; ++colIt)
             {
-
-                BlockConstAccessor block = colRange.first.bloc();
+                BlockConstAccessor block = colIt.bloc();
                 const BlockData& bdata = *(const BlockData*)block.elements(&buffer);
                 const Index j = block.getCol();
 


### PR DESCRIPTION
`transpose` and `add` are known at compile-time, so a `constexpr if` can be used to evaluate them, and discard statements.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
