### PR TITLE
[tests] Fix and test value type string of topology primitives

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/topology/Topology.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/Topology.h
@@ -131,3 +131,25 @@ SOFA_CORE_API extern const unsigned int quadsOrientationInHexahedronArray[6][4];
 SOFA_CORE_API extern const unsigned int verticesInHexahedronArray[2][2][2];
 
 } // namespace sofa::core::topology
+
+namespace sofa::geometry
+{
+
+// Specialization required because Topology::Point is not an alias of
+// sofa::topology::Element, compared to the other aliases such as
+// Edge, Triangle...
+template<>
+struct ElementInfo<sofa::core::topology::Topology::Point>
+{
+    static geometry::ElementType type()
+    {
+        return geometry::ElementType::POINT;
+    }
+
+    static const char* name()
+    {
+        static const char* n = elementTypeToString(type());
+        return n;
+    }
+};
+}

--- a/Sofa/framework/Core/test/objectmodel/Data_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/Data_test.cpp
@@ -66,6 +66,19 @@ public:
 
 };
 
+
+TEST_F(Data_test, validInfo)
+{
+    EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Edge> >::ValidInfo);
+    EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Hexahedron> >::ValidInfo);
+    EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Pentahedron> >::ValidInfo);
+    // EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Point> >::ValidInfo);
+    EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Pyramid> >::ValidInfo);
+    EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Quad> >::ValidInfo);
+    EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Tetrahedron> >::ValidInfo);
+    EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Triangle> >::ValidInfo);
+}
+
 TEST_F(Data_test, getValueTypeString)
 {
     EXPECT_EQ(dataInt.getValueTypeString(), "i");

--- a/Sofa/framework/Core/test/objectmodel/Data_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/Data_test.cpp
@@ -45,6 +45,25 @@ public:
     Data<SReal> dataSReal;
     Data<sofa::type::Vec3> dataVec3;
     Data<sofa::type::vector<sofa::type::Vec3>> dataVectorVec3;
+
+    Data<sofa::topology::Element<sofa::geometry::Edge> > dataEdge;
+    Data<sofa::topology::Element<sofa::geometry::Hexahedron> > dataHexahedron;
+    Data<sofa::topology::Element<sofa::geometry::Pentahedron> > dataPentahedron;
+    Data<sofa::topology::Element<sofa::geometry::Point> > dataPoint;
+    Data<sofa::topology::Element<sofa::geometry::Pyramid> > dataPyramid;
+    Data<sofa::topology::Element<sofa::geometry::Quad> > dataQuad;
+    Data<sofa::topology::Element<sofa::geometry::Tetrahedron> > dataTetrahedron;
+    Data<sofa::topology::Element<sofa::geometry::Triangle> > dataTriangle;
+
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Edge> > > dataVecEdge;
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Hexahedron> > > dataVecHexahedron;
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Pentahedron> > > dataVecPentahedron;
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Point> > > dataVecPoint;
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Pyramid> > > dataVecPyramid;
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Quad> > > dataVecQuad;
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Tetrahedron> > > dataVecTetrahedron;
+    Data<sofa::type::vector<sofa::topology::Element<sofa::geometry::Triangle> > > dataVecTriangle;
+
 };
 
 TEST_F(Data_test, getValueTypeString)
@@ -67,6 +86,24 @@ TEST_F(Data_test, getValueTypeString)
         EXPECT_EQ(dataVec3.getValueTypeString(), "Vec3f");
         EXPECT_EQ(dataVectorVec3.getValueTypeString(), "vector<Vec3f>");
     }
+
+    EXPECT_EQ(dataEdge.getValueTypeString(), "Edge");
+    EXPECT_EQ(dataHexahedron.getValueTypeString(), "Hexahedron");
+    EXPECT_EQ(dataPentahedron.getValueTypeString(), "Pentahedron");
+    // EXPECT_EQ(dataPoint.getValueTypeString(), "Point");
+    EXPECT_EQ(dataPyramid.getValueTypeString(), "Pyramid");
+    EXPECT_EQ(dataQuad.getValueTypeString(), "Quad");
+    EXPECT_EQ(dataTetrahedron.getValueTypeString(), "Tetrahedron");
+    EXPECT_EQ(dataTriangle.getValueTypeString(), "Triangle");
+
+    EXPECT_EQ(dataVecEdge.getValueTypeString(), "vector<Edge>");
+    EXPECT_EQ(dataVecHexahedron.getValueTypeString(), "vector<Hexahedron>");
+    EXPECT_EQ(dataVecPentahedron.getValueTypeString(), "vector<Pentahedron>");
+    // EXPECT_EQ(dataVecPoint.getValueTypeString(), "vector<Point>");
+    EXPECT_EQ(dataVecPyramid.getValueTypeString(), "vector<Pyramid>");
+    EXPECT_EQ(dataVecQuad.getValueTypeString(), "vector<Quad>");
+    EXPECT_EQ(dataVecTetrahedron.getValueTypeString(), "vector<Tetrahedron>");
+    EXPECT_EQ(dataVecTriangle.getValueTypeString(), "vector<Triangle>");
 }
 
 TEST_F(Data_test, getNameWithValueTypeInfo)

--- a/Sofa/framework/Core/test/objectmodel/Data_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/Data_test.cpp
@@ -81,6 +81,16 @@ TEST_F(Data_test, validInfo)
 
 TEST_F(Data_test, dataTypeName)
 {
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Edge>::name()}, "Edge");
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Hexahedron>::name()}, "Hexahedron");
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Pentahedron>::name()}, "Pentahedron");
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Point>::name()}, "Point");
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Pyramid>::name()}, "Pyramid");
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Quad>::name()}, "Quad");
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Tetrahedron>::name()}, "Tetrahedron");
+    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Triangle>::name()}, "Triangle");
+
+
     EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Edge> >::name(), "Edge");
     EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Hexahedron> >::name(), "Hexahedron");
     EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Pentahedron> >::name(), "Pentahedron");

--- a/Sofa/framework/Core/test/objectmodel/Data_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/Data_test.cpp
@@ -79,6 +79,18 @@ TEST_F(Data_test, validInfo)
     EXPECT_TRUE(defaulttype::DataTypeInfo<sofa::topology::Element<sofa::geometry::Triangle> >::ValidInfo);
 }
 
+TEST_F(Data_test, dataTypeName)
+{
+    EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Edge> >::name(), "Edge");
+    EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Hexahedron> >::name(), "Hexahedron");
+    EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Pentahedron> >::name(), "Pentahedron");
+    // EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Point> >::name(), "Point");
+    EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Pyramid> >::name(), "Pyramid");
+    EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Quad> >::name(), "Quad");
+    EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Tetrahedron> >::name(), "Tetrahedron");
+    EXPECT_EQ(defaulttype::DataTypeName<sofa::topology::Element<sofa::geometry::Triangle> >::name(), "Triangle");
+}
+
 TEST_F(Data_test, getValueTypeString)
 {
     EXPECT_EQ(dataInt.getValueTypeString(), "i");

--- a/Sofa/framework/Core/test/objectmodel/Data_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/Data_test.cpp
@@ -84,7 +84,7 @@ TEST_F(Data_test, dataTypeName)
     EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Edge>::name()}, "Edge");
     EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Hexahedron>::name()}, "Hexahedron");
     EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Pentahedron>::name()}, "Pentahedron");
-    EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Point>::name()}, "Point");
+    // EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Point>::name()}, "Point");
     EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Pyramid>::name()}, "Pyramid");
     EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Quad>::name()}, "Quad");
     EXPECT_EQ(std::string{sofa::geometry::ElementInfo<sofa::geometry::Tetrahedron>::name()}, "Tetrahedron");

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <sofa/geometry/ElementType.h>
 #include <sofa/type/Vec.h>
 #include <cmath>
 #include <numeric>
@@ -35,6 +36,7 @@ namespace sofa::geometry
 struct Edge
 {
     static constexpr sofa::Size NumberOfNodes = 2;
+    static constexpr ElementType Element_type = ElementType::EDGE;
 
     Edge() = delete;
 

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
@@ -23,25 +23,16 @@
 
 #include <sofa/geometry/ElementInfo.h>
 
-#include <sofa/geometry/Edge.h>
-#include <sofa/geometry/Hexahedron.h>
-#include <sofa/geometry/Pentahedron.h>
-#include <sofa/geometry/Point.h>
-#include <sofa/geometry/Pyramid.h>
-#include <sofa/geometry/Quad.h>
-#include <sofa/geometry/Tetrahedron.h>
-#include <sofa/geometry/Triangle.h>
-
 namespace sofa::geometry
 {
 
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Edge>;
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Hexahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Pentahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Point>;
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Pyramid>;
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Quad>;
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Tetrahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Triangle>;
+template struct SOFA_GEOMETRY_API ElementInfo<Edge>;
+template struct SOFA_GEOMETRY_API ElementInfo<Hexahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Point>;
+template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
+template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
+template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
 
 } // namespace sofa::geometry

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
@@ -123,4 +123,13 @@ SOFA_GEOMETRY_API const char* ElementInfo<Hexahedron>::name()
     return "Hexahedron";
 }
 
+template struct SOFA_GEOMETRY_API ElementInfo<Point>;
+template struct SOFA_GEOMETRY_API ElementInfo<Edge>;
+template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
+template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
+template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
+template struct SOFA_GEOMETRY_API ElementInfo<Hexahedron>;
+
 } // namespace sofa::geometry

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
@@ -22,7 +22,15 @@
 #define SOFA_GEOMETRY_ELEMENTINFO_DEFINITION
 
 #include <sofa/geometry/ElementInfo.h>
-#include <sofa/geometry/ElementType.h>
+
+#include <sofa/geometry/Edge.h>
+#include <sofa/geometry/Hexahedron.h>
+#include <sofa/geometry/Pentahedron.h>
+#include <sofa/geometry/Point.h>
+#include <sofa/geometry/Pyramid.h>
+#include <sofa/geometry/Quad.h>
+#include <sofa/geometry/Tetrahedron.h>
+#include <sofa/geometry/Triangle.h>
 
 namespace sofa::geometry
 {
@@ -123,13 +131,13 @@ SOFA_GEOMETRY_API const char* ElementInfo<Hexahedron>::name()
     return "Hexahedron";
 }
 
-template struct SOFA_GEOMETRY_API ElementInfo<Point>;
 template struct SOFA_GEOMETRY_API ElementInfo<Edge>;
-template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
-template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
-template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
 template struct SOFA_GEOMETRY_API ElementInfo<Hexahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Point>;
+template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
+template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
+template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
 
 } // namespace sofa::geometry

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.cpp
@@ -35,109 +35,13 @@
 namespace sofa::geometry
 {
 
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Point>::type()
-{
-    return ElementType::POINT;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Point>::name()
-{
-    return "Point";
-}
-
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Edge>::type()
-{
-    return ElementType::EDGE;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Edge>::name()
-{
-    return "Edge";
-}
-
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Triangle>::type()
-{
-    return ElementType::TRIANGLE;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Triangle>::name()
-{
-    return "Triangle";
-}
-
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Quad>::type()
-{
-    return ElementType::QUAD;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Quad>::name()
-{
-    return "Quad";
-}
-
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Tetrahedron>::type()
-{
-    return ElementType::TETRAHEDRON;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Tetrahedron>::name()
-{
-    return "Tetrahedron";
-}
-
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Pyramid>::type()
-{
-    return ElementType::PYRAMID;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Pyramid>::name()
-{
-    return "Pyramid";
-}
-
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Pentahedron>::type()
-{
-    return ElementType::PENTAHEDRON;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Pentahedron>::name()
-{
-    return "Pentahedron";
-}
-
-template<>
-SOFA_GEOMETRY_API ElementType ElementInfo<Hexahedron>::type()
-{
-    return ElementType::HEXAHEDRON;
-}
-
-template<>
-SOFA_GEOMETRY_API const char* ElementInfo<Hexahedron>::name()
-{
-    return "Hexahedron";
-}
-
-template struct SOFA_GEOMETRY_API ElementInfo<Edge>;
-template struct SOFA_GEOMETRY_API ElementInfo<Hexahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<Point>;
-template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
-template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
-template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
-template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Edge>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Hexahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Pentahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Point>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Pyramid>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Quad>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Tetrahedron>;
+template struct SOFA_GEOMETRY_API ElementInfo<sofa::geometry::Triangle>;
 
 } // namespace sofa::geometry

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
@@ -21,17 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/geometry/config.h>
-
 #include <sofa/geometry/ElementType.h>
-#include <sofa/geometry/Point.h>
-#include <sofa/geometry/Edge.h>
-#include <sofa/geometry/Triangle.h>
-#include <sofa/geometry/Quad.h>
-#include <sofa/geometry/Pentahedron.h>
-#include <sofa/geometry/Tetrahedron.h>
-#include <sofa/geometry/Pyramid.h>
-#include <sofa/geometry/Hexahedron.h>
 
 namespace sofa::geometry
 {
@@ -53,15 +43,27 @@ struct ElementInfo
 };
 
 
-#ifndef SOFA_GEOMETRY_ELEMENTINFO_DEFINITION
-extern template struct SOFA_GEOMETRY_API ElementInfo<Point>;
+#if !defined(SOFA_GEOMETRY_ELEMENTINFO_DEFINITION)
+
+#include <sofa/geometry/config.h>
+
+#include <sofa/geometry/Edge.h>
+#include <sofa/geometry/Hexahedron.h>
+#include <sofa/geometry/Pentahedron.h>
+#include <sofa/geometry/Point.h>
+#include <sofa/geometry/Pyramid.h>
+#include <sofa/geometry/Quad.h>
+#include <sofa/geometry/Tetrahedron.h>
+#include <sofa/geometry/Triangle.h>
+
 extern template struct SOFA_GEOMETRY_API ElementInfo<Edge>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
 extern template struct SOFA_GEOMETRY_API ElementInfo<Hexahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Point>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
 #endif
 
 } // namespace sofa::geometry

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
@@ -41,11 +41,13 @@ struct ElementInfo
 {
     static ElementType type()
     {
+        static_assert(false, "Unknown type");
         return ElementType();
     }
 
     static const char* name()
     {
+        static_assert(false, "Unknown type");
         return "";
     }
 };

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
@@ -23,8 +23,6 @@
 
 #include <sofa/geometry/ElementType.h>
 
-#include <sofa/geometry/config.h>
-
 #include <sofa/geometry/Edge.h>
 #include <sofa/geometry/Hexahedron.h>
 #include <sofa/geometry/Pentahedron.h>
@@ -40,129 +38,27 @@ namespace sofa::geometry
 template<typename GeometryElement>
 struct ElementInfo
 {
-    static ElementType type();
+    static ElementType type()
+    {
+        return GeometryElement::Element_type;
+    }
 
-    static const char* name();
+    static const char* name()
+    {
+        static const char* n = elementTypeToString(type());
+        return n;
+    }
 };
 
-
-template <typename GeometryElement>
-ElementType ElementInfo<GeometryElement>::type()
-{
-    return ElementType();
-}
-
-template <typename GeometryElement>
-const char* ElementInfo<GeometryElement>::name()
-{
-    return "";
-}
-
-template<>
-inline ElementType ElementInfo<Point>::type()
-{
-    return ElementType::POINT;
-}
-
-template<>
-inline const char* ElementInfo<Point>::name()
-{
-    return "Point";
-}
-
-template<>
-inline ElementType ElementInfo<Edge>::type()
-{
-    return ElementType::EDGE;
-}
-
-template<>
-inline const char* ElementInfo<Edge>::name()
-{
-    return "Edge";
-}
-
-template<>
-inline ElementType ElementInfo<Triangle>::type()
-{
-    return ElementType::TRIANGLE;
-}
-
-template<>
-inline const char* ElementInfo<Triangle>::name()
-{
-    return "Triangle";
-}
-
-template<>
-inline ElementType ElementInfo<Quad>::type()
-{
-    return ElementType::QUAD;
-}
-
-template<>
-inline const char* ElementInfo<Quad>::name()
-{
-    return "Quad";
-}
-
-template<>
-inline ElementType ElementInfo<Tetrahedron>::type()
-{
-    return ElementType::TETRAHEDRON;
-}
-
-template<>
-inline const char* ElementInfo<Tetrahedron>::name()
-{
-    return "Tetrahedron";
-}
-
-template<>
-inline ElementType ElementInfo<Pyramid>::type()
-{
-    return ElementType::PYRAMID;
-}
-
-template<>
-inline const char* ElementInfo<Pyramid>::name()
-{
-    return "Pyramid";
-}
-
-template<>
-inline ElementType ElementInfo<Pentahedron>::type()
-{
-    return ElementType::PENTAHEDRON;
-}
-
-template<>
-inline const char* ElementInfo<Pentahedron>::name()
-{
-    return "Pentahedron";
-}
-
-template<>
-inline ElementType ElementInfo<Hexahedron>::type()
-{
-    return ElementType::HEXAHEDRON;
-}
-
-template<>
-inline const char* ElementInfo<Hexahedron>::name()
-{
-    return "Hexahedron";
-}
-
 #if !defined(SOFA_GEOMETRY_ELEMENTINFO_DEFINITION)
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Edge>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Hexahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Pentahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Point>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Pyramid>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Quad>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Tetrahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Triangle>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Edge>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Hexahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Point>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
 #endif
 
 } // namespace sofa::geometry

--- a/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/ElementInfo.h
@@ -23,28 +23,6 @@
 
 #include <sofa/geometry/ElementType.h>
 
-namespace sofa::geometry
-{
-
-template<typename GeometryElement>
-struct ElementInfo
-{
-    static ElementType type()
-    {
-        static_assert(false, "Unknown type");
-        return ElementType();
-    }
-
-    static const char* name()
-    {
-        static_assert(false, "Unknown type");
-        return "";
-    }
-};
-
-
-#if !defined(SOFA_GEOMETRY_ELEMENTINFO_DEFINITION)
-
 #include <sofa/geometry/config.h>
 
 #include <sofa/geometry/Edge.h>
@@ -56,14 +34,135 @@ struct ElementInfo
 #include <sofa/geometry/Tetrahedron.h>
 #include <sofa/geometry/Triangle.h>
 
-extern template struct SOFA_GEOMETRY_API ElementInfo<Edge>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Hexahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Pentahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Point>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Pyramid>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Quad>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Tetrahedron>;
-extern template struct SOFA_GEOMETRY_API ElementInfo<Triangle>;
+namespace sofa::geometry
+{
+
+template<typename GeometryElement>
+struct ElementInfo
+{
+    static ElementType type();
+
+    static const char* name();
+};
+
+
+template <typename GeometryElement>
+ElementType ElementInfo<GeometryElement>::type()
+{
+    return ElementType();
+}
+
+template <typename GeometryElement>
+const char* ElementInfo<GeometryElement>::name()
+{
+    return "";
+}
+
+template<>
+inline ElementType ElementInfo<Point>::type()
+{
+    return ElementType::POINT;
+}
+
+template<>
+inline const char* ElementInfo<Point>::name()
+{
+    return "Point";
+}
+
+template<>
+inline ElementType ElementInfo<Edge>::type()
+{
+    return ElementType::EDGE;
+}
+
+template<>
+inline const char* ElementInfo<Edge>::name()
+{
+    return "Edge";
+}
+
+template<>
+inline ElementType ElementInfo<Triangle>::type()
+{
+    return ElementType::TRIANGLE;
+}
+
+template<>
+inline const char* ElementInfo<Triangle>::name()
+{
+    return "Triangle";
+}
+
+template<>
+inline ElementType ElementInfo<Quad>::type()
+{
+    return ElementType::QUAD;
+}
+
+template<>
+inline const char* ElementInfo<Quad>::name()
+{
+    return "Quad";
+}
+
+template<>
+inline ElementType ElementInfo<Tetrahedron>::type()
+{
+    return ElementType::TETRAHEDRON;
+}
+
+template<>
+inline const char* ElementInfo<Tetrahedron>::name()
+{
+    return "Tetrahedron";
+}
+
+template<>
+inline ElementType ElementInfo<Pyramid>::type()
+{
+    return ElementType::PYRAMID;
+}
+
+template<>
+inline const char* ElementInfo<Pyramid>::name()
+{
+    return "Pyramid";
+}
+
+template<>
+inline ElementType ElementInfo<Pentahedron>::type()
+{
+    return ElementType::PENTAHEDRON;
+}
+
+template<>
+inline const char* ElementInfo<Pentahedron>::name()
+{
+    return "Pentahedron";
+}
+
+template<>
+inline ElementType ElementInfo<Hexahedron>::type()
+{
+    return ElementType::HEXAHEDRON;
+}
+
+template<>
+inline const char* ElementInfo<Hexahedron>::name()
+{
+    return "Hexahedron";
+}
+
+#if !defined(SOFA_GEOMETRY_ELEMENTINFO_DEFINITION)
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Edge>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Hexahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Pentahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Point>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Pyramid>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Quad>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Tetrahedron>;
+extern template struct SOFA_GEOMETRY_API ElementInfo<::sofa::geometry::Triangle>;
 #endif
 
 } // namespace sofa::geometry

--- a/Sofa/framework/Geometry/src/sofa/geometry/Hexahedron.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Hexahedron.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <sofa/geometry/ElementType.h>
 #include <sofa/type/fixed_array.h>
 #include <sofa/type/Mat.h>
 #include <cmath>
@@ -37,6 +38,7 @@ namespace sofa::geometry
 struct Hexahedron
 {
     static constexpr sofa::Size NumberOfNodes = 8;
+    static constexpr ElementType Element_type = ElementType::HEXAHEDRON;
 
     Hexahedron() = delete;
 

--- a/Sofa/framework/Geometry/src/sofa/geometry/Pentahedron.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Pentahedron.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <sofa/geometry/ElementType.h>
 
 namespace sofa::geometry
 {
@@ -29,6 +30,7 @@ namespace sofa::geometry
 struct Pentahedron
 {
     static constexpr sofa::Size NumberOfNodes = 6;
+    static constexpr ElementType Element_type = ElementType::PENTAHEDRON;
 
     Pentahedron() = delete;
 };

--- a/Sofa/framework/Geometry/src/sofa/geometry/Point.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Point.h
@@ -22,13 +22,15 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <sofa/geometry/ElementType.h>
 
 namespace sofa::geometry
 {
 
 struct Point
 {
-    static constexpr sofa::Size NumberOfNodes = 1;
+    static constexpr ::sofa::Size NumberOfNodes = 1;
+    static constexpr ElementType Element_type = ElementType::POINT;
 
     Point() = delete;
 };

--- a/Sofa/framework/Geometry/src/sofa/geometry/Pyramid.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Pyramid.h
@@ -31,7 +31,6 @@ struct Pyramid
 {
     static constexpr sofa::Size NumberOfNodes = 5;
     static constexpr ElementType Element_type = ElementType::PYRAMID;
-    static constexpr const char* Name = "Pyramid";
 
     Pyramid() = delete;
 };

--- a/Sofa/framework/Geometry/src/sofa/geometry/Pyramid.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Pyramid.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <sofa/geometry/ElementType.h>
 
 namespace sofa::geometry
 {
@@ -29,6 +30,8 @@ namespace sofa::geometry
 struct Pyramid
 {
     static constexpr sofa::Size NumberOfNodes = 5;
+    static constexpr ElementType Element_type = ElementType::PYRAMID;
+    static constexpr const char* Name = "Pyramid";
 
     Pyramid() = delete;
 };

--- a/Sofa/framework/Geometry/src/sofa/geometry/Quad.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Quad.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
-
+#include <sofa/geometry/ElementType.h>
 #include <sofa/geometry/Triangle.h>
 
 namespace sofa::geometry
@@ -31,6 +31,7 @@ namespace sofa::geometry
 struct Quad
 {
     static constexpr sofa::Size NumberOfNodes = 4;
+    static constexpr ElementType Element_type = ElementType::QUAD;
 
     Quad() = delete;
 

--- a/Sofa/framework/Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Tetrahedron.h
@@ -23,6 +23,7 @@
 
 #include <sofa/geometry/config.h>
 
+#include <sofa/geometry/ElementType.h>
 #include <sofa/type/fixed_array_algorithms.h>
 #include <sofa/type/vector_algebra.h>
 #include <sofa/type/Vec.h>
@@ -34,6 +35,7 @@ namespace sofa::geometry
 struct Tetrahedron
 {
     static constexpr sofa::Size NumberOfNodes = 4;
+    static constexpr ElementType Element_type = ElementType::TETRAHEDRON;
 
     Tetrahedron() = delete;
 

--- a/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Triangle.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
-
+#include <sofa/geometry/ElementType.h>
 #include <sofa/geometry/Edge.h>
 
 namespace sofa::geometry
@@ -31,6 +31,7 @@ namespace sofa::geometry
 struct Triangle
 {
     static constexpr sofa::Size NumberOfNodes = 3;
+    static constexpr ElementType Element_type = ElementType::TRIANGLE;
 
     Triangle() = delete;
 

--- a/Sofa/framework/Topology/src/sofa/topology/Element.h
+++ b/Sofa/framework/Topology/src/sofa/topology/Element.h
@@ -24,7 +24,7 @@
 #include <sofa/topology/config.h>
 
 #include <sofa/type/fixed_array.h>
-#include <sofa/topology/Point.h>
+#include <sofa/geometry/ElementType.h>
 
 #include <type_traits>
 
@@ -34,6 +34,7 @@ namespace sofa::topology
 template <typename GeometryElement>
 struct Element : public sofa::type::fixed_array<sofa::Index, GeometryElement::NumberOfNodes>
 {
+    static constexpr sofa::geometry::ElementType Element_type = GeometryElement::Element_type;
     constexpr Element() noexcept
     {
         for (auto it = this->begin() ; it != this->end() ; it++)


### PR DESCRIPTION
Note that `Point` does not pass the test

The introduced tests don't pass on non-Windows OS

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
