### PR TITLE
[All] Plugins: Deprecate entrypoint getModuleComponentList()

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/init.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::animationloop

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/init.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -54,13 +53,6 @@ void init()
     {
      first = false;
     }
-}
-
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
 }
 
 } // namespace sofa::component::collision::detection::algorithm

--- a/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/init.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/src/sofa/component/collision/detection/intersection/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::collision::detection::intersection

--- a/Sofa/Component/Collision/Detection/src/sofa/component/collision/detection/init.cpp
+++ b/Sofa/Component/Collision/Detection/src/sofa/component/collision/detection/init.cpp
@@ -31,7 +31,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -62,10 +61,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::collision::detection

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/init.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/init.cpp
@@ -55,10 +55,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::collision::geometry

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/init.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::collision::response::contact

--- a/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/init.cpp
+++ b/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::collision::response::mapper

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::constraint::lagrangian::correction

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::constraint::lagrangian::model

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/init.cpp
@@ -29,7 +29,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -54,13 +53,6 @@ void init()
     {
         first = false;
     }
-}
-
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
 }
 
 } // namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/init.cpp
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Controller/src/sofa/component/controller/init.cpp
+++ b/Sofa/Component/Controller/src/sofa/component/controller/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::controller

--- a/Sofa/Component/Diffusion/src/sofa/component/diffusion/init.cpp
+++ b/Sofa/Component/Diffusion/src/sofa/component/diffusion/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::diffusion

--- a/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/init.cpp
+++ b/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::engine::analyze

--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/init.cpp
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::engine::generate

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/init.cpp
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::engine::select

--- a/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/init.cpp
+++ b/Sofa/Component/Engine/Transform/src/sofa/component/engine/transform/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::engine::transform

--- a/Sofa/Component/Haptics/src/sofa/component/haptics/init.cpp
+++ b/Sofa/Component/Haptics/src/sofa/component/haptics/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::haptics

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/init.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::io::mesh

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/init.cpp
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/init.cpp
@@ -29,7 +29,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -76,10 +75,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::linearsolver::direct

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/init.cpp
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::linearsolver::iterative

--- a/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/init.cpp
+++ b/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::linearsolver::ordering

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/init.cpp
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::linearsolver::preconditioner

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/init.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/init.cpp
@@ -42,7 +42,6 @@ extern "C" {
     SOFA_COMPONENT_LINEARSYSTEM_API const char* getModuleVersion();
     SOFA_COMPONENT_LINEARSYSTEM_API const char* getModuleLicense();
     SOFA_COMPONENT_LINEARSYSTEM_API const char* getModuleDescription();
-    SOFA_COMPONENT_LINEARSYSTEM_API const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -68,13 +67,6 @@ const char* getModuleLicense()
 const char* getModuleDescription()
 {
     return "This plugin defines a linear system and provides components able to assemble one from the scene.";
-}
-
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
 }
 
 } // namespace sofa::component::linearsystem

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/init.cpp
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::mapping::linear

--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/init.cpp
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::mapping::mappedmatrix

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/init.cpp
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::mapping::nonlinear

--- a/Sofa/Component/Mass/src/sofa/component/mass/init.cpp
+++ b/Sofa/Component/Mass/src/sofa/component/mass/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::mass

--- a/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/init.cpp
+++ b/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::mechanicalload

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/init.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::odesolver::backward

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/init.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::odesolver::forward

--- a/Sofa/Component/Playback/src/sofa/component/playback/init.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::playback

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/init.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::sceneutility

--- a/Sofa/Component/Setting/src/sofa/component/setting/init.cpp
+++ b/Sofa/Component/Setting/src/sofa/component/setting/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::setting

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/init.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/init.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::solidmechanics::fem::hyperelastic

--- a/Sofa/Component/SolidMechanics/FEM/NonUniform/src/sofa/component/solidmechanics/fem/nonuniform/init.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/NonUniform/src/sofa/component/solidmechanics/fem/nonuniform/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     initExternalModule();
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::solidmechanics::fem::nonuniform

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/init.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::solidmechanics::spring

--- a/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/init.cpp
+++ b/Sofa/Component/SolidMechanics/TensorMass/src/sofa/component/solidmechanics/tensormass/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::solidmechanics::tensormass

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/init.cpp
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::statecontainer

--- a/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/init.cpp
+++ b/Sofa/Component/Topology/Container/Constant/src/sofa/component/topology/container/constant/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::topology::container::constant

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/init.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::topology::container::dynamic

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/init.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::topology::container::grid

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/init.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::topology::mapping

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/init.cpp
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::topology::utility

--- a/Sofa/Component/Visual/src/sofa/component/visual/init.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     }
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::component::visual

--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/init.cpp
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     initExternalModule();
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::gl::component::rendering2d

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/init.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     initExternalModule();
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::gl::component::rendering3d

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/init.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/init.cpp
@@ -28,7 +28,6 @@ extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
     SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
-    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
 }
 
 void initExternalModule()
@@ -55,10 +54,4 @@ void init()
     initExternalModule();
 }
 
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
-    return classes.c_str();
-}
 } // namespace sofa::gl::component::shader

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SofaPluginManager.cpp
@@ -27,6 +27,7 @@
 #include <sofa/helper/system/PluginManager.h>
 #include <sofa/helper/system/DynamicLibrary.h>
 #include <sofa/helper/logging/Messaging.h>
+#include <sofa/core/ObjectFactory.h>
 
 #include <QMessageBox>
 #include <QTextEdit>
@@ -249,7 +250,21 @@ void SofaPluginManager::updateComponentList()
         return;
     }
 
-    QString cpts( plugin->getModuleComponentList() );
+    std::string componentListStr{};
+    const char* tempComponentList = plugin->getModuleComponentList();
+
+    // the plugin does not implement getModuleComponentList(), or returns nothing.
+    if (tempComponentList == nullptr)
+    {
+        const char* pluginNameStr = plugin->getModuleName();
+        componentListStr = sofa::core::ObjectFactory::getInstance()->listClassesFromTarget(pluginNameStr);
+    }
+    else
+    {
+        componentListStr = tempComponentList;
+    }
+
+    QString cpts(componentListStr.data());
     cpts.replace(", ","\n");
     cpts.replace(",","\n");
     std::istringstream in(cpts.toStdString());

--- a/Sofa/framework/Helper/src/sofa/helper/config.h.in
+++ b/Sofa/framework/Helper/src/sofa/helper/config.h.in
@@ -79,3 +79,7 @@ SOFA_ATTRIBUTE_DISABLED( \
 SOFA_ATTRIBUTE_DISABLED( \
 "v23.12", "v24.06", "This function is replaced by solveLCP.")
 #endif // SOFA_BUILD_SOFA_HELPER
+
+#define SOFA_ATTRIBUTE_DEPRECATED__PLUGIN_GETCOMPONENTLIST() \
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06",  \
+    "Using entrypoint GetComponentList() from a plugin has been deprecated. Use the helper function listClassesFromTarget() from ObjectFactory instead.")

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -212,7 +212,6 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
 
         [[maybe_unused]] const auto moduleDescriptionResult = getPluginEntry(p.getModuleDescription,d);
         [[maybe_unused]] const auto moduleLicenseResult = getPluginEntry(p.getModuleLicense,d);
-        [[maybe_unused]] const auto moduleComponentListResult = getPluginEntry(p.getModuleComponentList,d);
         [[maybe_unused]] const auto moduleVersionResult = getPluginEntry(p.getModuleVersion,d);
     }
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -212,6 +212,7 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
 
         [[maybe_unused]] const auto moduleDescriptionResult = getPluginEntry(p.getModuleDescription,d);
         [[maybe_unused]] const auto moduleLicenseResult = getPluginEntry(p.getModuleLicense,d);
+        [[maybe_unused]] const auto moduleComponentListResult = getPluginEntry(p.getModuleComponentList,d);
         [[maybe_unused]] const auto moduleVersionResult = getPluginEntry(p.getModuleVersion,d);
     }
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.h
@@ -24,6 +24,7 @@
 
 #include <sofa/helper/config.h>
 #include <sofa/helper/system/DynamicLibrary.h>
+#include <sofa/helper/logging/Messaging.h>
 #include <vector>
 #include <map>
 #include <memory>
@@ -96,9 +97,15 @@ public:
         static  const char* symbol;
         typedef const char* (*FuncPtr) ();
         FuncPtr func;
+
+        SOFA_ATTRIBUTE_DEPRECATED__PLUGIN_GETCOMPONENTLIST()
         const char* operator() () const
         {
-            if (func) return func();
+            if (func)
+            {
+                msg_warning("Plugin::GetModuleComponentList") << "This entrypoint is being deprecated, and should not be implemented anymore.";
+                return func();
+            }
             else return nullptr;
         }
         GetModuleComponentList():func(nullptr) {}

--- a/applications/plugins/MultiThreading/src/MultiThreading/initMultiThreading.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/initMultiThreading.cpp
@@ -34,7 +34,6 @@ SOFA_MULTITHREADING_PLUGIN_API const char* getModuleName();
 SOFA_MULTITHREADING_PLUGIN_API const char* getModuleVersion();
 SOFA_MULTITHREADING_PLUGIN_API const char* getModuleLicense();
 SOFA_MULTITHREADING_PLUGIN_API const char* getModuleDescription();
-SOFA_MULTITHREADING_PLUGIN_API const char* getModuleComponentList();
 }
 
 void init()
@@ -70,11 +69,6 @@ const char* getModuleLicense()
 const char* getModuleDescription()
 {
     return "MultiThreading SOFA Framework";
-}
-
-const char* getModuleComponentList()
-{
-    return "DataExchange, AnimationLoopParallelScheduler ";
 }
 
 }


### PR DESCRIPTION
99% of the modules/plugins implements getModuleComponentList() with
```
const char* getModuleComponentList()
{
    /// string containing the names of the classes provided by the plugin
    static std::string classes = core::ObjectFactory::getInstance()->listClassesFromTarget(MODULE_NAME);
    return classes.c_str();
}
```
And the rest either omitted to implement it, or just forgot to update the list. (e.g MultiThreading)

IMO getModuleComponentList() does not have really a meaning anymore and one should just use `ObjectFactory::listClassesFromTarget()` directly.
AFAIK, the only piece of code in the SOFA codebase using this entrypoint is Gui.Qt widget, displaying the component list for each loaded plugin.

This PR:
 - removes all the entrypoints from Sofa.Component.* (+MultiThreading)
 - deprecates getModuleComponentList() calls
 - Sofa.Gui.Qt: calls directly listClassesFromTarget(), but still tests if getModuleComponentList() needs to be called
 - warns at runtime if one plugin do implement getModuleComponentList()
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
