### PR TITLE
[Config] POC: enable assertions even in release mode

### DIFF
--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -395,6 +395,7 @@ if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)
 endif()
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionForceField.h
@@ -153,8 +153,8 @@ public:
         return name;
     }
 
-    using Inherit2::getMechModel1;
-    using Inherit2::getMechModel2;
+    BaseMechanicalState* getMechModel1() override { return Inherit2::getMechModel1(); }
+    BaseMechanicalState* getMechModel2() override { return Inherit2::getMechModel2(); }
 };
 
 #if !defined(SOFA_CORE_BEHAVIOR_MIXEDINTERACTIONFORCEFIELD_CPP)

--- a/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionConstraint.h
@@ -152,8 +152,8 @@ public:
         return obj;
     }
 
-    using Inherit2::getMechModel1;
-    using Inherit2::getMechModel2;
+    BaseMechanicalState* getMechModel1() override { return Inherit2::getMechModel1(); }
+    BaseMechanicalState* getMechModel2() override { return Inherit2::getMechModel2(); }
 
 protected:
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
@@ -169,8 +169,8 @@ public:
         return obj;
     }
 
-    using Inherit2::getMechModel1;
-    using Inherit2::getMechModel2;
+    BaseMechanicalState* getMechModel1() override { return Inherit2::getMechModel1(); }
+    BaseMechanicalState* getMechModel2() override { return Inherit2::getMechModel2(); }
 };
 
 #if !defined(SOFA_CORE_BEHAVIOR_PAIRINTERACTIONPROJECTIVECONSTRAINTSET_CPP)

--- a/Sofa/framework/DefaultType/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Helper Sofa.Type Sofa.LinearAlgebra)
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
@@ -143,15 +143,22 @@ struct SetTypeInfo
 
     static void setValueString(DataType &data, sofa::Size /*index*/, const std::string& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseType t;
-            BaseTypeInfo::setValueString(t, 0, value);
-            data.insert(t);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseType t;
+                BaseTypeInfo::setValueString(t, 0, value);
+                data.insert(t);
+            }
+            else
+            {
+                msg_error("SetTypeInfo") << "setValueString not implemented for set with composite values.";
+            }
         }
         else
         {
-            msg_error("SetTypeInfo") << "setValueString not implemented for set with composite values.";
+            msg_error("SetTypeInfo") << "setValueString not implemented for set with dymamic size.";
         }
     }
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
@@ -91,13 +91,17 @@ struct VectorTypeInfo
     template <typename T>
     static void getValue(const DataType &data, sofa::Size index, T& value)
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::getValue(data[index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::getValue(data[(index/BaseTypeInfo::size())], (index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::getValue(data[index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::getValue(data[(index / BaseTypeInfo::size())],
+                                       (index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {
@@ -118,13 +122,17 @@ struct VectorTypeInfo
     template<typename T>
     static void setValue(DataType &data, sofa::Size index, const T& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::setValue(data[index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::setValue(data[(index/BaseTypeInfo::size())], (index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::setValue(data[index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::setValue(data[(index / BaseTypeInfo::size())],
+                                       (index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {

--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -290,6 +290,7 @@ else()
     target_compile_definitions(${PROJECT_NAME} PRIVATE "SOFA_BUILD_MULTI_CONFIGURATION=0")
 endif()
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/LinearAlgebra/CMakeLists.txt
+++ b/Sofa/framework/LinearAlgebra/CMakeLists.txt
@@ -81,6 +81,7 @@ if (SOFA_LINEARALGEBRA_HAVE_OPENMP)
     target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
 endif()
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/Simulation/Common/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Common/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Core Sofa.Simulation.Core)
 target_link_libraries(${PROJECT_NAME} PRIVATE tinyxml2::tinyxml2) # Private because not exported in API
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -333,6 +333,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
 endif()
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/MappingGraphAlgorithms.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/MappingGraphAlgorithms.cpp
@@ -209,7 +209,7 @@ void MappingGraphAlgorithms::traverseComponentGroups(MappingGraphVisitor& visito
 
         sofa::simulation::parallelForEach(*taskScheduler,
             parallelNodes.begin(), parallelNodes.end(),
-            [&visitor, &scope](const auto& node)
+            [&visitor](const auto& node)
             {
                 for (auto& child : node->m_children)
                 {

--- a/Sofa/framework/Simulation/Graph/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Graph/CMakeLists.txt
@@ -23,6 +23,7 @@ sofa_find_package(Sofa.Simulation.Common REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Common)
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/Testing/CMakeLists.txt
+++ b/Sofa/framework/Testing/CMakeLists.txt
@@ -86,6 +86,7 @@ target_compile_options(${PROJECT_NAME} PUBLIC "-DGTEST_LINKED_AS_SHARED_LIBRARY=
 
 set(SOFA_TESTING_RESOURCES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/resources")
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(


### PR DESCRIPTION
⚠️ DO NOT MERGE ! ⚠️ 

The CI only compiles in debug for one configuration and only when a commit is done on the master.
AND a lot of failures just happen because of timeouts. So the readings are uncomfortable, to say the least

So This PR simply enable assertions in release mode (overriding the flags) and should show where the assertions happen,

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
