### PR TITLE
[image,Mapping.NonLinear] Properly includes config.h before ObjectFactory.h

### DIFF
--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.cpp
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.cpp
@@ -21,8 +21,9 @@
 ******************************************************************************/
 #define SOFA_COMPONENT_MAPPING_DistanceMultiMapping_CPP
 
-#include <sofa/core/ObjectFactory.h>
 #include <sofa/component/mapping/nonlinear/DistanceMultiMapping.inl>
+#include <sofa/core/ObjectFactory.h>
+
 
 namespace sofa::component::mapping::nonlinear
 {

--- a/applications/plugins/image/ImageTypes.cpp
+++ b/applications/plugins/image/ImageTypes.cpp
@@ -1,7 +1,7 @@
 #include <sofa/defaulttype/TemplatesAliases.h>
+#include <image/config.h>
 #include <sofa/core/ObjectFactory.h>
 
-#include <image/config.h>
 #include "ImageTypes.h"
 #if IMAGE_HAVE_MULTITHREADING
 #include <MultiThreading/DataExchange.inl>


### PR DESCRIPTION
This is required to properly define SOFA_TARGET






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
