### PR TITLE
[tools] Add metis relocation in post install fixup

### DIFF
--- a/tools/postinstall-fixup/common.sh
+++ b/tools/postinstall-fixup/common.sh
@@ -49,16 +49,19 @@ function move_metis()
   cd $INSTALL_DIR
   echo "Starting metis relocation..."
   if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
-    echo " - moving $(find ~+ -type f -name "metis.dll" | head -n 1) into $INSTALL_DIR/bin/$"
+    echo " - moving $(find ~+ -type f -name "metis.dll" | head -n 1) into $INSTALL_DIR/bin/"
     mv $(find ~+ -type f -name "metis.dll" | head -n 1) $INSTALL_DIR/bin/ || true
-    echo " - moving $(find ~+ -type f -name "metis.lib" | head -n 1) into $INSTALL_DIR/lib/$"
+    echo " - moving $(find ~+ -type f -name "metis.lib" | head -n 1) into $INSTALL_DIR/lib/"
     mv $(find ~+ -type f -name "metis.lib" | head -n 1) $INSTALL_DIR/lib/ || true
+  elif [[ "$(uname)" == "Darwin" ]]; then
+    echo " - moving $( find ~+ -type d -name "metis.framework" | head -n 1) into $INSTALL_DIR/lib/"
+      mv $( find ~+ -type d -name "metis.framework" | head -n 1 ) $INSTALL_DIR/lib/
   else
-    echo " - moving $( find ~+ -type f -name "libmetis*" | head -n 1) into $INSTALL_DIR/lib/$"
+    echo " - moving $( find ~+ -type f -name "libmetis*" | head -n 1) into $INSTALL_DIR/lib/"
     mv $( find ~+ -type f -name "libmetis*" | head -n 1) $INSTALL_DIR/lib/
   fi
-  echo " - moving $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) into $INSTALL_DIR/lib/cmake/$"
+  echo " - moving $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) into $INSTALL_DIR/lib/cmake/"
   mv $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) $INSTALL_DIR/lib/cmake/ || true
-  echo " - moving $(find ~+ -type f -name "metis.h" | head -n 1) into $INSTALL_DIR/include/$"
+  echo " - moving $(find ~+ -type f -name "metis.h" | head -n 1) into $INSTALL_DIR/include/"
   mv $(find ~+ -type f -name "metis.h" | head -n 1) $INSTALL_DIR/include/ || true
 }

--- a/tools/postinstall-fixup/common.sh
+++ b/tools/postinstall-fixup/common.sh
@@ -54,7 +54,8 @@ function move_metis()
     echo " - moving $(find ~+ -type f -name "metis.lib" | head -n 1) into $INSTALL_DIR/lib/$"
     mv $(find ~+ -type f -name "metis.lib" | head -n 1) $INSTALL_DIR/lib/ || true
   else
-    find ~+ -type f -name "libmetis*" | while read lib; do echo " - moving $lib} into $INSTALL_DIR/lib/$"; mv $lib} lib/; done
+    echo " - moving $( find ~+ -type f -name "libmetis*" | head -n 1) into $INSTALL_DIR/lib/$"
+    mv $( find ~+ -type f -name "libmetis*" | head -n 1) $INSTALL_DIR/lib/; done
   fi
   echo " - moving $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) into $INSTALL_DIR/lib/cmake/$"
   mv $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) $INSTALL_DIR/lib/cmake/ || true

--- a/tools/postinstall-fixup/common.sh
+++ b/tools/postinstall-fixup/common.sh
@@ -55,7 +55,7 @@ function move_metis()
     mv $(find ~+ -type f -name "metis.lib" | head -n 1) $INSTALL_DIR/lib/ || true
   else
     echo " - moving $( find ~+ -type f -name "libmetis*" | head -n 1) into $INSTALL_DIR/lib/$"
-    mv $( find ~+ -type f -name "libmetis*" | head -n 1) $INSTALL_DIR/lib/; done
+    mv $( find ~+ -type f -name "libmetis*" | head -n 1) $INSTALL_DIR/lib/
   fi
   echo " - moving $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) into $INSTALL_DIR/lib/cmake/$"
   mv $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) $INSTALL_DIR/lib/cmake/ || true

--- a/tools/postinstall-fixup/common.sh
+++ b/tools/postinstall-fixup/common.sh
@@ -41,3 +41,23 @@ function clean_default_plugins()
   done
   grep -v $disabled_plugins "$1/plugin_list.conf.default" >> "$1/plugin_list.conf"
 }
+
+function move_metis()
+{
+  INSTALL_DIR=$1
+
+  cd $INSTALL_DIR
+  echo "Starting metis relocation..."
+  if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
+    echo " - moving $(find ~+ -type f -name "metis.dll" | head -n 1) into $INSTALL_DIR/bin/$"
+    mv $(find ~+ -type f -name "metis.dll" | head -n 1) $INSTALL_DIR/bin/ || true
+    echo " - moving $(find ~+ -type f -name "metis.lib" | head -n 1) into $INSTALL_DIR/lib/$"
+    mv $(find ~+ -type f -name "metis.lib" | head -n 1) $INSTALL_DIR/lib/ || true
+  else
+    find ~+ -type f -name "libmetis*" | while read lib; do echo " - moving $lib} into $INSTALL_DIR/lib/$"; mv $lib} lib/; done
+  fi
+  echo " - moving $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) into $INSTALL_DIR/lib/cmake/$"
+  mv $(find ~+ -type d -name "metis" | grep lib/cmake/metis | head -n 1) $INSTALL_DIR/lib/cmake/ || true
+  echo " - moving $(find ~+ -type f -name "metis.h" | head -n 1) into $INSTALL_DIR/include/$"
+  mv $(find ~+ -type f -name "metis.h" | head -n 1) $INSTALL_DIR/include/ || true
+}

--- a/tools/postinstall-fixup/linux-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/linux-postinstall-fixup.sh
@@ -193,6 +193,7 @@ for deps_file in postinstall_deps_SOFA.tmp postinstall_deps_plugin_*.tmp; do
     done
 done
 
+move_metis "$INSTALL_DIR"
 
 # Add QtWebEngine dependencies
 if [ -e "$INSTALL_DIR/lib/libQt5WebEngineCore.so.5" ] && [ -d "$QT_LIBEXEC_DIR" ] && [ -d "$QT_WEBENGINE_DATA_DIR" ]; then

--- a/tools/postinstall-fixup/macos-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/macos-postinstall-fixup.sh
@@ -53,6 +53,8 @@ elif [ -d "$QT_DATA_DIR" ]; then
     cp -Rf $QT_DATA_DIR/plugins/styles $INSTALL_DIR/bin
 fi
 
+move_metis "$INSTALL_DIR"
+
 echo "Fixing up libs manually ..."
 
 check-all-deps() {

--- a/tools/postinstall-fixup/windows-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/windows-postinstall-fixup.sh
@@ -27,6 +27,8 @@ echo "INSTALL_DIR_BIN = $INSTALL_DIR_BIN"
 source $SCRIPT_DIR/common.sh
 clean_default_plugins "$INSTALL_DIR_BIN"
 
+move_metis "$INSTALL_DIR"
+
 # Copy all plugin libs in install/bin to make them easily findable
 cd "$INSTALL_DIR" && find -name "*.dll" -path "*/plugins/*" | while read lib; do
     cp "$lib" "$INSTALL_DIR_BIN"


### PR DESCRIPTION
Metis is installed only in the folder of the first plugin fetching it. Making the other one fail to find it. Moving it into the main folder with CMake is not really meaningful. The plugin should not fix something that is at higher level in the CMake hierarchy as itself (aka, fix install issue when another target depends on one of its dependency)...  



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
