### PR TITLE
[Collision.Response.Contact] Make contactId thread-safe

### DIFF
--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.cpp
@@ -26,18 +26,7 @@ namespace sofa::component::collision::response::contact
 
 ContactIdentifier::ContactIdentifier()
 {
-    if (!availableId.empty())
-    {
-        id = availableId.front();
-        availableId.pop_front();
-    }
-    else
-        id = cpt++;
-}
-
-ContactIdentifier::~ContactIdentifier()
-{
-    availableId.push_back(id);
+    id = cpt.fetch_add(1) ;
 }
 
 } //namespace sofa::component::collision::response::contact

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.h
@@ -36,9 +36,9 @@ public:
     virtual ~ContactIdentifier();
 
 protected:
-    inline static sofa::core::collision::DetectionOutput::ContactId cpt = 0;
+    inline static thread_local sofa::core::collision::DetectionOutput::ContactId cpt = 0;
     sofa::core::collision::DetectionOutput::ContactId id;
-    inline static std::list<sofa::core::collision::DetectionOutput::ContactId> availableId;
+    inline static thread_local std::list<sofa::core::collision::DetectionOutput::ContactId> availableId;
 };
 
 inline long cantorPolynomia(sofa::core::collision::DetectionOutput::ContactId x, sofa::core::collision::DetectionOutput::ContactId y)

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.h
@@ -33,12 +33,11 @@ class SOFA_COMPONENT_COLLISION_RESPONSE_CONTACT_API ContactIdentifier
 {
 public:
     ContactIdentifier();
-    virtual ~ContactIdentifier();
+    virtual ~ContactIdentifier() = default;
 
 protected:
-    inline static thread_local sofa::core::collision::DetectionOutput::ContactId cpt = 0;
+    inline static std::atomic<sofa::core::collision::DetectionOutput::ContactId> cpt = 0;
     sofa::core::collision::DetectionOutput::ContactId id;
-    inline static thread_local std::list<sofa::core::collision::DetectionOutput::ContactId> availableId;
 };
 
 inline long cantorPolynomia(sofa::core::collision::DetectionOutput::ContactId x, sofa::core::collision::DetectionOutput::ContactId y)

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactIdentifier.h
@@ -24,6 +24,7 @@
 
 #include <sofa/core/collision/DetectionOutput.h>
 #include <list>
+#include <atomic>
 
 
 namespace sofa::component::collision::response::contact


### PR DESCRIPTION
~~for thread-safety, and each thread/simu would have its own pool of contact id~~

~~An other solution would be to put a guard_lock/mutex each time the ids are accessed but it would share the same pool of contact id to the whole set of thread/simu~~

Make the counter of ContactId atomic.
A side effect is to remove the ability to restore previous contactid which was destroyed and set in a side container. I dont think we really need to save some "ids" because we will never overrun the 64 bit integer IMO (18446744073709551615 is quite big 🙃)
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
