### PR TITLE
[Testing] Fix installation of gtest headers

### DIFF
--- a/Sofa/framework/Testing/CMakeLists.txt
+++ b/Sofa/framework/Testing/CMakeLists.txt
@@ -33,6 +33,9 @@ if(NOT GTest_FOUND AND SOFA_ALLOW_FETCH_DEPENDENCIES)
         target_compile_options(gtest_main PRIVATE "-DGTEST_LINKED_AS_SHARED_LIBRARY=0")
         target_compile_options(gtest PRIVATE "-DGTEST_CREATE_SHARED_LIBRARY=1")
 
+        install(DIRECTORY ${googletest_SOURCE_DIR}/googletest/include/gtest DESTINATION include/extlibs/GTest/ COMPONENT headers)
+        target_include_directories(gtest PUBLIC "$<INSTALL_INTERFACE:include/extlibs/GTest/>")
+        
         include(SofaMacros)
         sofa_create_package_with_targets(
             PACKAGE_NAME GTest


### PR DESCRIPTION
... or so it seems.

There is not CI process for the install process and I could compile BeamAdapter_test target out of tree, but I would prefer if other people could test it 🧐



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
