### PR TITLE
[Constraint.Lagrangian.Solver] Fix assert in GenericConstraintSolver

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -496,17 +496,17 @@ sofa::type::vector<core::behavior::BaseConstraintCorrection*> GenericConstraintS
 
 void GenericConstraintSolver::applyMotionCorrection(
     const core::ConstraintParams* cParams,
-    const core::MultiVecCoordId xId,
+    const std::unique_ptr<core::MultiVecCoordId>& xId,
     const core::MultiVecDerivId vId,
     core::behavior::BaseConstraintCorrection* constraintCorrection) const
 {
     if (cParams->constOrder() == sofa::core::ConstraintOrder::POS_AND_VEL)
     {
-        constraintCorrection->applyMotionCorrection(cParams, xId, vId, cParams->dx(), this->getDx() );
+        constraintCorrection->applyMotionCorrection(cParams, *xId, vId, cParams->dx(), this->getDx() );
     }
     else if (cParams->constOrder() == sofa::core::ConstraintOrder::POS)
     {
-        constraintCorrection->applyPositionCorrection(cParams, xId, cParams->dx(), this->getDx());
+        constraintCorrection->applyPositionCorrection(cParams, *xId, cParams->dx(), this->getDx());
     }
     else if (cParams->constOrder() == sofa::core::ConstraintOrder::VEL)
     {
@@ -526,7 +526,11 @@ void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::Constr
 
     if (std::find(supportedCorrections.begin(), supportedCorrections.end(), cParams->constOrder()) != supportedCorrections.end())
     {
-        const core::MultiVecCoordId xId(res1);
+        std::unique_ptr<core::MultiVecCoordId> xId;
+        if (cParams->constOrder() != sofa::core::ConstraintOrder::VEL)
+        {
+            xId = std::make_unique<core::MultiVecCoordId>(res1);
+        }
         const core::MultiVecDerivId vId(cParams->constOrder() == sofa::core::ConstraintOrder::VEL ? res1 : res2);
 
         for (const auto& constraintCorrection : filteredConstraintCorrections())

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -496,21 +496,20 @@ sofa::type::vector<core::behavior::BaseConstraintCorrection*> GenericConstraintS
 
 void GenericConstraintSolver::applyMotionCorrection(
     const core::ConstraintParams* cParams,
-    const std::unique_ptr<core::MultiVecCoordId>& xId,
-    const core::MultiVecDerivId vId,
+    MultiVecId res1, MultiVecId res2,
     core::behavior::BaseConstraintCorrection* constraintCorrection) const
 {
     if (cParams->constOrder() == sofa::core::ConstraintOrder::POS_AND_VEL)
     {
-        constraintCorrection->applyMotionCorrection(cParams, *xId, vId, cParams->dx(), this->getDx() );
+        constraintCorrection->applyMotionCorrection(cParams, core::MultiVecCoordId{res1}, core::MultiVecDerivId{res2}, cParams->dx(), this->getDx() );
     }
     else if (cParams->constOrder() == sofa::core::ConstraintOrder::POS)
     {
-        constraintCorrection->applyPositionCorrection(cParams, *xId, cParams->dx(), this->getDx());
+        constraintCorrection->applyPositionCorrection(cParams, core::MultiVecCoordId{res1}, cParams->dx(), this->getDx());
     }
     else if (cParams->constOrder() == sofa::core::ConstraintOrder::VEL)
     {
-        constraintCorrection->applyVelocityCorrection(cParams, vId, cParams->dx(), this->getDx() );
+        constraintCorrection->applyVelocityCorrection(cParams, core::MultiVecDerivId{res1}, cParams->dx(), this->getDx() );
     }
 }
 
@@ -526,13 +525,6 @@ void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::Constr
 
     if (std::find(supportedCorrections.begin(), supportedCorrections.end(), cParams->constOrder()) != supportedCorrections.end())
     {
-        std::unique_ptr<core::MultiVecCoordId> xId;
-        if (cParams->constOrder() != sofa::core::ConstraintOrder::VEL)
-        {
-            xId = std::make_unique<core::MultiVecCoordId>(res1);
-        }
-        const core::MultiVecDerivId vId(cParams->constOrder() == sofa::core::ConstraintOrder::VEL ? res1 : res2);
-
         for (const auto& constraintCorrection : filteredConstraintCorrections())
         {
             {
@@ -541,7 +533,7 @@ void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::Constr
             }
 
             SCOPED_TIMER("ApplyCorrection");
-            applyMotionCorrection(cParams, xId, vId, constraintCorrection);
+            applyMotionCorrection(cParams, res1, res2, constraintCorrection);
         }
     }
 }

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <optional>
 #include <sofa/component/constraint/lagrangian/solver/config.h>
 #include <sofa/component/constraint/lagrangian/solver/GenericConstraintProblem.h>
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -141,7 +141,7 @@ private:
     void computeAndApplyMotionCorrection(const core::ConstraintParams* cParams, GenericConstraintSolver::MultiVecId res1, GenericConstraintSolver::MultiVecId res2) const;
     void applyMotionCorrection(
         const core::ConstraintParams* cParams,
-        const core::MultiVecCoordId xId,
+        const std::unique_ptr<core::MultiVecCoordId>& xId,
         const core::MultiVecDerivId vId,
         core::behavior::BaseConstraintCorrection* constraintCorrection) const;
     void storeConstraintLambdas(const core::ConstraintParams* cParams);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include <optional>
 #include <sofa/component/constraint/lagrangian/solver/config.h>
 #include <sofa/component/constraint/lagrangian/solver/GenericConstraintProblem.h>
 
@@ -141,8 +142,7 @@ private:
     void computeAndApplyMotionCorrection(const core::ConstraintParams* cParams, GenericConstraintSolver::MultiVecId res1, GenericConstraintSolver::MultiVecId res2) const;
     void applyMotionCorrection(
         const core::ConstraintParams* cParams,
-        const std::unique_ptr<core::MultiVecCoordId>& xId,
-        const core::MultiVecDerivId vId,
+        MultiVecId res1, MultiVecId res2,
         core::behavior::BaseConstraintCorrection* constraintCorrection) const;
     void storeConstraintLambdas(const core::ConstraintParams* cParams);
 


### PR DESCRIPTION
The construction of xId caused an assert when `cParams->constOrder() == sofa::core::ConstraintOrder::VEL`. It happens only in debug, and it had no consequence because it was not used.

Bug introduced in https://github.com/sofa-framework/sofa/pull/4213





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
