### PR TITLE
[Core] Remove unused debug trace

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.cpp
@@ -158,9 +158,9 @@ void BaseData::doDelInput(DDGNode* n)
 void BaseData::update()
 {
     cleanDirty();
-    for(DDGLinkIterator it=inputs.begin(); it!=inputs.end(); ++it)
+    for (DDGNode* input : inputs)
     {
-        (*it)->updateIfDirty();
+        input->updateIfDirty();
     }
 
     /// Check if there is a parent (so a predecessor in the DDG), if so
@@ -168,10 +168,6 @@ void BaseData::update()
     const auto parent = parentData.resolvePathAndGetTarget();
     if (parent)
     {
-#ifdef SOFA_DDG_TRACE
-        if (m_owner)
-            dmsg_warning(m_owner) << "Data " << m_name << ": update from parent " << parentBaseData->m_name;
-#endif
         updateValueFromLink(parent);
         // If the value is dirty clean it
         if(this->isDirty())


### PR DESCRIPTION
I did not find how the macro `SOFA_DDG_TRACE` was enabled. The code inside did not compile. The intended behavior can be obtained using a debugger.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
