### PR TITLE
[Core] Proposition to reduce the number of alias declarations

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -81,16 +81,16 @@ public:
     SOFA_CLASS2(SOFA_TEMPLATE(TetrahedronFEMForceField, DataTypes), SOFA_TEMPLATE(BaseLinearElasticityFEMForceField, DataTypes), SOFA_TEMPLATE(core::behavior::RotationFinder, DataTypes));
 
     typedef typename core::behavior::ForceField<DataTypes> InheritForceField;
-    typedef typename DataTypes::VecCoord VecCoord;
-    typedef typename DataTypes::VecDeriv VecDeriv;
-    typedef typename DataTypes::VecReal VecReal;
-    typedef VecCoord Vector;
-    typedef typename DataTypes::Coord Coord;
-    typedef typename DataTypes::Deriv Deriv;
-    typedef typename Coord::value_type Real;
+    using VecCoord = VecCoord_t<DataTypes>;
+    using VecDeriv = VecDeriv_t<DataTypes>;
+    using VecReal = VecReal_t<DataTypes>;
+    using Coord = Coord_t<DataTypes>;
+    using Deriv = Deriv_t<DataTypes>;
+    using Real = Real_t<DataTypes>;
+    using DataVecDeriv = DataVecDeriv_t<DataTypes>;
+    using DataVecCoord = DataVecCoord_t<DataTypes>;
 
-    typedef core::objectmodel::Data<VecDeriv>    DataVecDeriv;
-    typedef core::objectmodel::Data<VecCoord>    DataVecCoord;
+    using Vector = VecCoord;
 
     typedef core::topology::BaseMeshTopology::Tetra Element;
     typedef core::topology::BaseMeshTopology::SeqTetrahedra VecElement;

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -185,6 +185,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/topology/TopologySubsetData.inl
     ${SRC_ROOT}/topology/TopologySubsetData.cpp
     ${SRC_ROOT}/topology/TopologySubsetIndices.h
+    ${SRC_ROOT}/trait/DataTypes.h
     ${SRC_ROOT}/visual/Data[DisplayFlags].h
     ${SRC_ROOT}/visual/DisplayFlags.h
     ${SRC_ROOT}/visual/FlagTreeItem.h

--- a/Sofa/framework/Core/src/sofa/core/Multi2Mapping.h
+++ b/Sofa/framework/Core/src/sofa/core/Multi2Mapping.h
@@ -45,26 +45,6 @@ public:
     /// Output Model Type
     typedef TOut Out;
 
-    typedef typename In1::VecCoord In1VecCoord;
-    typedef typename In1::VecDeriv In1VecDeriv;
-    typedef typename In1::MatrixDeriv In1MatrixDeriv;
-    typedef Data<In1VecCoord> In1DataVecCoord;
-    typedef Data<In1VecDeriv> In1DataVecDeriv;
-    typedef Data<In1MatrixDeriv> In1DataMatrixDeriv;
-    typedef typename In2::VecCoord In2VecCoord;
-    typedef typename In2::VecDeriv In2VecDeriv;
-    typedef typename In2::MatrixDeriv In2MatrixDeriv;
-    typedef Data<In2VecCoord> In2DataVecCoord;
-    typedef Data<In2VecDeriv> In2DataVecDeriv;
-    typedef Data<In2MatrixDeriv> In2DataMatrixDeriv;
-
-    typedef typename Out::VecCoord OutVecCoord;
-    typedef typename Out::VecDeriv OutVecDeriv;
-    typedef typename Out::MatrixDeriv OutMatrixDeriv;
-    typedef Data<OutVecCoord> OutDataVecCoord;
-    typedef Data<OutVecDeriv> OutDataVecDeriv;
-    typedef Data<OutMatrixDeriv> OutDataMatrixDeriv;
-
     typedef MultiLink<Multi2Mapping<In1,In2,Out>, State< In1 >, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> LinkFromModels1;
     typedef typename LinkFromModels1::Container VecFromModels1;
     typedef MultiLink<Multi2Mapping<In1,In2,Out>, State< In2 >, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> LinkFromModels2;
@@ -123,9 +103,10 @@ public:
     /// The size of InPos vector is the same as the number of fromModels.
     /// The size of OutPos vector is the same as the number of OutModels.
     virtual void apply(
-        const MechanicalParams* mparams, const type::vector<OutDataVecCoord*>& dataVecOutPos,
-        const type::vector<const In1DataVecCoord*>& dataVecIn1Pos ,
-        const type::vector<const In2DataVecCoord*>& dataVecIn2Pos) = 0;
+        const MechanicalParams* mparams,
+        const type::vector<DataVecCoord_t<Out>*>& dataVecOutPos,
+        const type::vector<const DataVecCoord_t<In1>*>& dataVecIn1Pos ,
+        const type::vector<const DataVecCoord_t<In2>*>& dataVecIn2Pos) = 0;
 
     /// ApplyJ ///
     /// This method computes
@@ -138,19 +119,20 @@ public:
     /// The size of InDeriv vector is the same as the number of fromModels.
     /// The size of OutDeriv vector is the same as the number of OutModels.
     virtual void applyJ(
-        const MechanicalParams*, const type::vector< OutDataVecDeriv*>& dataVecOutVel,
-        const type::vector<const In1DataVecDeriv*>& dataVecIn1Vel,
-        const type::vector<const In2DataVecDeriv*>& dataVecIn2Vel)
+        const MechanicalParams*,
+        const type::vector< DataVecDeriv_t<Out>*>& dataVecOutVel,
+        const type::vector<const DataVecDeriv_t<In1>*>& dataVecIn1Vel,
+        const type::vector<const DataVecDeriv_t<In2>*>& dataVecIn2Vel)
     {
         //Not optimized at all...
-        type::vector<OutVecDeriv*> vecOutVel;
+        type::vector<VecDeriv_t<Out>*> vecOutVel;
         for(unsigned int i=0; i<dataVecOutVel.size(); i++)
             vecOutVel.push_back(dataVecOutVel[i]->beginEdit());
 
-        type::vector<const In1VecDeriv*> vecIn1Vel;
+        type::vector<const VecDeriv_t<In1>*> vecIn1Vel;
         for(unsigned int i=0; i<dataVecIn1Vel.size(); i++)
             vecIn1Vel.push_back(&dataVecIn1Vel[i]->getValue());
-        type::vector<const In2VecDeriv*> vecIn2Vel;
+        type::vector<const VecDeriv_t<In2>*> vecIn2Vel;
         for(unsigned int i=0; i<dataVecIn2Vel.size(); i++)
             vecIn2Vel.push_back(&dataVecIn2Vel[i]->getValue());
         this->applyJ(vecOutVel, vecIn1Vel, vecIn2Vel);
@@ -161,9 +143,9 @@ public:
     }
     /// Compat Method
     /// @deprecated
-    virtual void applyJ(const type::vector< OutVecDeriv*>& /* outDeriv */,
-            const type::vector<const In1VecDeriv*>& /* inDeriv1 */,
-            const type::vector<const In2VecDeriv*>& /* inDeriv2 */) {}
+    virtual void applyJ(const type::vector< VecDeriv_t<Out>*>& /* outDeriv */,
+            const type::vector<const VecDeriv_t<In1>*>& /* inDeriv1 */,
+            const type::vector<const VecDeriv_t<In2>*>& /* inDeriv2 */) {}
 
     /// ApplyJT (Force)///
     /// Apply the mapping to Force vectors.
@@ -174,20 +156,21 @@ public:
     /// The size of InDeriv vector is the same as the number of fromModels.
     /// The size of OutDeriv vector is the same as the number of OutModels.
     virtual void applyJT(
-        const MechanicalParams* mparams, const type::vector< In1DataVecDeriv*>& dataVecOut1Force,
-        const type::vector< In2DataVecDeriv*>& dataVecOut2Force,
-        const type::vector<const OutDataVecDeriv*>& dataVecInForce) = 0;
+        const MechanicalParams* mparams,
+        const type::vector< DataVecDeriv_t<In1>*>& dataVecOut1Force,
+        const type::vector< DataVecDeriv_t<In2>*>& dataVecOut2Force,
+        const type::vector<const DataVecDeriv_t<Out>*>& dataVecInForce) = 0;
 
     /// ApplyJT (Constraint)///
     void applyJT(const ConstraintParams* cparams, MultiMatrixDerivId inConst, ConstMultiMatrixDerivId outConst ) override;
 
     /// This method must be reimplemented by all mappings if they need to support constraints.
     virtual void applyJT(
-        const ConstraintParams* /* cparams */, const type::vector< In1DataMatrixDeriv*>& /* dataMatOut1Const */ ,
-        const type::vector< In2DataMatrixDeriv*>&  /* dataMatOut2Const */,
-        const type::vector<const OutDataMatrixDeriv*>& /* dataMatInConst */)
+        const ConstraintParams* /* cparams */, const type::vector< DataMatrixDeriv_t<In1>*>& /* dataMatOut1Const */ ,
+        const type::vector< DataMatrixDeriv_t<In2>*>&  /* dataMatOut2Const */,
+        const type::vector<const DataMatrixDeriv_t<Out>*>& /* dataMatInConst */)
     {
-        msg_error() << "This mapping does not support constraint because Multi2Mapping::applyJT(const ConstraintParams*, const type::vector< In1DataMatrixDeriv*>&, const type::vector< In2DataMatrixDeriv*>&, const type::vector<const OutDataMatrixDeriv*>&) is not overloaded.";
+        msg_error() << "This mapping does not support constraint because Multi2Mapping::applyJT(const ConstraintParams*, const type::vector< DataMatrixDeriv_t<In1>*>&, const type::vector< DataMatrixDeriv_t<In2>*>&, const type::vector<const DataMatrixDeriv_t<Out>*>&) is not overloaded.";
     }
 
     /// computeAccFromMapping
@@ -195,11 +178,11 @@ public:
 
     /// This method must be reimplemented by all mappings if they need to support composite accelerations
     virtual void computeAccFromMapping(
-        const MechanicalParams* /* mparams */, const type::vector< OutDataVecDeriv*>& /* dataVecOutAcc */,
-        const type::vector<const In1DataVecDeriv*>& /* dataVecIn1Vel */,
-        const type::vector<const In2DataVecDeriv*>& /* dataVecIn2Vel */,
-        const type::vector<const In1DataVecDeriv*>& /* dataVecIn1Acc */,
-        const type::vector<const In2DataVecDeriv*>& /* dataVecIn2Acc */)
+        const MechanicalParams* /* mparams */, const type::vector< DataVecDeriv_t<Out>*>& /* dataVecOutAcc */,
+        const type::vector<const DataVecDeriv_t<In1>*>& /* dataVecIn1Vel */,
+        const type::vector<const DataVecDeriv_t<In2>*>& /* dataVecIn2Vel */,
+        const type::vector<const DataVecDeriv_t<In1>*>& /* dataVecIn1Acc */,
+        const type::vector<const DataVecDeriv_t<In2>*>& /* dataVecIn2Acc */)
     {
     }
 
@@ -265,43 +248,43 @@ public:
     }
 
 protected:
-    void getVecIn1Coord     (const MultiVecCoordId id,         type::vector<      In1DataVecCoord*> &v) const
+    void getVecIn1Coord     (const MultiVecCoordId id,         type::vector<      DataVecCoord_t<In1>*> &v) const
     {   for (unsigned int i=0; i<fromModels1.size(); ++i) v.push_back(id[fromModels1[i]].write()); }
-    void getConstVecIn1Coord(const ConstMultiVecCoordId id,    type::vector<const In1DataVecCoord*> &v) const
+    void getConstVecIn1Coord(const ConstMultiVecCoordId id,    type::vector<const DataVecCoord_t<In1>*> &v) const
     {   for (unsigned int i=0; i<fromModels1.size(); ++i) v.push_back(id[fromModels1[i]].read());  }
-    void getVecIn1Deriv     (const MultiVecDerivId id,         type::vector<      In1DataVecDeriv*> &v) const
+    void getVecIn1Deriv     (const MultiVecDerivId id,         type::vector<      DataVecDeriv_t<In1>*> &v) const
     {   for (unsigned int i=0; i<fromModels1.size(); ++i) v.push_back(id[fromModels1[i]].write()); }
-    void getConstVecIn1Deriv(const ConstMultiVecDerivId id,    type::vector<const In1DataVecDeriv*> &v) const
+    void getConstVecIn1Deriv(const ConstMultiVecDerivId id,    type::vector<const DataVecDeriv_t<In1>*> &v) const
     {   for (unsigned int i=0; i<fromModels1.size(); ++i) v.push_back(id[fromModels1[i]].read());  }
-    void getMatIn1Deriv     (const MultiMatrixDerivId id,      type::vector<      In1DataMatrixDeriv*> &v) const
+    void getMatIn1Deriv     (const MultiMatrixDerivId id,      type::vector<      DataMatrixDeriv_t<In1>*> &v) const
     {   for (unsigned int i=0; i<fromModels1.size(); ++i) v.push_back(id[fromModels1[i]].write()); }
-    void getConstMatIn1Deriv(const ConstMultiMatrixDerivId id, type::vector<const In1DataMatrixDeriv*> &v) const
+    void getConstMatIn1Deriv(const ConstMultiMatrixDerivId id, type::vector<const DataMatrixDeriv_t<In1>*> &v) const
     {   for (unsigned int i=0; i<fromModels1.size(); ++i) v.push_back(id[fromModels1[i]].read());  }
 
-    void getVecIn2Coord     (const MultiVecCoordId id,         type::vector<      In2DataVecCoord*> &v) const
+    void getVecIn2Coord     (const MultiVecCoordId id,         type::vector<      DataVecCoord_t<In2>*> &v) const
     {   for (unsigned int i=0; i<fromModels2.size(); ++i) v.push_back(id[fromModels2[i]].write()); }
-    void getConstVecIn2Coord(const ConstMultiVecCoordId id,    type::vector<const In2DataVecCoord*> &v) const
+    void getConstVecIn2Coord(const ConstMultiVecCoordId id,    type::vector<const DataVecCoord_t<In2>*> &v) const
     {   for (unsigned int i=0; i<fromModels2.size(); ++i) v.push_back(id[fromModels2[i]].read());  }
-    void getVecIn2Deriv     (const MultiVecDerivId id,         type::vector<      In2DataVecDeriv*> &v) const
+    void getVecIn2Deriv     (const MultiVecDerivId id,         type::vector<      DataVecDeriv_t<In2>*> &v) const
     {   for (unsigned int i=0; i<fromModels2.size(); ++i) v.push_back(id[fromModels2[i]].write()); }
-    void getConstVecIn2Deriv(const ConstMultiVecDerivId id,    type::vector<const In2DataVecDeriv*> &v) const
+    void getConstVecIn2Deriv(const ConstMultiVecDerivId id,    type::vector<const DataVecDeriv_t<In2>*> &v) const
     {   for (unsigned int i=0; i<fromModels2.size(); ++i) v.push_back(id[fromModels2[i]].read());  }
-    void getMatIn2Deriv     (const MultiMatrixDerivId id,      type::vector<      In2DataMatrixDeriv*> &v) const
+    void getMatIn2Deriv     (const MultiMatrixDerivId id,      type::vector<      DataMatrixDeriv_t<In2>*> &v) const
     {   for (unsigned int i=0; i<fromModels2.size(); ++i) v.push_back(id[fromModels2[i]].write()); }
-    void getConstMatIn2Deriv(const ConstMultiMatrixDerivId id, type::vector<const In2DataMatrixDeriv*> &v) const
+    void getConstMatIn2Deriv(const ConstMultiMatrixDerivId id, type::vector<const DataMatrixDeriv_t<In2>*> &v) const
     {   for (unsigned int i=0; i<fromModels2.size(); ++i) v.push_back(id[fromModels2[i]].read());  }
 
-    void getVecOutCoord     (const MultiVecCoordId id,         type::vector<      OutDataVecCoord*> &v) const
+    void getVecOutCoord     (const MultiVecCoordId id,         type::vector<      DataVecCoord_t<Out>*> &v) const
     {   for (unsigned int i=0; i<toModels.size(); ++i)  v.push_back(id[toModels[i]].write());      }
-    void getConstVecOutCoord(const ConstMultiVecCoordId id,    type::vector<const OutDataVecCoord*> &v) const
+    void getConstVecOutCoord(const ConstMultiVecCoordId id,    type::vector<const DataVecCoord_t<Out>*> &v) const
     {   for (unsigned int i=0; i<toModels.size(); ++i)  v.push_back(id[toModels[i]].read());       }
-    void getVecOutDeriv     (const MultiVecDerivId id,         type::vector<      OutDataVecDeriv*> &v) const
+    void getVecOutDeriv     (const MultiVecDerivId id,         type::vector<      DataVecDeriv_t<Out>*> &v) const
     {   for (unsigned int i=0; i<toModels.size(); ++i)  v.push_back(id[toModels[i]].write());      }
-    void getConstVecOutDeriv(const ConstMultiVecDerivId id,    type::vector<const OutDataVecDeriv*> &v) const
+    void getConstVecOutDeriv(const ConstMultiVecDerivId id,    type::vector<const DataVecDeriv_t<Out>*> &v) const
     {   for (unsigned int i=0; i<toModels.size(); ++i)  v.push_back(id[toModels[i]].read());       }
-    void getMatOutDeriv     (const MultiMatrixDerivId id,      type::vector<      OutDataMatrixDeriv*> &v) const
+    void getMatOutDeriv     (const MultiMatrixDerivId id,      type::vector<      DataMatrixDeriv_t<Out>*> &v) const
     {   for (unsigned int i=0; i<toModels.size(); ++i)  v.push_back(id[toModels[i]].write());      }
-    void getConstMatOutDeriv(const ConstMultiMatrixDerivId id, type::vector<const OutDataMatrixDeriv*> &v) const
+    void getConstMatOutDeriv(const ConstMultiMatrixDerivId id, type::vector<const DataMatrixDeriv_t<Out>*> &v) const
     {   for (unsigned int i=0; i<toModels.size(); ++i)  v.push_back(id[toModels[i]].read());       }
 
 };

--- a/Sofa/framework/Core/src/sofa/core/Multi2Mapping.inl
+++ b/Sofa/framework/Core/src/sofa/core/Multi2Mapping.inl
@@ -141,11 +141,11 @@ type::vector<behavior::BaseMechanicalState*> Multi2Mapping<In1,In2,Out>::getMech
 template < class In1, class In2,class Out>
 void Multi2Mapping<In1,In2,Out>::apply (const MechanicalParams* mparams, MultiVecCoordId outPos, ConstMultiVecCoordId inPos )
 {
-    type::vector<OutDataVecCoord*> vecOutPos;
+    type::vector<DataVecCoord_t<Out>*> vecOutPos;
     getVecOutCoord(outPos, vecOutPos);
-    type::vector<const In1DataVecCoord*> vecIn1Pos;
+    type::vector<const DataVecCoord_t<In1>*> vecIn1Pos;
     getConstVecIn1Coord(inPos, vecIn1Pos);
-    type::vector<const In2DataVecCoord*> vecIn2Pos;
+    type::vector<const DataVecCoord_t<In2>*> vecIn2Pos;
     getConstVecIn2Coord(inPos, vecIn2Pos);
 
     this->apply(mparams, vecOutPos, vecIn1Pos, vecIn2Pos);
@@ -154,11 +154,11 @@ void Multi2Mapping<In1,In2,Out>::apply (const MechanicalParams* mparams, MultiVe
 template < class In1, class In2,class Out>
 void Multi2Mapping<In1,In2,Out>::applyJ (const MechanicalParams* mparams, MultiVecDerivId outVel, ConstMultiVecDerivId inVel )
 {
-    type::vector<OutDataVecDeriv*> vecOutVel;
+    type::vector<DataVecDeriv_t<Out>*> vecOutVel;
     getVecOutDeriv(outVel, vecOutVel);
-    type::vector<const In1DataVecDeriv*> vecIn1Vel;
+    type::vector<const DataVecDeriv_t<In1>*> vecIn1Vel;
     getConstVecIn1Deriv(inVel, vecIn1Vel);
-    type::vector<const In2DataVecDeriv*> vecIn2Vel;
+    type::vector<const DataVecDeriv_t<In2>*> vecIn2Vel;
     getConstVecIn2Deriv(inVel, vecIn2Vel);
     this->applyJ(mparams, vecOutVel, vecIn1Vel, vecIn2Vel);
 }
@@ -166,12 +166,12 @@ void Multi2Mapping<In1,In2,Out>::applyJ (const MechanicalParams* mparams, MultiV
 template < class In1, class In2,class Out>
 void Multi2Mapping<In1,In2,Out>::applyJT (const MechanicalParams* mparams, MultiVecDerivId inForce, ConstMultiVecDerivId outForce )
 {
-    type::vector<In1DataVecDeriv*> vecOut1Force;
+    type::vector<DataVecDeriv_t<In1>*> vecOut1Force;
     getVecIn1Deriv(inForce, vecOut1Force);
-    type::vector<In2DataVecDeriv*> vecOut2Force;
+    type::vector<DataVecDeriv_t<In2>*> vecOut2Force;
     getVecIn2Deriv(inForce, vecOut2Force);
 
-    type::vector<const OutDataVecDeriv*> vecInForce;
+    type::vector<const DataVecDeriv_t<Out>*> vecInForce;
     getConstVecOutDeriv(outForce, vecInForce);
     this->applyJT(mparams, vecOut1Force, vecOut2Force, vecInForce);
 }
@@ -179,12 +179,12 @@ void Multi2Mapping<In1,In2,Out>::applyJT (const MechanicalParams* mparams, Multi
 template < class In1, class In2,class Out>
 void Multi2Mapping<In1,In2,Out>::applyJT(const ConstraintParams* cparams, MultiMatrixDerivId inConst, ConstMultiMatrixDerivId outConst )
 {
-    type::vector<In1DataMatrixDeriv*> matOut1Const;
+    type::vector<DataMatrixDeriv_t<In1>*> matOut1Const;
     getMatIn1Deriv(inConst, matOut1Const);
-    type::vector<In2DataMatrixDeriv*> matOut2Const;
+    type::vector<DataMatrixDeriv_t<In2>*> matOut2Const;
     getMatIn2Deriv(inConst, matOut2Const);
 
-    type::vector<const OutDataMatrixDeriv*> matInConst;
+    type::vector<const DataMatrixDeriv_t<Out>*> matInConst;
     getConstMatOutDeriv(outConst, matInConst);
     this->applyJT(cparams, matOut1Const, matOut2Const, matInConst);
 }
@@ -192,17 +192,17 @@ void Multi2Mapping<In1,In2,Out>::applyJT(const ConstraintParams* cparams, MultiM
 template < class In1, class In2,class Out>
 void Multi2Mapping<In1,In2,Out>::computeAccFromMapping(const MechanicalParams* mparams, MultiVecDerivId outAcc, ConstMultiVecDerivId inVel, ConstMultiVecDerivId inAcc )
 {
-    type::vector<OutDataVecDeriv*> vecOutAcc;
+    type::vector<DataVecDeriv_t<Out>*> vecOutAcc;
     getVecOutDeriv(outAcc, vecOutAcc);
 
-    type::vector<const In1DataVecDeriv*> vecIn1Vel;
+    type::vector<const DataVecDeriv_t<In1>*> vecIn1Vel;
     getConstVecIn1Deriv(inVel, vecIn1Vel);
-    type::vector<const In1DataVecDeriv*> vecIn1Acc;
+    type::vector<const DataVecDeriv_t<In1>*> vecIn1Acc;
     getConstVecIn1Deriv(inAcc, vecIn1Acc);
 
-    type::vector<const In2DataVecDeriv*> vecIn2Vel;
+    type::vector<const DataVecDeriv_t<In2>*> vecIn2Vel;
     getConstVecIn2Deriv(inVel, vecIn2Vel);
-    type::vector<const In2DataVecDeriv*> vecIn2Acc;
+    type::vector<const DataVecDeriv_t<In2>*> vecIn2Acc;
     getConstVecIn2Deriv(inAcc, vecIn2Acc);
 
     this->computeAccFromMapping(mparams, vecOutAcc, vecIn1Vel, vecIn2Vel,vecIn1Acc, vecIn2Acc);

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Data.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Data.h
@@ -27,6 +27,7 @@
 #include <sofa/helper/accessor.h>
 #include <istream>
 #include <sofa/core/objectmodel/DataContentValue.h>
+#include <sofa/core/trait/DataTypes.h>
 namespace sofa
 {
 namespace core::objectmodel

--- a/Sofa/framework/Core/src/sofa/core/trait/DataTypes.h
+++ b/Sofa/framework/Core/src/sofa/core/trait/DataTypes.h
@@ -1,0 +1,63 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+namespace sofa
+{
+
+template <typename DataTypes>
+using Coord_t = typename DataTypes::Coord;
+
+template <typename DataTypes>
+using Real_t = typename DataTypes::Real;
+
+template <typename DataTypes>
+using VecReal_t = typename DataTypes::VecReal;
+
+template <typename DataTypes>
+using Deriv_t = typename DataTypes::Deriv;
+
+template <typename DataTypes>
+using MatrixDeriv_t = typename DataTypes::MatrixDeriv;
+
+template <typename DataTypes>
+using VecCoord_t = typename DataTypes::VecCoord;
+
+template <typename DataTypes>
+using VecDeriv_t = typename DataTypes::VecDeriv;
+
+namespace core::objectmodel
+{
+template<typename DataTypes>
+class Data;
+}
+
+template <typename DataTypes>
+using DataVecCoord_t = core::objectmodel::Data<VecCoord_t<DataTypes>>;
+
+template <typename DataTypes>
+using DataVecDeriv_t = core::objectmodel::Data<VecDeriv_t<DataTypes>>;
+
+template <typename DataTypes>
+using DataMatrixDeriv_t = core::objectmodel::Data<MatrixDeriv_t<DataTypes>>;
+
+}


### PR DESCRIPTION
The goal is to reduce the number of alias declarations. I propose 2 methods:

1. using traits (for example `DataVecCoord_t<Out>`). This is illustrated in `Multi2Mapping`.
2. ~~using a set of macros. The aliases are still declared, but it is hidden inside the macro.~~

I find the trait approach elegant (nothing is hidden and no use of macro or additional code), but too much verbose when only one template parameter is available (e.g. `TetrahedronFEMForceField`).

The advantage of the macro is that it does not require changes in the code other than the alias declarations.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
