### PR TITLE
[Defaulttype, LinearAlgera] Fix warnings

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
@@ -609,6 +609,7 @@ namespace sofa::linearalgebra
         template<class TSubBlock, std::enable_if_t<std::is_scalar_v<TSubBlock>, bool> = true>
         static void subBlock(const Block& b, IndexType row, IndexType col, TSubBlock& subBlock)
         {
+            SOFA_UNUSED(row);
             subBlock = b[col];
         }
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
@@ -194,6 +194,7 @@ public:
     template<class TSubBlock, std::enable_if_t<std::is_scalar_v<TSubBlock>, bool> = true>
     static void subBlock(const Block& b, IndexType row, IndexType col, TSubBlock& subBlock)
     {
+        SOFA_UNUSED(row);
         b.getsub(col, subBlock);
     }
 


### PR DESCRIPTION
Those headers are included almost everywhere so it triggers a large number of "unused var" warnings (~2k in a standard compilation), leading to big log files on the CI 😵

Only with clang though apparently.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
