### PR TITLE
[Config] Add TSAN option

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -63,7 +63,6 @@ if(MSVC)
 endif()
 option(SOFA_ENABLE_FAST_MATH "Enable floating-point model to fast (theoretically faster but can bring unexpected results/bugs)." OFF)
 
-
 ### SOFA_DEV_TOOL
 option(SOFA_WITH_DEVTOOLS "Compile with development extra features." ON)
 
@@ -178,6 +177,12 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
 
     if(SOFA_ENABLE_FAST_MATH)
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "-ffast-math")
+    endif()
+
+    option(SOFA_ENABLE_TSAN "Enable thread sanitizer (only gcc or clang)" OFF)
+    if(SOFA_ENABLE_TSAN)
+        list(APPEND SOFACONFIG_COMPILE_OPTIONS "-fsanitize=thread")
+        list(APPEND SOFACONFIG_LINK_OPTIONS "-fsanitize=thread")
     endif()
 endif()
 

--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -179,8 +179,8 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "-ffast-math")
     endif()
 
-    option(SOFA_ENABLE_TSAN "Enable thread sanitizer (only gcc or clang)" OFF)
-    if(SOFA_ENABLE_TSAN)
+    option(SOFA_ENABLE_THREAD_SANITIZER "Enable thread sanitizer (only gcc or clang)" OFF)
+    if(SOFA_ENABLE_THREAD_SANITIZER)
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "-fsanitize=thread")
         list(APPEND SOFACONFIG_LINK_OPTIONS "-fsanitize=thread")
     endif()


### PR DESCRIPTION
TSAN = thread sanitizer

Helpful for debugging race conditions in multithreaded context.
Only available for gcc and clang

https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
