### PR TITLE
[Core] BaseMapping: link mapConstraints to the "meta-alias" isMechanical

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/BaseMapping.cpp
+++ b/Sofa/framework/Core/src/sofa/core/BaseMapping.cpp
@@ -36,6 +36,7 @@ BaseMapping::BaseMapping()
     , f_mapMatrices(initData(&f_mapMatrices, false, "mapMatrices", "Are matrix explicit mapped?"))
 {
     this->addAlias(&f_mapForces, "isMechanical");
+    this->addAlias(&f_mapConstraints, "isMechanical");
     this->addAlias(&f_mapMasses, "isMechanical");
 }
 


### PR DESCRIPTION
setMechanical() and isMechanical() use the boolean states of forces, masses and constraints.
But the "meta-alias"(?) `isMechanical` only link forces and masses. So it would make sense to add constraints 🤔

Avoid cases like https://github.com/fredroy/BeamAdapter/commit/58b3db1eb11dab501eec7d6a50b6cce3fcaf9a51



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
