### PR TITLE
[SceneUtility] Initialize pointer to nullptr

### DIFF
--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.cpp
@@ -115,9 +115,11 @@ FileMessageHandlerComponent::FileMessageHandlerComponent() :
 
 FileMessageHandlerComponent::~FileMessageHandlerComponent()
 {
-    MessageDispatcher::rmHandler(m_handler) ;
-
-    delete m_handler ;
+    if (m_handler)
+    {
+        MessageDispatcher::rmHandler(m_handler) ;
+        delete m_handler ;
+    }
 }
 
 void FileMessageHandlerComponent::parse ( core::objectmodel::BaseObjectDescription* arg )

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.h
@@ -77,7 +77,7 @@ public:
     void parse ( core::objectmodel::BaseObjectDescription* arg ) override;
 
     Data<std::string>        d_filename        ; ///< Name of the file into which the message will be saved in.
-    helper::logging::MessageHandler*     m_handler         ;
+    helper::logging::MessageHandler*     m_handler { nullptr };
 
 
     bool                m_isValid    ;


### PR DESCRIPTION
It avoids a crash in the destructor when `m_handler` has not been affected. And pointers must be initialized anyway.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
