### PR TITLE
[GUI.Component] Add virtualization for attachment performer

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
@@ -101,12 +101,12 @@ public:
     {}
     ~AttachOperation() override {}
 
-    void setStiffness(double s) {setting->stiffness.setValue(s);}
-    double getStiffness() const { return setting->stiffness.getValue();}
-    void setArrowSize(double s) {setting->arrowSize.setValue(s);}
-    double getArrowSize() const { return setting->arrowSize.getValue();}
-    void setShowFactorSize(double s) { setting->showFactorSize.setValue(s); }
-    double getShowFactorSize() const { return setting->showFactorSize.getValue(); }
+    void setStiffness(double s) {setting->d_stiffness.setValue(s);}
+    double getStiffness() const { return setting->d_stiffness.getValue();}
+    void setArrowSize(double s) {setting->d_arrowSize.setValue(s);}
+    double getArrowSize() const { return setting->d_arrowSize.getValue();}
+    void setShowFactorSize(double s) { setting->d_showFactorSize.setValue(s); }
+    double getShowFactorSize() const { return setting->d_showFactorSize.getValue(); }
 
     static std::string getDescription() {return "Attach an object to the Mouse using a spring force field";}
 

--- a/Sofa/GUI/Component/CMakeLists.txt
+++ b/Sofa/GUI/Component/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEADER_FILES
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/AddRecordedCameraPerformer.h
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/AttachBodyPerformer.h
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/AttachBodyPerformer.inl
+    ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/BaseAttachBodyPerformer.h
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/ComponentMouseInteraction.h
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/ComponentMouseInteraction.inl
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/ConstraintAttachBodyPerformer.h

--- a/Sofa/GUI/Component/CMakeLists.txt
+++ b/Sofa/GUI/Component/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HEADER_FILES
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/AttachBodyPerformer.h
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/AttachBodyPerformer.inl
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/BaseAttachBodyPerformer.h
+    ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/BaseAttachBodyPerformer.inl
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/ComponentMouseInteraction.h
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/ComponentMouseInteraction.inl
     ${SOFAGUICOMPONENT_SOURCE_DIR}/performer/ConstraintAttachBodyPerformer.h

--- a/Sofa/GUI/Component/src/sofa/gui/component/AttachBodyButtonSetting.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/AttachBodyButtonSetting.cpp
@@ -33,9 +33,9 @@ int AttachBodyButtonSettingClass = core::RegisterObject("Attach Body Button conf
         ;
 
 AttachBodyButtonSetting::AttachBodyButtonSetting():
-    stiffness(initData(&stiffness, 1000.0_sreal, "stiffness", "Stiffness of the spring to attach a particule"))
-    , arrowSize(initData(&arrowSize, 0.0_sreal, "arrowSize", "Size of the drawn spring: if >0 an arrow will be drawn"))
-    , showFactorSize(initData(&showFactorSize, 1.0_sreal, "showFactorSize", "Show factor size of the JointSpringForcefield  when interacting with rigids"))
+    d_stiffness(initData(&d_stiffness, 1000.0_sreal, "stiffness", "Stiffness of the spring to attach a particule"))
+    , d_arrowSize(initData(&d_arrowSize, 0.0_sreal, "arrowSize", "Size of the drawn spring: if >0 an arrow will be drawn"))
+    , d_showFactorSize(initData(&d_showFactorSize, 1.0_sreal, "showFactorSize", "Show factor size of the JointSpringForcefield  when interacting with rigids"))
 {
 }
 

--- a/Sofa/GUI/Component/src/sofa/gui/component/AttachBodyButtonSetting.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/AttachBodyButtonSetting.h
@@ -40,6 +40,10 @@ public:
     Data<SReal> d_stiffness; ///< Stiffness of the spring to attach a particule
     Data<SReal> d_arrowSize; ///< Size of the drawn spring: if >0 an arrow will be drawn
     Data<SReal> d_showFactorSize; ///< Show factor size of the JointSpringForcefield  when interacting with rigids
+
+    SOFA_ATTRIBUTE_DISABLED__NAMING("v24.06", "v24.06", stiffness, d_stiffness);
+    SOFA_ATTRIBUTE_DISABLED__NAMING("v24.06", "v24.06", arrowSize, d_arrowSize);
+    SOFA_ATTRIBUTE_DISABLED__NAMING("v24.06", "v24.06", showFactorSize, d_showFactorSize);
 };
 
 } // namespace sofa::gui::component

--- a/Sofa/GUI/Component/src/sofa/gui/component/AttachBodyButtonSetting.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/AttachBodyButtonSetting.h
@@ -37,9 +37,9 @@ protected:
     AttachBodyButtonSetting();
 public:
     std::string getOperationType() override {return "Attach";}
-    Data<SReal> stiffness; ///< Stiffness of the spring to attach a particule
-    Data<SReal> arrowSize; ///< Size of the drawn spring: if >0 an arrow will be drawn
-    Data<SReal> showFactorSize; ///< Show factor size of the JointSpringForcefield  when interacting with rigids
+    Data<SReal> d_stiffness; ///< Stiffness of the spring to attach a particule
+    Data<SReal> d_arrowSize; ///< Size of the drawn spring: if >0 an arrow will be drawn
+    Data<SReal> d_showFactorSize; ///< Show factor size of the JointSpringForcefield  when interacting with rigids
 };
 
 } // namespace sofa::gui::component

--- a/Sofa/GUI/Component/src/sofa/gui/component/config.h.in
+++ b/Sofa/GUI/Component/src/sofa/gui/component/config.h.in
@@ -31,6 +31,13 @@
 #  define SOFA_GUI_COMPONENT_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
 
+#define SOFA_ATTRIBUTE_DISABLED__NAMING( deprecationDate, disableDate, oldName, newName) \
+    SOFA_ATTRIBUTE_DISABLED( \
+        deprecationDate, disableDate, \
+        "The attribute " sofa_tostring(oldName) " has been renamed to \'" sofa_tostring(newName) "\' to fit naming policy ") \
+        DeprecatedAndRemoved oldName
+
+
 namespace sofa::gui::component
 {
 	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AddRecordedCameraPerformer.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AddRecordedCameraPerformer.cpp
@@ -39,7 +39,7 @@ namespace sofa::gui::component::performer
 
 void AddRecordedCameraPerformer::start()
 {
-    const sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
+    const sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( m_interactor->getContext()->getRootContext() );
     if(root)
     {
         sofa::component::visual::RecordedCamera* currentCamera = root->getNodeObject<sofa::component::visual::RecordedCamera>();

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #define SOFA_COMPONENT_COLLISION_ATTACHBODYPERFORMER_CPP
 
+#include <sofa/gui/component/performer/BaseAttachBodyPerformer.inl>
 #include <sofa/gui/component/performer/AttachBodyPerformer.inl>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.h
@@ -22,10 +22,8 @@
 #pragma once
 #include <sofa/gui/component/config.h>
 
-#include <sofa/gui/component/performer/InteractionPerformer.h>
 #include <sofa/gui/component/performer/BaseAttachBodyPerformer.h>
 #include <sofa/gui/component/AttachBodyButtonSetting.h>
-#include <sofa/component/collision/response/mapper/BaseContactMapper.h>
 #include <sofa/core/behavior/BaseForceField.h>
 #include <sofa/core/visual/DisplayFlags.h>
 
@@ -35,22 +33,18 @@ namespace sofa::gui::component::performer
 struct BodyPicked;
 
 template <class DataTypes>
-class AttachBodyPerformer: public TInteractionPerformer<DataTypes>, public BaseAttachBodyPerformer
+class AttachBodyPerformer: public BaseAttachBodyPerformer<DataTypes>
 {
 public:
+
     typedef sofa::component::collision::response::mapper::BaseContactMapper< DataTypes >        MouseContactMapper;
     typedef sofa::core::behavior::MechanicalState< DataTypes >         MouseContainer;
     typedef sofa::core::behavior::BaseForceField              MouseForceField;
 
     AttachBodyPerformer(BaseMouseInteractor *i);
-    virtual ~AttachBodyPerformer();
+    virtual ~AttachBodyPerformer() = default;
 
-    void start();
-    void execute();
-    void draw(const core::visual::VisualParams* vparams);
-    virtual sofa::core::objectmodel::BaseObject* getInteractionObject() override;
-    virtual void clear() override;
-    virtual bool start_partial(const BodyPicked& picked) override;
+    virtual bool startPartial(const BodyPicked& picked) override;
     /*
     initialise MouseForceField according to template.
     StiffSpringForceField for Vec3
@@ -59,7 +53,6 @@ public:
 
     void setStiffness(SReal s) {stiffness=s;}
     void setArrowSize(float s) {size=s;}
-    void setShowFactorSize(float s) {showFactorSize = s;}
 
     virtual void configure(sofa::component::setting::MouseButtonSetting* setting)
     {
@@ -68,21 +61,12 @@ public:
         {
             setStiffness(s->stiffness.getValue());
             setArrowSize((float)s->arrowSize.getValue());
-            setShowFactorSize((float)s->showFactorSize.getValue());
         }
     }
 
 protected:
     SReal stiffness;
     SReal size;
-    SReal showFactorSize;
-
-
-
-    MouseContactMapper  *mapper;
-    MouseForceField::SPtr m_forcefield;
-
-    core::visual::DisplayFlags flags;
 };
 
 #if !defined(SOFA_COMPONENT_COLLISION_ATTACHBODYPERFORMER_CPP)

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.h
@@ -23,6 +23,7 @@
 #include <sofa/gui/component/config.h>
 
 #include <sofa/gui/component/performer/InteractionPerformer.h>
+#include <sofa/gui/component/performer/BaseAttachBodyPerformer.h>
 #include <sofa/gui/component/AttachBodyButtonSetting.h>
 #include <sofa/component/collision/response/mapper/BaseContactMapper.h>
 #include <sofa/core/behavior/BaseForceField.h>
@@ -34,7 +35,7 @@ namespace sofa::gui::component::performer
 struct BodyPicked;
 
 template <class DataTypes>
-class AttachBodyPerformer: public TInteractionPerformer<DataTypes>
+class AttachBodyPerformer: public TInteractionPerformer<DataTypes>, public BaseAttachBodyPerformer
 {
 public:
     typedef sofa::component::collision::response::mapper::BaseContactMapper< DataTypes >        MouseContactMapper;
@@ -47,7 +48,14 @@ public:
     void start();
     void execute();
     void draw(const core::visual::VisualParams* vparams);
-    void clear();
+    virtual sofa::core::objectmodel::BaseObject* getInteractionObject() override;
+    virtual void clear() override;
+    virtual bool start_partial(const BodyPicked& picked) override;
+    /*
+    initialise MouseForceField according to template.
+    StiffSpringForceField for Vec3
+    JointSpringForceField for Rigid3
+    */
 
     void setStiffness(SReal s) {stiffness=s;}
     void setArrowSize(float s) {size=s;}
@@ -69,12 +77,7 @@ protected:
     SReal size;
     SReal showFactorSize;
 
-    virtual bool start_partial(const BodyPicked& picked);
-    /*
-    initialise MouseForceField according to template.
-    StiffSpringForceField for Vec3
-    JointSpringForceField for Rigid3
-    */
+
 
     MouseContactMapper  *mapper;
     MouseForceField::SPtr m_forcefield;

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.h
@@ -51,22 +51,22 @@ public:
     JointSpringForceField for Rigid3
     */
 
-    void setStiffness(SReal s) {stiffness=s;}
-    void setArrowSize(float s) {size=s;}
+    void setStiffness(SReal s) {m_stiffness=s;}
+    void setArrowSize(float s) {m_size=s;}
 
     virtual void configure(sofa::component::setting::MouseButtonSetting* setting)
     {
         const auto* s = dynamic_cast<sofa::gui::component::AttachBodyButtonSetting*>(setting);
         if (s)
         {
-            setStiffness(s->stiffness.getValue());
-            setArrowSize((float)s->arrowSize.getValue());
+            setStiffness(s->d_stiffness.getValue());
+            setArrowSize((float)s->d_arrowSize.getValue());
         }
     }
 
 protected:
-    SReal stiffness;
-    SReal size;
+    SReal m_stiffness;
+    SReal m_size;
 };
 
 #if !defined(SOFA_COMPONENT_COLLISION_ATTACHBODYPERFORMER_CPP)

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.inl
@@ -90,6 +90,13 @@ AttachBodyPerformer<DataTypes>::AttachBodyPerformer(BaseMouseInteractor *i):
     flags.setShowInteractionForceFields(true);
 }
 
+
+template <class DataTypes>
+sofa::core::objectmodel::BaseObject* AttachBodyPerformer<DataTypes>::getInteractionObject()
+{
+    return m_forcefield.get();
+}
+
 template <class DataTypes>
 void AttachBodyPerformer<DataTypes>::clear()
 {

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.inl
@@ -44,23 +44,23 @@ bool AttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& picked)
     int index;
     if (picked.body)
     {
-        this->mapper = MouseContactMapper::Create(picked.body);
-        if (!this->mapper)
+        this->m_mapper = MouseContactMapper::Create(picked.body);
+        if (!this->m_mapper)
         {
             msg_warning(this->interactor) << "Problem with Mouse Mapper creation " ;
             return false;
         }
         const std::string name = "contactMouse";
-        mstateCollision = this->mapper->createMapping(name.c_str());
-        this->mapper->resize(1);
+        mstateCollision = this->m_mapper->createMapping(name.c_str());
+        this->m_mapper->resize(1);
 
         const unsigned int idx=picked.indexCollisionElement;
         typename DataTypes::CPos pointPicked=(typename DataTypes::CPos)picked.point;
         typename DataTypes::Real r=0.0;
         typename DataTypes::Coord dofPicked;
         DataTypes::setCPos(dofPicked, pointPicked);
-        index = this->mapper->addPointB(dofPicked, idx, r);
-        this->mapper->update();
+        index = this->m_mapper->addPointB(dofPicked, idx, r);
+        this->m_mapper->update();
 
         if (mstateCollision->getContext() != picked.body->getContext())
         {
@@ -93,11 +93,11 @@ bool AttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& picked)
     this->m_interactionObject = sofa::core::objectmodel::New< StiffSpringForceField<DataTypes> >(dynamic_cast<MouseContainer*>(this->interactor->getMouseContainer()), mstateCollision);
     auto* stiffspringforcefield = dynamic_cast< StiffSpringForceField< DataTypes >* >(this->m_interactionObject.get());
     stiffspringforcefield->setName("Spring-Mouse-Contact");
-    stiffspringforcefield->setArrowSize((float)this->size);
+    stiffspringforcefield->setArrowSize((float)this->m_size);
     stiffspringforcefield->setDrawMode(2); //Arrow mode if size > 0
 
 
-    stiffspringforcefield->addSpring(0,index, stiffness, 0.0, picked.dist);
+    stiffspringforcefield->addSpring(0,index, m_stiffness, 0.0, picked.dist);
     const core::objectmodel::TagSet &tags=mstateCollision->getTags();
     for (core::objectmodel::TagSet::const_iterator it=tags.begin(); it!=tags.end(); ++it)
         stiffspringforcefield->addTag(*it);

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/AttachBodyPerformer.inl
@@ -47,7 +47,7 @@ bool AttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& picked)
         this->m_mapper = MouseContactMapper::Create(picked.body);
         if (!this->m_mapper)
         {
-            msg_warning(this->interactor) << "Problem with Mouse Mapper creation " ;
+            msg_warning(this->m_interactor) << "Problem with Mouse Mapper creation " ;
             return false;
         }
         const std::string name = "contactMouse";
@@ -83,14 +83,14 @@ bool AttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& picked)
         index = picked.indexCollisionElement;
         if (!mstateCollision)
         {
-            msg_warning(this->interactor) << "incompatible MState during Mouse Interaction " ;
+            msg_warning(this->m_interactor) << "incompatible MState during Mouse Interaction " ;
             return false;
         }
     }
 
     using sofa::component::solidmechanics::spring::StiffSpringForceField;
 
-    this->m_interactionObject = sofa::core::objectmodel::New< StiffSpringForceField<DataTypes> >(dynamic_cast<MouseContainer*>(this->interactor->getMouseContainer()), mstateCollision);
+    this->m_interactionObject = sofa::core::objectmodel::New< StiffSpringForceField<DataTypes> >(dynamic_cast<MouseContainer*>(this->m_interactor->getMouseContainer()), mstateCollision);
     auto* stiffspringforcefield = dynamic_cast< StiffSpringForceField< DataTypes >* >(this->m_interactionObject.get());
     stiffspringforcefield->setName("Spring-Mouse-Contact");
     stiffspringforcefield->setArrowSize((float)this->m_size);

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
@@ -62,7 +62,7 @@ public:
 protected:
 
     sofa::core::objectmodel::BaseObject::SPtr m_interactionObject;
-    MouseContactMapper  *mapper;
-    core::visual::DisplayFlags flags;
+    MouseContactMapper  *m_mapper;
+    core::visual::DisplayFlags m_flags;
 };
 }

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <sofa/core/objectmodel/BaseObject.h>
+
+
+namespace sofa::gui::component::performer
+{
+struct BodyPicked;
+
+
+/**
+ * This class is a virtualization of attachment performer used to allow the blind use of either "AttachBodyPerformer" based on springs and "ConstraintAttachBodyPerformer" based on lagrangian
+ * constraints. An example of use can be found in the external plugin Sofa.IGTLink in the component "iGTLinkMouseInteractor"
+ */
+class BaseAttachBodyPerformer
+{
+public:
+    virtual ~BaseAttachBodyPerformer() = default;
+    virtual sofa::core::objectmodel::BaseObject* getInteractionObject() = 0;
+    virtual void clear() = 0;
+    virtual bool start_partial(const BodyPicked& picked) = 0;
+};
+}

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
@@ -7,6 +7,7 @@ namespace sofa::gui::component::performer
 {
 struct BodyPicked;
 
+<<<<<<< HEAD
 
 /**
  * This class is a virtualization of attachment performer used to allow the blind use of either "AttachBodyPerformer" based on springs and "ConstraintAttachBodyPerformer" based on lagrangian
@@ -16,6 +17,11 @@ class BaseAttachBodyPerformer
 {
 public:
     virtual ~BaseAttachBodyPerformer() = default;
+=======
+class BaseAttachBodyPerformer
+{
+public:
+>>>>>>> c82a8f7fb0 (ADD Virtualization layer)
     virtual sofa::core::objectmodel::BaseObject* getInteractionObject() = 0;
     virtual void clear() = 0;
     virtual bool start_partial(const BodyPicked& picked) = 0;

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
@@ -7,7 +7,6 @@ namespace sofa::gui::component::performer
 {
 struct BodyPicked;
 
-<<<<<<< HEAD
 
 /**
  * This class is a virtualization of attachment performer used to allow the blind use of either "AttachBodyPerformer" based on springs and "ConstraintAttachBodyPerformer" based on lagrangian
@@ -17,11 +16,6 @@ class BaseAttachBodyPerformer
 {
 public:
     virtual ~BaseAttachBodyPerformer() = default;
-=======
-class BaseAttachBodyPerformer
-{
-public:
->>>>>>> c82a8f7fb0 (ADD Virtualization layer)
     virtual sofa::core::objectmodel::BaseObject* getInteractionObject() = 0;
     virtual void clear() = 0;
     virtual bool start_partial(const BodyPicked& picked) = 0;

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.h
@@ -1,6 +1,33 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
 #pragma once
 
 #include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/gui/component/config.h>
+
+#include <sofa/gui/component/performer/InteractionPerformer.h>
+#include <sofa/component/collision/response/mapper/BaseContactMapper.h>
+#include <sofa/core/visual/DisplayFlags.h>
+#include <sofa/core/visual/VisualParams.h>
 
 
 namespace sofa::gui::component::performer
@@ -12,12 +39,30 @@ struct BodyPicked;
  * This class is a virtualization of attachment performer used to allow the blind use of either "AttachBodyPerformer" based on springs and "ConstraintAttachBodyPerformer" based on lagrangian
  * constraints. An example of use can be found in the external plugin Sofa.IGTLink in the component "iGTLinkMouseInteractor"
  */
-class BaseAttachBodyPerformer
+template <class DataTypes>
+class BaseAttachBodyPerformer :  public TInteractionPerformer<DataTypes>
 {
 public:
-    virtual ~BaseAttachBodyPerformer() = default;
-    virtual sofa::core::objectmodel::BaseObject* getInteractionObject() = 0;
-    virtual void clear() = 0;
-    virtual bool start_partial(const BodyPicked& picked) = 0;
+    typedef typename DataTypes::VecCoord VecCoord;
+    typedef sofa::component::collision::response::mapper::BaseContactMapper< DataTypes >        MouseContactMapper;
+    typedef sofa::core::behavior::MechanicalState< DataTypes >         MouseContainer;
+
+    explicit BaseAttachBodyPerformer(BaseMouseInteractor* i);
+    virtual ~BaseAttachBodyPerformer();
+
+    virtual void start();
+    virtual void draw(const core::visual::VisualParams* vparams);
+    virtual void clear();
+    virtual void execute();
+    sofa::core::objectmodel::BaseObject::SPtr getInteractionObject();
+
+    virtual bool startPartial(const BodyPicked& picked) = 0;
+
+
+protected:
+
+    sofa::core::objectmodel::BaseObject::SPtr m_interactionObject;
+    MouseContactMapper  *mapper;
+    core::visual::DisplayFlags flags;
 };
 }

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
@@ -32,10 +32,10 @@ namespace sofa::gui::component::performer
 template <class DataTypes>
 BaseAttachBodyPerformer<DataTypes>::BaseAttachBodyPerformer(BaseMouseInteractor* i)
     : TInteractionPerformer<DataTypes>(i)
-    , mapper(nullptr)
+    , m_mapper(nullptr)
 {
-    this->flags.setShowVisualModels(false);
-    this->flags.setShowInteractionForceFields(true);
+    this->m_flags.setShowVisualModels(false);
+    this->m_flags.setShowInteractionForceFields(true);
 };
 
 template <class DataTypes>
@@ -76,7 +76,7 @@ void BaseAttachBodyPerformer<DataTypes>::draw(const core::visual::VisualParams* 
     {
         core::visual::VisualParams* vp = const_cast<core::visual::VisualParams*>(vparams);
         const core::visual::DisplayFlags backup = vp->displayFlags();
-        vp->displayFlags() = flags;
+        vp->displayFlags() = m_flags;
         m_interactionObject->draw(vp);
         vp->displayFlags() = backup;
     }
@@ -92,11 +92,11 @@ void BaseAttachBodyPerformer<DataTypes>::clear()
         m_interactionObject.reset();
     }
 
-    if (mapper)
+    if (m_mapper)
     {
-        mapper->cleanup();
-        delete mapper;
-        mapper = nullptr;
+        m_mapper->cleanup();
+        delete m_mapper;
+        m_mapper = nullptr;
     }
 
     this->interactor->setDistanceFromMouse(0);

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
@@ -53,9 +53,11 @@ void BaseAttachBodyPerformer<DataTypes>::start()
         return;
     }
     const BodyPicked picked=this->m_interactor->getBodyPicked();
-    if (!picked.body && !picked.mstate) return;
+    if (!picked.body && !picked.mstate)
+        return;
 
-    if (!startPartial(picked)) return; //template specialized code is here
+    if (!startPartial(picked)) //template specialized code is here
+        return;
 
     double distanceFromMouse=picked.rayLength;
     this->m_interactor->setDistanceFromMouse(distanceFromMouse);

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
@@ -1,0 +1,124 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/gui/component/performer/BaseAttachBodyPerformer.h>
+#include <sofa/core/BaseMapping.h>
+#include <sofa/gui/component/performer/MouseInteractor.h>
+
+
+namespace sofa::gui::component::performer
+{
+
+template <class DataTypes>
+BaseAttachBodyPerformer<DataTypes>::BaseAttachBodyPerformer(BaseMouseInteractor* i)
+    : TInteractionPerformer<DataTypes>(i)
+    , mapper(nullptr)
+{
+    this->flags.setShowVisualModels(false);
+    this->flags.setShowInteractionForceFields(true);
+};
+
+template <class DataTypes>
+BaseAttachBodyPerformer<DataTypes>::~BaseAttachBodyPerformer()
+{
+    clear();
+};
+
+template <class DataTypes>
+void BaseAttachBodyPerformer<DataTypes>::start()
+{
+    if (m_interactionObject)
+    {
+        clear();
+        return;
+    }
+    const BodyPicked picked=this->interactor->getBodyPicked();
+    if (!picked.body && !picked.mstate) return;
+
+    if (!startPartial(picked)) return; //template specialized code is here
+
+    double distanceFromMouse=picked.rayLength;
+    this->interactor->setDistanceFromMouse(distanceFromMouse);
+    sofa::component::collision::geometry::Ray ray = this->interactor->getMouseRayModel()->getRay(0);
+    ray.setOrigin(ray.origin() + ray.direction()*distanceFromMouse);
+    sofa::core::BaseMapping *mapping;
+    this->interactor->getContext()->get(mapping); assert(mapping);
+    mapping->apply(core::mechanicalparams::defaultInstance());
+    mapping->applyJ(core::mechanicalparams::defaultInstance());
+    m_interactionObject->init();
+    this->interactor->setMouseAttached(true);
+}
+
+template <class DataTypes>
+void BaseAttachBodyPerformer<DataTypes>::draw(const core::visual::VisualParams* vparams)
+{
+    if (m_interactionObject)
+    {
+        core::visual::VisualParams* vp = const_cast<core::visual::VisualParams*>(vparams);
+        const core::visual::DisplayFlags backup = vp->displayFlags();
+        vp->displayFlags() = flags;
+        m_interactionObject->draw(vp);
+        vp->displayFlags() = backup;
+    }
+}
+
+template <class DataTypes>
+void BaseAttachBodyPerformer<DataTypes>::clear()
+{
+    if (m_interactionObject)
+    {
+        m_interactionObject->cleanup();
+        m_interactionObject->getContext()->removeObject(m_interactionObject);
+        m_interactionObject.reset();
+    }
+
+    if (mapper)
+    {
+        mapper->cleanup();
+        delete mapper;
+        mapper = nullptr;
+    }
+
+    this->interactor->setDistanceFromMouse(0);
+    this->interactor->setMouseAttached(false);
+}
+
+template <class DataTypes>
+void BaseAttachBodyPerformer<DataTypes>::execute()
+{
+    sofa::core::BaseMapping *mapping;
+    this->interactor->getContext()->get(mapping); assert(mapping);
+    mapping->apply(core::mechanicalparams::defaultInstance());
+    mapping->applyJ(core::mechanicalparams::defaultInstance());
+    this->interactor->setMouseAttached(true);
+}
+
+template <class DataTypes>
+sofa::core::objectmodel::BaseObject::SPtr BaseAttachBodyPerformer<DataTypes>::getInteractionObject()
+{
+        return m_interactionObject;
+};
+
+
+
+}

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
@@ -59,12 +59,15 @@ void BaseAttachBodyPerformer<DataTypes>::start()
 
     double distanceFromMouse=picked.rayLength;
     this->m_interactor->setDistanceFromMouse(distanceFromMouse);
+    
     sofa::component::collision::geometry::Ray ray = this->m_interactor->getMouseRayModel()->getRay(0);
     ray.setOrigin(ray.origin() + ray.direction()*distanceFromMouse);
+    
     sofa::core::BaseMapping *mapping;
     this->m_interactor->getContext()->get(mapping); assert(mapping);
     mapping->apply(core::mechanicalparams::defaultInstance());
     mapping->applyJ(core::mechanicalparams::defaultInstance());
+    
     m_interactionObject->init();
     this->m_interactor->setMouseAttached(true);
 }

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/BaseAttachBodyPerformer.inl
@@ -52,21 +52,21 @@ void BaseAttachBodyPerformer<DataTypes>::start()
         clear();
         return;
     }
-    const BodyPicked picked=this->interactor->getBodyPicked();
+    const BodyPicked picked=this->m_interactor->getBodyPicked();
     if (!picked.body && !picked.mstate) return;
 
     if (!startPartial(picked)) return; //template specialized code is here
 
     double distanceFromMouse=picked.rayLength;
-    this->interactor->setDistanceFromMouse(distanceFromMouse);
-    sofa::component::collision::geometry::Ray ray = this->interactor->getMouseRayModel()->getRay(0);
+    this->m_interactor->setDistanceFromMouse(distanceFromMouse);
+    sofa::component::collision::geometry::Ray ray = this->m_interactor->getMouseRayModel()->getRay(0);
     ray.setOrigin(ray.origin() + ray.direction()*distanceFromMouse);
     sofa::core::BaseMapping *mapping;
-    this->interactor->getContext()->get(mapping); assert(mapping);
+    this->m_interactor->getContext()->get(mapping); assert(mapping);
     mapping->apply(core::mechanicalparams::defaultInstance());
     mapping->applyJ(core::mechanicalparams::defaultInstance());
     m_interactionObject->init();
-    this->interactor->setMouseAttached(true);
+    this->m_interactor->setMouseAttached(true);
 }
 
 template <class DataTypes>
@@ -99,18 +99,18 @@ void BaseAttachBodyPerformer<DataTypes>::clear()
         m_mapper = nullptr;
     }
 
-    this->interactor->setDistanceFromMouse(0);
-    this->interactor->setMouseAttached(false);
+    this->m_interactor->setDistanceFromMouse(0);
+    this->m_interactor->setMouseAttached(false);
 }
 
 template <class DataTypes>
 void BaseAttachBodyPerformer<DataTypes>::execute()
 {
     sofa::core::BaseMapping *mapping;
-    this->interactor->getContext()->get(mapping); assert(mapping);
+    this->m_interactor->getContext()->get(mapping); assert(mapping);
     mapping->apply(core::mechanicalparams::defaultInstance());
     mapping->applyJ(core::mechanicalparams::defaultInstance());
-    this->interactor->setMouseAttached(true);
+    this->m_interactor->setMouseAttached(true);
 }
 
 template <class DataTypes>

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #define SOFA_COMPONENT_COLLISION_CONSTRAINTATTACHBODYPERFORMER_CPP
 
+#include <sofa/gui/component/performer/BaseAttachBodyPerformer.inl>
 #include <sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/Factory.inl>

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
@@ -26,6 +26,8 @@
 #include <sofa/component/collision/response/mapper/BaseContactMapper.h>
 #include <sofa/gui/component/AttachBodyButtonSetting.h>
 #include <sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h>
+#include <sofa/gui/component/performer/BaseAttachBodyPerformer.h>
+
 
 #include <sofa/core/visual/DisplayFlags.h>
 
@@ -51,7 +53,7 @@ namespace sofa::gui::component::performer
 struct BodyPicked;
 
 template <class DataTypes>
-class ConstraintAttachBodyPerformer: public TInteractionPerformer<DataTypes>
+class ConstraintAttachBodyPerformer: public TInteractionPerformer<DataTypes>, public BaseAttachBodyPerformer
 {
 public:
     typedef typename DataTypes::VecCoord VecCoord;
@@ -64,10 +66,13 @@ public:
     ConstraintAttachBodyPerformer(BaseMouseInteractor *i);
     virtual ~ConstraintAttachBodyPerformer();
 
+
     void start();
     void execute();
     void draw(const core::visual::VisualParams* vparams);
-    void clear();
+    virtual sofa::core::objectmodel::BaseObject* getInteractionObject() override;
+    virtual void clear() override;
+    virtual bool start_partial(const BodyPicked& picked) override;
 
     void setStiffness(SReal s) {stiffness=s;}
     void setArrowSize(float s) {size=s;}
@@ -88,7 +93,6 @@ protected:
     SReal size;
     SReal showFactorSize;
 
-    virtual bool start_partial(const BodyPicked& picked);
 
     MouseContactMapper  *mapper;
     sofa::component::constraint::lagrangian::model::BilateralLagrangianConstraint<defaulttype::Vec3Types>::SPtr m_constraint;

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
@@ -48,7 +48,7 @@ public:
 
 protected:
 
-    sofa::core::behavior::MechanicalState<DataTypes> *mstate1, *mstate2;
+    sofa::core::behavior::MechanicalState<DataTypes> *m_mstate1, *m_mstate2;
 };
 
 #if !defined(SOFA_COMPONENT_COLLISION_CONSTRAINTATTACHBODYPERFORMER_CPP)

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
@@ -20,32 +20,12 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <sofa/gui/component/config.h>
 
-#include <sofa/gui/component/performer/InteractionPerformer.h>
-#include <sofa/component/collision/response/mapper/BaseContactMapper.h>
-#include <sofa/gui/component/AttachBodyButtonSetting.h>
 #include <sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h>
 #include <sofa/gui/component/performer/BaseAttachBodyPerformer.h>
+#include <sofa/gui/component/ConstraintAttachButtonSetting.h>
 
 
-#include <sofa/core/visual/DisplayFlags.h>
-
-namespace sofa::gui::component
-{
-
-class ConstraintAttachBodyButtonSetting : public sofa::gui::component::AttachBodyButtonSetting
-{
-public:
-    SOFA_CLASS(ConstraintAttachBodyButtonSetting, sofa::gui::component::AttachBodyButtonSetting);
-protected:
-    ConstraintAttachBodyButtonSetting() {}
-public:
-    //        Data<SReal> snapDistance;
-    std::string getOperationType() override { return  "ConstraintAttachBody"; }
-};
-
-} // namespace sofa::gui::component
 
 namespace sofa::gui::component::performer
 {
@@ -53,51 +33,20 @@ namespace sofa::gui::component::performer
 struct BodyPicked;
 
 template <class DataTypes>
-class ConstraintAttachBodyPerformer: public TInteractionPerformer<DataTypes>, public BaseAttachBodyPerformer
+class ConstraintAttachBodyPerformer: public BaseAttachBodyPerformer<DataTypes>
 {
 public:
+
     typedef typename DataTypes::VecCoord VecCoord;
     typedef sofa::component::collision::response::mapper::BaseContactMapper< DataTypes >        MouseContactMapper;
     typedef sofa::core::behavior::MechanicalState< DataTypes >         MouseContainer;
-//        typedef sofa::component::constraint::lagrangian::model::BilateralLagrangianConstraint< DataTypes > MouseConstraint;
-
-//        typedef sofa::core::behavior::BaseForceField              MouseForceField;
 
     ConstraintAttachBodyPerformer(BaseMouseInteractor *i);
-    virtual ~ConstraintAttachBodyPerformer();
+    virtual ~ConstraintAttachBodyPerformer() = default;
 
-
-    void start();
-    void execute();
-    void draw(const core::visual::VisualParams* vparams);
-    virtual sofa::core::objectmodel::BaseObject* getInteractionObject() override;
-    virtual void clear() override;
-    virtual bool start_partial(const BodyPicked& picked) override;
-
-    void setStiffness(SReal s) {stiffness=s;}
-    void setArrowSize(float s) {size=s;}
-    void setShowFactorSize(float s) {showFactorSize = s;}
-
-    virtual void configure(sofa::component::setting::MouseButtonSetting * setting)
-    {
-        if (const auto* s = dynamic_cast<sofa::gui::component::ConstraintAttachBodyButtonSetting*>(setting))
-        {
-            setStiffness((double)s->stiffness.getValue());
-            setArrowSize((float)s->arrowSize.getValue());
-            setShowFactorSize((float)s->showFactorSize.getValue());
-        }
-    }
+    virtual bool startPartial(const BodyPicked& picked) override;
 
 protected:
-    SReal stiffness;
-    SReal size;
-    SReal showFactorSize;
-
-
-    MouseContactMapper  *mapper;
-    sofa::component::constraint::lagrangian::model::BilateralLagrangianConstraint<defaulttype::Vec3Types>::SPtr m_constraint;
-
-    core::visual::DisplayFlags flags;
 
     sofa::core::behavior::MechanicalState<DataTypes> *mstate1, *mstate2;
 };

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
@@ -55,7 +55,11 @@ void ConstraintAttachBodyPerformer<DataTypes>::start()
     this->interactor->setMouseAttached(true);
 }
 
-
+template <class DataTypes>
+sofa::core::objectmodel::BaseObject* ConstraintAttachBodyPerformer<DataTypes>::getInteractionObject()
+{
+    return m_constraint.get();
+}
 
 template <class DataTypes>
 void ConstraintAttachBodyPerformer<DataTypes>::execute()

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
@@ -23,126 +23,42 @@
 
 #include <sofa/gui/component/performer/ConstraintAttachBodyPerformer.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/gui/component/performer/MouseInteractor.h>
 #include <sofa/core/BaseMapping.h>
 #include <sofa/simulation/Node.h>
 
 namespace sofa::gui::component::performer
 {
 
-template <class DataTypes>
-void ConstraintAttachBodyPerformer<DataTypes>::start()
-{
-    if (m_constraint)
-    {
-        clear();
-        return;
-    }
-    const BodyPicked picked=this->interactor->getBodyPicked();
-    if (!picked.body && !picked.mstate) return;
-
-    if (!start_partial(picked)) return; //template specialized code is here
-
-    double distanceFromMouse=picked.rayLength;
-    this->interactor->setDistanceFromMouse(distanceFromMouse);
-    sofa::component::collision::geometry::Ray ray = this->interactor->getMouseRayModel()->getRay(0);
-    ray.setOrigin(ray.origin() + ray.direction()*distanceFromMouse);
-    sofa::core::BaseMapping *mapping;
-    this->interactor->getContext()->get(mapping); assert(mapping);
-    mapping->apply(core::mechanicalparams::defaultInstance());
-    mapping->applyJ(core::mechanicalparams::defaultInstance());
-    m_constraint->init();
-    this->interactor->setMouseAttached(true);
-}
-
-template <class DataTypes>
-sofa::core::objectmodel::BaseObject* ConstraintAttachBodyPerformer<DataTypes>::getInteractionObject()
-{
-    return m_constraint.get();
-}
-
-template <class DataTypes>
-void ConstraintAttachBodyPerformer<DataTypes>::execute()
-{
-    sofa::core::BaseMapping *mapping;
-    this->interactor->getContext()->get(mapping); assert(mapping);
-    mapping->apply(core::mechanicalparams::defaultInstance());
-    mapping->applyJ(core::mechanicalparams::defaultInstance());
-    this->interactor->setMouseAttached(true);
-}
-
-template <class DataTypes>
-void ConstraintAttachBodyPerformer<DataTypes>::draw(const core::visual::VisualParams* vparams)
-{
-    if (m_constraint)
-    {
-        core::visual::VisualParams* vp = const_cast<core::visual::VisualParams*>(vparams);
-        const core::visual::DisplayFlags backup = vp->displayFlags();
-        vp->displayFlags() = flags;
-        m_constraint->draw(vp);
-        vp->displayFlags() = backup;
-    }
-}
 
 template <class DataTypes>
 ConstraintAttachBodyPerformer<DataTypes>::ConstraintAttachBodyPerformer(BaseMouseInteractor *i):
-    TInteractionPerformer<DataTypes>(i),
-    mapper(nullptr)
-{
-    flags.setShowVisualModels(false);
-    flags.setShowInteractionForceFields(true);
-}
-
-template <class DataTypes>
-void ConstraintAttachBodyPerformer<DataTypes>::clear()
-{
-    if (m_constraint)
-    {
-        m_constraint->cleanup();
-        m_constraint->getContext()->removeObject(m_constraint);
-        m_constraint.reset();
-    }
-
-    if (mapper)
-    {
-        mapper->cleanup();
-        delete mapper; mapper=nullptr;
-    }
-
-    this->interactor->setDistanceFromMouse(0);
-    this->interactor->setMouseAttached(false);
-}
+  BaseAttachBodyPerformer<DataTypes>(i)
+{}
 
 
 template <class DataTypes>
-ConstraintAttachBodyPerformer<DataTypes>::~ConstraintAttachBodyPerformer()
-{
-    clear();
-}
-
-template <class DataTypes>
-bool ConstraintAttachBodyPerformer<DataTypes>::start_partial(const BodyPicked& picked)
+bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& picked)
 {
     core::behavior::MechanicalState<DataTypes>* mstateCollision=nullptr;
     int index;
     if (picked.body)
     {
-        mapper = MouseContactMapper::Create(picked.body);
-        if (!mapper)
+        this->mapper = MouseContactMapper::Create(picked.body);
+        if (!(this->mapper))
         {
             msg_error(this->interactor) << "Problem with Mouse Mapper creation.";
             return false;
         }
         const std::string name = "contactMouse";
-        mstateCollision = mapper->createMapping(name.c_str());
-        mapper->resize(1);
+        mstateCollision = this->mapper->createMapping(name.c_str());
+        this->mapper->resize(1);
 
         const typename DataTypes::Coord pointPicked=picked.point;
         const int idx=picked.indexCollisionElement;
         typename DataTypes::Real r=0.0;
 
-        index = mapper->addPointB(pointPicked, idx, r);
-        mapper->update();
+        index = this->mapper->addPointB(pointPicked, idx, r);
+        this->mapper->update();
 
         if (mstateCollision->getContext() != picked.body->getContext())
         {
@@ -178,8 +94,11 @@ bool ConstraintAttachBodyPerformer<DataTypes>::start_partial(const BodyPicked& p
 
     using sofa::component::constraint::lagrangian::model::BilateralLagrangianConstraint;
 
-    m_constraint = sofa::core::objectmodel::New<BilateralLagrangianConstraint<sofa::defaulttype::Vec3Types> >(mstate1, mstate2);
-    BilateralLagrangianConstraint< DataTypes >* bconstraint = static_cast< BilateralLagrangianConstraint< sofa::defaulttype::Vec3Types >* >(m_constraint.get());
+
+
+    this->m_interactionObject = sofa::core::objectmodel::New<BilateralLagrangianConstraint<sofa::defaulttype::Vec3Types> >(mstate1, mstate2);
+    auto* bconstraint = dynamic_cast< BilateralLagrangianConstraint< sofa::defaulttype::Vec3Types >* >(this->m_interactionObject.get());
+
     bconstraint->setName("Constraint-Mouse-Contact");
 
     type::Vec3d normal = point1-point2;

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
@@ -46,7 +46,7 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
         this->m_mapper = MouseContactMapper::Create(picked.body);
         if (!(this->m_mapper))
         {
-            msg_error(this->interactor) << "Problem with Mouse Mapper creation.";
+            msg_error(this->m_interactor) << "Problem with Mouse Mapper creation.";
             return false;
         }
         const std::string name = "contactMouse";
@@ -81,12 +81,12 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
         index = picked.indexCollisionElement;
         if (!mstateCollision)
         {
-            msg_error(this->interactor) << "incompatible MState during Mouse Interaction.";
+            msg_error(this->m_interactor) << "incompatible MState during Mouse Interaction.";
             return false;
         }
     }
 
-    m_mstate1 = dynamic_cast<MouseContainer*>(this->interactor->getMouseContainer());
+    m_mstate1 = dynamic_cast<MouseContainer*>(this->m_interactor->getMouseContainer());
     m_mstate2 = mstateCollision;
 
     type::Vec3d point1;

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
@@ -43,22 +43,22 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
     int index;
     if (picked.body)
     {
-        this->mapper = MouseContactMapper::Create(picked.body);
-        if (!(this->mapper))
+        this->m_mapper = MouseContactMapper::Create(picked.body);
+        if (!(this->m_mapper))
         {
             msg_error(this->interactor) << "Problem with Mouse Mapper creation.";
             return false;
         }
         const std::string name = "contactMouse";
-        mstateCollision = this->mapper->createMapping(name.c_str());
-        this->mapper->resize(1);
+        mstateCollision = this->m_mapper->createMapping(name.c_str());
+        this->m_mapper->resize(1);
 
         const typename DataTypes::Coord pointPicked=picked.point;
         const int idx=picked.indexCollisionElement;
         typename DataTypes::Real r=0.0;
 
-        index = this->mapper->addPointB(pointPicked, idx, r);
-        this->mapper->update();
+        index = this->m_mapper->addPointB(pointPicked, idx, r);
+        this->m_mapper->update();
 
         if (mstateCollision->getContext() != picked.body->getContext())
         {
@@ -86,8 +86,8 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
         }
     }
 
-    mstate1 = dynamic_cast<MouseContainer*>(this->interactor->getMouseContainer());
-    mstate2 = mstateCollision;
+    m_mstate1 = dynamic_cast<MouseContainer*>(this->interactor->getMouseContainer());
+    m_mstate2 = mstateCollision;
 
     type::Vec3d point1;
     type::Vec3d point2;
@@ -96,7 +96,7 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
 
 
 
-    this->m_interactionObject = sofa::core::objectmodel::New<BilateralLagrangianConstraint<sofa::defaulttype::Vec3Types> >(mstate1, mstate2);
+    this->m_interactionObject = sofa::core::objectmodel::New<BilateralLagrangianConstraint<sofa::defaulttype::Vec3Types> >(m_mstate1, m_mstate2);
     auto* bconstraint = dynamic_cast< BilateralLagrangianConstraint< sofa::defaulttype::Vec3Types >* >(this->m_interactionObject.get());
 
     bconstraint->setName("Constraint-Mouse-Contact");

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/FixParticlePerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/FixParticlePerformer.inl
@@ -34,7 +34,7 @@ namespace sofa::gui::component::performer
 template <class DataTypes>
 void FixParticlePerformer<DataTypes>::start()
 {
-    const BodyPicked &picked=this->interactor->getBodyPicked();
+    const BodyPicked &picked=this->m_interactor->getBodyPicked();
 
     type::vector<unsigned int > points;
     typename DataTypes::Coord fixPoint;

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/InciseAlongPathPerformer.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/InciseAlongPathPerformer.cpp
@@ -33,7 +33,7 @@ helper::Creator<InteractionPerformer::InteractionPerformerFactory, InciseAlongPa
 
 void InciseAlongPathPerformer::start()
 {
-    startBody=this->interactor->getBodyPicked();
+    startBody=this->m_interactor->getBodyPicked();
 
     if (startBody.body == 0)
         return;
@@ -50,10 +50,10 @@ void InciseAlongPathPerformer::start()
 void InciseAlongPathPerformer::execute()
 {
 
-    if (freezePerformer) // This performer has been freezed
+    if (m_freezePerformer) // This performer has been freezed
     {
         if (currentMethod == 1)
-            startBody=this->interactor->getBodyPicked();
+            startBody=this->m_interactor->getBodyPicked();
 
         return;
     }
@@ -85,12 +85,12 @@ void InciseAlongPathPerformer::execute()
         firstBody = secondBody;
         secondBody.body = nullptr;
 
-        this->interactor->setBodyPicked(secondBody);
+        this->m_interactor->setBodyPicked(secondBody);
     }
     else
     {
 
-        BodyPicked currentBody=this->interactor->getBodyPicked();
+        BodyPicked currentBody=this->m_interactor->getBodyPicked();
         if (currentBody.body == nullptr || startBody.body == nullptr) return;
 
         if (currentBody.indexCollisionElement == startBody.indexCollisionElement) return;
@@ -109,14 +109,14 @@ void InciseAlongPathPerformer::execute()
         firstBody = currentBody;
 
         currentBody.body=nullptr;
-        this->interactor->setBodyPicked(currentBody);
+        this->m_interactor->setBodyPicked(currentBody);
     }
 
 }
 
 void InciseAlongPathPerformer::setPerformerFreeze()
 {
-    freezePerformer = true;
+    m_freezePerformer = true;
     if (fullcut)
         this->PerformCompleteIncision();
 
@@ -207,14 +207,14 @@ InciseAlongPathPerformer::~InciseAlongPathPerformer()
     if (firstIncisionBody.body)
         firstIncisionBody.body = nullptr;
 
-    this->interactor->setBodyPicked(firstIncisionBody);
+    this->m_interactor->setBodyPicked(firstIncisionBody);
 }
 
 void InciseAlongPathPerformer::draw(const core::visual::VisualParams* vparams)
 {
     if (firstBody.body == nullptr) return;
 
-    BodyPicked currentBody=this->interactor->getBodyPicked();
+    BodyPicked currentBody=this->m_interactor->getBodyPicked();
 
     sofa::component::topology::container::dynamic::TriangleSetGeometryAlgorithms<defaulttype::Vec3Types>* topoGeo;
     firstBody.body->getContext()->get(topoGeo);

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/InteractionPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/InteractionPerformer.h
@@ -59,6 +59,10 @@ public:
     }
     BaseMouseInteractor *m_interactor;
     bool m_freezePerformer;
+
+    SOFA_ATTRIBUTE_DISABLED__NAMING("v24.06", "v24.06", interactor,m_interactor);
+    SOFA_ATTRIBUTE_DISABLED__NAMING("v24.06", "v24.06", freezePerformer,m_freezePerformer);
+
 };
 
 

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/InteractionPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/InteractionPerformer.h
@@ -39,7 +39,7 @@ class SOFA_GUI_COMPONENT_API InteractionPerformer
 public:
     typedef helper::Factory<std::string, InteractionPerformer, BaseMouseInteractor*> InteractionPerformerFactory;
 
-    InteractionPerformer(BaseMouseInteractor *i):interactor(i),freezePerformer(0) {}
+    InteractionPerformer(BaseMouseInteractor *i):m_interactor(i),m_freezePerformer(0) {}
     virtual ~InteractionPerformer() {}
 
     virtual void configure(sofa::component::setting::MouseButtonSetting* /*setting*/) {}
@@ -50,15 +50,15 @@ public:
     virtual void handleEvent(core::objectmodel::Event * ) {}
     virtual void draw(const core::visual::VisualParams* ) {}
 
-    virtual void setPerformerFreeze() {freezePerformer = true;}
+    virtual void setPerformerFreeze() {m_freezePerformer = true;}
 
     template <class RealObject>
     static RealObject* create( RealObject*, BaseMouseInteractor* interactor)
     {
         return new RealObject(interactor);
     }
-    BaseMouseInteractor *interactor;
-    bool freezePerformer;
+    BaseMouseInteractor *m_interactor;
+    bool m_freezePerformer;
 };
 
 

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/RemovePrimitivePerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/RemovePrimitivePerformer.inl
@@ -57,7 +57,7 @@ template <class DataTypes>
 void RemovePrimitivePerformer<DataTypes>::execute()
 {
     // - STEP 1: Get body picked and Mstate associated
-    picked=this->interactor->getBodyPicked();
+    picked=this->m_interactor->getBodyPicked();
     if (!picked.body) return;
 
     mstateCollision = dynamic_cast< core::behavior::MechanicalState<DataTypes>*    >(picked.body->getContext()->getMechanicalState());
@@ -81,7 +81,7 @@ void RemovePrimitivePerformer<DataTypes>::execute()
             topologyChangeManager.removeItemsFromCollisionModel(model, (int)picked.indexCollisionElement);
 
         picked.body=nullptr;
-        this->interactor->setBodyPicked(picked);
+        this->m_interactor->setBodyPicked(picked);
     }
     else // second case remove a zone of element
     {
@@ -124,7 +124,7 @@ void RemovePrimitivePerformer<DataTypes>::execute()
             // Handle Removing of topological element (from any type of topology)
             if(topologyModifier) topologyChangeManager.removeItemsFromCollisionModel(model.get(),ElemList_int );
             picked.body=nullptr;
-            this->interactor->setBodyPicked(picked);
+            this->m_interactor->setBodyPicked(picked);
 
             if (surfaceOnVolume) // In the case of deleting a volume from a surface an volumique collision model is needed (only tetra available for the moment)
             {

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/StartNavigationPerformer.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/StartNavigationPerformer.cpp
@@ -35,7 +35,7 @@ namespace sofa::gui::component::performer
 
     void StartNavigationPerformer::start()
     {
-        const sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
+        const sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( m_interactor->getContext()->getRootContext() );
         if(root)
         {
             sofa::component::visual::RecordedCamera* currentCamera = root->getNodeObject<sofa::component::visual::RecordedCamera>();

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/SuturePointPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/SuturePointPerformer.inl
@@ -44,26 +44,26 @@ void SuturePointPerformer<DataTypes>::start()
 {
     if (first) //first click
     {
-        const BodyPicked picked = this->interactor->getBodyPicked();
+        const BodyPicked picked = this->m_interactor->getBodyPicked();
         const auto* CollisionModel = dynamic_cast<sofa::component::collision::geometry::TriangleCollisionModel<sofa::defaulttype::Vec3Types>* >(picked.body);
 
         if (picked.body == nullptr || CollisionModel == nullptr)
         {
-            msg_error(this->interactor) << "No picked body in first clic.";
+            msg_error(this->m_interactor) << "No picked body in first clic.";
             return;
         }
 
-        firstPicked = this->interactor->getBodyPicked();
+        firstPicked = this->m_interactor->getBodyPicked();
         first = false;
     }
     else // second click
     {
-        const BodyPicked picked = this->interactor->getBodyPicked();
+        const BodyPicked picked = this->m_interactor->getBodyPicked();
         auto* CollisionModel = dynamic_cast<sofa::component::collision::geometry::TriangleCollisionModel<sofa::defaulttype::Vec3Types>* >(picked.body);
 
         if (picked.body == nullptr || CollisionModel == nullptr)
         {
-            msg_error(this->interactor) << "No picked body in second clic.";
+            msg_error(this->m_interactor) << "No picked body in second clic.";
             return;
         }
 
@@ -79,27 +79,27 @@ void SuturePointPerformer<DataTypes>::start()
 
         if (!SpringObject)
         {
-            msg_error(this->interactor) << "Can't find StiffSpringForceField.";
+            msg_error(this->m_interactor) << "Can't find StiffSpringForceField.";
             return;
         }
         else if (!triangleContainer)
         {
-            msg_error(this->interactor) << "Can't find a topology.";
+            msg_error(this->m_interactor) << "Can't find a topology.";
             return;
         }
         else if (triangleContainer->getTriangles().empty())
         {
-            msg_error(this->interactor) << "Can't find a topology with triangles.";
+            msg_error(this->m_interactor) << "Can't find a topology with triangles.";
             return;
         }
         else if (!MechanicalObject)
         {
-            msg_error(this->interactor) << "Can't find MechanicalObject.";
+            msg_error(this->m_interactor) << "Can't find MechanicalObject.";
             return;
         }
         else if (!FixObject)
         {
-            msg_error(this->interactor) << "Can't find FixObject.";
+            msg_error(this->m_interactor) << "Can't find FixObject.";
             return;
         }
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/QMouseOperations.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/QMouseOperations.cpp
@@ -67,13 +67,13 @@ QAttachOperation::QAttachOperation()
 
     QHBoxLayout *layout=new QHBoxLayout(this);
     QLabel *label=new QLabel(QString("Stiffness"), this);
-    stiffnessWidget = createWidgetFromData(&(setting->stiffness));
+    stiffnessWidget = createWidgetFromData(&(setting->d_stiffness));
 
     QLabel *labelSize=new QLabel(QString("Arrow Size"), this);
-    arrowSizeWidget = createWidgetFromData(&(setting->arrowSize));
+    arrowSizeWidget = createWidgetFromData(&(setting->d_arrowSize));
 
     QLabel *labelShowFactor=new QLabel(QString("Show Factor Size"), this);
-    showSizeFactorWidget = createWidgetFromData(&(setting->showFactorSize));
+    showSizeFactorWidget = createWidgetFromData(&(setting->d_showFactorSize));
 
     layout->addWidget(label);
     layout->addWidget(stiffnessWidget);
@@ -91,9 +91,9 @@ void QAttachOperation::configure(PickHandler *picker, sofa::component::setting::
     if (const sofa::gui::component::AttachBodyButtonSetting* attachSetting=dynamic_cast<sofa::gui::component::AttachBodyButtonSetting*>(button))
     {
         AttachOperation::configure(picker,GetMouseId(button->button.getValue().getSelectedId()));
-        setting->stiffness.copyValueFrom(&(attachSetting->stiffness));
-        setting->arrowSize.copyValueFrom(&(attachSetting->arrowSize) );
-        setting->showFactorSize.copyValueFrom(&( attachSetting->showFactorSize) ) ;
+        setting->d_stiffness.copyValueFrom(&(attachSetting->d_stiffness));
+        setting->d_arrowSize.copyValueFrom(&(attachSetting->d_arrowSize) );
+        setting->d_showFactorSize.copyValueFrom(&( attachSetting->d_showFactorSize) ) ;
 
         stiffnessWidget->updateWidgetValue();
         arrowSizeWidget->updateWidgetValue();

--- a/applications/plugins/SofaCUDA/sofa/gpu/gui/CudaMouseInteraction.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/gui/CudaMouseInteraction.cpp
@@ -10,6 +10,7 @@
 #include <sofa/gui/component/performer/ComponentMouseInteraction.inl>
 #include <sofa/gui/component/performer/AttachBodyPerformer.inl>
 #include <sofa/gui/component/performer/FixParticlePerformer.inl>
+#include <sofa/gui/component/performer/BaseAttachBodyPerformer.inl>
 
 #include <sofa/component/collision/detection/intersection/RayDiscreteIntersection.inl>
 #include <sofa/component/collision/detection/intersection/DiscreteIntersection.h>


### PR DESCRIPTION
Add virtualization layer to attachment performers.

There exists two of them, either using lagrangian based constraints or springs. A common method `start_partial` already existed that was supposed to add required components and parametrize them to either add bilateral constraint or a spring, but this common mechanism was not link with any virtual inheritance.

I need to handle both performers blindly using this method (`start_partial`) so I added a virtualization layer that makes more sens than what currently exists. I use it in this PR -> ([Sofa.IGTLink PR](https://github.com/sofa-framework/Sofa.IGTLink/pull/5)).

I've also took advantage of this refactoring to rename some attributes that where not following the naming policy, because why not. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
