### PR TITLE
[All] Fix subplugin regression tests

### DIFF
--- a/applications/plugins/RegressionStateScenes.regression-tests
+++ b/applications/plugins/RegressionStateScenes.regression-tests
@@ -2,6 +2,9 @@
 # REGRESSION_TEST DOES NOT SUPPORT DASHES ("-") IN SCENE NAMES.
 # USE UNDERSCORES ("_") INSTEAD.
 
+### References relative path ###
+../projects/Regression/references/application/plugins
+
 ### Sph Plugin ###
 SofaSphFluid/examples/SPHFluidForceField.scn 100 1e-4 1 1
 SofaSphFluid/examples/SPHFluidForceField_benchmarks.scn 100 1e-4 1 1

--- a/applications/plugins/RegressionStateScenes.regression-tests
+++ b/applications/plugins/RegressionStateScenes.regression-tests
@@ -3,7 +3,7 @@
 # USE UNDERSCORES ("_") INSTEAD.
 
 ### References relative path ###
-../projects/Regression/references/application/plugins
+../projects/Regression/references/applications/plugins
 
 ### Sph Plugin ###
 SofaSphFluid/examples/SPHFluidForceField.scn 100 1e-4 1 1

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -8,6 +8,9 @@
 # REGRESSION_TEST DOES NOT SUPPORT DASHES ("-") IN SCENE NAMES.
 # USE UNDERSCORES ("_") INSTEAD.
 
+### References relative path ###
+../applications/projects/Regression/references/examples
+
 ### Demo scenes ###
 Demos/TriangleSurfaceCutting.scn 100 1e-4 1 1
 Demos/chainAll.scn 100 1e-2 1 1

--- a/examples/RegressionTopologyScenes.regression-tests
+++ b/examples/RegressionTopologyScenes.regression-tests
@@ -2,6 +2,9 @@
 # REGRESSION_TEST DOES NOT SUPPORT DASHES ("-") IN SCENE NAMES.
 # USE UNDERSCORES ("_") INSTEAD.
 
+### References relative path ###
+../applications/projects/Regression/references/examples
+
 ### Topology scenes ###
 Component/Topology/Mapping/Tetra2TriangleTopologicalMapping.scn 30 1e-4 1
 


### PR DESCRIPTION
[ci-depends-on https://github.com/sofa-framework/Regression/pull/56]
[ci-depends-on https://github.com/sofa-framework/BeamAdapter/pull/125]

This PR is based on [PR #56](https://github.com/sofa-framework/Regression/pull/56) of Regression. 

This PR fixes the problem of running regression tests in plugins when their references are inside of the plugin and not Regression (e.g. BeamAdapter)

The idea is to have a stand alone `*.regression.tests` file that also includes the relative path of the reference folder. This is meant to be placed at the top of the reference file in a relative manne. This allows two things : 
1. Having a stand alone file ease the process of finding the reference folder for any new comer
2. Having a stand alone file ease the process of automatizing the retrieval of new regression test along with their reference folder without the need of modifying anything in the CI script.    

Tested on my side : only two remaining regression test failing from SofaSPH

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
