### PR TITLE
[Simulation.Common] Fix downstream project compilation with tinyXML2

### DIFF
--- a/Sofa/framework/Simulation/Common/Sofa.Simulation.CommonConfig.cmake.in
+++ b/Sofa/framework/Simulation/Common/Sofa.Simulation.CommonConfig.cmake.in
@@ -5,7 +5,6 @@
 
 find_package(Sofa.Core QUIET REQUIRED)
 find_package(Sofa.Simulation.Core QUIET REQUIRED)
-find_package(TinyXML2 QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Remove tinyXML find package in the common config file because the linkage is private and thus it is not required to find it for links against Sofa.Simulation.Common. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
