### PR TITLE
[Core] Warn when module name is empty

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
@@ -347,7 +347,13 @@ public:
             }
         }
 
-        return addCreator(classname, templatename, ObjectFactory::Creator::SPtr(new ObjectCreator<RealObject>));
+        auto* objectCreator = new ObjectCreator<RealObject>;
+        if (objectCreator->getTarget() == "")
+        {
+            dmsg_warning("ObjectFactory") << "Module name cannot be found when registering "
+                << RealObject::GetClass()->className << "<" << RealObject::GetClass()->templateName << "> into the object factory";
+        }
+        return addCreator(classname, templatename, ObjectFactory::Creator::SPtr(objectCreator));
     }
 
     /// This is the final operation that will actually commit the additions to the ObjectFactory.


### PR DESCRIPTION
Example:

```
[WARNING] [ObjectFactory] Module name cannot be found when registering BeamInterpolation<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering AdaptiveBeamSlidingConstraint<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering DeprecatedComponent<> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering AdaptiveBeamController<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering BeamAdapterActionController<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering InterventionalRadiologyController<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering SutureController<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering AdaptiveBeamForceFieldAndMass<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering AdaptiveInflatableBeamForceField<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering AdaptiveBeamMapping<Rigid3d,Vec3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering AdaptiveBeamMapping<Rigid3d,Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering BeamLengtthMapping<Rigid3d,Vec1d> into the object factory

```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
