### PR TITLE
[GitHub] Fix GH Discussions Announcements for Discord

### DIFF
--- a/.github/workflows/post-announcements.yml
+++ b/.github/workflows/post-announcements.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENTS_WEBHOOK_URL }}
-          MESSAGE: ":loudspeaker:  New post \"${{github.event.discussion.category.name}}\" :arrow_right: **[${{github.event.discussion.title}}](https://github.com/sofa-framework/sofa/discussions/${{github.event.discussion.number}})** by [${{github.event.discussion.author.login}}](https://github.com/${{github.event.discussion.author.login}})"
+          MESSAGE: ":loudspeaker:  New post \"${{github.event.discussion.category.name}}\" :arrow_right: **[${{github.event.discussion.title}}](https://github.com/sofa-framework/sofa/discussions/${{github.event.discussion.number}})** by [${{github.event.discussion.user.login}}](https://github.com/${{github.event.discussion.user.login}})"
           BOT_NAME: "Discussion announcement"
           EMBEDS_TITLE: "${{github.event.discussion.title}}"
           EMBEDS_URL: "https://github.com/sofa-framework/sofa/discussions/${{github.event.discussion.number}}"


### PR DESCRIPTION
Announcement messages on Discord showed some issues, this should fix them



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
