### PR TITLE
[Helper] Fix dl open when path are not canonical

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
@@ -126,7 +126,7 @@ void * DynamicLibrary::getSymbolAddress(Handle handle,
                     path = path.parent_path() / symlinkHandlePath;
                 }
             }
-            return absolute(path);
+            return std::filesystem::absolute(path);
         };
 
         Dl_info dli;

--- a/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
@@ -128,7 +128,7 @@ void * DynamicLibrary::getSymbolAddress(Handle handle,
         }
         catch(std::filesystem::filesystem_error& error)
         {
-            oss << "An exception was catch when trying to find real path of the library with the following message " << error.what();
+            oss << "An exception was caught when trying to find the real path of the library with the following message : " << error.what();
 
             // paths are broken, we cannot check if this symbol comes from this lib
             symbolAddress = nullptr;

--- a/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
@@ -114,31 +114,33 @@ void * DynamicLibrary::getSymbolAddress(Handle handle,
 #if not defined (WIN32)
     else // checking that the symbol really comes from the provided library
     {
-        constexpr auto getRealPath = [] (const auto& strpath)
-        {
-            std::filesystem::path path(strpath);
-            if(std::filesystem::is_symlink(path))
-            {
-                auto symlinkHandlePath = std::filesystem::read_symlink(path);
-                // symlink created by the build process are relative
-                if(symlinkHandlePath.is_relative())
-                {
-                    path = path.parent_path() / symlinkHandlePath;
-                }
-            }
-            return std::filesystem::canonical(path);
-        };
 
         Dl_info dli;
         ::dladdr(symbolAddress, &dli);
-        std::filesystem::path dlInfoPath = getRealPath(dli.dli_fname);
+        std::filesystem::path dlInfoPath;
+        std::filesystem::path handlePath;
+        std::ostringstream oss;
 
-        std::filesystem::path handlePath = getRealPath(handle.filename());
+        try
+        {
+            dlInfoPath = std::filesystem::canonical(dli.dli_fname);
+            handlePath = std::filesystem::canonical(handle.filename());
+        }
+        catch(std::filesystem::filesystem_error& error)
+        {
+            oss << "An exception was catch when trying to find real path of the library with the following message " << error.what();
+
+            // paths are broken, we cannot check if this symbol comes from this lib
+            symbolAddress = nullptr;
+            m_lastError = oss.str();
+
+            return symbolAddress;
+        }
+
 
         // Both paths should be exactly the same
         if(dlInfoPath.compare(handlePath) != 0)
         {
-            std::ostringstream oss;
             oss << symbol << " was found in the library " << dlInfoPath
                 << " , but it should have been found in this library " << handlePath << "\n."
                 << "The most probable reason is that your requested library " << handlePath.filename()

--- a/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
@@ -126,7 +126,7 @@ void * DynamicLibrary::getSymbolAddress(Handle handle,
                     path = path.parent_path() / symlinkHandlePath;
                 }
             }
-            return std::filesystem::absolute(path);
+            return std::filesystem::canonical(path);
         };
 
         Dl_info dli;

--- a/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
@@ -126,7 +126,7 @@ void * DynamicLibrary::getSymbolAddress(Handle handle,
                     path = path.parent_path() / symlinkHandlePath;
                 }
             }
-            return path;
+            return absolute(path);
         };
 
         Dl_info dli;

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -194,7 +194,7 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
     {
         if(! getPluginEntry(p.initExternalModule,d))
         {
-            const std::string msg = "Plugin loading failed (" + pluginPath + "): function initExternalModule() not found";
+            const std::string msg = "Plugin loading failed (" + pluginPath + "): function initExternalModule() not found. dlsym output following error : "+ DynamicLibrary::getLastError();
             msg_error("PluginManager") << msg;
             if (errlog) (*errlog) << msg << std::endl;
             return PluginLoadStatus::MISSING_SYMBOL;

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -194,7 +194,7 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
     {
         if(! getPluginEntry(p.initExternalModule,d))
         {
-            const std::string msg = "Plugin loading failed (" + pluginPath + "): function initExternalModule() not found. dlsym output following error : "+ DynamicLibrary::getLastError();
+            const std::string msg = "Plugin loading failed (" + pluginPath + "): function initExternalModule() not found. "+ DynamicLibrary::getLastError();
             msg_error("PluginManager") << msg;
             if (errlog) (*errlog) << msg << std::endl;
             return PluginLoadStatus::MISSING_SYMBOL;

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -194,7 +194,7 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
     {
         if(! getPluginEntry(p.initExternalModule,d))
         {
-            const std::string msg = "Plugin loading failed (" + pluginPath + "): function initExternalModule() not found. "+ DynamicLibrary::getLastError();
+            const std::string msg = "Plugin loading failed (" + pluginPath + "): function initExternalModule() not found. The following error was received: "+ DynamicLibrary::getLastError();
             msg_error("PluginManager") << msg;
             if (errlog) (*errlog) << msg << std::endl;
             return PluginLoadStatus::MISSING_SYMBOL;


### PR DESCRIPTION
Error where displayed when using generated binaries on another computer. I'm not sure why this didn't happend when it was launched on the computer that built the binaries... 

The path comparison didn't work when they weren't  in a canonical form. This method only appeared in c++17, but if I am right we only support the c++ version of the two last LTS, 22.04 distributing gcc11 which provides a full support of c++17. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
