### PR TITLE
[Contact] Fix crash if collision models are not provided

### DIFF
--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactListener.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactListener.h
@@ -118,8 +118,8 @@ public:
 
         if(arg)
         {
-            collModelPath1 = arg->getAttribute(std::string("collisionModel1"), nullptr );
-            collModelPath2 = arg->getAttribute(std::string("collisionModel2"), nullptr );
+            collModelPath1 = arg->getAttribute(std::string("collisionModel1"), "" );
+            collModelPath2 = arg->getAttribute(std::string("collisionModel2"), "" );
 
             // now 3 cases
             if ( strcmp( collModelPath1.c_str(),"" ) != 0  )


### PR DESCRIPTION
if `collisionModel1`, the `collModelPath1` is affected to `nullptr`, which leads to a crash.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
