### PR TITLE
[Core] Deprecate Compliant API in force fields

### DIFF
--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMapping.inl
@@ -81,9 +81,6 @@ void DistanceMapping<TIn, TOut>::init()
     directions.resize(links.size());
     invlengths.resize(links.size());
 
-    // only used for warning message
-    bool compliance = ((simulation::Node*)(this->getContext()))->forceField.size() && ((simulation::Node*)(this->getContext()))->forceField[0]->isCompliance.getValue();
-
     // compute the rest lengths if they are not known
     if( f_restLengths.getValue().size() != links.size() )
     {
@@ -94,25 +91,15 @@ void DistanceMapping<TIn, TOut>::init()
             for(unsigned i=0; i<links.size(); i++ )
             {
                 restLengths[i] = (pos[links[i][0]] - pos[links[i][1]]).norm();
-
-                msg_error_when(restLengths[i] <= std::numeric_limits<SReal>::epsilon() && compliance) << "Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof " << i << " if used with a compliance";
             }
         }
         else
         {
-            msg_error_when(compliance) << "Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance";
             for(unsigned i=0; i<links.size(); i++ )
+            {
                 restLengths[i] = (Real)0.;
+            }
         }
-    }
-    else if (compliance) // for warning message
-    {
-        helper::ReadAccessor< Data<type::vector<Real> > > restLengths(f_restLengths);
-        std::stringstream sstream;
-        for (unsigned i = 0; i < links.size(); i++)
-            if (restLengths[i] <= std::numeric_limits<SReal>::epsilon()) 
-                sstream << "Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof " << i << " if used with a compliance \n";
-        msg_error_when(!sstream.str().empty()) << sstream.str();
     }
 
     baseMatrices.resize( 1 );

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/DistanceMultiMapping.inl
@@ -97,9 +97,6 @@ void DistanceMultiMapping<TIn, TOut>::init()
 
     const type::vector<type::Vec2i>& pairs = d_indexPairs.getValue();
 
-    // only used for warning message
-    bool compliance = ((simulation::Node*)(this->getContext()))->forceField.size() && ((simulation::Node*)(this->getContext()))->forceField[0]->isCompliance.getValue();
-
     // compute the rest lengths if they are not known
     if( f_restLengths.getValue().size() != links.size() )
     {
@@ -119,24 +116,15 @@ void DistanceMultiMapping<TIn, TOut>::init()
                 const InCoord& pos1 = posPair1[pair1[1]];
 
                 restLengths[i] = (pos0 - pos1).norm();
-
-                msg_error_when(restLengths[i] == 0 && compliance) << "Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof " << i << " if used with a compliance";
             }
         }
         else
         {
-            msg_error_when(compliance) << "Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance";
             for(unsigned i=0; i<links.size(); i++ )
+            {
                 restLengths[i] = (Real)0.;
+            }
         }
-    }
-    else if( compliance ) // manually set // for warning message
-    {
-        helper::ReadAccessor< Data<type::vector<Real> > > restLengths(f_restLengths);
-        std::stringstream sstream;
-        for(unsigned i=0; i<links.size(); i++ )
-            if( restLengths[i]<=std::numeric_limits<SReal>::epsilon() ) sstream <<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance \n";
-        msg_error_when(!sstream.str().empty()) << sstream.str();
     }
 
     alloc();

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/SquareDistanceMapping.inl
@@ -71,10 +71,6 @@ void SquareDistanceMapping<TIn, TOut>::init()
 
     this->getToModel()->resize( links.size() );
 
-    // only used for warning message
-    const bool compliance = ((simulation::Node*)(this->getContext()))->forceField.size() && ((simulation::Node*)(this->getContext()))->forceField[0]->isCompliance.getValue();
-    msg_error_when(compliance) << "Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance";
-
     baseMatrices.resize( 1 );
     baseMatrices[0] = &jacobian;
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/HexahedronFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/HexahedronFEMForceField_test.cpp
@@ -92,7 +92,6 @@ struct HexahedronFEMForceField_test : public ForceField_test<_HexahedronFEMForce
         Inherited::force->f_poissonRatio.setValue(0);
         Inherited::force->f_youngModulus.setValue(10);
         Inherited::force->setMethod(2); // small method
-        Inherited::force->isCompliance.setValue(0);
 
         // Init simulation
         sofa::simulation::node::initRoot(Inherited::node.get());

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseForceField.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseForceField.cpp
@@ -31,7 +31,7 @@ namespace sofa::core::behavior
 
 BaseForceField::BaseForceField()
     : StateAccessor()
-    , isCompliance( initData(&isCompliance, false, "isCompliance", "Consider the component as a compliance, else as a stiffness"))
+    , isCompliance(this, "v24.12", "v25.06", "isCompliance", "Consider the component as a compliance, else as a stiffness")
     , rayleighStiffness( initData(&rayleighStiffness, 0_sreal, "rayleighStiffness", "Rayleigh damping - stiffness matrix coefficient"))
 {
 }

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseForceField.h
@@ -186,10 +186,12 @@ public:
     /// @{
 
     /// Considered as compliance, else considered as stiffness (default to false)
-    Data< bool > isCompliance;
+    SOFA_ATTRIBUTE_DEPRECATED__COMPLIANT()
+    objectmodel::lifecycle::DeprecatedData isCompliance;
 
     /// Return a pointer to the compliance matrix C
     /// \f$ C = K^{-1} \f$
+    SOFA_ATTRIBUTE_DEPRECATED__COMPLIANT()
     virtual const sofa::linearalgebra::BaseMatrix* getComplianceMatrix(const MechanicalParams*) { return nullptr; }
 
     /// \brief Accumulate the contribution of the C compliant matrix multiplied
@@ -202,6 +204,7 @@ public:
     /// where C is the Compliant matrix (inverse of the Stiffness matrix \f$ K \f$:
     /// \f$ C = K^{-1} \f$)
     ///
+    SOFA_ATTRIBUTE_DEPRECATED__COMPLIANT()
     virtual void addClambda(const MechanicalParams* /*mparams*/, MultiVecDerivId /*resId*/, MultiVecDerivId /*lambdaId*/, SReal /*cFactor*/ ){}
 
     /// @}

--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
@@ -109,12 +109,7 @@ public:
     /// @param dx Input vector used to compute \f$ df = kFactor K dx + bFactor B dx \f$
     virtual void addDForce(const MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx ) = 0;
 
-    /// Compute the product of the Compliance matrix C
-    /// with the Lagrange multipliers lambda
-    /// \f$ res += cFactor * C * lambda \f$
-    /// used by the graph-scattered (unassembled API when the ForceField is handled as a constraint)
-    void addClambda(const MechanicalParams* mparams, MultiVecDerivId resId, MultiVecDerivId lambdaId, SReal cFactor ) override;
-
+    SOFA_ATTRIBUTE_DEPRECATED__COMPLIANT()
     virtual void addClambda(const MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& lambda, SReal cFactor );
 
     /// Get the potential energy associated to this ForceField.

--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.inl
@@ -69,16 +69,6 @@ void ForceField<DataTypes>::addDForce(const MechanicalParams* mparams, MultiVecD
     }
 }
 
-
-template<class DataTypes>
-void ForceField<DataTypes>::addClambda(const MechanicalParams* mparams, MultiVecDerivId resId, MultiVecDerivId lambdaId, SReal cFactor )
-{
-    if (mparams && this->mstate)
-    {
-        addClambda(mparams, *resId[this->mstate.get()].write(), *lambdaId[this->mstate.get()].read(), cFactor);
-    }
-}
-
 template<class DataTypes>
 void ForceField<DataTypes>::addClambda(const MechanicalParams* /*mparams*/, DataVecDeriv& /*df*/, const DataVecDeriv& /*lambda*/, SReal /*cFactor*/ )
 {

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -67,3 +67,10 @@
 #define SOFA_ATTRIBUTE_DEPRECATED__CORE_INTERSECTION_AS_PARAMETER() \
     SOFA_ATTRIBUTE_DEPRECATED("v24.06", "v24.12", "Intersection detection methods now needs the Intersection method as a parameter.")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED__COMPLIANT()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__COMPLIANT() \
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Used only by the deprecated Compliant plugin.")
+#endif

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
@@ -248,7 +248,7 @@ void MechanicalOperations::accFromF(core::MultiVecDerivId a, core::ConstMultiVec
 }
 
 /// Compute the current force (given the latest propagated position and velocity)
-void MechanicalOperations::computeForce(core::MultiVecDerivId result, bool clear, bool accumulate, bool neglectingCompliance)
+void MechanicalOperations::computeForce(core::MultiVecDerivId result, bool clear, bool accumulate)
 {
     setF(result);
     if (clear)
@@ -256,7 +256,7 @@ void MechanicalOperations::computeForce(core::MultiVecDerivId result, bool clear
         executeVisitor( MechanicalResetForceVisitor(&mparams, result, false) );
         //finish();
     }
-    executeVisitor( MechanicalComputeForceVisitor(&mparams, result, accumulate, neglectingCompliance) );
+    executeVisitor( MechanicalComputeForceVisitor(&mparams, result, accumulate) );
 }
 
 
@@ -361,14 +361,14 @@ void MechanicalOperations::computeAcc(SReal t, core::MultiVecDerivId a, core::Mu
     projectResponse(a);
 }
 
-void MechanicalOperations::computeForce(SReal t, core::MultiVecDerivId f, core::MultiVecCoordId x, core::MultiVecDerivId v, bool neglectingCompliance)
+void MechanicalOperations::computeForce(SReal t, core::MultiVecDerivId f, core::MultiVecCoordId x, core::MultiVecDerivId v)
 {
     setF(f);
     setX(x);
     setV(v);
     executeVisitor( MechanicalProjectPositionAndVelocityVisitor(&mparams, t,x,v) );
     executeVisitor( MechanicalPropagateOnlyPositionAndVelocityVisitor(&mparams, t,x,v) );
-    computeForce(f,true,true,neglectingCompliance);
+    computeForce(f,true,true);
 
     projectResponse(f);
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
@@ -75,7 +75,7 @@ public:
     /// Compute Energy
     void computeEnergy(SReal &kineticEnergy, SReal &potentialEnergy);
     /// Compute the current force (given the latest propagated position and velocity)
-    void computeForce(core::MultiVecDerivId result, bool clear = true, bool accumulate = true, bool neglectingCompliance=true);
+    void computeForce(core::MultiVecDerivId result, bool clear = true, bool accumulate = true);
     /// Compute the current force delta (given the latest propagated displacement)
     void computeDf(core::MultiVecDerivId df, bool clear = true, bool accumulate = true);
     /// Compute the current force delta (given the latest propagated velocity)
@@ -92,7 +92,7 @@ public:
 
 
     void computeAcc(SReal t, core::MultiVecDerivId a, core::MultiVecCoordId x, core::MultiVecDerivId v); ///< Compute a(x,v) at time t. Parameters x and v not const due to propagation through mappings.
-    void computeForce(SReal t, core::MultiVecDerivId f, core::MultiVecCoordId x, core::MultiVecDerivId v, bool neglectingCompliance=true);  ///< Compute f(x,v) at time t. Parameters x and v not const due to propagation through mappings.
+    void computeForce(SReal t, core::MultiVecDerivId f, core::MultiVecCoordId x, core::MultiVecDerivId v);  ///< Compute f(x,v) at time t. Parameters x and v not const due to propagation through mappings.
     void computeContactAcc(SReal t, core::MultiVecDerivId a, core::MultiVecCoordId x, core::MultiVecDerivId v); // Parameters x and v not const due to propagation through mappings.
 
     /// @}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalAddMBKdxVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalAddMBKdxVisitor.cpp
@@ -40,10 +40,7 @@ Visitor::Result MechanicalAddMBKdxVisitor::fwdMappedMechanicalState(simulation::
 
 Visitor::Result MechanicalAddMBKdxVisitor::fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff)
 {
-    if( !ff->isCompliance.getValue() )
-        ff->addMBKdx( this->mparams, res);
-    else
-        ff->addMBKdx( &mparamsWithoutStiffness, res);
+    ff->addMBKdx( this->mparams, res);
     return RESULT_CONTINUE;
 }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeDfVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeDfVisitor.cpp
@@ -40,7 +40,7 @@ Visitor::Result MechanicalComputeDfVisitor::fwdMappedMechanicalState(simulation:
 
 Visitor::Result MechanicalComputeDfVisitor::fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff)
 {
-    if( !ff->isCompliance.getValue() ) ff->addDForce(this->mparams, res);
+    ff->addDForce(this->mparams, res);
     return RESULT_CONTINUE;
 }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeForceVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeForceVisitor.cpp
@@ -43,8 +43,7 @@ Visitor::Result MechanicalComputeForceVisitor::fwdMappedMechanicalState(simulati
 
 Visitor::Result MechanicalComputeForceVisitor::fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff)
 {
-    if( !neglectingCompliance || !ff->isCompliance.getValue() ) 
-        ff->addForce(this->mparams, res);
+    ff->addForce(this->mparams, res);
 
     return RESULT_CONTINUE;
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeForceVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeForceVisitor.h
@@ -34,11 +34,10 @@ class SOFA_SIMULATION_CORE_API MechanicalComputeForceVisitor : public Mechanical
 public:
     sofa::core::MultiVecDerivId res;
     bool accumulate; ///< Accumulate everything back to the DOFs through the mappings
-    bool neglectingCompliance; /// neglect Compliance?
 
     MechanicalComputeForceVisitor(const sofa::core::MechanicalParams* mparams,
-                                  sofa::core::MultiVecDerivId res, bool accumulate = true,  bool neglectingCompliance = true )
-            : MechanicalVisitor(mparams) , res(res), accumulate(accumulate), neglectingCompliance(neglectingCompliance)
+                                  sofa::core::MultiVecDerivId res, bool accumulate = true )
+            : MechanicalVisitor(mparams) , res(res), accumulate(accumulate)
     {
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();


### PR DESCRIPTION
API used only by the [Compliant plugin](https://github.com/sofa-framework/Compliant/), which is deprecated and archived



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
