### PR TITLE
[Core] cmake: Remove last traces of Sofa.Component.Compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,6 @@ if(SOFA_ENABLE_LEGACY_HEADERS)
     message("Using legacy headers is enabled.")
 endif()
 sofa_add_subdirectory(library Sofa/framework/Compat Sofa.Compat ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
-sofa_add_subdirectory(library Sofa/Component/Compat Sofa.Component.Compat ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 
 ### SOFA (framework and components)
 add_subdirectory(Sofa)

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -347,12 +347,6 @@ if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)
 endif()
 
-# SOFA-NG: make everybody be able to use Sofa.Component.Compat
-sofa_find_package(Sofa.Component.Compat QUIET)
-if(Sofa.Component.Compat_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Compat)
-endif()
-
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/Core/Sofa.CoreConfig.cmake.in
+++ b/Sofa/framework/Core/Sofa.CoreConfig.cmake.in
@@ -9,10 +9,6 @@ find_package(Sofa.Topology QUIET REQUIRED)
 find_package(Sofa.Helper QUIET REQUIRED)
 find_package(Sofa.DefaultType QUIET REQUIRED)
 
-if(SOFA_CORE_HAVE_SOFA_COMPONENT_COMPAT)
-    find_package(Sofa.Component.Compat QUIET REQUIRED)
-endif()
-
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()


### PR DESCRIPTION
- #4533

did not remove everything of Sofa.Component.Compat and was even throwing a (harmless) warning at the cmake configure stage.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
