### PR TITLE
[Config] Fix Findmetis module when using config mode

### DIFF
--- a/Sofa/framework/Config/cmake/Modules/Findmetis.cmake
+++ b/Sofa/framework/Config/cmake/Modules/Findmetis.cmake
@@ -46,12 +46,12 @@ macro(_metis_check_version)
   set(metis_VERSION_OK TRUE)
   if(${metis_VERSION} VERSION_LESS ${metis_FIND_VERSION})
     set(metis_VERSION_OK FALSE)
-    message(SEND_ERROR "metis version ${metis_VERSION} found in ${metis_INCLUDE_DIR}, "
+    message(WARNING "metis version ${metis_VERSION} found in ${metis_INCLUDE_DIR}, "
                        "but at least version ${metis_FIND_VERSION} is required")
   endif()
   if(${metis_FIND_VERSION_EXACT} AND NOT ${metis_VERSION} VERSION_EQUAL ${metis_FIND_VERSION})
     set(metis_VERSION_OK FALSE)
-    message(SEND_ERROR "metis version ${metis_VERSION} found in ${metis_INCLUDE_DIR}, "
+    message(WARNING "metis version ${metis_VERSION} found in ${metis_INCLUDE_DIR}, "
                        "but exact version ${metis_FIND_VERSION} is required")
   endif()
 endmacro()

--- a/Sofa/framework/Config/cmake/Modules/Findmetis.cmake
+++ b/Sofa/framework/Config/cmake/Modules/Findmetis.cmake
@@ -60,8 +60,8 @@ if(TARGET metis)
   set(metis_FOUND TRUE) # only metis_FOUND has been set
   if(metis_INCLUDE_DIR AND NOT DEFINED metis_VERSION)
     _metis_check_version()
+    set(metis_FOUND ${metis_VERSION_OK})
   endif()
-  set(metis_FOUND ${metis_VERSION_OK})
   add_library(metis::metis ALIAS metis)
 else()
 

--- a/Sofa/framework/Config/cmake/Modules/Findmetis.cmake
+++ b/Sofa/framework/Config/cmake/Modules/Findmetis.cmake
@@ -14,7 +14,7 @@
 # was used to provide the library, as some package managers (such vcpkg) defines only short name
 # for the target, whereas others (such as conan) defines a fully qualified name.
 
-find_package(metis NO_MODULE QUIET HINTS ${metis_DIR})
+find_package(metis NO_MODULE QUIET HINTS ${metis_DIR} NAMES metis Metis)
 
 
 if(NOT metis_FIND_VERSION)


### PR DESCRIPTION
Fix several bugs when having a metis package installed and its cmake config files are expected to be used by our Findmetis cmake module file:
- cmake config files provided by metis packages (at least conda, as APT do not provide such) are prefixed with an uppercase (e.g. MetisConfig.cmake instead of metisConfig.cmake), although all cmake variables and targets are then correctly set to lowercase. This will make the library not findable in config mode on case senstitive OS such linux. 
- do not fail if invalid version of metis is found on the system, instead allow fetching the right one (is SOFA_ALLOW_FETCH_DEPENDENCIES is ON)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
