### PR TITLE
[tests] Use appropriate gtest macro

### DIFF
--- a/Sofa/Component/Engine/Generate/tests/MergePoints_test.cpp
+++ b/Sofa/Component/Engine/Generate/tests/MergePoints_test.cpp
@@ -110,10 +110,10 @@ struct MergePoints_test : public BaseSimulationTest,
         ASSERT_EQ(points.size(),4);
         ASSERT_EQ(indices1.size(),2);
         ASSERT_EQ(indices2.size(),2);
-        ASSERT_TRUE( (Coord(0.0f, 0.0f, 0.0f)-points[0]).norm() < 0.000000001f);
-        ASSERT_TRUE( (Coord(1.0f, 0.0f, 0.0f)-points[1]).norm() < 0.000000001f);
-        ASSERT_TRUE( (Coord(0.0f, 1.0f, 0.0f)-points[2]).norm() < 0.000000001f);
-        ASSERT_TRUE( (Coord(0.0f, 0.0f, 1.0f)-points[3]).norm() < 0.000000001f);
+        ASSERT_LT( (Coord(0.0f, 0.0f, 0.0f)-points[0]).norm(), 0.000000001f);
+        ASSERT_LT( (Coord(1.0f, 0.0f, 0.0f)-points[1]).norm(), 0.000000001f);
+        ASSERT_LT( (Coord(0.0f, 1.0f, 0.0f)-points[2]).norm(), 0.000000001f);
+        ASSERT_LT( (Coord(0.0f, 0.0f, 1.0f)-points[3]).norm(), 0.000000001f);
         ASSERT_EQ(indices1[0],0);
         ASSERT_EQ(indices1[1],1);
         ASSERT_EQ(indices2[0],2);

--- a/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
@@ -109,9 +109,9 @@ void RestStiffSpringsForceField_test::checkDifference(MechanicalObject<Type>& mo
         }
         else
         {
-            ASSERT_TRUE( fabs(pos.x()-rpos.x()) < 1 );
-            ASSERT_TRUE( fabs(pos.y()-rpos.y()) < 1 );
-            ASSERT_TRUE( fabs(pos.z()-rpos.z()) < 1 );
+            ASSERT_LT( fabs(pos.x()-rpos.x()), 1 );
+            ASSERT_LT( fabs(pos.y()-rpos.y()), 1 );
+            ASSERT_LT( fabs(pos.z()-rpos.z()), 1 );
         }
     }
 }

--- a/Sofa/Component/SolidMechanics/Spring/tests/StiffSpringForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/StiffSpringForceField_test.cpp
@@ -195,8 +195,8 @@ struct StiffSpringForceField_test : public ForceField_test<_StiffSpringForceFiel
             std::cout << "          expected fc = " << fc << std::endl;
             std::cout << "            actual fc = " << actualfc.ref() << std::endl;
         }
-        ASSERT_TRUE( this->vectorMaxDiff(fp,actualfp)< this->errorMax*this->epsilon() );
-        ASSERT_TRUE( this->vectorMaxDiff(fc,actualfc)< this->errorMax*this->epsilon() );
+        ASSERT_LT( this->vectorMaxDiff(fp,actualfp), this->errorMax*this->epsilon() );
+        ASSERT_LT( this->vectorMaxDiff(fc,actualfc), this->errorMax*this->epsilon() );
     }
 
     ///@}

--- a/Sofa/Component/SolidMechanics/Testing/src/sofa/component/solidmechanics/testing/ForceFieldTestCreation.h
+++ b/Sofa/Component/SolidMechanics/Testing/src/sofa/component/solidmechanics/testing/ForceFieldTestCreation.h
@@ -164,8 +164,8 @@ struct ForceField_test : public BaseSimulationTest, NumericTest<typename _ForceF
         if( deltaRange.second / errorMax <= sofa::testing::g_minDeltaErrorRatio )
             ADD_FAILURE() << "The comparison threshold is too large for the finite difference delta";
 
-        ASSERT_TRUE(x.size()==v.size());
-        ASSERT_TRUE(x.size()==ef.size());
+        ASSERT_EQ(x.size(), v.size());
+        ASSERT_EQ(x.size(), ef.size());
         std::size_t n = x.size();
 
         // copy the position and velocities to the scene graph
@@ -195,7 +195,7 @@ struct ForceField_test : public BaseSimulationTest, NumericTest<typename _ForceF
             std::cout << "            expected f = " << ef << std::endl;
             std::cout << "            actual f = " <<  f.ref() << std::endl;
         }
-        ASSERT_TRUE( this->vectorMaxDiff(f,ef)< errorMax*this->epsilon() );
+        ASSERT_LT( this->vectorMaxDiff(f,ef), errorMax*this->epsilon() );
 
         if( !checkStiffness ) return;
 

--- a/Sofa/framework/Core/test/DataEngine_test.cpp
+++ b/Sofa/framework/Core/test/DataEngine_test.cpp
@@ -91,21 +91,21 @@ struct DataEngine_test: public BaseTest
     void testTrackedData(T& engine)
     {
         // input did not change, it is not dirtied, so neither its associated DataTracker
-        ASSERT_TRUE(engine.output.getValue()==TestEngine::NO_CHANGED);
+        ASSERT_EQ(engine.output.getValue(), TestEngine::NO_CHANGED);
 
         // modifying input sets it as dirty, so its associated DataTracker too
         engine.input.setValue(true);
-        ASSERT_TRUE(engine.output.getValue()==TestEngine::CHANGED);
+        ASSERT_EQ(engine.output.getValue(), TestEngine::CHANGED);
 
         // nothing changes, no one is dirty
         engine.update();
-        ASSERT_TRUE(engine.output.getValue()==TestEngine::NO_CHANGED);
+        ASSERT_EQ(engine.output.getValue(), TestEngine::NO_CHANGED);
 
         // modifying input sets it as dirty, so its associated DataTracker too
         engine.input.setValue(true);
         // cleaning/accessing the input will not clean its associated DataTracker
         engine.input.cleanDirty();
-        ASSERT_TRUE(engine.output.getValue()==TestEngine::CHANGED);
+        ASSERT_EQ(engine.output.getValue(), TestEngine::CHANGED);
     }
 
 };

--- a/Sofa/framework/Helper/test/system/thread/CircularQueue_test.cpp
+++ b/Sofa/framework/Helper/test/system/thread/CircularQueue_test.cpp
@@ -85,7 +85,7 @@ protected:
         {
             while(!queue.pop(value)) 
                 std::this_thread::yield();
-            EXPECT_TRUE(lastValue < value);
+            EXPECT_LT(lastValue, value);
             lastValue = value;
         }
     }

--- a/Sofa/framework/LinearAlgebra/test/Matrix_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/Matrix_test.cpp
@@ -317,7 +317,7 @@ struct TestSparseMatrices : public NumericTest<typename T::Real>
         }
         mb.compress();
 
-        ASSERT_TRUE( Inherit::matrixMaxDiff(ma,mb) < 100*Inherit::epsilon() );
+        ASSERT_LT( Inherit::matrixMaxDiff(ma,mb), 100*Inherit::epsilon() );
 
         // building with ordered blocks
 
@@ -343,7 +343,7 @@ struct TestSparseMatrices : public NumericTest<typename T::Real>
         }
         mb.compress();
 
-        ASSERT_TRUE( Inherit::matrixMaxDiff(ma,mb) < 100*Inherit::epsilon() );
+        ASSERT_LT( Inherit::matrixMaxDiff(ma,mb), 100*Inherit::epsilon() );
 
 
 
@@ -371,7 +371,7 @@ struct TestSparseMatrices : public NumericTest<typename T::Real>
         }
         mb.compress();
 
-        ASSERT_TRUE( Inherit::matrixMaxDiff(ma,mb) < 100*Inherit::epsilon() );
+        ASSERT_LT( Inherit::matrixMaxDiff(ma,mb), 100*Inherit::epsilon() );
 
 
 
@@ -402,7 +402,7 @@ struct TestSparseMatrices : public NumericTest<typename T::Real>
         }
         mb.compress();
 
-        ASSERT_TRUE( Inherit::matrixMaxDiff(ma,mb) < 100*Inherit::epsilon() );
+        ASSERT_LT( Inherit::matrixMaxDiff(ma,mb), 100*Inherit::epsilon() );
     }
 
     bool checkEigenMatrixBlockFromCompressedRowSparseMatrix()
@@ -437,14 +437,14 @@ TYPED_TEST_SUITE(TestSparseMatrices, TestSparseMatricesImplementations);
 
 // ==============================
 // Set/get value tests
-TYPED_TEST(TestSparseMatrices, set_fullMat ) { ASSERT_TRUE( this->matrixMaxDiff(this->mat,this->fullMat) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, set_crs_scalar ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMat,this->crsScalar ) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, set_crs1 ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMat,this->crs1) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, set_crs2 ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMat,this->crs2) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, set_mapMat ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMat,this->mapMat) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, set_eiBlock1 ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMat,this->eiBlock1) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, set_eiBlock2 ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMat,this->eiBlock2) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, set_eiBase ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMat,this->eiBase) < 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_fullMat ) { ASSERT_LT( this->matrixMaxDiff(this->mat,this->fullMat), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_crs_scalar ) { ASSERT_LT( this->matrixMaxDiff(this->fullMat,this->crsScalar ), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_crs1 ) { ASSERT_LT( this->matrixMaxDiff(this->fullMat,this->crs1), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_crs2 ) { ASSERT_LT( this->matrixMaxDiff(this->fullMat,this->crs2), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_mapMat ) { ASSERT_LT( this->matrixMaxDiff(this->fullMat,this->mapMat), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_eiBlock1 ) { ASSERT_LT( this->matrixMaxDiff(this->fullMat,this->eiBlock1), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_eiBlock2 ) { ASSERT_LT( this->matrixMaxDiff(this->fullMat,this->eiBlock2), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, set_eiBase ) { ASSERT_LT( this->matrixMaxDiff(this->fullMat,this->eiBase), 100*this->epsilon() ); }
 TYPED_TEST(TestSparseMatrices, eigenMatrix_update ) { ASSERT_TRUE( this->checkEigenMatrixUpdate() ); }
 TYPED_TEST(TestSparseMatrices, eigenMatrix_block_row_filling ) { this->checkEigenMatrixBlockRowFilling(); }
 TYPED_TEST(TestSparseMatrices, eigenMatrixBlockFromCompressedRowSparseMatrix ) { ASSERT_TRUE( this->checkEigenMatrixBlockFromCompressedRowSparseMatrix() ); }
@@ -454,26 +454,26 @@ TYPED_TEST(TestSparseMatrices, eigenMapToDenseMatrix ) { ASSERT_TRUE( this->chec
 // Matrix-Vector product tests
 TYPED_TEST(TestSparseMatrices, set_fullVec_nrows_reference )
 {
-    ASSERT_TRUE(this->vectorMaxDiff(this->vecM,this->fullVec_nrows_reference) < this->epsilon() );
+    ASSERT_LT(this->vectorMaxDiff(this->vecM,this->fullVec_nrows_reference), this->epsilon() );
 }
 TYPED_TEST(TestSparseMatrices, fullMat_vector_product )
 {
     //    fullMat.opMulV(&fullVec_nrows_result,&fullVec_ncols);
     this->fullVec_nrows_result = this->fullMat * this->fullVec_ncols;
-    ASSERT_TRUE(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result) < this->epsilon() );
+    ASSERT_LT(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result), this->epsilon() );
 }
 TYPED_TEST(TestSparseMatrices, mapMat_vector_product )
 {
     //    mapMat.opMulV(&fullVec_nrows_result,&fullVec_ncols);
     this->fullVec_nrows_result = this->mapMat * this->fullVec_ncols;
-    ASSERT_TRUE(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result) < this->epsilon() );
+    ASSERT_LT(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result), this->epsilon() );
 }
 TYPED_TEST(TestSparseMatrices, eiBlock1_vector_product )
 {
     //    eiBlock1.opMulV(&fullVec_nrows_result,&fullVec_ncols);
     //    eiBlock1.multVector(fullVec_nrows_result,fullVec_ncols);
     this->fullVec_nrows_result = this->eiBlock1 * this->fullVec_ncols;
-    ASSERT_TRUE(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result) < this->epsilon() );
+    ASSERT_LT(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result), this->epsilon() );
 
 }
 TYPED_TEST(TestSparseMatrices, crs1_vector_product )
@@ -481,32 +481,32 @@ TYPED_TEST(TestSparseMatrices, crs1_vector_product )
     //    EXPECT_TRUE(NROWS%BROWS==0 && NCOLS%BCOLS==0) << "Error: CompressedRowSparseMatrix * Vector crashes when the size of the matrix is not a multiple of the size of the matrix blocks. Aborting this test, and reporting a failure."; // otherwise the product crashes
     //    crs1.opMulV(&fullVec_nrows_result,&fullVec_ncols);
     this->fullVec_nrows_result = this->crs1 * this->fullVec_ncols;
-    ASSERT_TRUE(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result) < this->epsilon() );
+    ASSERT_LT(this->vectorMaxDiff(this->fullVec_nrows_reference,this->fullVec_nrows_result), this->epsilon() );
 }
 
 
 // ==============================
 // Matrix product tests
-TYPED_TEST(TestSparseMatrices, full_matrix_product ) { ASSERT_TRUE( this->matrixMaxDiff(this->matMultiplication,this->fullMultiplication) < 100*this->epsilon() );  }
-TYPED_TEST(TestSparseMatrices, crs_scalar_matrix_product ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMultiplication,this->crsScalarMultiplication) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, crs_matrix_product ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMultiplication,this->crsMultiplication) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, EigenBase_matrix_product ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullMultiplication,this->eiBaseMultiplication) < 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, full_matrix_product ) { ASSERT_LT( this->matrixMaxDiff(this->matMultiplication,this->fullMultiplication), 100*this->epsilon() );  }
+TYPED_TEST(TestSparseMatrices, crs_scalar_matrix_product ) { ASSERT_LT( this->matrixMaxDiff(this->fullMultiplication,this->crsScalarMultiplication), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, crs_matrix_product ) { ASSERT_LT( this->matrixMaxDiff(this->fullMultiplication,this->crsMultiplication), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, EigenBase_matrix_product ) { ASSERT_LT( this->matrixMaxDiff(this->fullMultiplication,this->eiBaseMultiplication), 100*this->epsilon() ); }
 //TYPED_TEST(TestSparseMatrices, EigenSparseDense_matrix_product ) { ASSERT_TRUE( EigenDenseMatrix(this->eiBaseMultiplication.compressedMatrix) == this->eiDenseMultiplication ); }
-TYPED_TEST(TestSparseMatrices, full_matrix_transposeproduct ) { ASSERT_TRUE( this->matrixMaxDiff(this->matTransposeMultiplication,this->fullTransposeMultiplication) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, crs_scalar_matrix_transposeproduct ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullTransposeMultiplication,this->crsScalarTransposeMultiplication) < 100*this->epsilon() ); }
-TYPED_TEST(TestSparseMatrices, crs_matrix_transposeproduct ) { ASSERT_TRUE( this->matrixMaxDiff(this->fullTransposeMultiplication,this->crsTransposeMultiplication) < 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, full_matrix_transposeproduct ) { ASSERT_LT( this->matrixMaxDiff(this->matTransposeMultiplication,this->fullTransposeMultiplication), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, crs_scalar_matrix_transposeproduct ) { ASSERT_LT( this->matrixMaxDiff(this->fullTransposeMultiplication,this->crsScalarTransposeMultiplication), 100*this->epsilon() ); }
+TYPED_TEST(TestSparseMatrices, crs_matrix_transposeproduct ) { ASSERT_LT( this->matrixMaxDiff(this->fullTransposeMultiplication,this->crsTransposeMultiplication), 100*this->epsilon() ); }
 
 // Matrix addition
 TYPED_TEST(TestSparseMatrices, crs_matrix_addition )
 {
     this->crs2 = this->crs1 + this->crs1;
-    ASSERT_TRUE( this->matrixMaxDiff(this->mat*2,this->crs2) < 100*this->epsilon() );
+    ASSERT_LT( this->matrixMaxDiff(this->mat*2,this->crs2), 100*this->epsilon() );
 
     this->crs2 += this->crs1;
-    ASSERT_TRUE( this->matrixMaxDiff(this->mat*3,this->crs2) < 100*this->epsilon() );
+    ASSERT_LT( this->matrixMaxDiff(this->mat*3,this->crs2), 100*this->epsilon() );
 
     this->crs2 -= this->crs1;
-    ASSERT_TRUE( this->matrixMaxDiff(this->mat*2,this->crs2) < 100*this->epsilon() );
+    ASSERT_LT( this->matrixMaxDiff(this->mat*2,this->crs2), 100*this->epsilon() );
 }
 
 #if BENCHMARK_MATRIX_PRODUCT

--- a/Sofa/framework/LinearAlgebra/test/SparseMatrixStorageOrder_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/SparseMatrixStorageOrder_test.cpp
@@ -61,8 +61,8 @@ struct TestSparseMatrixTranspose : public sofa::testing::SparseMatrixTest<typena
         {
             for(typename Transpose::InnerIterator it(transposeMatrix, i); it; ++it )
             {
-                ASSERT_TRUE(it.row() < nbRows) << it.row() << " " << nbRows;
-                ASSERT_TRUE(it.col() < nbCols) << it.col() << " " << nbCols;
+                ASSERT_LT(it.row(), nbRows) << it.row() << " " << nbRows;
+                ASSERT_LT(it.col(), nbCols) << it.col() << " " << nbCols;
                 const Real initialValue = matrix.coeff(it.row(), it.col());
 
                 triplets.emplace_back(it.row(), it.col(), it.value());

--- a/Sofa/framework/Type/test/Quater_test.cpp
+++ b/Sofa/framework/Type/test/Quater_test.cpp
@@ -57,8 +57,8 @@ TEST(QuaterTest, EulerAngles)
         // make sure the angles don't lead to a singularity
         for (const auto& angle : eulerAngles)
         {
-            ASSERT_TRUE(std::abs(angle - M_PI / 2) >= 1e-3);
-            ASSERT_TRUE(std::abs(angle + M_PI / 2) >= 1e-3);
+            ASSERT_GE(std::abs(angle - M_PI / 2), 1e-3);
+            ASSERT_GE(std::abs(angle + M_PI / 2), 1e-3);
         }
 
         // Transform Euler angles back to a quaternion (q1)


### PR DESCRIPTION
Because will give more details if the appropriate macro is used for comparison when a test fails



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
