### PR TITLE
[Core] Add topology subset indices test

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
@@ -137,7 +137,7 @@ protected:
     * Internal method called at the end of @sa remove method to apply internal mechanism, such as updating the map size
     * @param nbElements Number of element removed.
     */
-    virtual void removePostProcess(sofa::Size nbElements);
+    virtual void removePostProcess(sofa::Index elemId);
 
     /**
     * Internal method called at the end of @sa add method to apply internal mechanism, such as updating the map size.

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.h
@@ -76,6 +76,12 @@ public:
     */
     virtual Index indexOfElement(Index index) const;
 
+    /** Method to return the indices position of all the occurrence of the element inside the vector map @sa m_map2Elements
+    * @param {Index} element index of the full Data vector to find in the vector map
+    * @return {type::vector<Index>} positions of all the occurrence of the element in the vector map. return empty vector if not found.
+    */
+    virtual const type::vector<Index> indicesOfElement(Index index) const;
+
     /// Swaps values of this subsetmap at indices i1 and i2. (only if i1 and i2 < subset size())
     void swap(Index i1, Index i2) override;
 
@@ -99,7 +105,7 @@ public:
         const sofa::type::vector< sofa::type::vector< SReal > >& coefs,
         const sofa::type::vector< AncestorElem >& ancestorElems) override;
 
-    /// Remove the data using a set of indices. Will remove only the data contains by this subset.
+    /// Remove elems with inputted indices. Will remove only the data contains by this subset.
     void remove(const sofa::type::vector<Index>& index) override;
 
     /// Reorder the values. TODO epernod 2021-05-24: check if needed and implement it if needed.

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -77,6 +77,16 @@ Index TopologySubsetData <ElementType, VecT>::indexOfElement(Index index) const
 }
 
 template <typename ElementType, typename VecT>
+const type::vector<Index> TopologySubsetData <ElementType, VecT>::indicesOfElement(Index index) const
+{
+    type::vector<Index> returnVec;
+    for (unsigned int i = 0; i < m_map2Elements.size(); ++i)
+        if (index == m_map2Elements[i])
+            returnVec.push_back(i);
+    return returnVec;
+}
+
+template <typename ElementType, typename VecT>
 void TopologySubsetData <ElementType, VecT>::add(sofa::Size nbElements,
     const sofa::type::vector<sofa::type::vector<Index> >& ancestors,
     const sofa::type::vector<sofa::type::vector<SReal> >& coefs)
@@ -159,7 +169,7 @@ void TopologySubsetData <ElementType, VecT>::move(const sofa::type::vector<Index
 
 
 template <typename ElementType, typename VecT>
-void TopologySubsetData <ElementType, VecT>::remove(const sofa::type::vector<Index>& index)
+void TopologySubsetData<ElementType, VecT>::remove(const sofa::type::vector<Index>& index)
 {
     helper::WriteOnlyAccessor<Data<container_type> > data = this;
     
@@ -174,19 +184,18 @@ void TopologySubsetData <ElementType, VecT>::remove(const sofa::type::vector<Ind
             return;
 
         // Check if this element is inside the subset map
-        Index dataId = this->indexOfElement(elemId);
-        
-        if (dataId != sofa::InvalidID) // index in the map, need to update the subsetData
+        auto dataIds = this->indicesOfElement(elemId);
+        for(const Index & id : dataIds)
         {
+
             // if in the map, apply callback if set
             if (this->p_onDestructionCallback)
             {
-                this->p_onDestructionCallback(dataId, data[dataId]);
+                this->p_onDestructionCallback(id, data[id]);
             }
-
             // Like in topological change, will swap before poping back
             Index lastDataId = data.size() - 1;
-            this->swap(dataId, lastDataId);
+            this->swap(id, lastDataId);
 
             // Remove last subsetData element and update the map
             data.resize(lastDataId);
@@ -197,10 +206,10 @@ void TopologySubsetData <ElementType, VecT>::remove(const sofa::type::vector<Ind
         if (lastTopoElemId == sofa::InvalidID)
             continue;
 
-        dataId = this->indexOfElement(lastTopoElemId);
-        if (dataId != sofa::InvalidID)
+        auto lastTopoId = this->indicesOfElement(lastTopoElemId);
+        for(const Index & id : lastTopoId)
         {
-            updateLastIndex(dataId, elemId);
+            updateLastIndex(id, elemId);
         }
         lastTopoElemId--;
     }

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -167,6 +167,7 @@ void TopologySubsetData <ElementType, VecT>::remove(const sofa::type::vector<Ind
     Index lastTopoElemId = this->getLastElementIndex();
     
     // check for each element index to remove if it concern this subsetData
+    // The index vector is supposed to be sorted in descendent index order
     for (Index elemId : index)
     {
         if (data.size() == 0)

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -185,21 +185,19 @@ void TopologySubsetData<ElementType, VecT>::remove(const sofa::type::vector<Inde
 
         // Check if this element is inside the subset map
         auto dataIds = this->indicesOfElement(elemId);
+        //Need to delete in descendent order to guarantee that indices of elements to delete are kept constant after the deletion.
+        std::sort(dataIds.begin(),dataIds.end(),std::greater<>());
         for(const Index & id : dataIds)
         {
-
             // if in the map, apply callback if set
             if (this->p_onDestructionCallback)
             {
                 this->p_onDestructionCallback(id, data[id]);
             }
-            // Like in topological change, will swap before poping back
-            Index lastDataId = data.size() - 1;
-            this->swap(id, lastDataId);
 
-            // Remove last subsetData element and update the map
-            data.resize(lastDataId);
-            removePostProcess(lastDataId);
+            //Erase instead of swap to keep the list order
+            data.erase(data.begin() + id);
+            removePostProcess(id);
         }
 
         // Need to check if last element index is in the map. If yes need to replace that value to follow topological changes
@@ -247,9 +245,9 @@ void TopologySubsetData <ElementType, VecT>::swapPostProcess(Index i1, Index i2)
 
 
 template <typename ElementType, typename VecT>
-void TopologySubsetData <ElementType, VecT>::removePostProcess(sofa::Size nbElements)
+void TopologySubsetData <ElementType, VecT>::removePostProcess(sofa::Index elemId)
 {
-    m_map2Elements.resize(nbElements);
+        m_map2Elements.erase(m_map2Elements.begin() + elemId);
 }
 
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
@@ -79,10 +79,10 @@ void TopologySubsetIndices::swapPostProcess(Index i1, Index i2)
 }
 
 
-void TopologySubsetIndices::removePostProcess(sofa::Size nbElements)
+void TopologySubsetIndices::removePostProcess(sofa::Index elemId)
 {
     // nothing to do here
-    SOFA_UNUSED(nbElements);
+    SOFA_UNUSED(elemId);
 }
 
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.cpp
@@ -46,6 +46,20 @@ Index TopologySubsetIndices::indexOfElement(Index index) const
     return sofa::InvalidID;
 }
 
+
+const type::vector<Index> TopologySubsetIndices::indicesOfElement(Index index) const
+{
+    const container_type& data = m_value.getValue();
+    type::vector<Index> returnVec;
+    for (Index idElem = 0; idElem < data.size(); idElem++)
+    {
+        if (data[idElem] == index)
+            returnVec.push_back(idElem);
+    }
+
+    return returnVec;
+}
+
 void TopologySubsetIndices::createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology)
 {
     this->Inherit::createTopologyHandler(_topology);

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
@@ -57,7 +57,7 @@ public:
 protected:
     void swapPostProcess(Index i1, Index i2) override;
 
-    void removePostProcess(sofa::Size nbElements) override;
+    void removePostProcess(sofa::Index elemId) override;
 
     void addPostProcess(sofa::Index dataLastId) override;
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
@@ -47,9 +47,12 @@ public:
     
     Index indexOfElement(Index index) const override;
 
+    const type::vector<Index> indicesOfElement(Index index) const override;
+
     void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology) override;
 
     Index getLastElementIndex() const override;
+
 
 protected:
     void swapPostProcess(Index i1, Index i2) override;

--- a/Sofa/framework/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Core/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCE_FILES
     objectmodel/SingleLink_test.cpp
     objectmodel/VectorData_test.cpp
     topology/BaseMeshTopology_test.cpp
+    topology/TopologySubsetIndices_test.cpp
     DataEngine_test.cpp
     Engine_test.cpp
     MatrixAccumulator_test.cpp

--- a/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
+++ b/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
@@ -1,0 +1,77 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/topology/BaseTopologyData.h>
+#include <sofa/core/topology/TopologySubsetIndices.h>
+#include <gtest/gtest.h>
+
+namespace sofa::core::topology
+{
+
+class SimplePointTopology: public BaseMeshTopology
+{
+   public:
+    SimplePointTopology(unsigned size)
+    {
+        m_points.reserve(size);
+        for(unsigned i=0; i<size; ++i)
+        {
+            m_points.push_back(i);
+        }
+    }
+
+    virtual const SeqEdges& getEdges() {}
+    virtual const SeqTriangles& getTriangles() {}
+    virtual const SeqQuads& getQuads() {}
+    virtual const SeqTetrahedra& getTetrahedra() {}
+    virtual const SeqHexahedra& getHexahedra() {}
+
+    virtual sofa::geometry::ElementType getTopologyType() const
+    {
+        return sofa::geometry::ElementType::POINT;
+    }
+
+
+    virtual Size getNbPoints() const { return m_points.size(); }
+
+    type::vector<sofa::Index> m_points;
+};
+
+TEST(TopologySubsetIndices_test, removePoints)
+{
+    const EdgeSetTopologyContainer::SPtr edgeContainer = sofa::core::objectmodel::New< EdgeSetTopologyContainer >();
+
+
+    sofa::core::topology::BaseTopologyData<type::vector<Index>>::InitData initData ;
+    TopologySubsetIndices data(initData);
+
+    data.setValue({0,2,3,1,0,2});
+
+    type::vector<Index> indexToRemove{1,0};
+    data.remove(indexToRemove);
+
+    EXPECT_EQ(0,data.getValue()[0]);
+    EXPECT_EQ(1,data.getValue()[1]);
+    EXPECT_EQ(0,data.getValue()[2]);
+
+}
+
+}

--- a/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
+++ b/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
@@ -32,9 +32,6 @@ class SimplePointTopology: public BaseMeshTopology
     SimplePointTopology(unsigned size)
     : m_data(initData(&m_data,"topologoSI",""))
     {
-        sofa::core::topology::BaseTopologyData<type::vector<Index>>::InitData initData ;
-        (initData);
-
         m_points.reserve(size);
         for(unsigned i=0; i<size; ++i)
         {
@@ -48,11 +45,11 @@ class SimplePointTopology: public BaseMeshTopology
         m_data.createTopologyHandler(this);
     }
 
-    virtual const SeqEdges& getEdges() {}
-    virtual const SeqTriangles& getTriangles() {}
-    virtual const SeqQuads& getQuads() {}
-    virtual const SeqTetrahedra& getTetrahedra() {}
-    virtual const SeqHexahedra& getHexahedra() {}
+    virtual const SeqEdges& getEdges() { return m_edges; }
+    virtual const SeqTriangles& getTriangles() { return m_triangles; }
+    virtual const SeqQuads& getQuads() { return m_quads; }
+    virtual const SeqTetrahedra& getTetrahedra() { return m_tetra; }
+    virtual const SeqHexahedra& getHexahedra() { return m_hexa; }
 
     virtual sofa::geometry::ElementType getTopologyType() const
     {
@@ -76,6 +73,11 @@ class SimplePointTopology: public BaseMeshTopology
             m_points.push_back(i);
     }
 
+    sofa::type::vector<Edge> m_edges;
+    sofa::type::vector<Triangle> m_triangles;
+    sofa::type::vector<Quad> m_quads;
+    sofa::type::vector<Tetra> m_tetra;
+    sofa::type::vector<Hexa> m_hexa;
 
     TopologySubsetIndices m_data;
     type::vector<sofa::Index> m_points;

--- a/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
+++ b/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
@@ -30,12 +30,22 @@ class SimplePointTopology: public BaseMeshTopology
 {
    public:
     SimplePointTopology(unsigned size)
+    : m_data(initData(&m_data,"topologoSI",""))
     {
+        sofa::core::topology::BaseTopologyData<type::vector<Index>>::InitData initData ;
+        (initData);
+
         m_points.reserve(size);
         for(unsigned i=0; i<size; ++i)
         {
             m_points.push_back(i);
         }
+    }
+
+    virtual void init()
+    {
+        BaseMeshTopology::init();
+        m_data.createTopologyHandler(this);
     }
 
     virtual const SeqEdges& getEdges() {}
@@ -52,26 +62,62 @@ class SimplePointTopology: public BaseMeshTopology
 
     virtual Size getNbPoints() const { return m_points.size(); }
 
+
+    TopologySubsetIndices m_data;
     type::vector<sofa::Index> m_points;
 };
 
 TEST(TopologySubsetIndices_test, removePoints)
 {
-    const EdgeSetTopologyContainer::SPtr edgeContainer = sofa::core::objectmodel::New< EdgeSetTopologyContainer >();
-
-
-    sofa::core::topology::BaseTopologyData<type::vector<Index>>::InitData initData ;
-    TopologySubsetIndices data(initData);
-
-    data.setValue({0,2,3,1,0,2});
+    SimplePointTopology PointContainer(4);
+    PointContainer.init();
+    PointContainer.m_data.setValue({0,2,3,1,0,2});
 
     type::vector<Index> indexToRemove{1,0};
-    data.remove(indexToRemove);
+    PointContainer.m_data.remove(indexToRemove);
 
-    EXPECT_EQ(0,data.getValue()[0]);
-    EXPECT_EQ(1,data.getValue()[1]);
-    EXPECT_EQ(0,data.getValue()[2]);
+    EXPECT_EQ(3,PointContainer.m_data.getValue().size());
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[0]);
+    EXPECT_EQ(1,PointContainer.m_data.getValue()[1]);
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[2]);
 
 }
+
+
+TEST(TopologySubsetIndices_test, swapPoints)
+{
+    SimplePointTopology PointContainer(4);
+    PointContainer.init();
+    PointContainer.m_data.setValue({0,2,3,1,0,2});
+
+    PointContainer.m_data.swap(0,5);
+
+    EXPECT_EQ(6,PointContainer.m_data.getValue().size());
+    EXPECT_EQ(2,PointContainer.m_data.getValue()[0]);
+    EXPECT_EQ(2,PointContainer.m_data.getValue()[1]);
+    EXPECT_EQ(3,PointContainer.m_data.getValue()[2]);
+    EXPECT_EQ(1,PointContainer.m_data.getValue()[3]);
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[4]);
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[5]);
+}
+
+TEST(TopologySubsetIndices_test, renumber)
+{
+    SimplePointTopology PointContainer(4);
+    PointContainer.init();
+    PointContainer.m_data.setValue({0,2,3,1,0,2});
+
+    PointContainer.m_data.renumber({5,2,3,4,1,0});
+
+    EXPECT_EQ(6,PointContainer.m_data.getValue().size());
+    EXPECT_EQ(2,PointContainer.m_data.getValue()[0]);
+    EXPECT_EQ(3,PointContainer.m_data.getValue()[1]);
+    EXPECT_EQ(1,PointContainer.m_data.getValue()[2]);
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[3]);
+    EXPECT_EQ(2,PointContainer.m_data.getValue()[4]);
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[5]);
+
+}
+
 
 }

--- a/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
+++ b/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
@@ -94,8 +94,8 @@ TEST(TopologySubsetIndices_test, removePoints)
 
     EXPECT_EQ(3,PointContainer.m_data.getValue().size());
     EXPECT_EQ(0,PointContainer.m_data.getValue()[0]);
-    EXPECT_EQ(0,PointContainer.m_data.getValue()[1]);
-    EXPECT_EQ(1,PointContainer.m_data.getValue()[2]);
+    EXPECT_EQ(1,PointContainer.m_data.getValue()[1]);
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[2]);
 
 }
 

--- a/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
+++ b/Sofa/framework/Core/test/topology/TopologySubsetIndices_test.cpp
@@ -61,6 +61,20 @@ class SimplePointTopology: public BaseMeshTopology
 
 
     virtual Size getNbPoints() const { return m_points.size(); }
+    void removePoints(const unsigned nb)
+    {
+        if(nb >= m_points.size())
+            m_points.clear();
+        else
+            m_points.resize(m_points.size() - nb);
+    }
+
+    void addPoints(const unsigned nb)
+    {
+        m_points.reserve(m_points.size() + nb);
+        for(unsigned i=m_points.size(); i<(m_points.size() + nb);++i)
+            m_points.push_back(i);
+    }
 
 
     TopologySubsetIndices m_data;
@@ -78,8 +92,8 @@ TEST(TopologySubsetIndices_test, removePoints)
 
     EXPECT_EQ(3,PointContainer.m_data.getValue().size());
     EXPECT_EQ(0,PointContainer.m_data.getValue()[0]);
-    EXPECT_EQ(1,PointContainer.m_data.getValue()[1]);
-    EXPECT_EQ(0,PointContainer.m_data.getValue()[2]);
+    EXPECT_EQ(0,PointContainer.m_data.getValue()[1]);
+    EXPECT_EQ(1,PointContainer.m_data.getValue()[2]);
 
 }
 


### PR DESCRIPTION
During my Way of the Cross of fusing StiffSpring and its parent, I saw that the topological change of removing points didn't work as planned for topologySubsetIndices when there is multiple occurrence of the same element  in the data. 

I've fixed that and added tests. 

One question is remaining though : here I kept the original mechanism using a swap of the deleted element and the last one. This is efficient in term of memory but it has the side effect of changing the indices order in the data. 
--> My question is, *is that what we want ?* Do we prefer memory/time efficiency over order coherency for this data ? Is it logical to get a random order of the vector out of a simple topological change ?  This answer will change a bit the way I'll finish the refactoring in https://github.com/sofa-framework/sofa/pull/4649 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
