### PR TITLE
[Engine.Analyze] Fix initialization of distance type

### DIFF
--- a/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
+++ b/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
@@ -47,7 +47,7 @@ Distances< DataTypes >::Distances ( sofa::component::topology::container::dynami
     showGradientMap ( initData ( &showGradientMap, false, "showGradients","show gradients for each point of the target point set." ) ),
     showGradientsScaleFactor ( initData ( &showGradientsScaleFactor, 0.1, "showGradientsScaleFactor","scale for the gradients displayed." ) ),
     offset ( initData ( &offset, Coord(), "offset","translation offset between the topology and the point set." ) ),
-    distanceType ( initData ( &distanceType, TYPE_GEODESIC, "distanceType","type of distance to compute for inserted frames." ) ),
+    distanceType ( initData ( &distanceType, {"Geodesic","Harmonic","Stiffness Diffusion", "Vorono\xEF", "Harmonic with Stiffness"}, "distanceType","type of distance to compute for inserted frames." ) ),
     initTarget ( initData ( &initTarget, false, "initTarget","initialize the target MechanicalObject from the grid." ) ),
     initTargetStep ( initData ( &initTargetStep, 1, "initTargetStep","initialize the target MechanicalObject from the grid using this step." ) ),
     zonesFramePair ( initData ( &zonesFramePair, "zonesFramePair","Correspondance between the segmented value and the frames." ) ),
@@ -60,10 +60,6 @@ Distances< DataTypes >::Distances ( sofa::component::topology::container::dynami
 {
     this->addAlias(&fileDistance, "fileDistance");
     zonesFramePair.setDisplayed( false); // GUI can not display map.
-
-    sofa::helper::OptionsGroup distanceTypeOptions{"Geodesic","Harmonic","Stiffness Diffusion", "Vorono\xEF", "Harmonic with Stiffness"};
-    distanceTypeOptions.setSelectedItem(TYPE_GEODESIC);
-    distanceType.setValue(distanceTypeOptions);
 
     this->f_printLog.setValue(true);
 }

--- a/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
+++ b/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
@@ -47,7 +47,7 @@ Distances< DataTypes >::Distances ( sofa::component::topology::container::dynami
     showGradientMap ( initData ( &showGradientMap, false, "showGradients","show gradients for each point of the target point set." ) ),
     showGradientsScaleFactor ( initData ( &showGradientsScaleFactor, 0.1, "showGradientsScaleFactor","scale for the gradients displayed." ) ),
     offset ( initData ( &offset, Coord(), "offset","translation offset between the topology and the point set." ) ),
-    distanceType ( initData ( &distanceType, {"Geodesic","Harmonic","Stiffness Diffusion", "Vorono\xEF", "Harmonic with Stiffness"}, "distanceType","type of distance to compute for inserted frames." ) ),
+    distanceType ( initData ( &distanceType, {"Geodesic","Harmonic","Stiffness Diffusion", "Voronoi", "Harmonic with Stiffness"}, "distanceType","type of distance to compute for inserted frames." ) ),
     initTarget ( initData ( &initTarget, false, "initTarget","initialize the target MechanicalObject from the grid." ) ),
     initTargetStep ( initData ( &initTargetStep, 1, "initTargetStep","initialize the target MechanicalObject from the grid using this step." ) ),
     zonesFramePair ( initData ( &zonesFramePair, "zonesFramePair","Correspondance between the segmented value and the frames." ) ),


### PR DESCRIPTION
`distanceType` is an OptionsGroup, and it is cannot be initialized using a single value. In this case, the wrong overload of `initData` was picked.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
