### PR TITLE
[GUI.Qt] Notice user a new version is available

### DIFF
--- a/Sofa/GUI/Qt/CMakeLists.txt
+++ b/Sofa/GUI/Qt/CMakeLists.txt
@@ -148,6 +148,7 @@ set(MOC_HEADER_FILES
     ${SRC_ROOT}/SofaVideoRecorderManager.h
     ${SRC_ROOT}/SofaPluginManager.h
     ${SRC_ROOT}/SofaSceneGraphWidget.h
+    ${SRC_ROOT}/VersionChecker.h
     ${SRC_ROOT}/WDoubleLineEdit.h    
     )
 set(HEADER_FILES
@@ -202,6 +203,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/SofaVideoRecorderManager.cpp    
     ${SRC_ROOT}/StructDataWidget.cpp
     ${SRC_ROOT}/TableDataWidget.cpp
+    ${SRC_ROOT}/VersionChecker.cpp
     ${SRC_ROOT}/WDoubleLineEdit.cpp
     ${SRC_ROOT}/viewer/SofaViewer.cpp
     ${SRC_ROOT}/SofaSceneGraphWidget.cpp

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.cpp
@@ -127,6 +127,7 @@ using sofa::gui::qt::DocBrowser;
 using sofa::core::ExecParams;
 
 #include <sofa/gui/common/ArgumentParser.h>
+#include <sofa/gui/qt/VersionChecker.h>
 
 
 using namespace sofa::gui::common;
@@ -415,8 +416,18 @@ RealGUI::RealGUI ( const char* viewername)
     timeLabel = new QLabel ( "Time: 999.9999", statusBar() );
     timeLabel->setMinimumSize ( timeLabel->sizeHint() );
     timeLabel->clear();
+
+    sofaVersionLabel = new QLabel ("v27.12 is available");
+    sofaVersionLabel->setMinimumSize ( sofaVersionLabel->sizeHint() );
+    // sofaVersionLabel->clear();
+
+    VersionChecker* versionChecker = new VersionChecker;
+    versionChecker->checkLatestVersion("sofa-framework", "sofa");
+
     statusBar()->addWidget ( fpsLabel );
     statusBar()->addWidget ( timeLabel );
+    statusBar()->addPermanentWidget ( sofaVersionLabel );
+
 
     statWidget = new QSofaStatWidget(TabStats);
     TabStats->layout()->addWidget(statWidget);

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/RealGUI.h
@@ -125,6 +125,7 @@ public:
 protected:
     QLabel* fpsLabel;
     QLabel* timeLabel;
+    QLabel* sofaVersionLabel;
 
 
 private:

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/VersionChecker.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/VersionChecker.cpp
@@ -1,0 +1,81 @@
+#include <sofa/gui/qt/VersionChecker.h>
+
+namespace sofa::gui::qt
+{
+VersionChecker::VersionChecker(QObject* parent): QObject(parent)
+{}
+
+void VersionChecker::checkLatestVersion(const QString& owner,
+    const QString& repo)
+{
+    QThread* thread = new QThread;
+    connect(thread, &QThread::started, this,
+        [this, owner, repo]() {
+            QNetworkAccessManager* manager = new QNetworkAccessManager;
+            connect(manager, &QNetworkAccessManager::finished, this, &VersionChecker::onReplyFinished);
+
+            const QUrl url("https://api.github.com/repos/" + owner + "/" + repo + "/releases/latest");
+            QNetworkRequest request(url);
+            request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+            manager->get(request);
+    });
+    connect(this, &VersionChecker::versionCheckFinished, this, &VersionChecker::onVersionCheckFinished);
+    connect(this, &VersionChecker::versionCheckFinished, thread, &QThread::quit);
+    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+    connect(thread, &QThread::finished, this, &VersionChecker::deleteLater);
+    moveToThread(thread);
+    thread->start();
+}
+
+void VersionChecker::onReplyFinished(QNetworkReply* reply)
+{
+    if (reply->error() == QNetworkReply::NoError)
+    {
+        QByteArray responseData = reply->readAll();
+        QJsonDocument jsonDocument = QJsonDocument::fromJson(responseData);
+
+        QString latestVersion;
+        if (jsonDocument.isObject())
+        {
+            QJsonObject jsonObject = jsonDocument.object();
+            QJsonValue versionValue = jsonObject.value("tag_name");
+            if (versionValue.isString())
+            {
+                latestVersion = versionValue.toString();
+            }
+        }
+
+        emit versionCheckFinished(latestVersion);
+    }
+    else
+    {
+        std::cout << "Error " << reply->error() << std::endl;
+        emit versionCheckFinished("");
+    }
+
+    reply->deleteLater();
+}
+
+void VersionChecker::onVersionCheckFinished(const QString& latestVersion)
+{
+    std::string currentVersion = "1.0"; // Your software's current version
+
+    if (latestVersion.isEmpty())
+    {
+        std::cout << "Unable to retrieve latest version from GitHub." << std::endl;
+    }
+    else
+    {
+        if (latestVersion > currentVersion.c_str())
+        {
+            std::cout << "A newer version (" << latestVersion.toStdString() << ") is available!" << std::endl;
+        }
+        else
+        {
+            std::cout << "You are using the latest version (" << currentVersion << ")." << std::endl;
+        }
+    }
+}
+
+}

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/VersionChecker.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/VersionChecker.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/gui/qt/config.h>
+
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QUrl>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QThread>
+#include <iostream>
+
+namespace sofa::gui::qt
+{
+
+class SOFA_GUI_QT_API VersionChecker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit VersionChecker(QObject* parent = nullptr);
+
+    void checkLatestVersion(const QString& owner, const QString& repo);
+
+signals:
+    void versionCheckFinished(const QString& latestVersion);
+
+private slots:
+    void onReplyFinished(QNetworkReply* reply);
+
+    static void onVersionCheckFinished(const QString& latestVersion);
+};
+}


### PR DESCRIPTION
I suggest to add a message in GUI that a newer version of SOFA is available if an old version is used. I would look like:

![image](https://github.com/sofa-framework/sofa/assets/10572752/4aeaabcf-ec81-4585-b53c-9a8f24ac68f1)


I chose to rely on Qt because otherwise it requires a new lib for the http request, and Qt is already here. But having Qt is not enough. I have an error related to ssl (similar error to https://stackoverflow.com/questions/53805704/tls-initialization-failed-on-get-request). It requires additional components in the Qt installation. I did not try it myself because it changes the installation process of SOFA. So before going further, we need to conclude that this feature is desirable (and is not a gadget). If it is, we can decide to rely on Qt and its additional component, or to go with a simpler C++ library (https://github.com/JosephP91/curlcpp for example). The second solution would open the version checker to ImGui.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
