### PR TITLE
[CollisionOBBCapsule] Fix duplicated registration in the factory

### DIFF
--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.cpp
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.cpp
@@ -30,7 +30,6 @@ using namespace sofa::defaulttype;
 
 int CapsuleCollisionModelClass = core::RegisterObject("Collision model which represents a set of Capsules")
         .add< CapsuleCollisionModel<sofa::defaulttype::Vec3Types> >()
-        .add< CapsuleCollisionModel<sofa::defaulttype::Rigid3Types> >()
         ;
 
 template class COLLISIONOBBCAPSULE_API TCapsule<defaulttype::Vec3Types>;


### PR DESCRIPTION
The rigid type is registered both in applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.cpp and applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/RigidCapsuleModel.cpp



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
