### PR TITLE
[image] Fix module name

### DIFF
--- a/applications/plugins/image/config.h.in
+++ b/applications/plugins/image/config.h.in
@@ -48,4 +48,10 @@
 #  define SOFA_IMAGE_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
 
+namespace image
+{
+	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
+	constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
+} // namespace image
+
 #endif

--- a/applications/plugins/image/initImage.cpp
+++ b/applications/plugins/image/initImage.cpp
@@ -87,12 +87,12 @@ void initExternalModule()
 
 const char* getModuleName()
 {
-    return "Image Plugin";
+    return image::MODULE_NAME;
 }
 
 const char* getModuleVersion()
 {
-    return "0.1";
+    return image::MODULE_VERSION;
 }
 
 const char* getModuleLicense()


### PR DESCRIPTION
The module name is used by the PluginManager to identify a plugin. And there seems to have a need that the plugin binary filename matches the module name.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
