### PR TITLE
[LinearSystem] Detect changes in sparsity pattern when using ConstantSparsityPatternSystem

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.h
@@ -29,6 +29,10 @@ namespace sofa::component::linearsystem
 {
 
 using core::matrixaccumulator::no_check_policy;
+template<core::matrixaccumulator::Contribution c, class TStrategy>
+class SparsityPatternLocalMatrix;
+template<core::matrixaccumulator::Contribution c, class TStrategy>
+class SparsityPatternLocalMappedMatrix;
 
 /**
  * Assembling method benefitting from the constant sparsity pattern of the linear system in order to increase the
@@ -91,6 +95,15 @@ protected:
     template <core::matrixaccumulator::Contribution c>
     void replaceLocalMatricesNonMapped(const core::MechanicalParams* mparams, LocalMatrixMaps<c, Real>& matrixMaps);
 
+    template<core::matrixaccumulator::Contribution c, class TStrategy = sofa::core::matrixaccumulator::NoIndexVerification>
+    void replaceLocalMatrixNonMapped(const core::MechanicalParams* mparams,
+        LocalMatrixMaps<c, Real>& matrixMaps,
+        sofa::core::matrixaccumulator::get_component_type<c>* component,
+        BaseAssemblingMatrixAccumulator<c>*& localMatrix,
+        const typename Inherit1::PairMechanicalStates& states,
+        SparsityPatternLocalMatrix<c, TStrategy>* sparsityPatternMatrix);
+
+
 
     template<core::matrixaccumulator::Contribution c>
     void reinitLocalMatrices(LocalMatrixMaps<c, Real>& matrixMaps);
@@ -99,6 +112,9 @@ protected:
     static void buildHashTable(linearalgebra::CompressedRowSparseMatrix<SReal>& M, ConstantCRSMapping& mapping);
 
     void makeCreateDispatcher() override;
+
+    std::shared_ptr<sofa::core::matrixaccumulator::IndexVerificationStrategy>
+    makeIndexVerificationStrategy(sofa::core::objectmodel::BaseObject* component) override;
 
 private:
     template<Contribution c>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.inl
@@ -264,17 +264,24 @@ void ConstantSparsityPatternSystem<TMatrix, TVector>::replaceLocalMatricesNonMap
     {
         for (auto& [states, localMatrix] : localMatrixMap)
         {
-            if (auto* sparsityPatternMatrix = dynamic_cast<SparsityPatternLocalMatrix<c>*>(localMatrix))
+            const bool isMapped0 = this->getMappingGraph().hasAnyMappingInput(states[0]);
+            const bool isMapped1 = this->getMappingGraph().hasAnyMappingInput(states[1]);
+            if (const bool isAnyMapped = isMapped0 || isMapped1; !isAnyMapped)
             {
-                replaceLocalMatrixNonMapped(mparams, matrixMaps, component, localMatrix, states, sparsityPatternMatrix);
-            }
-            else if (auto* sparsityPatternMatrixWithCheck = dynamic_cast<SparsityPatternLocalMatrix<c, StrategyCheckerType>*>(localMatrix))
-            {
-                replaceLocalMatrixNonMapped(mparams, matrixMaps, component, localMatrix, states, sparsityPatternMatrixWithCheck);
-            }
-            else
-            {
-                dmsg_error() << "not a sparsity pattern matrix (SparsityPatternLocalMatrix)";
+                if (auto* sparsityPatternMatrix = dynamic_cast<SparsityPatternLocalMatrix<c>*>(localMatrix))
+                {
+                    replaceLocalMatrixNonMapped(mparams, matrixMaps, component, localMatrix, states, sparsityPatternMatrix);
+                }
+                else if (auto* sparsityPatternMatrixWithCheck = dynamic_cast<SparsityPatternLocalMatrix<c, StrategyCheckerType>*>(localMatrix))
+                {
+                    replaceLocalMatrixNonMapped(mparams, matrixMaps, component, localMatrix, states, sparsityPatternMatrixWithCheck);
+                }
+                else
+                {
+                    dmsg_error() << "The component '" << localMatrix->getPathName()
+                            << "' was expected to be a sparsity pattern matrix "
+                            "(SparsityPatternLocalMatrix != " << localMatrix->getClassName() << ")";
+                }
             }
         }
     }

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.inl
@@ -31,6 +31,9 @@ namespace sofa::component::linearsystem
 /// Check that the incoming rows and columns are expected by the constant sparsity pattern
 struct CheckNoChangeInInsertionOrder : virtual core::matrixaccumulator::IndexVerificationStrategy
 {
+    using verify_index = std::true_type;
+    using skip_insertion_if_error = std::true_type;
+
     sofa::core::objectmodel::BaseObject* m_messageComponent { nullptr };
 
     [[nodiscard]]
@@ -49,7 +52,7 @@ struct CheckNoChangeInInsertionOrder : virtual core::matrixaccumulator::IndexVer
 
     std::size_t* currentId { nullptr };
 
-    void checkRowColIndices(const sofa::SignedIndex row, const sofa::SignedIndex col) override
+    bool checkRowColIndices(const sofa::SignedIndex row, const sofa::SignedIndex col) override
     {
         if (currentId)
         {
@@ -63,7 +66,8 @@ struct CheckNoChangeInInsertionOrder : virtual core::matrixaccumulator::IndexVer
                     logger() << "According to the constant sparsity pattern, the "
                             "expected row and column are [" << expectedRow << ", " <<
                             expectedCol << "], but " << "[" << row << ", " << col <<
-                            "] was received. Insertion is ignored.";
+                            "] was received.";
+                    return false;
                 }
             }
             else
@@ -72,8 +76,10 @@ struct CheckNoChangeInInsertionOrder : virtual core::matrixaccumulator::IndexVer
                         "The constant sparsity pattern did not expect more"
                         " incoming matrix values at this stage (current id = "
                         << *currentId << ", insertion list size = " << pairInsertionOrderList.size() << ")";
+                return false;
             }
         }
+        return true;
     }
 };
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
@@ -253,6 +253,9 @@ protected:
     /// To override if matrix accumulation methods differs from this class.
     virtual void makeCreateDispatcher();
 
+    virtual std::shared_ptr<sofa::core::matrixaccumulator::IndexVerificationStrategy>
+    makeIndexVerificationStrategy(sofa::core::objectmodel::BaseObject* component);
+
 private:
     template<Contribution c>
     static std::unique_ptr<CreateMatrixDispatcher<c>> makeCreateDispatcher();
@@ -268,7 +271,7 @@ struct LocalMatrixMaps
     /// The local matrix (value) that has been created and associated to a mapped component (key)
     std::map< ComponentType*, std::map<PairMechanicalStates, AssemblingMappedMatrixAccumulator<c, Real>*> > mappedLocalMatrix;
     /// A verification strategy allowing to verify that the matrix indices provided are valid
-    std::map< ComponentType*, std::shared_ptr<core::matrixaccumulator::RangeVerification> > indexVerificationStrategy;
+    std::map< ComponentType*, std::shared_ptr<core::matrixaccumulator::IndexVerificationStrategy> > indexVerificationStrategy;
 
 
     std::map< ComponentType*, std::map<PairMechanicalStates, BaseAssemblingMatrixAccumulator<c>* > > componentLocalMatrix;

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
@@ -947,14 +947,10 @@ BaseAssemblingMatrixAccumulator<c>* MatrixLinearSystem<TMatrix, TVector>::create
 
     if (d_checkIndices.getValue())
     {
-        if (auto concreteLocalMatrix
-            = dynamic_cast<AssemblingMatrixAccumulator<c, core::matrixaccumulator::IndexVerificationStrategy>*>(localMatrix.get()))
+        const auto it = getLocalMatrixMap<c>().indexVerificationStrategy.find(object);
+        if (it != getLocalMatrixMap<c>().indexVerificationStrategy.end())
         {
-            const auto it = getLocalMatrixMap<c>().indexVerificationStrategy.find(object);
-            if (it != getLocalMatrixMap<c>().indexVerificationStrategy.end())
-            {
-                concreteLocalMatrix->indexVerificationStrategy = it->second;
-            }
+            localMatrix->setIndexCheckerStrategy(it->second);
         }
     }
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMappedMatrix.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMappedMatrix.h
@@ -39,7 +39,6 @@ public:
     using ComponentType = typename Inherit1::ComponentType;
 
     using Inherit1::add;
-    using Inherit1::InsertionOrderError;
 
 protected:
     void add(const no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value) override;
@@ -53,20 +52,18 @@ template <core::matrixaccumulator::Contribution c, class TBlockType>
 void ConstantLocalMappedMatrix<c, TBlockType>::add(const no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
     float value)
 {
-    if (this->checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
-    {
-        this->m_mappedMatrix->colsValue[this->compressedInsertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
-    }
+    SOFA_UNUSED(row);
+    SOFA_UNUSED(col);
+    this->m_mappedMatrix->colsValue[this->compressedInsertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
 }
 
 template <core::matrixaccumulator::Contribution c, class TBlockType>
 void ConstantLocalMappedMatrix<c, TBlockType>::add(const no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
     double value)
 {
-    if (this->checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
-    {
-        this->m_mappedMatrix->colsValue[this->compressedInsertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
-    }
+    SOFA_UNUSED(row);
+    SOFA_UNUSED(col);
+    this->m_mappedMatrix->colsValue[this->compressedInsertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
 }
 
 template <core::matrixaccumulator::Contribution c, class TBlockType>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMappedMatrix.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMappedMatrix.h
@@ -39,6 +39,7 @@ public:
     using ComponentType = typename Inherit1::ComponentType;
 
     using Inherit1::add;
+    using Inherit1::InsertionOrderError;
 
 protected:
     void add(const no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value) override;
@@ -52,18 +53,20 @@ template <core::matrixaccumulator::Contribution c, class TBlockType>
 void ConstantLocalMappedMatrix<c, TBlockType>::add(const no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
     float value)
 {
-    SOFA_UNUSED(row);
-    SOFA_UNUSED(col);
-    this->m_mappedMatrix->colsValue[this->insertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
+    if (this->checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
+    {
+        this->m_mappedMatrix->colsValue[this->compressedInsertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
+    }
 }
 
 template <core::matrixaccumulator::Contribution c, class TBlockType>
 void ConstantLocalMappedMatrix<c, TBlockType>::add(const no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
     double value)
 {
-    SOFA_UNUSED(row);
-    SOFA_UNUSED(col);
-    this->m_mappedMatrix->colsValue[this->insertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
+    if (this->checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
+    {
+        this->m_mappedMatrix->colsValue[this->compressedInsertionOrderList[this->currentId++]] += this->m_cachedFactor * value;
+    }
 }
 
 template <core::matrixaccumulator::Contribution c, class TBlockType>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMatrix.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMatrix.h
@@ -36,11 +36,28 @@ public:
     using ComponentType = typename Inherit1::ComponentType;
 
     using Inherit1::add;
+    using Row = sofa::SignedIndex;
+    using Col = sofa::SignedIndex;
 
-    sofa::type::vector<std::size_t> insertionOrderList;
+    /// list of expected rows and columns
+    sofa::type::vector<std::pair<Row, Col> > pairInsertionOrderList;
+
+    /// list of indices in the compressed values
+    sofa::type::vector<std::size_t> compressedInsertionOrderList;
+
     std::size_t currentId {};
 
+    /// Enumeration representing possible errors during insertion into the compressed matrix
+    enum class InsertionOrderError : char
+    {
+        NO_INSERTION_ERROR,
+        NOT_EXPECTED_ROW_COL,
+        TOO_MUCH_INCOMING_VALUES
+    };
+
 protected:
+
+    InsertionOrderError checkInsertionOrderIsConstant(sofa::SignedIndex row, sofa::SignedIndex col);
 
     void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value) override;
     void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, double value) override;
@@ -49,22 +66,53 @@ protected:
 
 };
 
+
+template <class TMatrix, core::matrixaccumulator::Contribution c>
+auto ConstantLocalMatrix<TMatrix, c>::checkInsertionOrderIsConstant(
+    const sofa::SignedIndex row,
+    const sofa::SignedIndex col) -> InsertionOrderError
+{
+    if (currentId < pairInsertionOrderList.size())
+    {
+        const auto& [expectedRow, expectedCol] = pairInsertionOrderList[currentId];
+        const bool isRowExpected = expectedRow == row;
+        const bool isColExpected = expectedCol == col;
+        if (!isRowExpected || !isColExpected)
+        {
+            msg_error() << "According to the constant sparsity pattern, the "
+                    "expected row and column are [" << expectedRow << ", " <<
+                    expectedCol << "], but " << "[" << row << ", " << col <<
+                    "] was received. Insertion is ignored.";
+            return InsertionOrderError::NOT_EXPECTED_ROW_COL;
+        }
+        return InsertionOrderError::NO_INSERTION_ERROR;
+    }
+    else
+    {
+        msg_error() <<
+                "The constant sparsity pattern did not expect more incoming matrix values at this stage. Insertion is ignored.";
+        return InsertionOrderError::TOO_MUCH_INCOMING_VALUES;
+    }
+}
+
 template <class TMatrix, core::matrixaccumulator::Contribution c>
 void ConstantLocalMatrix<TMatrix, c>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value)
 {
-    SOFA_UNUSED(row);
-    SOFA_UNUSED(col);
-    static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[insertionOrderList[currentId++]]
-        += this->m_cachedFactor * value;
+    if (checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
+    {
+        static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[compressedInsertionOrderList[currentId++]]
+                += this->m_cachedFactor * value;
+    }
 }
 
 template <class TMatrix, core::matrixaccumulator::Contribution c>
 void ConstantLocalMatrix<TMatrix, c>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, double value)
 {
-    SOFA_UNUSED(row);
-    SOFA_UNUSED(col);
-    static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[insertionOrderList[currentId++]]
-        += this->m_cachedFactor * value;
+    if (checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
+    {
+        static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[compressedInsertionOrderList[currentId++]]
+            += this->m_cachedFactor * value;
+    }
 }
 
 template <class TMatrix, core::matrixaccumulator::Contribution c>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMatrix.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/ConstantLocalMatrix.h
@@ -28,36 +28,23 @@ namespace sofa::component::linearsystem
 /**
  * Local matrix using the insertion order to insert the value directly into the compressed matrix
  */
-template<class TMatrix, core::matrixaccumulator::Contribution c>
-class ConstantLocalMatrix : public virtual AssemblingMatrixAccumulator<c>
+template<class TMatrix, core::matrixaccumulator::Contribution c, class TStrategy = sofa::core::matrixaccumulator::NoIndexVerification>
+class ConstantLocalMatrix : public virtual AssemblingMatrixAccumulator<c, TStrategy>
 {
 public:
-    SOFA_CLASS(ConstantLocalMatrix, AssemblingMatrixAccumulator<c>);
+    SOFA_CLASS(ConstantLocalMatrix, SOFA_TEMPLATE2(AssemblingMatrixAccumulator, c, TStrategy));
     using ComponentType = typename Inherit1::ComponentType;
 
     using Inherit1::add;
     using Row = sofa::SignedIndex;
     using Col = sofa::SignedIndex;
 
-    /// list of expected rows and columns
-    sofa::type::vector<std::pair<Row, Col> > pairInsertionOrderList;
-
     /// list of indices in the compressed values
     sofa::type::vector<std::size_t> compressedInsertionOrderList;
 
     std::size_t currentId {};
 
-    /// Enumeration representing possible errors during insertion into the compressed matrix
-    enum class InsertionOrderError : char
-    {
-        NO_INSERTION_ERROR,
-        NOT_EXPECTED_ROW_COL,
-        TOO_MUCH_INCOMING_VALUES
-    };
-
 protected:
-
-    InsertionOrderError checkInsertionOrderIsConstant(sofa::SignedIndex row, sofa::SignedIndex col);
 
     void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value) override;
     void add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, double value) override;
@@ -66,57 +53,26 @@ protected:
 
 };
 
-
-template <class TMatrix, core::matrixaccumulator::Contribution c>
-auto ConstantLocalMatrix<TMatrix, c>::checkInsertionOrderIsConstant(
-    const sofa::SignedIndex row,
-    const sofa::SignedIndex col) -> InsertionOrderError
+template <class TMatrix, core::matrixaccumulator::Contribution c, class TStrategy>
+void ConstantLocalMatrix<TMatrix, c, TStrategy>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value)
 {
-    if (currentId < pairInsertionOrderList.size())
-    {
-        const auto& [expectedRow, expectedCol] = pairInsertionOrderList[currentId];
-        const bool isRowExpected = expectedRow == row;
-        const bool isColExpected = expectedCol == col;
-        if (!isRowExpected || !isColExpected)
-        {
-            msg_error() << "According to the constant sparsity pattern, the "
-                    "expected row and column are [" << expectedRow << ", " <<
-                    expectedCol << "], but " << "[" << row << ", " << col <<
-                    "] was received. Insertion is ignored.";
-            return InsertionOrderError::NOT_EXPECTED_ROW_COL;
-        }
-        return InsertionOrderError::NO_INSERTION_ERROR;
-    }
-    else
-    {
-        msg_error() <<
-                "The constant sparsity pattern did not expect more incoming matrix values at this stage. Insertion is ignored.";
-        return InsertionOrderError::TOO_MUCH_INCOMING_VALUES;
-    }
-}
-
-template <class TMatrix, core::matrixaccumulator::Contribution c>
-void ConstantLocalMatrix<TMatrix, c>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value)
-{
-    if (checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
-    {
-        static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[compressedInsertionOrderList[currentId++]]
+    SOFA_UNUSED(row);
+    SOFA_UNUSED(col);
+    static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[compressedInsertionOrderList[currentId++]]
                 += this->m_cachedFactor * value;
-    }
 }
 
-template <class TMatrix, core::matrixaccumulator::Contribution c>
-void ConstantLocalMatrix<TMatrix, c>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, double value)
+template <class TMatrix, core::matrixaccumulator::Contribution c, class TStrategy>
+void ConstantLocalMatrix<TMatrix, c, TStrategy>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, double value)
 {
-    if (checkInsertionOrderIsConstant(row, col) == InsertionOrderError::NO_INSERTION_ERROR)
-    {
-        static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[compressedInsertionOrderList[currentId++]]
-            += this->m_cachedFactor * value;
-    }
+    SOFA_UNUSED(row);
+    SOFA_UNUSED(col);
+    static_cast<TMatrix*>(this->m_globalMatrix)->colsValue[compressedInsertionOrderList[currentId++]]
+                += this->m_cachedFactor * value;
 }
 
-template <class TMatrix, core::matrixaccumulator::Contribution c>
-void ConstantLocalMatrix<TMatrix, c>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
+template <class TMatrix, core::matrixaccumulator::Contribution c, class TStrategy>
+void ConstantLocalMatrix<TMatrix, c, TStrategy>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
     const sofa::type::Mat<3, 3, float>& value)
 {
     for (sofa::SignedIndex i = 0; i < 3; ++i)
@@ -128,8 +84,8 @@ void ConstantLocalMatrix<TMatrix, c>::add(const core::matrixaccumulator::no_chec
     }
 }
 
-template <class TMatrix, core::matrixaccumulator::Contribution c>
-void ConstantLocalMatrix<TMatrix, c>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
+template <class TMatrix, core::matrixaccumulator::Contribution c, class TStrategy>
+void ConstantLocalMatrix<TMatrix, c, TStrategy>::add(const core::matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col,
     const sofa::type::Mat<3, 3, double>& value)
 {
     for (sofa::SignedIndex i = 0; i < 3; ++i)

--- a/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.cpp
+++ b/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.cpp
@@ -80,31 +80,37 @@ logger() const
                : msg_error("RangeVerification");
 }
 
-void matrixaccumulator::RangeVerification::checkRowIndex(sofa::SignedIndex row)
+bool matrixaccumulator::RangeVerification::checkRowIndex(sofa::SignedIndex row)
 {
     if (row < minRowIndex)
     {
         logger() << "Trying to accumulate a matrix entry out of the allowed submatrix: minimum "
             "row index is " << minRowIndex << " while " << row << " was provided";
+        return false;
     }
     if (row > maxRowIndex)
     {
         logger() << "Trying to accumulate a matrix entry out of the allowed submatrix: maximum "
             "row index is " << maxRowIndex << " while " << row << " was provided";
+        return false;
     }
+    return true;
 }
 
-void matrixaccumulator::RangeVerification::checkColIndex(sofa::SignedIndex col)
+bool matrixaccumulator::RangeVerification::checkColIndex(sofa::SignedIndex col)
 {
     if (col < minColIndex)
     {
         logger() << "Trying to accumulate a matrix entry out of the allowed submatrix: minimum "
             "column index is " << minColIndex << " while " << col << " was provided";
+        return false;
     }
     if (col > maxColIndex)
     {
         logger() << "Trying to accumulate a matrix entry out of the allowed submatrix: maximum "
             "column index is " << maxColIndex << " while " << col << " was provided";
+        return false;
     }
+    return true;
 }
 }

--- a/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
+++ b/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
@@ -29,6 +29,11 @@
 namespace sofa::core
 {
 
+namespace matrixaccumulator
+{
+    struct IndexVerificationStrategy;
+}
+
 class SOFA_CORE_API MatrixAccumulatorInterface
 {
 public:
@@ -50,6 +55,8 @@ public:
 
     template<sofa::Size L, sofa::Size C, class real>
     void matAdd(sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<L, C, real>& value);
+
+    virtual void setIndexCheckerStrategy(std::shared_ptr<matrixaccumulator::IndexVerificationStrategy>) {}
 };
 
 template <sofa::Size L, sofa::Size C, class real>
@@ -155,7 +162,12 @@ public:
     SOFA_CLASS(MatrixAccumulatorIndexChecker, TBaseMatrixAccumulator);
 
     [[maybe_unused]]
-    std::shared_ptr<TStrategy> indexVerificationStrategy;
+    std::shared_ptr<matrixaccumulator::IndexVerificationStrategy> indexVerificationStrategy;
+
+    void setIndexCheckerStrategy(std::shared_ptr<matrixaccumulator::IndexVerificationStrategy> strategy) override
+    {
+        indexVerificationStrategy = strategy;
+    }
 
     void add(const sofa::SignedIndex row, const sofa::SignedIndex col, const float value) override final
     {

--- a/Sofa/framework/Core/test/MatrixAccumulator_test.cpp
+++ b/Sofa/framework/Core/test/MatrixAccumulator_test.cpp
@@ -90,21 +90,22 @@ TEST(MatrixAccumulatorIndexChecker, RangeVerification)
         accumulator->add(3123, 45432, 0.);
     }
 
-    accumulator->indexVerificationStrategy = std::make_shared<core::matrixaccumulator::RangeVerification>();
+    const auto rangeVerificationStrategy = std::make_shared<core::matrixaccumulator::RangeVerification>();
+    accumulator->setIndexCheckerStrategy(rangeVerificationStrategy);
 
     {
         EXPECT_MSG_NOEMIT(Error);
         accumulator->add(3123, 45432, 0.);
     }
 
-    accumulator->indexVerificationStrategy->maxColIndex = 20;
+    rangeVerificationStrategy->maxColIndex = 20;
 
     {
         EXPECT_MSG_NOEMIT(Error);
         accumulator->add(3123, 20, 0.);
     }
 
-    accumulator->indexVerificationStrategy->maxRowIndex = 40;
+    rangeVerificationStrategy->maxRowIndex = 40;
 
     {
         EXPECT_MSG_EMIT(Error);

--- a/examples/Component/LinearSystem/ConstantSparsityPatternSystem.scn
+++ b/examples/Component/LinearSystem/ConstantSparsityPatternSystem.scn
@@ -22,7 +22,7 @@
 
     <Node name="beams">
         <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
-        <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="true"/>
+        <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="true" checkIndices="false"/>
         <EigenSimplicialLDLT template="CompressedRowSparseMatrixd" linearSystem="@A"/>
 
         <Node name="object_a">


### PR DESCRIPTION
ConstantSparsityPatternSystem relies on the assumption that the sparsity pattern of the mechanical matrix is constant. If the pattern is not constant, the component crashes.
This PR introduces a verification that the pattern follows the initial pattern. In case of a mismatch, an error is emitted and the insertion is skipped. This allows the simulation not to crash and inform the user. However, this behavior is available only if `checkIndices` is enabled. It is disabled by default because the check is time consuming, and the goal of this component is performance-oriented.

To illustrate the new behavior, one can test the following scene:

```xml
<Node name="root" dt="0.02" gravity="0 -10 0">
    <Node name="plugins">
        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
        <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [EigenSimplicialLDLT] -->
        <RequiredPlugin name="Sofa.Component.LinearSystem"/> <!-- Needed to use components [ConstantSparsityPatternSystem] -->
        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
        <RequiredPlugin name="Sofa.Component.MechanicalLoad"/> <!-- Needed to use components [PlaneForceField] -->
        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [HexahedronFEMForceField] -->
        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
    </Node>

    <VisualStyle displayFlags="showBehaviorModels showForceFields" />

    <DefaultAnimationLoop/>
    <DefaultVisualManagerLoop/>

    <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
    <!-- A constant sparsity pattern is assumed, but the presence of PlaneForceField invalid this assumption
        Indices checking is enabled in order to detect that the pattern is not constant.
        As soon as the pattern is no longer constant, insertions in the matrix are ignored.
        Since it happens for all forces from PlaneForceField, they can be considered semi-explicit.
     -->
    <ConstantSparsityPatternSystem template="CompressedRowSparseMatrix" name="A" printLog="true" checkIndices="true"/>
    <EigenSimplicialLDLT template="CompressedRowSparseMatrix" linearSystem="@A"/>
    <MechanicalObject name="DoFs" />
    <UniformMass name="mass" totalMass="320" />
    <RegularGridTopology name="grid" nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
    <BoxROI name="box" box="-10 -1 -0.0001  -5 4 0.0001"/>
    <FixedProjectiveConstraint indices="@box.indices" />
    <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
    <PlaneForceField name="planeForce" stiffness="1000" damping="20" normal="0 1 0" d="-3" showPlane="true"/>

</Node>
```

Note that a lot of changes was about fixing the index checking in ConstantSparsityPatternSystem. It was never implemented.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
