### PR TITLE
[Type] Clean and test MatSym

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/MatSym.h
+++ b/Sofa/framework/Type/src/sofa/type/MatSym.h
@@ -46,17 +46,17 @@ public:
     typedef Vec<D,Real> Coord;
     static constexpr auto NumberStoredValues = D * (D + 1) / 2;
 
-    constexpr MatSym()
+    constexpr MatSym() noexcept
     {
         clear();
     }
 
-    constexpr explicit MatSym(NoInit)
+    constexpr explicit MatSym(NoInit) noexcept
     {
     }
 
     /// Constructor from 6 elements
-    template<sofa::Size TD = D, typename = std::enable_if_t<D == 3> >
+    template<sofa::Size TD = D, typename = std::enable_if_t<TD == 3> >
     constexpr MatSym(
         const real& v1, const real& v2, const real& v3,
         const real& v4, const real& v5, const real& v6)

--- a/Sofa/framework/Type/src/sofa/type/MatSym.h
+++ b/Sofa/framework/Type/src/sofa/type/MatSym.h
@@ -31,30 +31,35 @@
 
 namespace sofa::type
 {
-////class for 3*3 symmetric matrix only
 
-template <int D,class real=float>
-class MatSym : public VecNoInit<D*(D+1)/2,real>
-//class Mat : public Vec<L,Vec<C,real> >
+/**
+ * Dense symmetric matrix of size DxD storing only D*(D+1)/2 values
+ * \tparam D Size of the matrix
+ * \tparam real Type of scalar
+ */
+template <int D, class real = SReal>
+class MatSym : public VecNoInit<D * (D + 1) / 2, real>
 {
 public:
 
-    // enum { N = L*C };
-
     typedef real Real;
     typedef Vec<D,Real> Coord;
+    static constexpr auto NumberStoredValues = D * (D + 1) / 2;
 
-
-    MatSym()
+    constexpr MatSym()
     {
         clear();
     }
 
-    explicit MatSym(NoInit)
+    constexpr explicit MatSym(NoInit)
     {
     }
+
     /// Constructor from 6 elements
-    explicit MatSym(const real& v1,const real& v2,const real& v3,const real& v4,const real& v5,const real& v6)
+    template<sofa::Size TD = D, typename = std::enable_if_t<D == 3> >
+    constexpr MatSym(
+        const real& v1, const real& v2, const real& v3,
+        const real& v4, const real& v5, const real& v6)
     {
         this->elems[0] = v1;
         this->elems[1] = v2;
@@ -64,111 +69,113 @@ public:
         this->elems[5] = v6;
     }
 
-
     /// Constructor from an element
-    explicit MatSym(const int sizeM,const real& v)
+    constexpr MatSym(const int sizeM, const real& v)
     {
-        for( int i=0; i<sizeM*(sizeM+1)/2; i++ )
+        assert(sizeM <= D);
+        for (int i = 0; i < sizeM * (sizeM + 1) / 2; ++i)
+        {
             this->elems[i] = v;
+        }
     }
 
     /// Constructor from another matrix
     template<typename real2>
-    MatSym(const MatSym<D,real2>& m)
+    explicit MatSym(const MatSym<D, real2>& m)
     {
-        std::copy(m.begin(), m.begin()+D*(D+1)/2, this->begin());
+        std::copy(m.begin(), m.begin() + NumberStoredValues, this->begin());
     }
 
 
     /// Assignment from another matrix
-    template<typename real2> void operator=(const MatSym<D,real2>& m)
+    template<typename real2>
+    void operator=(const MatSym<D, real2>& m)
     {
-        std::copy(m.begin(), m.begin()+D*(D+1)/2, this->begin());
+        std::copy(m.begin(), m.begin() + NumberStoredValues, this->begin());
     }
-
 
     /// Sets each element to 0.
     void clear()
     {
-        for (int i=0; i<D*(D+1)/2; i++)
-            this->elems[i]=0;
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
+            this->elems[i] = 0;
+        }
     }
 
     /// Sets each element to r.
     void fill(real r)
     {
-        for (int i=0; i<D*(D+1)/2; i++)
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
             this->elems[i].fill(r);
+        }
     }
 
     /// Write access to element (i,j).
-    inline real& operator()(int i, int j)
+    inline real& operator()(const int i, const int j)
     {
-        if(i>=j)
-        {  return this->elems[(i*(i+1))/2+j];}
-        else
-        {return this->elems[(j*(j+1))/2+i];}
+        if (i >= j)
+        {
+            return this->elems[(i * (i + 1)) / 2 + j];
+        }
+        return this->elems[(j * (j + 1)) / 2 + i];
     }
 
     /// Read-only access to element (i,j).
     inline const real& operator()(int i, int j) const
     {
-        if(i>=j)
-        {  return this->elems[(i*(i+1))/2+j];}
-        else
-        {return this->elems[(j*(j+1))/2+i];}
-    }
-
-    //convert matrix to sym
-    //template<int D>
-    void Mat2Sym( const Mat<D,D,real>& M, MatSym<D,real>& W)
-    {
-        for (int j=0; j<D; j++)
-            for (int i=0; i <= j; i++)
-                W(i,j) = (Real)((M(i,j) + M(j,i))/2.0);
-    }
-
-    // convert to Voigt notation
-
-    inline Vec<D*(D+1)/2 ,real> getVoigt()
-    {
-        Vec<D*(D+1)/2 ,real> result;
-        if (D==2)
+        if (i >= j)
         {
-            result[0] = this->elems[0]; result[1] = this->elems[2]; result[2] = 2*this->elems[1];
+            return this->elems[(i * (i + 1)) / 2 + j];
         }
-        else
+        return this->elems[(j * (j + 1)) / 2 + i];
+    }
+
+    /// convert matrix to sym
+    static void Mat2Sym( const Mat<D, D, real>& M, MatSym<D, real>& W)
+    {
+        for (int j = 0; j < D; j++)
         {
-            result[0] = this->elems[0]; result[1] = this->elems[2]; result[2] = this->elems[5];
-            result[3]=2*this->elems[4]; result[4]=2*this->elems[3]; result[5]=2*this->elems[1];
+            for (int i = 0; i <= j; i++)
+            {
+                W(i, j) = (M(i, j) + M(j, i)) / 2;
+            }
+        }
+    }
+
+    /// convert to Voigt notation (supported only for D == 2 and D == 3)
+    template<sofa::Size TD = D, typename = std::enable_if_t<D == 3 || D == 2> >
+    inline Vec<NumberStoredValues, real> getVoigt() const
+    {
+        Vec<NumberStoredValues, real> result {NOINIT};
+        if constexpr (D == 2)
+        {
+            result[0] = this->elems[0];
+            result[1] = this->elems[2];
+            result[2] = 2 * this->elems[1];
+        }
+        else if constexpr (D == 3)
+        {
+            result[0] = this->elems[0];
+            result[1] = this->elems[2];
+            result[2] = this->elems[5];
+            result[3] = 2 * this->elems[4];
+            result[4] = 2 * this->elems[3];
+            result[5] = 2 * this->elems[1];
         }
         return result;
-
     }
 
-
-    //convert into 3*3 matrix
-
-    /*  Mat<D,D,real> convert() const
-    {
-      Mat<D,D,real> m;
-      for(int k=0; k<D;k++){
-    	for (int l=0;l<k;l++){
-    		m[k][l]=m[l][k]=(*this)(k,l);
-    	}
-    }
-      return m;
-    }
-     */
     /// Set matrix to identity.
-    void identity()
+    constexpr void identity()
     {
-        for (int i=0; i<D; i++)
+        for (int i = 0; i < D; i++)
         {
-            this->elems[i*(i+1)/2+i]=1;
-            for (int j=i+1; j<D; j++)
+            this->elems[i * (i + 1) / 2 + i] = 1;
+            for (int j = i + 1; j < D; j++)
             {
-                this->elems[i*(i+1)/2+j]=0;
+                this->elems[i * (i + 1) / 2 + j] = 0;
             }
         }
     }
@@ -176,77 +183,95 @@ public:
     /// @name Tests operators
     /// @{
 
-    bool operator==(const MatSym<D,real>& b) const
+    bool operator==(const MatSym<D, real>& b) const
     {
-        for (int i=0; i<D*(D+1)/2; i++)
-            if (this->elems[i] != b[i]) return false;
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
+            if (this->elems[i] != b[i])
+            {
+                return false;
+            }
+        }
         return true;
     }
 
-    bool operator!=(const MatSym< D,real>& b) const
+    bool operator!=(const MatSym<D, real>& b) const
     {
-        for (int i=0; i<D*(D+1)/2; i++)
-            if (this->elems[i]!=b[i]) return true;
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
+            if (this->elems[i] != b[i])
+            {
+                return true;
+            }
+        }
         return false;
     }
-
 
     /// @}
 
     // LINEAR ALGEBRA
 
     /// Matrix multiplication operator: product of two symmetric matrices
-    //template <int D>
-    Mat<D,D,real> SymSymMultiply(const MatSym<D,real>& m) const
+    [[nodiscard]] Mat<D, D, real> SymSymMultiply(const MatSym<D, real>& m) const
     {
-        Mat<D,D,real> r(NOINIT);
+        Mat<D, D, real> r(NOINIT);
 
-        for(int i=0; i<D; i++)
+        for (int i = 0; i < D; i++)
         {
-            for(int j=0; j<D; j++)
+            for (int j = 0; j < D; j++)
             {
-                r[i][j]=(*this)(i,0) * m(0,j);
-                for(int k=1; k<D; k++) { r[i][j] += (*this)(i,k) * m(k,j);}
-            }
-        }
-        return r;
-    }
-
-    //Multiplication by a non symmetric matrix on the right
-
-    // template <int D>
-    Mat<D,D,real> SymMatMultiply(const Mat<D,D,real>& m) const
-    {
-        Mat<D,D,real> r(NOINIT);
-
-        for(int i=0; i<D; i++)
-        {
-            for(int j=0; j<D; j++)
-            {
-                r[i][j]=(*this)(i,0) * m[0][j];
-                for(int k=1; k<D; k++)
+                r[i][j] = (*this)(i, 0) * m(0, j);
+                for (int k = 1; k < D; k++)
                 {
-                    r[i][j] += (*this)(i,k) * m[k][j];
+                    r[i][j] += (*this)(i, k) * m(k, j);
                 }
             }
         }
         return r;
     }
-    //Multiplication by a non symmetric matrix on the left
 
-    // template <int D>
-    Mat<D,D,real> MatSymMultiply(const Mat<D,D,real>& m) const
+    Mat<D, D, real> operator*(const MatSym<D, real>& m) const
+    {
+        return SymSymMultiply(m);
+    }
+
+    //Multiplication by a non symmetric matrix on the right
+    [[nodiscard]] Mat<D,D,real> SymMatMultiply(const Mat<D,D,real>& m) const
     {
         Mat<D,D,real> r(NOINIT);
 
-        for(int i=0; i<D; i++)
+        for (int i = 0; i < D; i++)
         {
-            for(int j=0; j<D; j++)
+            for (int j = 0; j < D; j++)
             {
-                r[i][j]=m(i,0)* (*this)(0,j);
-                for(int k=1; k<D; k++)
+                r[i][j] = (*this)(i, 0) * m[0][j];
+                for (int k = 1; k < D; k++)
                 {
-                    r[i][j] += m(i,k) * (*this)(k,j);
+                    r[i][j] += (*this)(i, k) * m[k][j];
+                }
+            }
+        }
+        return r;
+    }
+
+    Mat<D,D,real> operator*(const Mat<D,D,real>& m) const
+    {
+        return SymMatMultiply(m);
+    }
+
+    //Multiplication by a non symmetric matrix on the left
+    Mat<D, D, real> MatSymMultiply(const Mat<D, D, real>& m) const
+    {
+        Mat<D, D, real> r(NOINIT);
+
+        for (int i = 0; i < D; i++)
+        {
+            for (int j = 0; j < D; j++)
+            {
+                r[i][j] = m(i, 0) * (*this)(0, j);
+                for (int k = 1; k < D; k++)
+                {
+                    r[i][j] += m(i, k) * (*this)(k, j);
                 }
             }
         }
@@ -255,136 +280,146 @@ public:
 
 
     /// Matrix addition operator with a symmetric matrix
-    MatSym< D,real> operator+(const MatSym<D,real>& m) const
+    MatSym<D, real> operator+(const MatSym<D, real>& m) const
     {
-        MatSym< D,real> r;
-        for(int i = 0; i < D*(D+1)/2; i++)
+        MatSym<D, real> r(NOINIT);
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
             r[i] = (*this)[i] + m[i];
+        }
         return r;
     }
 
     /// Matrix addition operator with a non-symmetric matrix
-    Mat<D,D,real> operator+(const Mat<D,D,real>& m) const
+    Mat<D, D, real> operator+(const Mat<D, D, real>& m) const
     {
-        Mat<D,D,real> r(NOINIT);
-        for(int i = 0; i < D; i++)
+        Mat<D, D, real> r(NOINIT);
+        for (int i = 0; i < D; i++)
         {
-            for(int j=0; j<D; j++)
+            for (int j = 0; j < D; j++)
             {
-                r[i][j]=(*this)(i,j)+m[i][j];
+                r[i][j] = (*this)(i, j) + m[i][j];
             }
         }
         return r;
-
     }
+
     /// Matrix substractor operator with a symmetric matrix
-    MatSym< D,real> operator-(const MatSym< D,real>& m) const
+    MatSym<D, real> operator-(const MatSym<D, real>& m) const
     {
-        MatSym<D,real> r;
-        for(int i = 0; i < D*(D+1)/2; i++)
+        MatSym<D, real> r(NOINIT);
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
             r[i] = (*this)[i] - m[i];
+        }
         return r;
     }
 
     /// Matrix substractor operator with a non-symmetric matrix
-    Mat<D,D,real> operator-(const Mat<D,D,real>& m) const
+    Mat<D, D, real> operator-(const Mat<D, D, real>& m) const
     {
-        Mat<D,D,real> r(NOINIT);
-        for(int i = 0; i < D; i++)
+        Mat<D, D, real> r(NOINIT);
+        for (int i = 0; i < D; i++)
         {
-            for(int j=0; j<D; j++)
+            for (int j = 0; j < D; j++)
             {
-                r[i][j]=(*this)(i,j)-m[i][j];
+                r[i][j] = (*this)(i, j) - m[i][j];
             }
         }
         return r;
-
     }
-
 
     /// Multiplication operator Matrix * Vector.
     Coord operator*(const Coord& v) const
     {
-
-
         Coord r(NOINIT);
-        for(int i=0; i<D; i++)
+        for (int i = 0; i < D; i++)
         {
-            r[i]=(*this)(i,0) * v[0];
-            for(int j=1; j<D; j++)
-                r[i] += (*this)(i,j) * v[j];
+            r[i] = (*this)(i, 0) * v[0];
+            for (int j = 1; j < D; j++)
+            {
+                r[i] += (*this)(i, j) * v[j];
+            }
         }
         return r;
     }
 
-
     /// Scalar multiplication operator.
-    MatSym<D,real> operator*(real f) const
+    MatSym<D, real> operator*(real f) const
     {
-        MatSym<D,real> r(NOINIT);
-        for(int i=0; i<D*(D+1)/2; i++)
+        MatSym<D, real> r(NOINIT);
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
             r[i] = (*this)[i] * f;
+        }
         return r;
     }
 
     /// Scalar matrix multiplication operator.
-    friend MatSym<D,real> operator*(real r, const MatSym< D,real>& m)
+    friend MatSym<D, real> operator*(real r, const MatSym<D, real>& m)
     {
-        return m*r;
+        return m * r;
     }
 
     /// Scalar division operator.
-    MatSym< D,real> operator/(real f) const
+    MatSym<D, real> operator/(real f) const
     {
-        MatSym< D,real> r(NOINIT);
-        for(int i=0; i<D*(D+1)/2; i++)
+        MatSym<D, real> r(NOINIT);
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
             r[i] = (*this)[i] / f;
+        }
         return r;
     }
 
     /// Scalar multiplication assignment operator.
     void operator *=(real r)
     {
-        for(int i=0; i<D*(D+1)/2; i++)
-            this->elems[i]*=r;
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
+            this->elems[i] *= r;
+        }
     }
 
     /// Scalar division assignment operator.
     void operator /=(real r)
     {
-        for(int i=0; i<D*(D+1)/2; i++)
-            this->elems[i]/=r;
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
+            this->elems[i] /= r;
+        }
     }
 
     /// Addition assignment operator.
     void operator +=(const MatSym< D,real>& m)
     {
-        for(int i=0; i<D*(D+1)/2; i++)
-            this->elems[i]+=m[i];
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
+            this->elems[i] += m[i];
+        }
     }
-
-
 
     /// Substraction assignment operator.
     void operator -=(const MatSym< D,real>& m)
     {
-        for(int i=0; i<D*(D+1)/2; i++)
-            this->elems[i]-=m[i];
+        for (int i = 0; i < NumberStoredValues; i++)
+        {
+            this->elems[i] -= m[i];
+        }
     }
 
     /// Invert matrix m
     bool invert(const MatSym<D,real>& m)
     {
-
         return invertMatrix((*this), m);
-
     }
-
-
-
 };
 
-
+template <int D, class real>
+Mat<D, D, real> operator*(const Mat<D, D, real>& a, const MatSym<D, real>& b)
+{
+    return b.MatSymMultiply(a);
+}
 
 /// Determinant of a 3x3 matrix.
 template<class real>
@@ -398,28 +433,27 @@ inline real determinant(const MatSym<3,real>& m)
             - m(2,0)*m(1,1)*m(0,2);
 }
 /// Determinant of a 2x2 matrix.
-template<class real>
-inline real determinant(const MatSym<2,real>& m)
+template <class real>
+inline real determinant(const MatSym<2, real>& m)
 {
-    //     m(0,0)*m(1,1) - m(1,0)*m(0,1);
-    return m(0,0)*m(1,1) - m(0,1)*m(0,1);
+    return m(0, 0) * m(1, 1) - m(0, 1) * m(0, 1);
 }
 
 #define MIN_DETERMINANT  1.0e-100
 
 
 /// Trace of a 3x3 matrix.
-template<class real>
-inline real trace(const MatSym<3,real>& m)
+template <class real>
+inline real trace(const MatSym<3, real>& m)
 {
-    return m(0,0)+m(1,1)+m(2,2);
-
+    return m(0, 0) + m(1, 1) + m(2, 2);
 }
+
 /// Trace of a 2x2 matrix.
-template<class real>
-inline real trace(const MatSym<2,real>& m)
+template <class real>
+inline real trace(const MatSym<2, real>& m)
 {
-    return m(0,0)+m(1,1);
+    return m(0, 0) + m(1, 1);
 }
 
 /// Matrix inversion (general case).
@@ -504,8 +538,8 @@ bool invertMatrix(MatSym<S,real>& dest, const MatSym<S,real>& from)
 }
 
 /// Matrix inversion (special case 3x3).
-template<class real>
-bool invertMatrix(MatSym<3,real>& dest, const MatSym<3,real>& from)
+template <class real>
+bool invertMatrix(MatSym<3, real>& dest, const MatSym<3, real>& from)
 {
     real det=determinant(from);
 

--- a/Sofa/framework/Type/src/sofa/type/MatSym.h
+++ b/Sofa/framework/Type/src/sofa/type/MatSym.h
@@ -145,7 +145,7 @@ public:
     }
 
     /// convert to Voigt notation (supported only for D == 2 and D == 3)
-    template<sofa::Size TD = D, typename = std::enable_if_t<D == 3 || D == 2> >
+    template<sofa::Size TD = D, typename = std::enable_if_t<TD == 3 || TD == 2> >
     inline Vec<NumberStoredValues, real> getVoigt() const
     {
         Vec<NumberStoredValues, real> result {NOINIT};

--- a/Sofa/framework/Type/src/sofa/type/MatSym.h
+++ b/Sofa/framework/Type/src/sofa/type/MatSym.h
@@ -37,7 +37,7 @@ namespace sofa::type
  * \tparam D Size of the matrix
  * \tparam real Type of scalar
  */
-template <int D, class real = SReal>
+template <sofa::Size D, class real = SReal>
 class MatSym : public VecNoInit<D * (D + 1) / 2, real>
 {
 public:
@@ -70,10 +70,10 @@ public:
     }
 
     /// Constructor from an element
-    constexpr MatSym(const int sizeM, const real& v)
+    constexpr MatSym(const sofa::Size sizeM, const real& v)
     {
         assert(sizeM <= D);
-        for (int i = 0; i < sizeM * (sizeM + 1) / 2; ++i)
+        for (sofa::Size i = 0; i < sizeM * (sizeM + 1) / 2; ++i)
         {
             this->elems[i] = v;
         }
@@ -97,7 +97,7 @@ public:
     /// Sets each element to 0.
     void clear()
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             this->elems[i] = 0;
         }
@@ -106,7 +106,7 @@ public:
     /// Sets each element to r.
     void fill(real r)
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             this->elems[i].fill(r);
         }
@@ -123,7 +123,7 @@ public:
     }
 
     /// Read-only access to element (i,j).
-    inline const real& operator()(int i, int j) const
+    inline const real& operator()(const int i, const int j) const
     {
         if (i >= j)
         {
@@ -170,10 +170,10 @@ public:
     /// Set matrix to identity.
     constexpr void identity()
     {
-        for (int i = 0; i < D; i++)
+        for (sofa::Size i = 0; i < D; i++)
         {
             this->elems[i * (i + 1) / 2 + i] = 1;
-            for (int j = i + 1; j < D; j++)
+            for (sofa::Size j = i + 1; j < D; j++)
             {
                 this->elems[i * (i + 1) / 2 + j] = 0;
             }
@@ -185,7 +185,7 @@ public:
 
     bool operator==(const MatSym<D, real>& b) const
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             if (this->elems[i] != b[i])
             {
@@ -197,7 +197,7 @@ public:
 
     bool operator!=(const MatSym<D, real>& b) const
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             if (this->elems[i] != b[i])
             {
@@ -216,12 +216,12 @@ public:
     {
         Mat<D, D, real> r(NOINIT);
 
-        for (int i = 0; i < D; i++)
+        for (sofa::Size i = 0; i < D; i++)
         {
-            for (int j = 0; j < D; j++)
+            for (sofa::Size j = 0; j < D; j++)
             {
                 r[i][j] = (*this)(i, 0) * m(0, j);
-                for (int k = 1; k < D; k++)
+                for (sofa::Size k = 1; k < D; k++)
                 {
                     r[i][j] += (*this)(i, k) * m(k, j);
                 }
@@ -240,12 +240,12 @@ public:
     {
         Mat<D,D,real> r(NOINIT);
 
-        for (int i = 0; i < D; i++)
+        for (sofa::Size i = 0; i < D; i++)
         {
-            for (int j = 0; j < D; j++)
+            for (sofa::Size j = 0; j < D; j++)
             {
                 r[i][j] = (*this)(i, 0) * m[0][j];
-                for (int k = 1; k < D; k++)
+                for (sofa::Size k = 1; k < D; k++)
                 {
                     r[i][j] += (*this)(i, k) * m[k][j];
                 }
@@ -264,12 +264,12 @@ public:
     {
         Mat<D, D, real> r(NOINIT);
 
-        for (int i = 0; i < D; i++)
+        for (sofa::Size i = 0; i < D; i++)
         {
-            for (int j = 0; j < D; j++)
+            for (sofa::Size j = 0; j < D; j++)
             {
                 r[i][j] = m(i, 0) * (*this)(0, j);
-                for (int k = 1; k < D; k++)
+                for (sofa::Size k = 1; k < D; k++)
                 {
                     r[i][j] += m(i, k) * (*this)(k, j);
                 }
@@ -283,7 +283,7 @@ public:
     MatSym<D, real> operator+(const MatSym<D, real>& m) const
     {
         MatSym<D, real> r(NOINIT);
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             r[i] = (*this)[i] + m[i];
         }
@@ -294,9 +294,9 @@ public:
     Mat<D, D, real> operator+(const Mat<D, D, real>& m) const
     {
         Mat<D, D, real> r(NOINIT);
-        for (int i = 0; i < D; i++)
+        for (sofa::Size i = 0; i < D; i++)
         {
-            for (int j = 0; j < D; j++)
+            for (sofa::Size j = 0; j < D; j++)
             {
                 r[i][j] = (*this)(i, j) + m[i][j];
             }
@@ -308,7 +308,7 @@ public:
     MatSym<D, real> operator-(const MatSym<D, real>& m) const
     {
         MatSym<D, real> r(NOINIT);
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             r[i] = (*this)[i] - m[i];
         }
@@ -319,9 +319,9 @@ public:
     Mat<D, D, real> operator-(const Mat<D, D, real>& m) const
     {
         Mat<D, D, real> r(NOINIT);
-        for (int i = 0; i < D; i++)
+        for (sofa::Size i = 0; i < D; i++)
         {
-            for (int j = 0; j < D; j++)
+            for (sofa::Size j = 0; j < D; j++)
             {
                 r[i][j] = (*this)(i, j) - m[i][j];
             }
@@ -333,10 +333,10 @@ public:
     Coord operator*(const Coord& v) const
     {
         Coord r(NOINIT);
-        for (int i = 0; i < D; i++)
+        for (sofa::Size i = 0; i < D; i++)
         {
             r[i] = (*this)(i, 0) * v[0];
-            for (int j = 1; j < D; j++)
+            for (sofa::Size j = 1; j < D; j++)
             {
                 r[i] += (*this)(i, j) * v[j];
             }
@@ -348,7 +348,7 @@ public:
     MatSym<D, real> operator*(real f) const
     {
         MatSym<D, real> r(NOINIT);
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             r[i] = (*this)[i] * f;
         }
@@ -365,7 +365,7 @@ public:
     MatSym<D, real> operator/(real f) const
     {
         MatSym<D, real> r(NOINIT);
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             r[i] = (*this)[i] / f;
         }
@@ -375,7 +375,7 @@ public:
     /// Scalar multiplication assignment operator.
     void operator *=(real r)
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             this->elems[i] *= r;
         }
@@ -384,7 +384,7 @@ public:
     /// Scalar division assignment operator.
     void operator /=(real r)
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             this->elems[i] /= r;
         }
@@ -393,7 +393,7 @@ public:
     /// Addition assignment operator.
     void operator +=(const MatSym< D,real>& m)
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             this->elems[i] += m[i];
         }
@@ -402,7 +402,7 @@ public:
     /// Substraction assignment operator.
     void operator -=(const MatSym< D,real>& m)
     {
-        for (int i = 0; i < NumberStoredValues; i++)
+        for (sofa::Size i = 0; i < NumberStoredValues; i++)
         {
             this->elems[i] -= m[i];
         }
@@ -415,7 +415,7 @@ public:
     }
 };
 
-template <int D, class real>
+template <sofa::Size D, class real>
 Mat<D, D, real> operator*(const Mat<D, D, real>& a, const MatSym<D, real>& b)
 {
     return b.MatSymMultiply(a);
@@ -457,10 +457,10 @@ inline real trace(const MatSym<2, real>& m)
 }
 
 /// Matrix inversion (general case).
-template<int S, class real>
+template<sofa::Size S, class real>
 bool invertMatrix(MatSym<S,real>& dest, const MatSym<S,real>& from)
 {
-    int i, j, k;
+    sofa::Size i, j, k;
     Vec<S,int> r, c, row, col;
 
     MatSym<S,real> m1 = from;
@@ -578,13 +578,13 @@ bool invertMatrix(MatSym<2,real>& dest, const MatSym<2,real>& from)
 }
 #undef MIN_DETERMINANT
 
-template<int D,class real>
+template<sofa::Size D,class real>
 std::ostream& operator<<(std::ostream& o, const MatSym<D,real>& m)
 {
     o << '[' ;
-    for(int i=0; i<D; i++)
+    for(sofa::Size i=0; i<D; i++)
     {
-        for(int j=0; j<D; j++)
+        for(sofa::Size j=0; j<D; j++)
         {
             o<<" "<<m(i,j);
         }
@@ -594,7 +594,7 @@ std::ostream& operator<<(std::ostream& o, const MatSym<D,real>& m)
     return o;
 }
 
-template<int D,class real>
+template<sofa::Size D,class real>
 std::istream& operator>>(std::istream& in, MatSym<D,real>& m)
 {
     int c;
@@ -606,7 +606,7 @@ std::istream& operator>>(std::istream& in, MatSym<D,real>& m)
         c = in.peek();
     }
     ///////////////////////////////////////////////
-    for(int i=0; i<D; i++)
+    for(sofa::Size i=0; i<D; i++)
     {
         c = in.peek();
         while (c==' ' || c==',')
@@ -614,7 +614,7 @@ std::istream& operator>>(std::istream& in, MatSym<D,real>& m)
             in.get(); c = in.peek();
         }
 
-        for(int j=0; j<D; j++)
+        for(sofa::Size j=0; j<D; j++)
         {
             in >> m(i,j);
         }
@@ -633,32 +633,32 @@ std::istream& operator>>(std::istream& in, MatSym<D,real>& m)
 }
 
 /// Compute the scalar product of two matrix (sum of product of all terms)
-template <int D, typename real>
+template <sofa::Size D, typename real>
 inline real scalarProduct(const MatSym<D,real>& left, const MatSym<D,real>& right)
 {
     real sympart(0.),dialpart(0.);
-    for(int i=0; i<D; i++)
-        for(int j=i+1; j<D; j++)
+    for(sofa::Size i=0; i<D; i++)
+        for(sofa::Size j=i+1; j<D; j++)
             sympart += left(i,j) * right(i,j);
 
-    for(int d=0; d<D; d++)
+    for(sofa::Size d=0; d<D; d++)
         dialpart += left(d,d) * right(d,d);
 
 
     return 2. * sympart  + dialpart ;
 }
 
-template <int D, typename real>
+template <sofa::Size D, typename real>
 inline real scalarProduct(const MatSym<D,real>& left, const Mat<D,D,real>& right)
 {
     real product(0.);
-    for(int i=0; i<D; i++)
-        for(int j=0; j<D; j++)
+    for(sofa::Size i=0; i<D; i++)
+        for(sofa::Size j=0; j<D; j++)
             product += left(i,j) * right(i,j);
     return product;
 }
 
-template <int D, typename real>
+template <sofa::Size D, typename real>
 inline real scalarProduct(const Mat<D,D,real>& left, const MatSym<D,real>& right)
 {
     return scalarProduct(right, left);

--- a/Sofa/framework/Type/test/CMakeLists.txt
+++ b/Sofa/framework/Type/test/CMakeLists.txt
@@ -4,13 +4,14 @@ project(Sofa.Type_test)
 
 set(SOURCE_FILES
     Color_test.cpp
+    MatSym_test.cpp
+    MatTypes_test.cpp
     Material_test.cpp
     Quater_test.cpp
     SVector_test.cpp
-    vector_test.cpp
-    MatTypes_test.cpp
     VecTypes_test.cpp
     fixed_array_test.cpp
+    vector_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/Sofa/framework/Type/test/MatSym_test.cpp
+++ b/Sofa/framework/Type/test/MatSym_test.cpp
@@ -29,7 +29,7 @@
 namespace sofa
 {
 
-template <int D, class _Real = SReal>
+template <sofa::Size D, class _Real = SReal>
 struct MatSymTestParameterPack
 {
     static constexpr auto Size = D;
@@ -60,9 +60,9 @@ public:
 
         const Eigen::Matrix<Real, Size, Size> W = convert<Eigen::Matrix<Real, Size, Size>>().inverse();
 
-        for (int i = 0; i < Size; ++i)
+        for (sofa::Size i = 0; i < Size; ++i)
         {
-            for (int j = 0; j < Size; ++j)
+            for (sofa::Size j = 0; j < Size; ++j)
             {
                 EXPECT_NEAR(W(i, j), M_inverse(i, j), testing::NumericTest<Real>::epsilon());
             }
@@ -105,9 +105,9 @@ protected:
     MatrixType convert() const
     {
         MatrixType result;
-        for (int i = 0; i < Size; ++i)
+        for (sofa::Size i = 0; i < Size; ++i)
         {
-            for (int j = 0; j < Size; ++j)
+            for (sofa::Size j = 0; j < Size; ++j)
             {
                 result(i, j) = m_symmetricMatrix(i, j);
             }

--- a/Sofa/framework/Type/test/MatSym_test.cpp
+++ b/Sofa/framework/Type/test/MatSym_test.cpp
@@ -1,0 +1,187 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <Eigen/Dense>
+#include <sofa/type/MatSym.h>
+#include <gtest/gtest.h>
+#include <sofa/testing/LinearCongruentialRandomGenerator.h>
+#include <sofa/testing/NumericTest.h>
+
+
+namespace sofa
+{
+
+template <int D, class _Real = SReal>
+struct MatSymTestParameterPack
+{
+    static constexpr auto Size = D;
+    using Real = _Real;
+};
+
+template <class ParameterPack>
+class MatSymTest : public testing::NumericTest<typename ParameterPack::Real>
+{
+public:
+    using Real = typename ParameterPack::Real;
+    static constexpr auto Size = ParameterPack::Size;
+
+    void onSetUp() override
+    {
+        sofa::testing::LinearCongruentialRandomGenerator lcg(96547);
+
+        for (sofa::Size i = 0; i < sofa::type::MatSym<Size, Real>::size(); ++i)
+        {
+            m_symmetricMatrix[i] = lcg.generateInRange(-10., 10.);
+        }
+    }
+
+    void inversion() const
+    {
+        type::MatSym<Size, Real> M_inverse;
+        sofa::type::invertMatrix(M_inverse, m_symmetricMatrix);
+
+        const Eigen::Matrix<Real, Size, Size> W = convert<Eigen::Matrix<Real, Size, Size>>().inverse();
+
+        for (int i = 0; i < Size; ++i)
+        {
+            for (int j = 0; j < Size; ++j)
+            {
+                EXPECT_NEAR(W(i, j), M_inverse(i, j), testing::NumericTest<Real>::epsilon());
+            }
+        }
+    }
+
+    void rightProduct() const
+    {
+        const auto other = getRandomMatrix<sofa::type::Mat<Size, Size, Real>>();
+
+        const auto product = m_symmetricMatrix * other;
+        const auto genericProduct = convert<sofa::type::Mat<Size, Size, Real>>() * other;
+
+        EXPECT_EQ(product, genericProduct);
+    }
+
+    void leftProduct() const
+    {
+        const auto other = getRandomMatrix<sofa::type::Mat<Size, Size, Real>>();
+
+        const auto product = other * m_symmetricMatrix;
+        const auto genericProduct = other * convert<sofa::type::Mat<Size, Size, Real>>();
+
+        EXPECT_EQ(product, genericProduct);
+    }
+
+    void trace() const
+    {
+        const Real expectedTrace = convert<Eigen::Matrix<Real, Size, Size>>().trace();
+        EXPECT_NEAR(
+            expectedTrace,
+            sofa::type::trace(m_symmetricMatrix),
+            testing::NumericTest<Real>::epsilon());
+    }
+
+protected:
+    sofa::type::MatSym<Size, Real> m_symmetricMatrix;
+
+    template<class MatrixType>
+    MatrixType convert() const
+    {
+        MatrixType result;
+        for (int i = 0; i < Size; ++i)
+        {
+            for (int j = 0; j < Size; ++j)
+            {
+                result(i, j) = m_symmetricMatrix(i, j);
+            }
+        }
+        return result;
+    }
+
+    template<class MatrixType>
+    static MatrixType getRandomMatrix()
+    {
+        MatrixType randomMatrix;
+
+        sofa::testing::LinearCongruentialRandomGenerator lcg(783352);
+
+        for (sofa::Size i = 0; i < Size; ++i)
+        {
+            for (sofa::Size j = 0; j < Size; ++j)
+            {
+                randomMatrix(i, j) = lcg.generateInRange(-10., 10.);
+            }
+        }
+
+        return randomMatrix;
+    }
+};
+
+using ::testing::Types;
+typedef Types<
+    MatSymTestParameterPack<2, SReal>,
+    MatSymTestParameterPack<3, SReal>
+> DataTypes;
+
+TYPED_TEST_SUITE(MatSymTest, DataTypes);
+
+TYPED_TEST(MatSymTest, inversion )
+{
+    ASSERT_NO_THROW (this->inversion());
+}
+
+TYPED_TEST(MatSymTest, rightProduct )
+{
+    ASSERT_NO_THROW (this->rightProduct());
+}
+
+TYPED_TEST(MatSymTest, leftProduct)
+{
+    ASSERT_NO_THROW (this->leftProduct());
+}
+
+TYPED_TEST(MatSymTest, trace)
+{
+    ASSERT_NO_THROW (this->trace());
+}
+
+
+template<class _Real>
+class MatSym3x3Test : public MatSymTest<MatSymTestParameterPack<3, _Real>>
+{
+public:
+    void elementAccessor() const
+    {
+        EXPECT_EQ(this->m_symmetricMatrix(0, 0), this->m_symmetricMatrix[0]);
+        EXPECT_EQ(this->m_symmetricMatrix(0, 1), this->m_symmetricMatrix[1]);
+        EXPECT_EQ(this->m_symmetricMatrix(1, 1), this->m_symmetricMatrix[2]);
+        EXPECT_EQ(this->m_symmetricMatrix(0, 2), this->m_symmetricMatrix[3]);
+        EXPECT_EQ(this->m_symmetricMatrix(1, 2), this->m_symmetricMatrix[4]);
+        EXPECT_EQ(this->m_symmetricMatrix(2, 2), this->m_symmetricMatrix[5]);
+    }
+};
+
+TYPED_TEST_SUITE(MatSym3x3Test, Types<SReal>);
+TYPED_TEST(MatSym3x3Test, elementAccessor)
+{
+    ASSERT_NO_THROW (this->elementAccessor());
+}
+
+}


### PR DESCRIPTION
A bit of cleaning (formatting, removal of commented code, use of our friend `std::enable_if_t` etc) for `sofa::type::MatSym`. I added the `operator*` on matrices (symmetric and non-symmetric). I also added simple unit tests.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
