### PR TITLE
[PlayBack] Add option to set period in the WriteStateCreator visitor

### DIFF
--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteState.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteState.cpp
@@ -43,14 +43,15 @@ WriteStateCreator::WriteStateCreator(const core::ExecParams* params)
 #endif
     , recordX(true)
     , recordV(true)
+    , recordF(false)
     , createInMapping(false)
     , counterWriteState(0)
 {
 }
 
-WriteStateCreator::WriteStateCreator(const core::ExecParams* params, const std::string &n, bool _recordX, bool _recordV, bool _recordF, bool _createInMapping, int c)
+WriteStateCreator::WriteStateCreator(const core::ExecParams* params, const std::string & _sceneName, bool _recordX, bool _recordV, bool _recordF, bool _createInMapping, int _counterState)
     :simulation::Visitor(params)
-    , sceneName(n)
+    , sceneName(_sceneName)
 #if SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB
     , extension(".txt.gz")
 #else
@@ -60,7 +61,7 @@ WriteStateCreator::WriteStateCreator(const core::ExecParams* params, const std::
     , recordV(_recordV)
     , recordF(_recordF)
     , createInMapping(_createInMapping)
-    , counterWriteState(c)
+    , counterWriteState(_counterState)
 {
 }
 
@@ -107,6 +108,8 @@ void WriteStateCreator::addWriteState(sofa::core::behavior::BaseMechanicalState 
         ws->d_filename.setValue(ofilename.str());
         if (!m_times.empty())
             ws->d_time.setValue(m_times);
+
+        ws->d_period.setValue(m_period);
 
         ws->init();
         ws->f_listening.setValue(true);  //Activated at init

--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteState.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteState.h
@@ -113,7 +113,7 @@ class SOFA_COMPONENT_PLAYBACK_API WriteStateCreator: public simulation::Visitor
 {
 public:
     WriteStateCreator(const core::ExecParams* params);
-    WriteStateCreator(const core::ExecParams* params, const std::string &n, bool _recordX, bool _recordV, bool _recordF, bool _createInMapping, int c=0);
+    WriteStateCreator(const core::ExecParams* params, const std::string &_sceneName, bool _recordX, bool _recordV, bool _recordF, bool _createInMapping, int _counterState=0);
     Result processNodeTopDown( simulation::Node*  ) override;
 
     void setSceneName(std::string &n) { sceneName = n; }
@@ -124,7 +124,8 @@ public:
     void setCounter(int c) { counterWriteState = c; }
     const char* getClassName() const override { return "WriteStateCreator"; }
 
-    void setExportTimes(const type::vector<double> times) { m_times = times; }
+    void setExportTimes(const type::vector<double>& times) { m_times = times; }
+    void setPeriod(double period) { m_period = period; }
 protected:
     std::string sceneName;
     std::string extension;
@@ -134,6 +135,7 @@ protected:
     bool createInMapping;
 
     int counterWriteState; //avoid to have two same files if two mechanical objects has the same name
+    double m_period = 0.0;
 
     void addWriteState(sofa::core::behavior::BaseMechanicalState*ms, simulation::Node* gnode);
 


### PR DESCRIPTION
This option was missing in the visitor to init writeState components with a period.
Teaser: it will be useful in the new version of Regression

Also rename some parameters to be more explicit. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
