### PR TITLE
[Config] CMake: fix warning about upper/lowercase for Difflib

### DIFF
--- a/Sofa/framework/Config/cmake/Modules/FindDiffLib.cmake
+++ b/Sofa/framework/Config/cmake/Modules/FindDiffLib.cmake
@@ -1,4 +1,4 @@
-find_path(DIFFLIB_INCLUDE_DIR difflib.h
+find_path(difflib_INCLUDE_DIR difflib.h
 		  HINTS ${difflib_ROOT}
 		  # If cross-compiling and typically use CMAKE_FIND_ROOT_PATH variable,
 		  # each of its directory entry will be prepended to PATHS locations, and
@@ -9,7 +9,7 @@ find_path(DIFFLIB_INCLUDE_DIR difflib.h
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(DIFFLIB
-		REQUIRED_VARS DIFFLIB_INCLUDE_DIR
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(DiffLib
+		REQUIRED_VARS difflib_INCLUDE_DIR
 )
 mark_as_advanced(difflib_INCLUDE_DIR)

--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -258,7 +258,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${JS
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${STB_INCLUDE_DIR}>")
 
 # DiffLib (header only)
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${DIFFLIB_INCLUDE_DIR}>")
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${difflib_INCLUDE_DIR}>")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
