### PR TITLE
[LinearAlgebra] Trigger error on the Eigen version

### DIFF
--- a/Sofa/framework/LinearAlgebra/CMakeLists.txt
+++ b/Sofa/framework/LinearAlgebra/CMakeLists.txt
@@ -62,7 +62,7 @@ set(SOURCE_FILES
     ${SOFALINEARALGEBRASRC_ROOT}/init.cpp
 )
 
-sofa_find_package(Eigen3 REQUIRED)
+sofa_find_package(Eigen3 3.3.5 REQUIRED)
 
 if (SOFA_OPENMP AND "${EIGEN3_VERSION}" VERSION_LESS 3.2.10)
     sofa_find_package(OpenMP BOTH_SCOPES) # will set/update SOFA_LINEARALGEBRA_HAVE_OPENMP


### PR DESCRIPTION
The fix from Eigen https://gitlab.com/libeigen/eigen/-/commit/80142362ac35ca77bfc5ccf7ba49c9f034b57abc, making `SparseMatrixProduct` compile, is available starting 3.3.5.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
