### PR TITLE
[Simulation.Core] Make TSAN pass for caduceus

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -63,7 +63,6 @@ if(MSVC)
 endif()
 option(SOFA_ENABLE_FAST_MATH "Enable floating-point model to fast (theoretically faster but can bring unexpected results/bugs)." OFF)
 
-
 ### SOFA_DEV_TOOL
 option(SOFA_WITH_DEVTOOLS "Compile with development extra features." ON)
 
@@ -178,6 +177,12 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
 
     if(SOFA_ENABLE_FAST_MATH)
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "-ffast-math")
+    endif()
+
+    option(SOFA_ENABLE_TSAN "Enable thread sanitizer (only gcc or clang)" OFF)
+    if(SOFA_ENABLE_TSAN)
+        list(APPEND SOFACONFIG_COMPILE_OPTIONS "-fsanitize=thread")
+        list(APPEND SOFACONFIG_LINK_OPTIONS "-fsanitize=thread")
     endif()
 endif()
 

--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -179,8 +179,8 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "-ffast-math")
     endif()
 
-    option(SOFA_ENABLE_TSAN "Enable thread sanitizer (only gcc or clang)" OFF)
-    if(SOFA_ENABLE_TSAN)
+    option(SOFA_ENABLE_THREAD_SANITIZER "Enable thread sanitizer (only gcc or clang)" OFF)
+    if(SOFA_ENABLE_THREAD_SANITIZER)
         list(APPEND SOFACONFIG_COMPILE_OPTIONS "-fsanitize=thread")
         list(APPEND SOFACONFIG_LINK_OPTIONS "-fsanitize=thread")
     endif()

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultTaskScheduler.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultTaskScheduler.h
@@ -32,7 +32,7 @@
 #include <map>
 #include <string> 
 #include <mutex>
-
+#include <atomic>
 
 
 namespace sofa::simulation
@@ -96,8 +96,10 @@ private:
     static const std::string _name;
 
     std::map< std::thread::id, WorkerThread*> _threads;
-            
-    const Task::Status*	m_mainTaskStatus;
+
+    std::atomic<const Task::Status*> m_mainTaskStatus;
+    void setMainTaskStatus(const Task::Status* mainTaskStatus);
+    bool testMainTaskStatus(const Task::Status*);
             
     std::mutex  m_wakeUpMutex;
             

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/WorkerThread.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/WorkerThread.cpp
@@ -211,7 +211,7 @@ bool WorkerThread::pushTask(Task *task)
     }
 
 
-    if (!m_taskScheduler->testMainTaskStatus(nullptr))
+    if (m_taskScheduler->testMainTaskStatus(nullptr))
     {
         m_taskScheduler->setMainTaskStatus(task->getStatus());
         m_taskScheduler->wakeUpWorkers();


### PR DESCRIPTION
Based on 
- #4534 

Some race conditions arise in the DefautlTaskScheduler, main ones are
- usage of m_mainTaskStatus (solved with an atomic?)
- start() and create_and_attach() are racing for  m_taskScheduler (solved with a small change of place of affectation)

Obviously, the opinion of @alxbilger about the fix in this PR would be greatly beneficial 😅 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
