### PR TITLE
[cmake] Remove error in Findcxxopt

### DIFF
--- a/Sofa/framework/Config/cmake/Modules/Findcxxopts.cmake
+++ b/Sofa/framework/Config/cmake/Modules/Findcxxopts.cmake
@@ -28,12 +28,12 @@ macro(_cxxopts_check_version)
   set(cxxopts_VERSION_OK TRUE)
   if(${cxxopts_VERSION} VERSION_LESS ${cxxopts_FIND_VERSION})
     set(cxxopts_VERSION_OK FALSE)
-    message(SEND_ERROR "cxxopts version ${cxxopts_VERSION} found in ${cxxopts_INCLUDE_DIR}/cxxopts.hpp, "
+    message(WARNING "cxxopts version ${cxxopts_VERSION} found in ${cxxopts_INCLUDE_DIR}/cxxopts.hpp, "
                         "but at least version ${cxxopts_FIND_VERSION} is required")
   endif()
   if(${cxxopts_FIND_VERSION_EXACT} AND NOT ${cxxopts_VERSION} VERSION_EQUAL ${cxxopts_FIND_VERSION})
     set(cxxopts_VERSION_OK FALSE)
-    message(SEND_ERROR "cxxopts version ${cxxopts_VERSION} found in ${cxxopts_INCLUDE_DIR}, "
+    message(WARNING "cxxopts version ${cxxopts_VERSION} found in ${cxxopts_INCLUDE_DIR}, "
                         "but exact version ${cxxopts_FIND_VERSION_EXACT} is required")
   endif()
 endmacro()


### PR DESCRIPTION
Remove error and send warning when cxxopt is found but version mismatch



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
