### PR TITLE
[runsofa] Allowing multiple argv

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
@@ -81,6 +81,7 @@ void ArgumentParser::parse()
     std::vector<cxxopts::KeyValue> vecArg;
     try
     {
+        extra.clear();
         m_options.parse_positional("input-file");
         const auto temp = m_options.parse(copyArgc, copyArgv);
         vecArg = temp.arguments();
@@ -95,8 +96,6 @@ void ArgumentParser::parse()
     for (const auto& arg : vecArg)
     {
         m_parseResult[arg.key()] = arg.value();
-        if(arg.key() == "argv")
-            extra.push_back(arg.value());
 
         //go through all possible keys (because of the short/long names)
         for (const auto& callback : m_mapCallbacks)

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -304,7 +304,7 @@ int main(int argc, char** argv)
         "enable interactive mode for the GUI which includes idle and mouse events (EXPERIMENTAL)"
     );
     argParser->addArgument(
-        cxxopts::value<std::vector<std::string> >(),
+        cxxopts::value<std::vector<std::string> >(sofa::gui::common::ArgumentParser::extra),
         "argv",
         "forward extra args to the python interpreter"
     );


### PR DESCRIPTION
We can forward extra args to the python interpreter with the option `--argv`. 
This PR allows to do: 
```comand
runSofa myscene.py --argv arg1,arg2,arg3
```
instead of 
```comand
runSofa myscene.py --argv arg1 --argv arg2 --argv arg3
```
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
