### PR TITLE
[Core] Factorize two variables with the same meaning (constraint id)

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
@@ -39,8 +39,9 @@ public:
 protected:
     BaseConstraintSet()
         : group(initData(&group, 0, "group", "ID of the group containing this constraint. This ID is used to specify which constraints are solved by which solver, by specifying in each solver which groups of constraints it should handle."))
-        , m_constraintIndex(initData(&m_constraintIndex, 0u, "constraintIndex", "Constraint index (first index in the right hand term resolution vector)"))
+        , d_constraintIndex(initData(&d_constraintIndex, 0u, "constraintIndex", "Constraint index (first index in the right hand term resolution vector)"))
     {
+        m_constraintIndex.setParent(&d_constraintIndex);
     }
 
     ~BaseConstraintSet() override { }
@@ -57,7 +58,7 @@ public:
     /// \param cId is Id of the first constraint in the sparse matrix
     virtual void setConstraintId(unsigned cId)
     {
-        m_constraintIndex.setValue(cId);
+        d_constraintIndex.setValue(cId);
     }
 
     /// Process geometrical data.
@@ -78,7 +79,7 @@ public:
     /// \param cParams defines the state vectors to use for positions and velocities. Also defines the order of the constraint (POS, VEL, ACC)
     virtual void getConstraintViolation(const ConstraintParams* cParams, linearalgebra::BaseVector *v)
     {
-        getConstraintViolation(cParams, v, m_constraintIndex.getValue());
+        getConstraintViolation(cParams, v, d_constraintIndex.getValue());
     }
 
     /// Construct the Constraint violations vector
@@ -94,10 +95,16 @@ protected:
 
     Data< int > group; ///< ID of the group containing this constraint. This ID is used to specify which constraints are solved by which solver, by specifying in each solver which groups of constraints it should handle.
 public:
-    Data< unsigned int > m_constraintIndex; ///< Constraint index (first index in the right hand term resolution vector)
+    Data< unsigned int > d_constraintIndex; ///< Constraint index (first index in the right hand term resolution vector)
+
+    SOFA_ATTRIBUTE_DEPRECATED__CORE_RENAME_DATA_IN_CORE()
+    Data< unsigned int > m_constraintIndex;
 
     bool insertInNode( objectmodel::BaseNode* node ) override;
     bool removeInNode( objectmodel::BaseNode* node ) override;
+
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Use d_constraintIndex instead")
+    DeprecatedAndRemoved m_cId;
 
 };
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
@@ -95,7 +95,7 @@ protected:
 
     Data< int > group; ///< ID of the group containing this constraint. This ID is used to specify which constraints are solved by which solver, by specifying in each solver which groups of constraints it should handle.
 public:
-    Data< unsigned int > d_constraintIndex; ///< Constraint index (first index in the right hand term resolution vector)
+    Data< sofa::Index > d_constraintIndex; ///< Constraint index (first index in the right hand term resolution vector)
 
     SOFA_ATTRIBUTE_DEPRECATED__CORE_RENAME_DATA_IN_CORE()
     Data< unsigned int > m_constraintIndex;

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
@@ -55,8 +55,9 @@ public:
     /// Set the id of the constraint (this id is build in the getConstraintViolation function)
     ///
     /// \param cId is Id of the first constraint in the sparse matrix
-    virtual void setConstraintId(unsigned cId) {
-        m_cId = cId;
+    virtual void setConstraintId(unsigned cId)
+    {
+        m_constraintIndex.setValue(cId);
     }
 
     /// Process geometrical data.
@@ -75,8 +76,9 @@ public:
     ///
     /// \param v is the result vector that contains the whole constraints violations
     /// \param cParams defines the state vectors to use for positions and velocities. Also defines the order of the constraint (POS, VEL, ACC)
-    virtual void getConstraintViolation(const ConstraintParams* cParams, linearalgebra::BaseVector *v) {
-        getConstraintViolation(cParams,v,m_cId);
+    virtual void getConstraintViolation(const ConstraintParams* cParams, linearalgebra::BaseVector *v)
+    {
+        getConstraintViolation(cParams, v, m_constraintIndex.getValue());
     }
 
     /// Construct the Constraint violations vector
@@ -96,7 +98,6 @@ public:
 
     bool insertInNode( objectmodel::BaseNode* node ) override;
     bool removeInNode( objectmodel::BaseNode* node ) override;
-    unsigned m_cId;
 
 };
 

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -74,3 +74,12 @@
 #define SOFA_ATTRIBUTE_DEPRECATED__COMPLIANT() \
     SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Used only by the deprecated Compliant plugin.")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED__CORE_RENAME_DATA_IN_CORE()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__CORE_RENAME_DATA_IN_CORE() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v24.12", "v25.06", \
+        "Data renamed according to the guidelines")
+#endif


### PR DESCRIPTION
I suspect that `m_cId` (introduced in https://github.com/sofa-framework/sofa/commit/142aa4ba1f5299301633600ba8031e8159b67d55) and `m_constraintIndex` mean the same thing. I suggest to remove `m_cId` and to keep the Data.

Related to https://github.com/sofa-framework/sofa/pull/4763 and https://github.com/SofaDefrost/SoftRobots/pull/283



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
