### PR TITLE
[Sofa.Testing] Add SimpleApi in Config.cmake.in

### DIFF
--- a/Sofa/framework/Testing/Sofa.TestingConfig.cmake.in
+++ b/Sofa/framework/Testing/Sofa.TestingConfig.cmake.in
@@ -10,6 +10,7 @@ find_package(Sofa.Helper QUIET REQUIRED)
 find_package(Sofa.DefaultType QUIET REQUIRED)
 find_package(Sofa.Core QUIET REQUIRED)
 find_package(Sofa.Simulation.Graph QUIET REQUIRED)
+find_package(Sofa.SimpleApi QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Following https://github.com/sofa-framework/sofa/pull/4495
This is to fix https://github.com/sofa-framework/BeamAdapter/actions/runs/8069371516/job/22044285700?pr=140
```
CMake Error at BeamAdapter_test/CMakeLists.txt:5 (find_package):
  Found package configuration file:

    D:/a/BeamAdapter/BeamAdapter/sofa/lib/cmake/Sofa.Testing/Sofa.TestingConfig.cmake

  but it set Sofa.Testing_FOUND to FALSE so package "Sofa.Testing" is
  considered to be NOT FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing:
  Sofa.SimpleApi



-- Configuring incomplete, errors occurred!
```


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
