### PR TITLE
[Simulation.Core] Remove useless and annoying timers

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -36,8 +36,6 @@ UpdateBoundingBoxVisitor::UpdateBoundingBoxVisitor(const sofa::core::ExecParams*
 
 Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
 {
-    const std::string msg = "BoundingBoxVisitor - ProcessTopDown: " + node->getName();
-    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
     using namespace sofa::core::objectmodel;
     type::vector<BaseObject*> objectList;
     type::vector<BaseObject*>::iterator object;
@@ -47,7 +45,6 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
         nodeBBox->invalidate();
     for ( object = objectList.begin(); object != objectList.end(); ++object)
     {
-        sofa::helper::ScopedAdvancedTimer("ComputeBBox: " + (*object)->getName());
         // warning the second parameter should NOT be false
         // otherwise every object will participate to the bounding box
         // when it makes no sense for some of them
@@ -65,9 +62,6 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
 
 void UpdateBoundingBoxVisitor::processNodeBottomUp(simulation::Node* node)
 {
-    const std::string msg = "BoundingBoxVisitor - ProcessBottomUp: " + node->getName();
-    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
-
     sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
     Node::ChildIterator childNode;
     for( childNode = node->child.begin(); childNode!=node->child.end(); ++childNode)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateMappingVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateMappingVisitor.cpp
@@ -31,19 +31,12 @@ namespace sofa::simulation
 
 void UpdateMappingVisitor::processMapping(simulation::Node* /*n*/, core::BaseMapping* obj)
 {
-    const std::string msg = "MappingVisitor - processMapping: " + obj->getName();
-    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
-
     obj->apply(core::mechanicalparams::defaultInstance(), core::VecCoordId::position(), core::ConstVecCoordId::position());
     obj->applyJ(core::mechanicalparams::defaultInstance(), core::VecDerivId::velocity(), core::ConstVecDerivId::velocity());
 }
 
 void UpdateMappingVisitor::processMechanicalMapping(simulation::Node* /*n*/, core::BaseMapping* obj)
-{
-    // mechanical mappings with isMechanical flag not set are now processed by the MechanicalPropagatePositionVisitor visitor
-    const std::string msg = "MappingVisitor - processMechanicalMapping: " + obj->getName();
-    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
-}
+{}
 
 Visitor::Result UpdateMappingVisitor::processNodeTopDown(simulation::Node* node)
 {


### PR DESCRIPTION
Useless:

For example, the timer in `UpdateMappingVisitor::processMechanicalMapping` does not measure anything.

Annoying:

I don't think it is a good practice to add timer on individual components. In particular, the ones I removed measure neglectable durations. The fact that there is one timer for every component adds a lot of pollution in the analysis of the timings, for nothing because it is neglectable.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
