### PR TITLE
[SofaCUDA] Initialize module from another module

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOFACUDA_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/SofaCUDA")
 
 set(HEADER_FILES
     config.h.in
+    init.h
     
     ### Common
     sofa/gpu/cuda/CudaBaseVector.h
@@ -99,7 +100,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     ### Common
-    main.cpp
+    init.cpp
     sofa/gpu/cuda/CudaBaseVector.cpp
     sofa/gpu/cuda/mycuda.cpp
 

--- a/applications/plugins/SofaCUDA/init.cpp
+++ b/applications/plugins/SofaCUDA/init.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaCUDA/config.h>
+#include <SofaCUDA/init.h>
 #include <sofa/gpu/cuda/mycuda.h>
 #include <sofa/core/ObjectFactory.h>
 
@@ -40,7 +41,7 @@ SOFA_GPU_CUDA_API bool moduleIsInitialized();
 
 bool isModuleInitialized = false;
 
-void initExternalModule()
+void init()
 {
     static bool first = true;
     if (first)
@@ -48,6 +49,11 @@ void initExternalModule()
         isModuleInitialized = sofa::gpu::cuda::mycudaInit();
         first = false;
     }
+}
+
+void initExternalModule()
+{
+    init();
 }
 
 const char* getModuleName()

--- a/applications/plugins/SofaCUDA/init.h
+++ b/applications/plugins/SofaCUDA/init.h
@@ -1,0 +1,27 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <SofaCUDA/config.h>
+namespace sofa::gpu::cuda
+{
+SOFA_GPU_CUDA_API void init();
+} // namespace sofa::gpu::cuda


### PR DESCRIPTION
With this PR, `sofa::gpu::cuda::init()` can be called from outside.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
