### PR TITLE
[Helper] Fix Colormap when using HSV to RGB

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/ColorMap.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ColorMap.cpp
@@ -174,28 +174,32 @@ void ColorMap::reinit()
         const float step = (2.0f/3.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(type::RGBAColor::fromHSVA(i*step, 1.0f, 1.0f, 1.0f));
+            const auto h = i * step * 360;
+            entries.push_back(type::RGBAColor::fromHSVA(h, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Blue to Red") {
         // List the colors
         const float step = (2.0f/3.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(type::RGBAColor::fromHSVA(2.0f/3.0f - i*step, 1.0f, 1.0f, 1.0f));
+            const auto h = (2.0f / 3.0f - i * step) * 360;
+            entries.push_back(type::RGBAColor::fromHSVA(h, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Yellow to Cyan") {
         // List the colors
         const float step = (0.5f - 1.0f/6.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(type::RGBAColor::fromHSVA(1.0f/6.0f + i*step, 1.0f, 1.0f, 1.0f));
+            const auto h = (1.0f / 6.0f + i * step) * 360;
+            entries.push_back(type::RGBAColor::fromHSVA(h, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Cyan to Yellow") {
         // List the colors
         const float step = (0.5f - 1.0f/6.0f)/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.push_back(type::RGBAColor::fromHSVA(0.5f-i*step, 1.0f, 1.0f, 1.0f));
+            const auto h = (0.5f - i * step) * 360;
+            entries.push_back(type::RGBAColor::fromHSVA(h, 1.0f, 1.0f, 1.0f));
         }
     } else if (scheme == "Red to Yellow") {
         const float step = 1.0f/(nColors);
@@ -315,7 +319,8 @@ void ColorMap::reinit()
         const float step = 1.0f/(nColors-1);
         for (unsigned int i=0; i<nColors; i++)
         {
-            entries.emplace_back(type::RGBAColor::fromHSVA(i*step,1.f,1.f, 1.0f));
+            const auto h = i * step * 360;
+            entries.emplace_back(type::RGBAColor::fromHSVA(h,1.f,1.f, 1.0f));
         }
     }
 }
@@ -328,26 +333,7 @@ void ColorMap::reinit()
 // Ref: Alvy Ray Smith, Color Gamut Transform Pairs, SIGGRAPH '78
 type::Vec3f ColorMap::hsv2rgb(const type::Vec3f&hsv)
 {
-    /*Color3 rgb(0.0f, 0.0f, 0.0f);
-
-    float i, f;
-    f = modff(hsv[0] * 6.0f, &i);
-
-    float x = hsv[2] * (1.0f - hsv[1]),
-           y = hsv[2] * (1.0f - hsv[1] * f),
-           z = hsv[2] * (1.0f - hsv[1] * (1.0f - f));
-
-    switch ((int)i % 6) {
-        case 0: rgb = Color3(hsv[2],      z,      x); break;
-        case 1: rgb = Color3(     y, hsv[2],      x); break;
-        case 2: rgb = Color3(     x, hsv[2],      z); break;
-        case 3: rgb = Color3(     x,      y, hsv[2]); break;
-        case 4: rgb = Color3(     z,      x, hsv[2]); break;
-        case 5: rgb = Color3(hsv[2],      x,      y); break;
-    }
-
-    return rgb;*/
-    auto rgba = type::RGBAColor::fromHSVA( hsv[0], hsv[1],hsv[2], 1.0f );
+    auto rgba = type::RGBAColor::fromHSVA( hsv[0] * 360, hsv[1],hsv[2], 1.0f );
 
     return { rgba[0], rgba[1], rgba[2] };
 }


### PR DESCRIPTION
it was not noticed in #4270 that the two version of RGB from HSV was different on Hue value 
(one is normalized [0...1], the other in RGBAColor is not and is in degree [0...360])

for those interested : http://wiki.gis.com/wiki/index.php/HSV_Color_Space

FYI while debugging, an issue in TetraFEMForcefield has been found #4407
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
