### PR TITLE
[VolumetricRendering] Fix crashes in batch mode

### DIFF
--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
@@ -327,24 +327,21 @@ void OglTetrahedralModel<DataTypes>::drawTransparent(const core::visual::VisualP
 template<class DataTypes>
 void OglTetrahedralModel<DataTypes>::computeBBox(const core::ExecParams * params, bool /* onlyVisible */)
 {
-    if (m_topology)
+    const type::vector<Coord>& position = m_positions.getValue();
+
+    if (m_topology && position.size() > 0)
     {
-        const core::topology::BaseMeshTopology::SeqTetrahedra& vec = m_topology->getTetrahedra();
-        core::topology::BaseMeshTopology::SeqTetrahedra::const_iterator it;
-        Coord v;
-        const type::vector<Coord>& position = m_positions.getValue();
         const SReal max_real = std::numeric_limits<SReal>::max();
-        const SReal min_real = std::numeric_limits<SReal>::min();
+        const SReal min_real = std::numeric_limits<SReal>::lowest();
 
         SReal maxBBox[3] = { min_real,min_real,min_real };
         SReal minBBox[3] = { max_real,max_real,max_real };
 
-        for (it = vec.begin(); it != vec.end(); it++)
+        for(const auto& tetra : m_topology->getTetrahedra())
         {
             for (unsigned int i = 0; i< 4; i++)
             {
-                v = position[(*it)[i]];
-                //v = x[(*it)[i]];
+                const auto& v = position[tetra[i]];
 
                 if (minBBox[0] > v[0]) minBBox[0] = v[0];
                 if (minBBox[1] > v[1]) minBBox[1] = v[1];

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
@@ -178,6 +178,13 @@ void OglTetrahedralModel<DataTypes>::initVisual()
 template<class DataTypes>
 void OglTetrahedralModel<DataTypes>::updateVisual()
 {
+    // Workaround if updateVisual() is called without an opengl context
+    const auto* vparams = core::visual::VisualParams::defaultInstance();
+    if (!vparams->isSupported(core::visual::API_OpenGL))
+    {
+        return;
+    }
+
     if ((modified && !m_positions.getValue().empty())
         || useTopology)
     {

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
@@ -224,6 +224,13 @@ void OglVolumetricModel::initVisual()
 
 void OglVolumetricModel::updateVisual()
 {
+    // Workaround if updateVisual() is called without an opengl context
+    const auto* vparams = core::visual::VisualParams::defaultInstance();
+    if (!vparams->isSupported(core::visual::API_OpenGL))
+    {
+        return;
+    }
+
     if (b_modified || d_tetrahedra.isDirty() || d_hexahedra.isDirty() || m_positions.isDirty())
     {
         //if(b_useTopology)


### PR DESCRIPTION
Those 2 components are purely based on OpenGL (opengl code in update visual and draw().
But unexpectedly, updateVisual() is called, even in batch mode
This PR simply skips the updateVisual() if the Visual params does not handle opengl (which is the case in batch)

Philosophical question: should we really updateVisual if there is no visual ?

https://github.com/sofa-framework/sofa/blob/26f65f15accb058053f49fbcd862cf59dec50352/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp#L274

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
