### PR TITLE
[GUI] Remove the New/Save/SaveAs menu options

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
@@ -78,7 +78,6 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
-    <addaction name="fileNewAction"/>
     <addaction name="fileOpenAction"/>
     <addaction name="fileReloadAction"/>
     <addaction name="fileSaveAction"/>
@@ -659,24 +658,6 @@ State 2: dirty, in that state the button reflect the fact that the scene graph v
     </layout>
    </widget>
   </widget>
-  <action name="fileNewAction">
-   <property name="icon">
-    <iconset>
-     <normaloff>image2</normaloff>image2</iconset>
-   </property>
-   <property name="text">
-    <string>&amp;New</string>
-   </property>
-   <property name="iconText">
-    <string>New</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+N</string>
-   </property>
-   <property name="name" stdset="0">
-    <cstring>fileNewAction</cstring>
-   </property>
-  </action>
   <action name="fileOpenAction">
    <property name="icon">
     <iconset>
@@ -886,22 +867,6 @@ State 2: dirty, in that state the button reflect the fact that the scene graph v
  </includes>
  <resources/>
  <connections>
-  <connection>
-   <sender>fileNewAction</sender>
-   <signal>triggered()</signal>
-   <receiver>GUI</receiver>
-   <slot>fileNew()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>fileOpenAction</sender>
    <signal>triggered()</signal>

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GUI.ui
@@ -80,8 +80,6 @@
     </property>
     <addaction name="fileOpenAction"/>
     <addaction name="fileReloadAction"/>
-    <addaction name="fileSaveAction"/>
-    <addaction name="fileSaveAsAction"/>
     <addaction name="separator"/>
     <addaction name="separator"/>
     <addaction name="fileExitAction"/>
@@ -690,41 +688,6 @@ State 2: dirty, in that state the button reflect the fact that the scene graph v
     <cstring>fileReloadAction</cstring>
    </property>
   </action>
-  <action name="fileSaveAction">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset>
-     <normaloff>image4</normaloff>image4</iconset>
-   </property>
-   <property name="text">
-    <string>&amp;Save</string>
-   </property>
-   <property name="iconText">
-    <string>Save</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+S</string>
-   </property>
-   <property name="name" stdset="0">
-    <cstring>fileSaveAction</cstring>
-   </property>
-  </action>
-  <action name="fileSaveAsAction">
-   <property name="text">
-    <string>Save &amp;As...</string>
-   </property>
-   <property name="iconText">
-    <string>Save As</string>
-   </property>
-   <property name="shortcut">
-    <string/>
-   </property>
-   <property name="name" stdset="0">
-    <cstring>fileSaveAsAction</cstring>
-   </property>
-  </action>
   <action name="fileExitAction">
    <property name="text">
     <string>E&amp;xit</string>
@@ -888,38 +851,6 @@ State 2: dirty, in that state the button reflect the fact that the scene graph v
    <signal>triggered()</signal>
    <receiver>GUI</receiver>
    <slot>fileReload()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>fileSaveAction</sender>
-   <signal>triggered()</signal>
-   <receiver>GUI</receiver>
-   <slot>fileSave()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>fileSaveAsAction</sender>
-   <signal>triggered()</signal>
-   <receiver>GUI</receiver>
-   <slot>fileSaveAs()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -1783,44 +1783,6 @@ void RealGUI::setSleepingNode(sofa::simulation::Node* node, bool sleeping)
 
 //------------------------------------
 
-void RealGUI::fileSaveAs(Node *node)
-{
-    if (node == nullptr) node = currentSimulation();
-    const std::string filename(this->windowFilePath().toStdString());
-
-
-    QString filter( "Scenes (");
-
-    int nb=0;
-    SceneLoaderFactory::SceneLoaderList* loaders = SceneLoaderFactory::getInstance()->getEntries();
-    for (SceneLoaderFactory::SceneLoaderList::iterator it=loaders->begin(); it!=loaders->end(); it++)
-    {
-        SceneLoader::ExtensionList extensions;
-        (*it)->getExtensionList(&extensions);
-        for (SceneLoader::ExtensionList::iterator itExt=extensions.begin(); itExt!=extensions.end(); itExt++)
-        {
-            if( (*it)->canWriteFileExtension( itExt->c_str() ) )
-            {
-                if (nb!=0) filter +=" ";
-                filter += "*.";
-                filter += QString( itExt->c_str() );
-                ++nb;
-            }
-        }
-    }
-
-    filter += ")";
-
-
-    QString s = getSaveFileName ( this, filename.empty() ?nullptr:filename.c_str(), filter, "save file dialog", "Choose where the scene will be saved" );
-    if (s.length() > 0) {
-        fileSaveAs(node, s.toStdString().c_str());
-    }
-
-}
-
-//------------------------------------
-
 void RealGUI::lockAnimation(bool value)
 {
     if(value)

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -833,35 +833,6 @@ void RealGUI::setTitle ( std::string windowTitle )
 
 //------------------------------------
 
-void RealGUI::fileNew()
-{
-    std::string newScene("config/newScene.scn");
-    if (DataRepository.findFile (newScene))
-        fileOpen(DataRepository.getFile ( newScene ).c_str());
-}
-
-//------------------------------------
-
-void RealGUI::fileSave()
-{
-    const std::string filename(this->windowFilePath().toStdString());
-    const std::string message="You are about to overwrite your current scene: "  + filename + "\nAre you sure you want to do that ?";
-
-    if ( QMessageBox::warning ( this, "Saving the Scene",message.c_str(), QMessageBox::Yes | QMessageBox::Default, QMessageBox::No ) != QMessageBox::Yes )
-        return;
-
-    fileSaveAs ( currentSimulation(), filename.c_str() );
-}
-
-//------------------------------------
-
-void RealGUI::fileSaveAs ( Node *node, const char* filename )
-{
-    sofa::simulation::node::exportGraph ( node, filename );
-}
-
-//------------------------------------
-
 void RealGUI::fileReload()
 {
     std::string filename(this->windowFilePath().toStdString());

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
@@ -223,8 +223,6 @@ public:
     virtual void unloadScene(bool _withViewer = true);
 
     virtual void setTitle( std::string windowTitle );
-    virtual void fileSaveAs(Node* node,const char* filename);
-//    virtual void saveXML();
 
     void setViewerResolution(int w, int h) override;
     void setFullScreen() override { setFullScreen(true); }
@@ -322,7 +320,6 @@ public slots:
     virtual void newRootNode(sofa::simulation::Node* root, const char* path);
     virtual void activateNode(sofa::simulation::Node* , bool );
     virtual void setSleepingNode(sofa::simulation::Node*, bool);
-    virtual void fileSaveAs(sofa::simulation::Node *node);
     virtual void lockAnimation(bool);
     virtual void fileRecentlyOpened(QAction * action);
     virtual void playpauseGUI(bool value);
@@ -357,14 +354,9 @@ public slots:
     virtual void displayProflierWindow(bool);
     virtual void currentTabChanged(int index);
 
-    virtual void fileNew();
     virtual void popupOpenFileSelector();
     virtual void fileReload();
-    virtual void fileSave();
     virtual void fileExit();
-    virtual void fileSaveAs() {
-        fileSaveAs((Node *)nullptr);
-    }
     virtual void helpAbout() { /* TODO */ }
     virtual void editRecordDirectory();
     virtual void editGnuplotDirectory();


### PR DESCRIPTION
Since SOFA is no modeler, remove the New option form the GUI as pointed out in #4520
However, the code in RealGUI.cpp remains



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
