### PR TITLE
[AnimationLoop] Remove duplicated Constraint Visitors 

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -74,6 +74,7 @@ using sofa::simulation::mechanicalvisitor::MechanicalEndIntegrationVisitor;
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
 
 #include <sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h>
+#include <sofa/simulation/mechanicalvisitor/MechanicalBuildConstraintMatrix.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalAccumulateMatrixDeriv.h>
 
 /// Change that to true if you want to print extra message on this component.
@@ -88,32 +89,6 @@ using namespace sofa::defaulttype;
 using namespace helper::system::thread;
 using namespace core::behavior;
 using namespace sofa::simulation;
-
-sofa::simulation::Visitor::Result MechanicalSetConstraint::fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c)
-{
-    const ctime_t t0 = begin(node, c);
-
-    c->setConstraintId(contactId);
-    c->buildConstraintMatrix(cparams, res, contactId);
-
-    end(node, c, t0);
-    return RESULT_CONTINUE;
-}
-
-const char* MechanicalSetConstraint::getClassName() const
-{
-    return "MechanicalSetConstraint";
-}
-
-bool MechanicalSetConstraint::isThreadSafe() const
-{
-    return false;
-}
-
-bool MechanicalSetConstraint::stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
-{
-    return false; // !map->isMechanical();
-}
 
 ConstraintProblem::ConstraintProblem(bool printLog)
 {

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -74,6 +74,7 @@ using sofa::simulation::mechanicalvisitor::MechanicalEndIntegrationVisitor;
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
 
 #include <sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h>
+#include <sofa/simulation/mechanicalvisitor/MechanicalAccumulateMatrixDeriv.h>
 
 /// Change that to true if you want to print extra message on this component.
 /// You can eventually link that to an object attribute.
@@ -110,28 +111,6 @@ bool MechanicalSetConstraint::isThreadSafe() const
 }
 
 bool MechanicalSetConstraint::stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
-{
-    return false; // !map->isMechanical();
-}
-
-void MechanicalAccumulateConstraint2::bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map)
-{
-    const ctime_t t0 = begin(node, map);
-    map->applyJT(cparams, res, res);
-    end(node, map, t0);
-}
-
-const char* MechanicalAccumulateConstraint2::getClassName() const
-{
-    return "MechanicalAccumulateConstraint2";
-}
-
-bool MechanicalAccumulateConstraint2::isThreadSafe() const
-{
-    return false;
-}
-
-bool MechanicalAccumulateConstraint2::stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
 {
     return false; // !map->isMechanical();
 }

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -73,6 +73,7 @@ using sofa::simulation::mechanicalvisitor::MechanicalEndIntegrationVisitor;
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
 
+#include <sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h>
 
 /// Change that to true if you want to print extra message on this component.
 /// You can eventually link that to an object attribute.
@@ -86,22 +87,6 @@ using namespace sofa::defaulttype;
 using namespace helper::system::thread;
 using namespace core::behavior;
 using namespace sofa::simulation;
-
-sofa::simulation::Visitor::Result MechanicalGetConstraintResolutionVisitor::fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet)
-{
-    if (core::behavior::BaseConstraint *c=cSet->toBaseConstraint())
-    {
-        const ctime_t t0 = begin(node, c);
-        c->getConstraintResolution(_cparams, _res, _offset);
-        end(node, c, t0);
-    }
-    return RESULT_CONTINUE;
-}
-
-bool MechanicalGetConstraintResolutionVisitor::stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
-{
-    return false; // !map->isMechanical();
-}
 
 sofa::simulation::Visitor::Result MechanicalSetConstraint::fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c)
 {

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
@@ -46,7 +46,9 @@ namespace sofa::component::constraint::lagrangian::solver
 namespace sofa::component::animationloop
 {
 
-using MechanicalGetConstraintResolutionVisitor = sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor;
+using MechanicalGetConstraintResolutionVisitor
+SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR()
+= sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor;
 
 class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalSetConstraint : public simulation::BaseMechanicalVisitor
 {

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
@@ -41,6 +41,7 @@
 namespace sofa::simulation::mechanicalvisitor
 {
     class MechanicalAccumulateMatrixDeriv;
+    class MechanicalBuildConstraintMatrix;
 }
 
 namespace sofa::component::constraint::lagrangian::solver
@@ -55,30 +56,9 @@ using MechanicalGetConstraintResolutionVisitor
 SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR("Use sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor instead.")
 = sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor;
 
-class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalSetConstraint : public simulation::BaseMechanicalVisitor
-{
-public:
-    MechanicalSetConstraint(const core::ConstraintParams* _cparams, core::MultiMatrixDerivId _res, unsigned int &_contactId)
-        : simulation::BaseMechanicalVisitor(_cparams)
-        , res(_res)
-        , contactId(_contactId)
-        , cparams(_cparams)
-    {}
-
-    Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c) override;
-    /// Return a class name for this visitor
-    /// Only used for debugging / profiling purposes
-    const char* getClassName() const override;
-    bool isThreadSafe() const override;
-    // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override;
-
-protected:
-
-    sofa::core::MultiMatrixDerivId res;
-    unsigned int &contactId;
-    const sofa::core::ConstraintParams *cparams;
-};
+using MechanicalSetConstraint
+SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR("Use sofa::simulation::mechanicalvisitor::MechanicalBuildConstraintMatrix instead.")
+= sofa::simulation::mechanicalvisitor::MechanicalBuildConstraintMatrix;
 
 using MechanicalAccumulateConstraint2
 SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR("Use sofa::simulation::mechanicalvisitor::MechanicalAccumulateMatrixDeriv instead.")

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
@@ -24,40 +24,29 @@
 
 
 #include <sofa/helper/map.h>
+#include <sofa/linearalgebra/FullMatrix.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/core/VecId.h>
 #include <sofa/core/behavior/BaseConstraintCorrection.h>
 #include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/ConstraintParams.h>
 #include <sofa/core/fwd.h>
-#include <sofa/linearalgebra/FullMatrix.h>
 
 #include <sofa/simulation/CollisionAnimationLoop.h>
 #include <sofa/simulation/MechanicalVisitor.h>
-#include <sofa/core/ConstraintParams.h>
 #include <sofa/simulation/fwd.h>
 
 #include <vector>
 
+namespace sofa::component::constraint::lagrangian::solver
+{
+    class MechanicalGetConstraintResolutionVisitor;
+}
+
 namespace sofa::component::animationloop
 {
 
-class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalGetConstraintResolutionVisitor : public simulation::BaseMechanicalVisitor
-{
-public:
-    MechanicalGetConstraintResolutionVisitor(const core::ConstraintParams* params, std::vector<core::behavior::ConstraintResolution*>& res, unsigned int offset)
-        : simulation::BaseMechanicalVisitor(params), _res(res),_offset(offset), _cparams(params)
-    {}
-
-    Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override;
-    // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override;
-
-private:
-    std::vector<core::behavior::ConstraintResolution*>& _res;
-    unsigned int _offset;
-    const sofa::core::ConstraintParams *_cparams;
-};
-
+using MechanicalGetConstraintResolutionVisitor = sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor;
 
 class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalSetConstraint : public simulation::BaseMechanicalVisitor
 {

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
@@ -38,6 +38,11 @@
 
 #include <vector>
 
+namespace sofa::simulation::mechanicalvisitor
+{
+    class MechanicalAccumulateMatrixDeriv;
+}
+
 namespace sofa::component::constraint::lagrangian::solver
 {
     class MechanicalGetConstraintResolutionVisitor;
@@ -47,7 +52,7 @@ namespace sofa::component::animationloop
 {
 
 using MechanicalGetConstraintResolutionVisitor
-SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR()
+SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR("Use sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor instead.")
 = sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor;
 
 class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalSetConstraint : public simulation::BaseMechanicalVisitor
@@ -75,30 +80,9 @@ protected:
     const sofa::core::ConstraintParams *cparams;
 };
 
-
-class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalAccumulateConstraint2 : public simulation::BaseMechanicalVisitor
-{
-public:
-    MechanicalAccumulateConstraint2(const core::ConstraintParams* _cparams, core::MultiMatrixDerivId _res)
-        : simulation::BaseMechanicalVisitor(_cparams)
-        , res(_res)
-        , cparams(_cparams)
-    {}
-
-    void bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override;
-    /// Return a class name for this visitor
-    /// Only used for debugging / profiling purposes
-    const char* getClassName() const override;
-
-    bool isThreadSafe() const override;
-    // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override;
-
-protected:
-    core::MultiMatrixDerivId res;
-    const sofa::core::ConstraintParams *cparams;
-};
-
+using MechanicalAccumulateConstraint2
+SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR("Use sofa::simulation::mechanicalvisitor::MechanicalAccumulateMatrixDeriv instead.")
+= sofa::simulation::mechanicalvisitor::MechanicalAccumulateMatrixDeriv;
 
 class SOFA_COMPONENT_ANIMATIONLOOP_API ConstraintProblem
 {

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/config.h.in
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/config.h.in
@@ -41,12 +41,12 @@
 #endif
 
 #ifdef SOFA_BUILD_SOFA_COMPONENT_ANIMATIONLOOP
-#define SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR()
+#define SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR(msg)
 #else
-#define SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR() \
+#define SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR(msg) \
     SOFA_ATTRIBUTE_DEPRECATED( \
         "v24.06", "v24.12", \
-        "Use sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor instead.")
+        msg)
 #endif
 
 namespace sofa::component::animationloop

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/config.h.in
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/config.h.in
@@ -40,6 +40,15 @@
         "Data renamed according to the guidelines")
 #endif
 
+#ifdef SOFA_BUILD_SOFA_COMPONENT_ANIMATIONLOOP
+#define SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__DUPLICATED_CONSTRAINT_RESOLUTION_VISITOR() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v24.06", "v24.12", \
+        "Use sofa::component::constraint::lagrangian::solver::MechanicalGetConstraintResolutionVisitor instead.")
+#endif
+
 namespace sofa::component::animationloop
 {
 	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.cpp
@@ -26,11 +26,11 @@
 
 namespace sofa::component::constraint::lagrangian::solver
 {
-MechanicalGetConstraintResolutionVisitor::MechanicalGetConstraintResolutionVisitor(const core::ConstraintParams* params, std::vector<core::behavior::ConstraintResolution*>& res)
+MechanicalGetConstraintResolutionVisitor::MechanicalGetConstraintResolutionVisitor(const core::ConstraintParams* params, std::vector<core::behavior::ConstraintResolution*>& res, unsigned int offset)
 : simulation::BaseMechanicalVisitor(params)
 , cparams(params)
 , _res(res)
-, _offset(0)
+, _offset(offset)
 {
 #ifdef SOFA_DUMP_VISITOR_INFO
     setReadWriteVectors();

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h
@@ -30,7 +30,7 @@ namespace sofa::component::constraint::lagrangian::solver
 class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API MechanicalGetConstraintResolutionVisitor : public simulation::BaseMechanicalVisitor
 {
 public:
-    MechanicalGetConstraintResolutionVisitor(const core::ConstraintParams* params, std::vector<core::behavior::ConstraintResolution*>& res);
+    MechanicalGetConstraintResolutionVisitor(const core::ConstraintParams* params, std::vector<core::behavior::ConstraintResolution*>& res, unsigned int offset = 0);
 
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override;
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h
@@ -48,7 +48,6 @@ public:
 private:
     /// Constraint parameters
     const sofa::core::ConstraintParams *cparams;
-    const DeprecatedAndRemoved _cparams{};
 
     std::vector<core::behavior::ConstraintResolution*>& _res;
     unsigned int _offset;

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h
@@ -48,6 +48,7 @@ public:
 private:
     /// Constraint parameters
     const sofa::core::ConstraintParams *cparams;
+    const DeprecatedAndRemoved _cparams{};
 
     std::vector<core::behavior::ConstraintResolution*>& _res;
     unsigned int _offset;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalBuildConstraintMatrix.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalBuildConstraintMatrix.cpp
@@ -29,6 +29,7 @@ namespace sofa::simulation::mechanicalvisitor
 Visitor::Result MechanicalBuildConstraintMatrix::fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c)
 {
     const ctime_t t0 = begin(node, c);
+    c->setConstraintId(contactId);
     c->buildConstraintMatrix(cparams, res, contactId);
     end(node, c, t0);
     return RESULT_CONTINUE;


### PR DESCRIPTION
ConstraintAL contains 3 visitors which seems to be duplicated with other in simulation::core and constraint.lagrangian.solver

- MechanicalGetConstraintResolutionVisitor
Almost similar class (with the same name) in Constraint.Lagrangian.Solver and AnimationLoop.
The one in AnimationLoop allows setting a custom offset with its ctor (whereas the one in C.L.S is 0) so I added the same feature with a default value.
Slightly breaking because `cparams` are named differently 😅

- MechanicalAccumulateConstraint2 -> MechanicalAccumulateMatrixDeriv
nice `2`at the end 😅
MechanicalAccumulateConstraint2 is less complete than the other one so there should be no compat problem

- MechanicalSetConstraint -> MechanicalAccumulateMatrixDeriv
MechanicalSetConstraint also set a constraintId (MechanicalAccumulateMatrixDeriv does not) but it seems that this id is actually never used in implemented constraints (m_cid). In any case I add the set in MechanicalAccumulateMatrixDeriv.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
