### PR TITLE
[Geomagic] Update GeomagicDriver.cpp to fire error when hd.h is not found

### DIFF
--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
@@ -346,7 +346,7 @@ void GeomagicDriver::initDevice()
     updatePosition();
     sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 #else
-    msg_error() << "GeomagicDriver initialisation failed because OpenHaptics (HD/hd.h) has not been found. Please install openHaptics and specify OpenHaptics_DIR at CMake configure stage.";
+    msg_error() << "GeomagicDriver initialization failed because the Geomagic plugin was built without OpenHaptics (HD/hd.h). If you build the plugin yourself, install OpenHaptics and specify OpenHaptics_DIR at CMake configure stage.";
     sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
 #endif
 }

--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
@@ -346,6 +346,7 @@ void GeomagicDriver::initDevice()
     updatePosition();
     sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 #else
+    msg_error() << "GeomagicDriver initialisation failed because OpenHaptics (HD/hd.h) has not been found. Please install openHaptics and specify OpenHaptics_DIR at CMake configure stage.";
     sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
 #endif
 }


### PR DESCRIPTION
quick PR from the pool regarding discussion #4561



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
