### PR TITLE
[Topology.Mapping] Edge2QuadTopologicalMapping: use States directly

### DIFF
--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Edge2QuadTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Edge2QuadTopologicalMapping.cpp
@@ -33,8 +33,6 @@
 #include <map>
 #include <sofa/defaulttype/VecTypes.h>
 
-#include <sofa/core/behavior/MechanicalState.h>
-
 #include <cmath>
 
 #include <sofa/defaulttype/RigidTypes.h>
@@ -112,8 +110,8 @@ void Edge2QuadTopologicalMapping::init()
 
     
     // INITIALISATION of QUADULAR mesh from EDGE mesh :
-    const core::behavior::MechanicalState<Rigid3Types>* from_mstate = dynamic_cast<core::behavior::MechanicalState<Rigid3Types>*>(fromModel->getContext()->getMechanicalState());
-    core::behavior::MechanicalState<Vec3Types>* to_mstate = dynamic_cast<core::behavior::MechanicalState<Vec3Types>*>(toModel->getContext()->getMechanicalState());
+    const core::State<Rigid3Types>* from_mstate = dynamic_cast<core::State<Rigid3Types>*>(fromModel->getContext()->getState());
+    core::State<Vec3Types>* to_mstate = dynamic_cast<core::State<Vec3Types>*>(toModel->getContext()->getState());
 
     if (fromModel)
     {
@@ -299,8 +297,8 @@ void Edge2QuadTopologicalMapping::init()
     }
     else
     {
-        // Check type Rigid3 of input mechanical object (required)
-        msg_error() << "Mechanical object associated with the input is not of type Rigid. Edge2QuadTopologicalMapping only supports Rigid3Types to Vec3Types";
+        // Check type Rigid3 of input state object (required)
+        msg_error() << "State object associated with the input is not of type Rigid. Edge2QuadTopologicalMapping only supports Rigid3Types to Vec3Types";
         d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
     }
 }

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Edge2QuadTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Edge2QuadTopologicalMapping.cpp
@@ -20,22 +20,15 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/component/topology/mapping/Edge2QuadTopologicalMapping.h>
-#include <sofa/core/visual/VisualParams.h>
 
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/topology/TopologyChange.h>
+
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/defaulttype/RigidTypes.h>
 
 #include <sofa/component/topology/container/dynamic/QuadSetTopologyModifier.h>
 #include <sofa/component/topology/container/dynamic/QuadSetTopologyContainer.h>
-
-#include <sofa/core/topology/TopologyChange.h>
-
-#include <sofa/type/Vec.h>
-#include <map>
-#include <sofa/defaulttype/VecTypes.h>
-
-#include <cmath>
-
-#include <sofa/defaulttype/RigidTypes.h>
 
 
 namespace sofa::component::topology::mapping

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Edge2QuadTopologicalMapping.h
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Edge2QuadTopologicalMapping.h
@@ -22,14 +22,11 @@
 #pragma once
 
 #include <sofa/component/topology/mapping/config.h>
-#include <sofa/core/topology/TopologicalMapping.h>
 
 #include <sofa/type/Vec.h>
-#include <sofa/defaulttype/RigidTypes.h>
-#include <map>
+#include <sofa/core/topology/TopologicalMapping.h>
+#include <sofa/core/State.h>
 
-#include <sofa/core/BaseMapping.h>
-#include <sofa/core/behavior/MechanicalState.h>
 
 
 namespace sofa::component::topology::container::dynamic
@@ -54,10 +51,7 @@ class SOFA_COMPONENT_TOPOLOGY_MAPPING_API Edge2QuadTopologicalMapping : public s
 {
 public:
     SOFA_CLASS(Edge2QuadTopologicalMapping,sofa::core::topology::TopologicalMapping);
-
-    using RigidCoord = sofa::core::State<defaulttype::Rigid3Types>::Coord;
-    using Vec3Coord = sofa::core::State<defaulttype::Vec3Types>::Coord;
-    
+        
     using Index = sofa::core::topology::BaseMeshTopology::Index;
     using Edge = sofa::core::topology::BaseMeshTopology::Edge;
     using Quad = sofa::core::topology::BaseMeshTopology::Quad;

--- a/examples/Component/Topology/Mapping/Edge2QuadTopologicalMapping.scn
+++ b/examples/Component/Topology/Mapping/Edge2QuadTopologicalMapping.scn
@@ -36,17 +36,13 @@
         
         
         <Node name="VisuBeam" activated="true">
-			<MechanicalObject template="Vec3" name="SurfDof" />
+			<OglModel template="Vec3" name="SurfDof" color="0.7 0.7 0.7" />
 			<QuadSetTopologyContainer  name="Container" />
 			<QuadSetTopologyModifier   name="Modifier" />
             <QuadSetGeometryAlgorithms name="GeomAlgo"  template="Vec3" drawQuads="1"/>
 			<Edge2QuadTopologicalMapping nbPointsOnEachCircle="10" radius="2" input="@../MeshLines" output="@Container" flipNormals="true"/>
             <TubularMapping nbPointsOnEachCircle="10" radius="2" input="@../BeamDof" output="@SurfDof" />
             
-			<Node name="VisuOgl" activated="true">
-				<OglModel name="Visual" color="0.7 0.7 0.7" />
-				<IdentityMapping input="@../SurfDof" output="@Visual"/>
-			</Node>
 		</Node>
 	</Node>  
 </Node>


### PR DESCRIPTION
Based on 
- #4362 
(for the scene, not compilation)

diff: https://github.com/fredroy/sofa/compare/geoalgo_states..edge2quad_state

No need to pass by a intermediary MechanicalObject anymore (+subsequent Mapping as well)

Avoids:
- using mechanical mappings for visual mappings (no useless applyJ/applyJT calls)
- to call an other mapping as well
- setting the (not doing its purpose) `isMechanical`  flag

---
- With the example (Edge2QuadTopologicalMapping.scn)

with GUI (glfw)
```
master 10000 iterations done in 20.618 s ( 485.013 FPS)
pr     10000 iterations done in 16.601 s ( 602.373 FPS)
```

no GUI (batch)
```
master 10000 iterations done in 17.3933 s ( 574.935 FPS)
pr     10000 iterations done in 13.6906 s ( 730.43 FPS)
```

- With [modified] BeamAdapter's scene (with gui)
```
master 5000 iterations done in 35.184 s ( 142.11 FPS)
pr     5000 iterations done in 29.48 s ( 169.607 FPS)
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
