### PR TITLE
[Spring] Remove duplicated spring indices

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.h
@@ -153,7 +153,7 @@ public:
 
     void removeSpring(sofa::Index idSpring);
 
-    void addSpring(sofa::Index m1, sofa::Index m2, SReal ks, SReal kd, SReal initlen);
+    virtual void addSpring(sofa::Index m1, sofa::Index m2, SReal ks, SReal kd, SReal initlen);
 
     void addSpring(const Spring & spring);
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
@@ -60,8 +60,6 @@ public:
     static constexpr auto N = DataTypes::spatial_dimensions;
     typedef type::Mat<N,N,Real> Mat;
 
-    SetIndex d_indices1; ///< Indices of the source points on the first model
-    SetIndex d_indices2; ///< Indices of the fixed points on the second model
 
     core::objectmodel::Data<sofa::type::vector<SReal> > d_lengths; ///< List of lengths to create the springs. Must have the same than indices1 & indices2, or if only one element, it will be applied to all springs. If empty, 0 will be applied everywhere
 protected:

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
@@ -98,6 +98,7 @@ public:
     using Inherit::addKToMatrix;
     void addKToMatrix(const sofa::core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
+    virtual void addSpring(sofa::Index m1, sofa::Index m2, SReal ks, SReal kd, SReal initlen) override;
 
 
 protected:

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
@@ -53,12 +53,14 @@ public:
     typedef type::vector<sofa::Index> SetIndexArray;
     typedef sofa::core::topology::TopologySubsetIndices SetIndex;
 
-
     typedef typename Inherit::Spring Spring;
 
     typedef core::behavior::MechanicalState<DataTypes> MechanicalState;
     static constexpr auto N = DataTypes::spatial_dimensions;
     typedef type::Mat<N,N,Real> Mat;
+
+    core::objectmodel::lifecycle::DeprecatedData d_indices1{this, "v24.06", "v24.12", "indices1", "This data has been replaced by the data springsIndices1 "};
+    core::objectmodel::lifecycle::DeprecatedData d_indices2{this, "v24.06", "v24.12", "indices2", "This data has been replaced by the data springsIndices2"};
 
 
     core::objectmodel::Data<sofa::type::vector<SReal> > d_lengths; ///< List of lengths to create the springs. Must have the same than indices1 & indices2, or if only one element, it will be applied to all springs. If empty, 0 will be applied everywhere

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.inl
@@ -115,6 +115,16 @@ void StiffSpringForceField<DataTypes>::createSpringsFromInputs()
     this->springs.endEdit();
 }
 
+template<class DataTypes>
+void StiffSpringForceField<DataTypes>::addSpring(sofa::Index m1, sofa::Index m2, SReal ks, SReal kd, SReal initlen)
+{
+    sofa::helper::getWriteAccessor(this->d_springsIndices[0]).push_back(m1);
+    sofa::helper::getWriteAccessor(this->d_springsIndices[1]).push_back(m2);
+    sofa::helper::getWriteAccessor(this->d_lengths).push_back(initlen);
+    this->ks.setValue(ks);
+    this->kd.setValue(kd);
+
+}
 
 template<class DataTypes>
 void StiffSpringForceField<DataTypes>::addSpringForce(

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.inl
@@ -43,13 +43,11 @@ StiffSpringForceField<DataTypes>::StiffSpringForceField(SReal ks, SReal kd)
 template<class DataTypes>
 StiffSpringForceField<DataTypes>::StiffSpringForceField(MechanicalState* object1, MechanicalState* object2, SReal ks, SReal kd)
     : SpringForceField<DataTypes>(object1, object2, ks, kd)
-    , d_indices1(initData(&d_indices1, "indices1", "Indices of the source points on the first model"))
-    , d_indices2(initData(&d_indices2, "indices2", "Indices of the fixed points on the second model"))
     , d_lengths(initData(&d_lengths, "lengths", "List of lengths to create the springs. Must have the same than indices1 & indices2, or if only one element, it will be applied to all springs. If empty, 0 will be applied everywhere"))
 {
     this->addAlias(&d_lengths, "length");
 
-    this->addUpdateCallback("updateSprings", { &d_indices1, &d_indices2, &d_lengths, &this->ks, &this->kd}, [this](const core::DataTracker& t)
+    this->addUpdateCallback("updateSprings", { &this->d_springsIndices[0],&this->d_springsIndices[1], &d_lengths, &this->ks, &this->kd}, [this](const core::DataTracker& t)
     {
         SOFA_UNUSED(t);
         createSpringsFromInputs();
@@ -63,7 +61,7 @@ void StiffSpringForceField<DataTypes>::init()
 {
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
 
-    if (d_indices1.isSet() && d_indices2.isSet())
+    if (this->d_springsIndices[0].isSet() && this->d_springsIndices[1].isSet())
     {
         createSpringsFromInputs();
     }
@@ -76,8 +74,8 @@ void StiffSpringForceField<DataTypes>::init()
 template<class DataTypes>
 void StiffSpringForceField<DataTypes>::createSpringsFromInputs()
 {
-    const auto& indices1 = d_indices1.getValue();
-    const auto& indices2 = d_indices2.getValue();
+    const auto& indices1 = this->d_springsIndices[0].getValue();
+    const auto& indices2 = this->d_springsIndices[1].getValue();
 
     if (indices1.size() != indices2.size())
     {


### PR DESCRIPTION
This component was using a set of data to define indices on which to apply springs. But those data already exist in the parent class. This was resulting in strange behaviors when using `AttachBodyPerformer` (which uses this component to attach an object to the mouse) out of the GUI API. 

In fact the performer was acting on the parent data which is not directly used by the StiffSpringForcefield. A nebulous chain of update triggered by a GUI update made it work with the mouse interactor anyway, but not when the performer was own by a graph component. 

Anyway this mechanism doesn't seem to have any added value and now the performer works great even outside the GUI interaction API.  

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
