### PR TITLE
[Core,Helper] Prevent to create objects from unloaded plugins

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -182,7 +182,7 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
             Creator::SPtr c = it2->second;
             const auto& unloadedPlugins = helper::system::PluginManager::getInstance().unloadedPlugins();
             const auto creatorTarget = c->getTarget();
-            if (std::find(unloadedPlugins.begin(), unloadedPlugins.end(), creatorTarget) != unloadedPlugins.end())
+            if (unloadedPlugins.find(creatorTarget) != unloadedPlugins.end())
             {
                 creators_errors[templatename].emplace_back(
                     "The object was previously registered, but its module has been unloaded.");
@@ -211,7 +211,7 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
                 Creator::SPtr c = it3->second;
                 const auto& unloadedPlugins = helper::system::PluginManager::getInstance().unloadedPlugins();
                 const auto creatorTarget = c->getTarget();
-                if (std::find(unloadedPlugins.begin(), unloadedPlugins.end(), creatorTarget) != unloadedPlugins.end())
+                if (unloadedPlugins.find(creatorTarget) != unloadedPlugins.end())
                 {
                     creators_errors[templatename].emplace_back(
                         "The object was previously registered, but its module has been unloaded.");

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -118,12 +118,11 @@ void findTemplatedCreator(
     std::vector< std::pair<std::string, ObjectFactory::Creator::SPtr> >& creators,
     objectmodel::BaseObjectDescription* arg)
 {
-    const auto& unloadedPlugins = helper::system::PluginManager::getInstance().unloadedPlugins();
-    const auto creatorTarget = creator->getTarget();
-    if (unloadedPlugins.find(creatorTarget) != unloadedPlugins.end())
+    if (helper::system::PluginManager::getInstance().isPluginUnloaded(creator->getTarget()))
     {
         creatorsErrors[templateName].emplace_back(
-            "The object was previously registered, but its module has been unloaded.");
+            "The object was previously registered, but the module that "
+            "registered the object has been unloaded, preventing the object creation.");
         arg->clearErrors();
     }
     else

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -212,9 +212,15 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
         }
 
         // If object cannot be created with the given template (or the default one), try all possible ones
-        for (const auto& [templateName, creator] : entry->creatorMap)
+        if (creators.empty())
         {
-            findTemplatedCreator(context, creator, templateName, creators_errors, creators, arg);
+            for (const auto& [creatorTemplateName, creator] : entry->creatorMap)
+            {
+                if (creatorTemplateName != templatename)
+                {
+                    findTemplatedCreator(context, creator, creatorTemplateName, creators_errors, creators, arg);
+                }
+            }
         }
     }
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -333,6 +333,11 @@ const std::unordered_set<std::string>& PluginManager::unloadedPlugins() const
     return m_unloadedPlugins;
 }
 
+bool PluginManager::isPluginUnloaded(const std::string& pluginName) const
+{
+    return m_unloadedPlugins.find(pluginName) != m_unloadedPlugins.end();
+}
+
 Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /*suffix*/, bool /*ignoreCase*/)
 {
     const std::string pluginPath = plugin;

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -222,8 +222,8 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
         }
     }
 
-    const auto unloadedIt = std::find(m_unloadedPlugins.begin(), m_unloadedPlugins.end(), p.getModuleName());
-    if (unloadedIt != m_unloadedPlugins.end())
+    if (const auto unloadedIt = m_unloadedPlugins.find(p.getModuleName());
+        unloadedIt != m_unloadedPlugins.end())
     {
         m_unloadedPlugins.erase(unloadedIt);
     }
@@ -302,7 +302,7 @@ bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* er
     else
     {
         const auto it = m_pluginMap.find(pluginPath);
-        m_unloadedPlugins.push_back(it->second.getModuleName());
+        m_unloadedPlugins.insert(it->second.getModuleName());
 
         m_pluginMap.erase(it);
         removeOnPluginLoadedCallback(pluginPath);
@@ -311,7 +311,7 @@ bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* er
     }
 }
 
-const sofa::type::vector<std::string>& PluginManager::unloadedPlugins() const
+const std::unordered_set<std::string>& PluginManager::unloadedPlugins() const
 {
     return m_unloadedPlugins;
 }

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -253,7 +253,7 @@ std::string PluginManager::GetPluginNameFromPath(const std::string& pluginPath)
         return filename.substr(0,pos);
     }
 
-    return sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(pluginPath.c_str());;
+    return sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(pluginPath.c_str());
 }
 
 auto PluginManager::loadPluginByName(const std::string& pluginName, const std::string& suffix, bool ignoreCase,
@@ -292,23 +292,40 @@ auto PluginManager::loadPlugin(const std::string& plugin, const std::string& suf
 
 bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* errlog)
 {
-    if(!pluginIsLoaded(pluginPath))
+    const auto [foundPluginPath, isPluginLoaded] = this->isPluginLoaded(pluginPath);
+    if(!isPluginLoaded)
     {
-        const std::string msg = "Plugin not loaded: " + pluginPath;
-        msg_error("PluginManager::unloadPlugin()") << msg;
-        if (errlog) (*errlog) << msg << std::endl;
+        const std::string msg = "Trying to unload a plugin that was not already loaded: '" + pluginPath + "'";
+        msg_error("PluginManager") << msg;
+        if (errlog)
+        {
+            (*errlog) << msg << msgendl;
+        }
         return false;
     }
-    else
+
+    if (const auto it = m_pluginMap.find(foundPluginPath);
+        it != m_pluginMap.end())
     {
-        const auto it = m_pluginMap.find(pluginPath);
         m_unloadedPlugins.insert(it->second.getModuleName());
 
         m_pluginMap.erase(it);
-        removeOnPluginLoadedCallback(pluginPath);
+        removeOnPluginLoadedCallback(foundPluginPath);
 
         return true;
     }
+
+    //this should not happen
+    const std::string msg = "Trying to unload a plugin that is not found, even"
+                            " if it has been detected as loaded (probably a bug)"
+                            ": '" + pluginPath + "' (loaded path found: '"
+                            + foundPluginPath + "')";
+    msg_error("PluginManager") << msg;
+    if (errlog)
+    {
+        (*errlog) << msg << msgendl;
+    }
+    return false;
 }
 
 const std::unordered_set<std::string>& PluginManager::unloadedPlugins() const
@@ -413,7 +430,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
     name  += suffix;
     const std::string libName = DynamicLibrary::prefix + name + "." + DynamicLibrary::extension;
 
-    // First try: case sensitive
+    // First try: case-sensitive
     for (const auto & prefix : searchPaths)
     {
         const std::array<std::string, 4> paths = {
@@ -429,7 +446,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
         }
     }
 
-    // Second try: case insensitive and recursive
+    // Second try: case-insensitive and recursive
     if (ignoreCase)
     {
         if(!recursive) maxRecursiveDepth = 0;
@@ -474,7 +491,15 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
 
 bool PluginManager::pluginIsLoaded(const std::string& plugin)
 {
-    if (plugin.empty()) return false;
+    return isPluginLoaded(plugin).second;
+}
+
+std::pair<std::string, bool> PluginManager::isPluginLoaded(const std::string& plugin)
+{
+    if (plugin.empty())
+    {
+        return {plugin, false};
+    }
 
     std::string pluginPath;
 
@@ -488,22 +513,22 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
         {
             // path is invalid
             msg_error("PluginManager") << "Could not check if the plugin is loaded as the path is invalid: " << plugin;
-            return false;
+            return {plugin, false};
         }
 
         pluginPath = plugin;
 
-        // argument is a path but we need to check if it was not already loaded with a different path
+        // argument is a path, but we need to check if it was not already loaded with a different path
         const auto& pluginName = GetPluginNameFromPath(pluginPath);
         for (const auto& [loadedPath, loadedPlugin] : m_pluginMap)
         {
             if (pluginName == loadedPlugin.getModuleName() && pluginPath != loadedPath)
             {
                 // we did find a plugin with the same, but it does not have the same path...
-                msg_warning("PluginManager") << "This plugin " << pluginName << " has been loaded from a different path, it will certainly lead to bugs or crashes... " << msgendl
+                msg_warning("PluginManager") << "The plugin " << pluginName << " has been loaded from a different path, it will certainly lead to bugs or crashes... " << msgendl
                                              << "You tried to load: " << pluginPath << msgendl
                                              << "Already loaded: " << loadedPath;
-                return true;
+                return {loadedPath, true};
             }
         }
 
@@ -511,12 +536,11 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
     else
     {
         // plugin argument is a name
-        /// Here is the iteration in the loaded plugin map
-        for(auto k : m_pluginMap)
+        for(const auto& [loadedPath, loadedPlugin] : m_pluginMap)
         {
-            if(plugin == k.second.getModuleName())
+            if (plugin == loadedPlugin.getModuleName())
             {
-                return true;
+                return {loadedPath, true};
             }
         }
 
@@ -527,7 +551,8 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
 
     /// Check that the path (either provided by user or through the call to findPlugin()
     /// leads to a loaded plugin.
-    return m_pluginMap.find(pluginPath) != m_pluginMap.end();
+    const bool isPluginPathInMap = m_pluginMap.find(pluginPath) != m_pluginMap.end();
+    return {pluginPath, isPluginPathInMap};
 }
 
 bool PluginManager::checkDuplicatedPlugin(const Plugin& plugin, const std::string& pluginPath)

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -222,6 +222,12 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
         }
     }
 
+    const auto unloadedIt = std::find(m_unloadedPlugins.begin(), m_unloadedPlugins.end(), p.getModuleName());
+    if (unloadedIt != m_unloadedPlugins.end())
+    {
+        m_unloadedPlugins.erase(unloadedIt);
+    }
+
     return PluginLoadStatus::SUCCESS;
 }
 
@@ -295,10 +301,19 @@ bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* er
     }
     else
     {
-        m_pluginMap.erase(m_pluginMap.find(pluginPath));
+        const auto it = m_pluginMap.find(pluginPath);
+        m_unloadedPlugins.push_back(it->second.getModuleName());
+
+        m_pluginMap.erase(it);
         removeOnPluginLoadedCallback(pluginPath);
+
         return true;
     }
+}
+
+const sofa::type::vector<std::string>& PluginManager::unloadedPlugins() const
+{
+    return m_unloadedPlugins;
 }
 
 Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /*suffix*/, bool /*ignoreCase*/)

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -213,6 +213,8 @@ public:
     /// Register a plugin. Merely an alias for loadPlugin()
     PluginLoadStatus registerPlugin(const std::string& plugin, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog = nullptr);
 
+    [[nodiscard]] const sofa::type::vector<std::string>& unloadedPlugins() const;
+
     void init();
     void init(const std::string& pluginPath);
 
@@ -233,7 +235,7 @@ public:
 
     Plugin* getPlugin(const std::string& plugin, const std::string& = getDefaultSuffix(), bool = true);
     Plugin* getPluginByName(const std::string& pluginName);
-    
+
     template <typename Entry>
     bool getEntryFromPlugin(const Plugin* plugin, Entry& entry)
     {
@@ -260,6 +262,8 @@ private:
 
     PluginMap m_pluginMap;
     std::map<std::string, std::function<void(const std::string&, const Plugin&)>> m_onPluginLoadedCallbacks;
+
+    sofa::type::vector<std::string> m_unloadedPlugins;
 };
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -215,6 +215,8 @@ public:
 
     [[nodiscard]] const std::unordered_set<std::string>& unloadedPlugins() const;
 
+    [[nodiscard]] bool isPluginUnloaded(const std::string& pluginName) const;
+
     void init();
     void init(const std::string& pluginPath);
 
@@ -274,6 +276,7 @@ private:
     PluginMap m_pluginMap;
     std::map<std::string, std::function<void(const std::string&, const Plugin&)>> m_onPluginLoadedCallbacks;
 
+    // contains the list of plugin names that were unloaded
     std::unordered_set<std::string> m_unloadedPlugins;
 };
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -188,7 +188,7 @@ public:
     /// - If not registered and not loaded in memory, it will load the plugin in memory, call entrypoints and register into the map
     /// @param plugin Can be just the filename of the library to load (without extension) or the full path
     /// @param suffix An optional suffix to apply to the filename. Defaults to "_d" with debug builds and is empty otherwise.
-    /// @param ignoreCase Specify if the plugin search should be case insensitive (activated by default). 
+    /// @param ignoreCase Specify if the plugin search should be case-insensitive (activated by default).
     ///                   Not used if the plugin string passed as a parameter is a full path
     /// @param errlog An optional stream for error logging.
     PluginLoadStatus loadPlugin(const std::string& plugin, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog = nullptr);
@@ -201,7 +201,7 @@ public:
     /// Loads a plugin library in process memory. 
     /// @param pluginName The filename without extension of the plugin to load
     /// @param suffix An optional suffix to apply to the filename. Defaults to "_d" with debug builds, empty otherwise.
-    /// @param ignoreCase Specify if the plugin search should be case insensitive (activated by default). 
+    /// @param ignoreCase Specify if the plugin search should be case-insensitive (activated by default).
     ///                   Not used if the plugin string passed as a parameter is a full path
     /// @param errlog An optional stream for error logging.
     PluginLoadStatus loadPluginByName(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog= nullptr);
@@ -220,6 +220,17 @@ public:
 
     std::string findPlugin(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, int maxRecursiveDepth = 3);
     bool pluginIsLoaded(const std::string& plugin);
+
+    /**
+     * Determine if a plugin name or plugin path is known from the plugin
+     * manager (i.e. has been loaded by the plugin manager) with the found path.
+     * @param plugin A path to a plugin or a plugin name
+     * @return A pair consisting of the found plugin path (or the plugin path
+     * that was last tried) and a bool value set to true if the plugin has been
+     * found in the plugin registration map
+     */
+    std::pair<std::string, bool> isPluginLoaded(const std::string& plugin);
+
     bool checkDuplicatedPlugin(const Plugin& plugin, const std::string& pluginPath);
 
     inline friend std::ostream& operator<< ( std::ostream& os, const PluginManager& pluginManager )

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -29,7 +29,7 @@
 #include <map>
 #include <memory>
 #include <functional>
-
+#include <unordered_set>
 #include <sofa/type/vector.h>
 
 namespace sofa::helper::system
@@ -213,7 +213,7 @@ public:
     /// Register a plugin. Merely an alias for loadPlugin()
     PluginLoadStatus registerPlugin(const std::string& plugin, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, std::ostream* errlog = nullptr);
 
-    [[nodiscard]] const sofa::type::vector<std::string>& unloadedPlugins() const;
+    [[nodiscard]] const std::unordered_set<std::string>& unloadedPlugins() const;
 
     void init();
     void init(const std::string& pluginPath);
@@ -263,7 +263,7 @@ private:
     PluginMap m_pluginMap;
     std::map<std::string, std::function<void(const std::string&, const Plugin&)>> m_onPluginLoadedCallbacks;
 
-    sofa::type::vector<std::string> m_unloadedPlugins;
+    std::unordered_set<std::string> m_unloadedPlugins;
 };
 
 

--- a/Sofa/framework/Helper/test/CMakeLists.txt
+++ b/Sofa/framework/Helper/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCE_FILES
 add_subdirectory(system/TestPluginA)
 add_subdirectory(system/TestPluginB)
 add_subdirectory(system/TestPluginC)
+add_subdirectory(system/FailingPlugin)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Helper)

--- a/Sofa/framework/Helper/test/system/FailingPlugin/CMakeLists.txt
+++ b/Sofa/framework/Helper/test/system/FailingPlugin/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+project(FailingPlugin VERSION 0.7)
+
+
+set(HEADER_FILES
+    ComponentFailingPlugin.h
+    FailingPlugin.h
+)
+
+set(SOURCE_FILES
+    ComponentFailingPlugin.cpp
+    init.cpp
+)
+
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES})
+target_link_libraries(${PROJECT_NAME} Sofa.Core Sofa.DefaultType)
+
+sofa_create_package_with_targets(
+    PACKAGE_NAME ${PROJECT_NAME}
+    PACKAGE_VERSION ${PROJECT_VERSION}
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+    )

--- a/Sofa/framework/Helper/test/system/FailingPlugin/ComponentFailingPlugin.cpp
+++ b/Sofa/framework/Helper/test/system/FailingPlugin/ComponentFailingPlugin.cpp
@@ -1,0 +1,45 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include "ComponentFailingPlugin.h"
+
+#include <sofa/core/ObjectFactory.h>
+
+
+namespace sofa::test
+{
+    
+ComponentFailingPlugin::ComponentFailingPlugin()
+{
+}
+
+
+ComponentFailingPlugin::~ComponentFailingPlugin()
+{
+}
+
+
+int ComponentFailingPluginClass = core::RegisterObject("ComponentFailingPlugin").add< ComponentFailingPlugin >();
+
+
+} // namespace sofa::test
+
+

--- a/Sofa/framework/Helper/test/system/FailingPlugin/ComponentFailingPlugin.h
+++ b/Sofa/framework/Helper/test/system/FailingPlugin/ComponentFailingPlugin.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <FailingPlugin/FailingPlugin.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+
+
+namespace sofa::test
+{
+
+class SOFA_FAILINGPLUGIN_API ComponentFailingPlugin : public sofa::core::objectmodel::BaseObject
+{
+
+public:
+    SOFA_CLASS(ComponentFailingPlugin, sofa::core::objectmodel::BaseObject);
+
+protected:
+    ComponentFailingPlugin();
+    ~ComponentFailingPlugin() override;
+};
+
+} // namespace sofa::test
+

--- a/Sofa/framework/Helper/test/system/FailingPlugin/FailingPlugin.h
+++ b/Sofa/framework/Helper/test/system/FailingPlugin/FailingPlugin.h
@@ -1,0 +1,36 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/helper/config.h>
+
+#ifdef SOFA_BUILD_FAILINGPLUGIN
+#  define SOFA_TARGET FailingPlugin
+#  define SOFA_FAILINGPLUGIN_API SOFA_EXPORT_DYNAMIC_LIBRARY
+#else
+#  define SOFA_FAILINGPLUGIN_API SOFA_IMPORT_DYNAMIC_LIBRARY
+#endif
+
+namespace failingplugin
+{
+    SOFA_FAILINGPLUGIN_API void init();
+}

--- a/Sofa/framework/Helper/test/system/FailingPlugin/FailingPluginConfig.cmake.in
+++ b/Sofa/framework/Helper/test/system/FailingPlugin/FailingPluginConfig.cmake.in
@@ -1,0 +1,13 @@
+# CMake package configuration file for the plugin @PROJECT_NAME@
+
+@PACKAGE_GUARD@
+@PACKAGE_INIT@
+
+find_package(Sofa.Core QUIET REQUIRED)
+find_package(Sofa.DefaultType QUIET REQUIRED)
+
+if(NOT TARGET @PROJECT_NAME@)
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+endif()
+
+check_required_components(@PROJECT_NAME@)

--- a/Sofa/framework/Helper/test/system/FailingPlugin/init.cpp
+++ b/Sofa/framework/Helper/test/system/FailingPlugin/init.cpp
@@ -1,0 +1,75 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <FailingPlugin/FailingPlugin.h>
+
+extern "C" {
+
+static int counter = 0;
+
+SOFA_FAILINGPLUGIN_API void initExternalModule()
+{
+    static bool first = true;
+
+    if (first)
+    {
+        first = false;
+    }
+    counter++;
+}
+
+SOFA_FAILINGPLUGIN_API bool moduleIsInitialized()
+{
+    //always return false for testing
+    return false;
+}
+
+SOFA_FAILINGPLUGIN_API const char* getModuleName()
+{
+    return "FailingPlugin";
+}
+
+SOFA_FAILINGPLUGIN_API const char* getModuleVersion()
+{
+    return "0.7";
+}
+
+SOFA_FAILINGPLUGIN_API const char* getModuleLicense()
+{
+    return "LicenseTest";
+}
+
+SOFA_FAILINGPLUGIN_API const char* getModuleDescription()
+{
+    return "A plugin that always fail to initialize";
+}
+
+SOFA_FAILINGPLUGIN_API const char* getModuleComponentList()
+{
+    return "ComponentFailingPlugin";
+}
+
+} // extern "C"
+
+namespace failingplugin
+{
+    SOFA_FAILINGPLUGIN_API void init() {}
+}

--- a/Sofa/framework/Helper/test/system/PluginManager_test.cpp
+++ b/Sofa/framework/Helper/test/system/PluginManager_test.cpp
@@ -297,13 +297,13 @@ TEST_F(PluginManager_test, failingPlugin)
 
     ASSERT_EQ(pm.getPluginMap().size(), 0u);
 
-    EXPECT_EQ(std::find(pm.unloadedPlugins().begin(), pm.unloadedPlugins().end(), failingPluginName), pm.unloadedPlugins().end());
+    EXPECT_EQ(pm.unloadedPlugins().find(failingPluginName), pm.unloadedPlugins().end());
     EXPECT_FALSE(sofa::core::ObjectFactory::getInstance()->hasCreator("ComponentFailingPlugin"));
     {
         EXPECT_MSG_EMIT(Error); //because initialization will fail
         pm.loadPluginByName(failingPluginName);
     }
-    EXPECT_NE(std::find(pm.unloadedPlugins().begin(), pm.unloadedPlugins().end(), failingPluginName), pm.unloadedPlugins().end());
+    EXPECT_NE(pm.unloadedPlugins().find(failingPluginName), pm.unloadedPlugins().end());
 
     const std::string pluginPath = pm.findPlugin(failingPluginName);
     EXPECT_EQ(pm.getPluginMap().find(pluginPath), pm.getPluginMap().end());

--- a/Sofa/framework/Helper/test/system/PluginManager_test.cpp
+++ b/Sofa/framework/Helper/test/system/PluginManager_test.cpp
@@ -318,6 +318,9 @@ TEST_F(PluginManager_test, failingPlugin)
     EXPECT_NE(std::find_if(description.getErrors().begin(), description.getErrors().end(),
         [](const std::string& error)
         {
-            return error.find("The object was previously registered, but its module has been unloaded.") != std::string::npos;
+            return error.find(
+                "The object was previously registered, but the module that "
+                "registered the object has been unloaded, preventing the object creation.")
+            != std::string::npos;
         }), description.getErrors().end());
 }

--- a/Sofa/framework/Helper/test/system/PluginManager_test.cpp
+++ b/Sofa/framework/Helper/test/system/PluginManager_test.cpp
@@ -19,10 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/PluginManager.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/FileSystem.h>
 #include <sofa/helper/Utils.h>
+#include <sofa/simulation/graph/DAGNode.h>
 
 #include <sofa/testing/BaseTest.h>
 using sofa::testing::BaseTest;
@@ -34,6 +36,7 @@ using sofa::helper::system::FileSystem;
 
 static std::string pluginAName = "TestPluginA";
 static std::string pluginBName = "TestPluginB";
+static std::string failingPluginName = "FailingPlugin";
 
 #ifdef NDEBUG
 static std::string pluginAFileName = "TestPluginA";
@@ -284,4 +287,37 @@ TEST_F(PluginManager_test, testPluginAAsDependencyOfPluginB)
     EXPECT_FALSE(p.getModuleDescription.func != nullptr);
     EXPECT_FALSE(p.getModuleComponentList.func != nullptr);
 
+}
+
+
+TEST_F(PluginManager_test, failingPlugin)
+{
+    std::string testModuleName = "FailingPlugin";
+    PluginManager&pm = PluginManager::getInstance();
+
+    ASSERT_EQ(pm.getPluginMap().size(), 0u);
+
+    EXPECT_EQ(std::find(pm.unloadedPlugins().begin(), pm.unloadedPlugins().end(), failingPluginName), pm.unloadedPlugins().end());
+    EXPECT_FALSE(sofa::core::ObjectFactory::getInstance()->hasCreator("ComponentFailingPlugin"));
+    {
+        EXPECT_MSG_EMIT(Error); //because initialization will fail
+        pm.loadPluginByName(failingPluginName);
+    }
+    EXPECT_NE(std::find(pm.unloadedPlugins().begin(), pm.unloadedPlugins().end(), failingPluginName), pm.unloadedPlugins().end());
+
+    const std::string pluginPath = pm.findPlugin(failingPluginName);
+    EXPECT_EQ(pm.getPluginMap().find(pluginPath), pm.getPluginMap().end());
+
+    EXPECT_TRUE(sofa::core::ObjectFactory::getInstance()->hasCreator("ComponentFailingPlugin"));
+
+    sofa::core::objectmodel::BaseObjectDescription description("ComponentFailingPlugin", "ComponentFailingPlugin");
+    const auto tmpNode = sofa::core::objectmodel::New<sofa::simulation::graph::DAGNode>("tmp");
+    EXPECT_EQ(sofa::core::ObjectFactory::getInstance()->createObject(tmpNode.get(), &description), nullptr);
+
+    EXPECT_FALSE(description.getErrors().empty());
+    EXPECT_NE(std::find_if(description.getErrors().begin(), description.getErrors().end(),
+        [](const std::string& error)
+        {
+            return error.find("The object was previously registered, but its module has been unloaded.") != std::string::npos;
+        }), description.getErrors().end());
 }


### PR DESCRIPTION
When a plugin is loaded, the ObjectFactory is populated of Components from this plugin. However, when this plugin is "unloaded", it was still possible to create a component from the plugin. This PR detects that the ObjectFactory tries to instantiate an object that is from an unloaded plugin.
It is particularly useful when the initialization of the plugin fails (SofaCUDA for example). When the initialization fails, the plugin is unloaded.
A unit test is provided



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
