### PR TITLE
[SofaCUDA] extern template instantiations

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -39,12 +39,14 @@ set(HEADER_FILES
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaBarycentricMapping.h
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaBarycentricMapping.inl
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaBarycentricMappingRigid.h
+    ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaBeamLinearMapping.h
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaIdentityMapping.h
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaIdentityMapping.inl
     ${SOFACUDA_SOURCE_DIR}/component/mapping/nonlinear/CudaRigidMapping.h
     ${SOFACUDA_SOURCE_DIR}/component/mapping/nonlinear/CudaRigidMapping.inl
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaSubsetMapping.h
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaSubsetMapping.inl
+    ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaSubsetMultiMapping.h
 
 
     ### Mass
@@ -71,6 +73,7 @@ set(HEADER_FILES
     ${SOFACUDA_SOURCE_DIR}/component/solidmechanics/fem/elastic/CudaTriangularFEMForceFieldOptim.inl
 
     ### ForceFields
+    ${SOFACUDA_SOURCE_DIR}/component/mechanicalload/CudaConstantForceField.h
     ${SOFACUDA_SOURCE_DIR}/component/mechanicalload/CudaEllipsoidForceField.h
     ${SOFACUDA_SOURCE_DIR}/component/mechanicalload/CudaEllipsoidForceField.inl
     ${SOFACUDA_SOURCE_DIR}/component/mechanicalload/CudaLinearForceField.h

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaBeamLinearMapping.h
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaBeamLinearMapping.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,48 +19,27 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_COMPONENT_MAPPING_CUDABEAMLINEARMAPPING_CPP
-#include <SofaCUDA/component/mapping/linear/CudaBeamLinearMapping.h>
-#include <sofa/component/mapping/linear/BeamLinearMapping.inl>
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
+#pragma once
+
+#include <SofaCUDA/config.h>
+#include <sofa/component/mapping/linear/BeamLinearMapping.h>
+
+#if !defined(SOFA_COMPONENT_MAPPING_CUDABEAMLINEARMAPPING_CPP)
+
+#include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/gpu/cuda/CudaTypes.h>
-
-namespace sofa::gpu::cuda
-{
-
-using namespace sofa::component::mapping::linear;
-using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
-
-
-// Register in the Factory
-int BeamLinearMappingCudaClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping<Rigid3Types, CudaVec3Types> >()
-
-#ifdef SOFA_GPU_CUDA_DOUBLE
-        .add< BeamLinearMapping<Rigid3Types, CudaVec3dTypes> >()
-#endif
-        ;
-
-} // namespace sofa::gpu::cuda
 
 namespace sofa::component::mapping::linear
 {
 
-using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
-
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3Types>;
-
+extern template class SOFA_GPU_CUDA_API BeamLinearMapping< defaulttype::Rigid3Types, sofa::gpu::cuda::CudaVec3Types>;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API BeamLinearMapping< defaulttype::Rigid3Types, sofa::gpu::cuda::CudaVec3dTypes>;
+#endif
+
+} // namespace sofa::component::mapping::linear
 #endif
 
 
-} // namespace sofa::component::mapping::linear
+

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaSubsetMultiMapping.cpp
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaSubsetMultiMapping.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_COMPONENT_MAPPING_CUDASUBSETMULTIMAPPING_CPP
+#include <SofaCUDA/component/mapping/linear/CudaSubsetMultiMapping.h>
 #include <sofa/component/mapping/linear/SubsetMultiMapping.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/gpu/cuda/CudaTypes.h>

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaSubsetMultiMapping.h
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/mapping/linear/CudaSubsetMultiMapping.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,48 +19,34 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_COMPONENT_MAPPING_CUDABEAMLINEARMAPPING_CPP
-#include <SofaCUDA/component/mapping/linear/CudaBeamLinearMapping.h>
-#include <sofa/component/mapping/linear/BeamLinearMapping.inl>
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
+#pragma once
+
+#include <SofaCUDA/config.h>
+#include <sofa/component/mapping/linear/SubsetMultiMapping.h>
+
+#if !defined(SOFA_COMPONENT_MAPPING_CUDASUBSETMULTIMAPPING_CPP)
+
 #include <sofa/gpu/cuda/CudaTypes.h>
-
-namespace sofa::gpu::cuda
-{
-
-using namespace sofa::component::mapping::linear;
-using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
-
-
-// Register in the Factory
-int BeamLinearMappingCudaClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping<Rigid3Types, CudaVec3Types> >()
-
-#ifdef SOFA_GPU_CUDA_DOUBLE
-        .add< BeamLinearMapping<Rigid3Types, CudaVec3dTypes> >()
-#endif
-        ;
-
-} // namespace sofa::gpu::cuda
 
 namespace sofa::component::mapping::linear
 {
 
-using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
+using namespace sofa::gpu::cuda;
 
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3Types>;
-
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaVec3Types, CudaVec3Types >;
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaVec1Types, CudaVec1Types >;
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3Types, CudaRigid3Types >;
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3Types, CudaVec3Types >;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaVec3dTypes, CudaVec3dTypes >;
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaVec1dTypes, CudaVec1dTypes >;
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3dTypes, CudaRigid3dTypes >;
+extern template class SOFA_GPU_CUDA_API SubsetMultiMapping< CudaRigid3dTypes, CudaVec3dTypes >;
+#endif
+
+} // namespace sofa::component::mapping::linear
 #endif
 
 
-} // namespace sofa::component::mapping::linear
+

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/mechanicalload/CudaConstantForceField.cpp
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/mechanicalload/CudaConstantForceField.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_COMPONENT_FORCEFIELD_CUDACONSTANTFORCEFIELD_CPP
+#include <SofaCUDA/component/mechanicalload/CudaConstantForceField.h>
 #include <sofa/component/mechanicalload/ConstantForceField.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/behavior/ForceField.inl>

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/component/mechanicalload/CudaConstantForceField.h
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/component/mechanicalload/CudaConstantForceField.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,48 +19,38 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_COMPONENT_MAPPING_CUDABEAMLINEARMAPPING_CPP
-#include <SofaCUDA/component/mapping/linear/CudaBeamLinearMapping.h>
-#include <sofa/component/mapping/linear/BeamLinearMapping.inl>
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
+#pragma once
+
+#include <SofaCUDA/config.h>
+#include <sofa/component/mechanicalload/ConstantForceField.h>
+
+#if !defined(SOFA_COMPONENT_FORCEFIELD_CUDACONSTANTFORCEFIELD_CPP)
+
 #include <sofa/gpu/cuda/CudaTypes.h>
 
-namespace sofa::gpu::cuda
+namespace sofa::component::mechanicalload
 {
 
-using namespace sofa::component::mapping::linear;
-using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
+using namespace sofa::gpu::cuda;
 
-
-// Register in the Factory
-int BeamLinearMappingCudaClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-
-        .add< BeamLinearMapping<Rigid3Types, CudaVec3Types> >()
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec3Types>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec2Types>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec1Types>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec6Types>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid3Types>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid2Types>;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-        .add< BeamLinearMapping<Rigid3Types, CudaVec3dTypes> >()
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec2dTypes>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec1dTypes>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaVec6dTypes>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid3dTypes>;
+extern template class SOFA_GPU_CUDA_API ConstantForceField<CudaRigid2dTypes>;
 #endif
-        ;
 
-} // namespace sofa::gpu::cuda
-
-namespace sofa::component::mapping::linear
-{
-
-using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
-
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3Types>;
-
-
-#ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API BeamLinearMapping< Rigid3Types, sofa::gpu::cuda::CudaVec3dTypes>;
+} // namespace sofa::component::mechanicalload
 #endif
 
 
-} // namespace sofa::component::mapping::linear
+


### PR DESCRIPTION
The extern template instantiations allows to include ` SofaCUDA/config.h` before `ObjectFactor.h`. That is why the module name is defined properly in this PR. The extern template instantiations don't act directly on the module name, just the order of includes.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
