### PR TITLE
[GUI.Qt] Some cleaning in qt RealGui

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -1399,11 +1399,11 @@ void RealGUI::initViewer(BaseViewer* _viewer)
     }
     init(); //init data member from RealGUI for the viewer initialisation in the GUI
 
-    // Is our viewer embedded or not ?
+    // Is our viewer not a qt::viewer::SofaViewer ?
     sofa::gui::qt::viewer::SofaViewer* sofaViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(_viewer);
     if( sofaViewer == nullptr )
     {
-        std::cout<<"initViewer: The viewer isn't embedded in the GUI"<<std::endl;
+        msg_error("RealGUI") << "initViewer failed as given _viewer is not of type sofa::gui::qt::viewer::SofaViewer*";
     }
     else
     {

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -1138,12 +1138,23 @@ void RealGUI::createViewer(const char* _viewerName, bool _updateViewerList/*=fal
 void RealGUI::registerViewer(BaseViewer* _viewer)
 {
     // Change our viewer
-    const BaseViewer* old = m_viewer;
-    m_viewer = _viewer;
-    if(m_viewer != nullptr)
-        delete old;
-    else
+    if(_viewer == nullptr)
+    {
         msg_error("RealGUI")<<"when registerViewer, the viewer is nullptr";
+        return;
+    }
+
+    sofa::gui::qt::viewer::SofaViewer* tmpViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(_viewer);
+    if(tmpViewer != nullptr)
+    {
+        const sofa::gui::qt::viewer::SofaViewer* old = m_viewer;
+        m_viewer = tmpViewer;
+        delete old;
+    }
+    else
+    {
+        msg_error("RealGUI")<<"when registerViewer, the viewer can't be cast as sofa::gui::qt::viewer::SofaViewer*";
+    }
 }
 
 //------------------------------------
@@ -1157,7 +1168,7 @@ BaseViewer* RealGUI::getViewer()
 
 sofa::gui::qt::viewer::SofaViewer* RealGUI::getSofaViewer()
 {
-    return dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(m_viewer);
+    return m_viewer;
 }
 
 //------------------------------------
@@ -1321,8 +1332,6 @@ void RealGUI::eventNewTime()
 
 void RealGUI::keyPressEvent ( QKeyEvent * e )
 {
-    sofa::gui::qt::viewer::SofaViewer* sofaViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(getViewer());
-
     if (e->modifiers()) return;
 
     // ignore if there are modifiers (i.e. CTRL of SHIFT)
@@ -1370,8 +1379,8 @@ void RealGUI::keyPressEvent ( QKeyEvent * e )
     }
     default:
     {
-        if (sofaViewer)
-            sofaViewer->keyPressEvent(e);
+        if (m_viewer)
+            m_viewer->keyPressEvent(e);
         break;
     }
     }

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -324,7 +324,6 @@ RealGUI::RealGUI ( const char* viewername)
       m_sofaWindowDataGraph(nullptr),
       #endif
       simulationGraph(nullptr),
-      m_createViewersOpt(true),
       m_isEmbeddedViewer(true),
       m_dumpState(false),
       m_dumpStateStream(nullptr),
@@ -433,8 +432,8 @@ RealGUI::RealGUI ( const char* viewername)
     informationOnPickCallBack = InformationOnPickCallBack(this);
 
     viewerMap.clear();
-    if (m_createViewersOpt)
-        createViewer(viewername, true);
+
+    createViewer(viewername, true);
 
     currentTabChanged ( tabs->currentIndex() );
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -951,7 +951,7 @@ void RealGUI::setViewerResolution ( int w, int h )
 #if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
     const QRect screen = QApplication::desktop()->availableGeometry(QApplication::desktop()->screenNumber(this));
 #else
-    const QRect screen = QGuiApplication::primaryScreen()->availableGeometry();// QGuiApplication::screens().at(QApplication::desktop()->screenNumber(this))->availableGeometry();
+    const QRect screen = QGuiApplication::primaryScreen()->availableGeometry();
 #endif
     QSize newWinSize(winSize.width() - viewSize.width() + w, winSize.height() - viewSize.height() + h);
     if (newWinSize.width() > screen.width()) newWinSize.setWidth(screen.width()-20);
@@ -977,7 +977,7 @@ void RealGUI::setFullScreen (bool enable)
 
     if (enable)
     {
-        std::cout << "Set Full Screen Mode" << std::endl;
+        msg_info("RealGUI") << "Set Full Screen Mode";
         showFullScreen();
         m_fullScreen = true;
 
@@ -986,7 +986,7 @@ void RealGUI::setFullScreen (bool enable)
     }
     else
     {
-        std::cout << "Set Windowed Mode" << std::endl;
+        msg_info("RealGUI") << "Set Windowed Mode";
         showNormal();
         m_fullScreen = false;
         dockWidget->setVisible(true);

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
@@ -151,8 +151,6 @@ public:
     QSofaListView* simulationGraph;
 
 protected:
-    /// create a viewer by default, otherwise you have to manage your own viewer
-    bool m_isEmbeddedViewer;
     bool m_dumpState;
     std::ofstream* m_dumpStateStream;
     std::ostringstream m_dumpVisitorStream;
@@ -253,9 +251,6 @@ public:
     /// TODO: Find a better way to do this
     sofa::gui::qt::viewer::SofaViewer* getSofaViewer();
 
-    /// Our viewer is a QObject SofaViewer
-    bool isEmbeddedViewer();
-
     virtual void removeViewer();
 
     void dragEnterEvent( QDragEnterEvent* event) override;
@@ -275,12 +270,6 @@ protected:
 
     /// init the viewer for the GUI (embeded or not we have to connect some info about viewer in the GUI)
     void initViewer(common::BaseViewer* _viewer) override;
-
-    /// Our viewer is a QObject SofaViewer
-    void isEmbeddedViewer(bool _onOff)
-    {
-        m_isEmbeddedViewer = _onOff;
-    }
 
     virtual int exitApplication(unsigned int _retcode = 0)
     {

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
@@ -161,7 +161,7 @@ protected:
     int m_animationOBJcounter;// save a succession of .obj indexed by _animationOBJcounter
     bool m_displayComputationTime;
     bool m_fullScreen;
-    common::BaseViewer* m_viewer;
+    sofa::gui::qt::viewer::SofaViewer* m_viewer;
     // Clock before the last simulation step (or zero if the
     // simulation hasn't run yet).
     clock_t m_clockBeforeLastStep;

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
@@ -152,7 +152,6 @@ public:
 
 protected:
     /// create a viewer by default, otherwise you have to manage your own viewer
-    bool m_createViewersOpt;
     bool m_isEmbeddedViewer;
     bool m_dumpState;
     std::ofstream* m_dumpStateStream;


### PR DESCRIPTION
continue porting old changes from branch https://github.com/epernod/sofa/pull/13/files

Some cleaning in Qt Gui:
- Rome old options not used? like m_isEmbeddedViewer or m_createViewersOpt
- Store SofaViewer* directly to avoid multiple dynamic casts



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
