### PR TITLE
[all] Add PenalityContact vector Data display

### DIFF
--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/PenalityContactForceField.h
@@ -31,6 +31,44 @@
 namespace sofa::component::collision::response::contact
 {
 
+template <class T>
+class PenalityContact
+{
+public:
+    //using Coord = T::Coord;
+    //using Deriv = T::Deriv;
+    //using Real = Coord::value_type;
+    typedef typename T::Coord Coord;
+    typedef typename T::Deriv Deriv;
+    typedef typename Coord::value_type Real;
+
+    sofa::Index m1, m2;         ///< the indices of the vertices the force is applied to
+    sofa::Index index1, index2; ///< the indices of the two collision elements (currently unused)
+    Deriv norm;         ///< contact normal, from m1 to m2
+    Real dist;          ///< distance threshold below which a repulsion force is applied
+    Real ks;            ///< spring stiffness
+    Real pen;           ///< current penetration depth
+    int age;            ///< how old is this contact
+
+    PenalityContact(sofa::Index _m1 = 0, sofa::Index _m2 = 0, sofa::Index _index1 = 0, sofa::Index _index2 = 0, Deriv _norm = Deriv(), Real _dist = (Real)0, Real _ks = (Real)0, Real /*_mu_s*/ = (Real)0, Real /*_mu_v*/ = (Real)0, Real _pen = (Real)0, int _age = 0)
+        : m1(_m1), m2(_m2), index1(_index1), index2(_index2), norm(_norm), dist(_dist), ks(_ks),/*mu_s(_mu_s),mu_v(_mu_v),*/pen(_pen), age(_age)
+    {
+    }
+
+    inline friend std::istream& operator >> (std::istream& in, PenalityContact& c)
+    {
+        in >> c.m1 >> c.m2 >> c.index1 >> c.index2 >> c.norm >> c.dist >> c.ks >>/*c.mu_s>>c.mu_v>>*/c.pen >> c.age;
+        return in;
+    }
+
+    inline friend std::ostream& operator << (std::ostream& out, const PenalityContact& c)
+    {
+        out << c.m1 << " " << c.m2 << " " << c.index1 << " " << c.index2 << " " << c.norm << " " << c.dist << " " << c.ks << " " <</*c.mu_s<<" " <<c.mu_v<<" " <<*/c.pen << " " << c.age;
+        return out;
+    }
+};
+
+
 /** Distance-based, frictionless penalty force. The force is applied to vertices attached to collision elements.
   */
 template<class DataTypes>
@@ -52,41 +90,12 @@ public:
     typedef core::objectmodel::Data<VecCoord>    DataVecCoord;
 
     typedef core::behavior::MechanicalState<DataTypes> MechanicalState;
-protected:
 
-    class Contact
-    {
-    public:
-
-        sofa::Index m1, m2;         ///< the indices of the vertices the force is applied to
-        sofa::Index index1, index2; ///< the indices of the two collision elements (currently unused)
-        Deriv norm;         ///< contact normal, from m1 to m2
-        Real dist;          ///< distance threshold below which a repulsion force is applied
-        Real ks;            ///< spring stiffness
-        Real pen;           ///< current penetration depth
-        int age;            ///< how old is this contact
-
-        Contact(sofa::Index _m1=0, sofa::Index _m2=0, sofa::Index _index1=0, sofa::Index _index2=0, Deriv _norm=Deriv(), Real _dist=(Real)0, Real _ks=(Real)0, Real /*_mu_s*/=(Real)0, Real /*_mu_v*/=(Real)0, Real _pen=(Real)0, int _age=0)
-            : m1(_m1),m2(_m2),index1(_index1),index2(_index2),norm(_norm),dist(_dist),ks(_ks),/*mu_s(_mu_s),mu_v(_mu_v),*/pen(_pen),age(_age)
-        {
-        }
-
-
-        inline friend std::istream& operator >> ( std::istream& in, Contact& c )
-        {
-            in>>c.m1>>c.m2>>c.index1>>c.index2>>c.norm>>c.dist>>c.ks>>/*c.mu_s>>c.mu_v>>*/c.pen>>c.age;
-            return in;
-        }
-
-        inline friend std::ostream& operator << ( std::ostream& out, const Contact& c )
-        {
-            out << c.m1<< " " <<c.m2<< " " << c.index1<< " " <<c.index2<< " " <<c.norm<< " " <<c.dist<<" " <<c.ks<<" " <</*c.mu_s<<" " <<c.mu_v<<" " <<*/c.pen<<" " <<c.age;
-            return out;
-        }
-    };
+    using Contact = PenalityContact<DataTypes>;
 
     Data<sofa::type::vector<Contact> > contacts; ///< Contacts
 
+protected:
     // contacts from previous frame
     sofa::type::vector<Contact> prevContacts;
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QModelViewTableDataContainer.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QModelViewTableDataContainer.h
@@ -22,9 +22,6 @@
 #pragma once
 #include "SimpleDataWidget.h"
 #include "StructDataWidget.h"
-#ifdef TODOTOPO
-#include <SofaBaseTopology/PointSubsetData.h>
-#endif
 #include <sofa/core/topology/TopologyData.h>
 
 #include "QMouseWheelAdjustementGuard.h"
@@ -665,37 +662,7 @@ class vector_data_trait < sofa::type::vector<T> > : public vector_data_trait< st
 {
 };
 
-////////////////////////////////////////////////////////////////
-/// PointSubset support
-////////////////////////////////////////////////////////////////
-#ifdef TODOTOPO
-template<>
-class vector_data_trait < sofa::component::topology::PointSubset >
-{
-public:
-    typedef sofa::component::topology::PointSubset data_type;
-    typedef unsigned int value_type;
-    enum { NDIM = 1 };
-    static int size(const data_type& d) { return d.size(); }
-    static const char* header(const data_type& /*d*/, int /*i*/ = 0)
-    {
-        return nullptr;
-    }
-    static const value_type* get(const data_type& d, int i = 0)
-    {
-        return ((unsigned)i < (unsigned)size(d)) ? &(d[i]) : nullptr;
-    }
-    static void set( const value_type& v, data_type& d, int i = 0)
-    {
-        if ((unsigned)i < (unsigned)size(d))
-            d[i] = v;
-    }
-    static void resize( int s, data_type& d)
-    {
-        d.resize(s);
-    }
-};
-#endif
+
 ////////////////////////////////////////////////////////////////
 /// std::map from strings support
 ////////////////////////////////////////////////////////////////

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/StructDataWidget.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/StructDataWidget.h
@@ -27,6 +27,7 @@
 #include <sofa/component/solidmechanics/spring/JointSpring.h>
 #include <sofa/component/solidmechanics/spring/JointSpringForceField.h>
 #include <sofa/component/solidmechanics/spring/GearSpringForceField.h>
+#include <sofa/component/collision/response/contact/PenalityContactForceField.h>
 
 #include <sofa/helper/io/Mesh.h>
 #include <sofa/type/RGBAColor.h>
@@ -529,7 +530,7 @@ class data_widget_container < sofa::type::Material > : public struct_data_widget
 /// sofa::component::interactionforcefield::PenalityContactForceField Contact support
 ////////////////////////////////////////////////////////////////
 
-#define CLASS typename sofa::component::interactionforcefield::PenalityContact< T >
+#define CLASS typename sofa::component::collision::response::contact::PenalityContact< T >
 
 template<class T>
 class struct_data_trait < CLASS >

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/StructDataWidget.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/StructDataWidget.h
@@ -523,4 +523,41 @@ template<>
 class data_widget_container < sofa::type::Material > : public struct_data_widget_container < sofa::type::Material >
 {};
 
+
+
+////////////////////////////////////////////////////////////////
+/// sofa::component::interactionforcefield::PenalityContactForceField Contact support
+////////////////////////////////////////////////////////////////
+
+#define CLASS typename sofa::component::interactionforcefield::PenalityContact< T >
+
+template<class T>
+class struct_data_trait < CLASS >
+{
+public:
+    typedef CLASS data_type;
+    enum { NVAR = 9 };
+    static void set(data_type& /*d*/)
+    {
+    }
+};
+
+template<class T> STRUCT_DATA_VAR(CLASS, 0, "VertexId 1", "VertexId 1", sofa::Index, m1);
+template<class T> STRUCT_DATA_VAR(CLASS, 1, "VertexId 2", "VertexId 2", sofa::Index, m2);
+template<class T> STRUCT_DATA_VAR(CLASS, 2, "ElemId 1", "ElemId 1", sofa::Index, index1);
+template<class T> STRUCT_DATA_VAR(CLASS, 3, "ElemId 2", "ElemId 2", sofa::Index, index2);
+
+template<class T> STRUCT_DATA_VAR(CLASS, 4, "Normal", "Norm", typename data_type::Deriv, norm);
+template<class T> STRUCT_DATA_VAR(CLASS, 5, "Distance", "Dist", typename data_type::Real, dist);
+
+template<class T> STRUCT_DATA_VAR(CLASS, 6, "Stiffness", "Ks", typename data_type::Real, ks);
+template<class T> STRUCT_DATA_VAR(CLASS, 7, "Penetration", "Pene", typename data_type::Real, pen);
+template<class T> STRUCT_DATA_VAR(CLASS, 8, "Age", "Age", int, age);
+
+template<class T>
+class data_widget_container < CLASS > : public struct_data_widget_container < CLASS >
+{};
+
+#undef CLASS
+
 } //namespace sofa::gui::qt

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/TableDataWidget.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/TableDataWidget.cpp
@@ -39,10 +39,6 @@ Creator<DataWidgetFactory, TableDataWidget< sofa::type::vector<float>, TABLE_HOR
 Creator<DataWidgetFactory, TableDataWidget< sofa::type::vector<double>, TABLE_HORIZONTAL > > DWClass_vectord("default",true);
 Creator<DataWidgetFactory, TableDataWidget< sofa::type::vector<std::string> > > DWClass_vectorstring("default",true);
 
-#ifdef TODOTOPO
-Creator<DataWidgetFactory, TableDataWidget< sofa::component::topology::PointSubset, TABLE_HORIZONTAL > > DWClass_PointSubset("default",true);
-#endif
-
 Creator<DataWidgetFactory, TableDataWidget< sofa::core::topology::BaseMeshTopology::SeqEdges      > > DWClass_SeqEdges     ("default",true);
 Creator<DataWidgetFactory, TableDataWidget< sofa::core::topology::BaseMeshTopology::SeqTriangles  > > DWClass_SeqTriangles ("default",true);
 Creator<DataWidgetFactory, TableDataWidget< sofa::core::topology::BaseMeshTopology::SeqQuads      > > DWClass_SeqQuads     ("default",true);

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/TableDataWidget.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/TableDataWidget.cpp
@@ -122,4 +122,7 @@ Creator<DataWidgetFactory, TableDataWidget< sofa::type::vector<sofa::component::
 Creator<DataWidgetFactory, TableDataWidget< sofa::type::vector<sofa::component::solidmechanics::spring::JointSpring<sofa::defaulttype::Rigid3Types> > > > DWClass_vectorJointSpring3f("default",true);
 Creator<DataWidgetFactory, TableDataWidget< sofa::type::vector<sofa::component::solidmechanics::spring::GearSpring<sofa::defaulttype::Rigid3Types> > > > DWClass_vectorGearSpring3f("default",true);
 
+Creator<DataWidgetFactory, TableDataWidget< sofa::type::vector<sofa::component::collision::response::contact::PenalityContact<defaulttype::Vec3Types> > > > DWClass_vectorPenalityContact("default",true);
+
+
 } //namespace sofa::gui::qt


### PR DESCRIPTION
Start porting old (useful?) changes from old dev branches: https://github.com/epernod/sofa/pull/11/files

This changes allow to display the Contacts as a qt table instead of raw line data:
![image](https://github.com/sofa-framework/sofa/assets/21199245/04a7ad35-8583-4406-82ec-526d241d02df)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
