### PR TITLE
[GUI.Component] ConstraintAttachBodyPerformer: Add RigidType support

### DIFF
--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.cpp
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.cpp
@@ -34,4 +34,7 @@ namespace sofa::gui::component::performer
 template class SOFA_GUI_COMPONENT_API ConstraintAttachBodyPerformer<defaulttype::Vec3Types>;
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, ConstraintAttachBodyPerformer<defaulttype::Vec3Types> >  ConstraintAttachBodyPerformerVec3dClass("ConstraintAttachBody",true);
 
+template class SOFA_GUI_COMPONENT_API ConstraintAttachBodyPerformer<defaulttype::RigidTypes>;
+helper::Creator<InteractionPerformer::InteractionPerformerFactory, ConstraintAttachBodyPerformer<defaulttype::RigidTypes> >  ConstraintAttachBodyPerformerRigidClass("ConstraintAttachBody",true);
+
 } // namespace sofa::gui::component::performer

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.h
@@ -53,6 +53,7 @@ protected:
 
 #if !defined(SOFA_COMPONENT_COLLISION_CONSTRAINTATTACHBODYPERFORMER_CPP)
 extern template class SOFA_GUI_COMPONENT_API ConstraintAttachBodyPerformer<defaulttype::Vec3Types>;
+extern template class SOFA_GUI_COMPONENT_API ConstraintAttachBodyPerformer<defaulttype::RigidTypes>;
 #endif
 
 } // namespace sofa::gui::component::performer

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
@@ -25,6 +25,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/BaseMapping.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/type/isRigidType.h>
 
 namespace sofa::gui::component::performer
 {
@@ -95,6 +96,20 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
 
     this->m_interactionObject = sofa::core::objectmodel::New<BilateralLagrangianConstraint<DataTypes> >(m_mstate1, m_mstate2);
     auto* bconstraint = dynamic_cast< BilateralLagrangianConstraint< DataTypes >* >(this->m_interactionObject.get());
+
+    if constexpr (sofa::type::isRigidType<DataTypes>())
+    {
+        // BilateralLagrangianConstraint::d_keepOrientDiff is protected
+        auto* keepOrientDiffBaseData = bconstraint->findData("keepOrientationDifference");
+        assert(keepOrientDiffBaseData);
+        auto* keepOrientDiffData = dynamic_cast<Data<bool>*>(keepOrientDiffBaseData);
+        assert(keepOrientDiffData);
+
+        // setting "keepOrientDiffData" to True
+        // would avoid having the beam forced to be oriented with the world frame.
+        // But it crashes in v24.12 so for now, we set to false.
+        keepOrientDiffData->setValue(false);
+    }
 
     bconstraint->setName("Constraint-Mouse-Contact");
 

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
@@ -107,8 +107,10 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
 
         // setting "keepOrientDiffData" to True
         // would avoid having the beam forced to be oriented with the world frame.
-        // But it crashes in v24.12 so for now, we set to false.
+        // But it is unstable in v24.12 so for now, we set to false.
         keepOrientDiffData->setValue(false);
+        
+        bconstraint->init();
     }
 
     bconstraint->setName("Constraint-Mouse-Contact");
@@ -118,7 +120,9 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
     static const typename DataTypes::Deriv normal {};
 
     bconstraint->addContact(normal, point1, point2, 0.0, 0, index, point2, point1);
-
+    
+    bconstraint->bwdInit();
+    
     const core::objectmodel::TagSet &tags=mstateCollision->getTags();
     for (auto tag : tags)
         bconstraint->addTag(tag);

--- a/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
+++ b/Sofa/GUI/Component/src/sofa/gui/component/performer/ConstraintAttachBodyPerformer.inl
@@ -52,12 +52,13 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
         const std::string name = "contactMouse";
         mstateCollision = this->m_mapper->createMapping(name.c_str());
         this->m_mapper->resize(1);
-
-        const typename DataTypes::Coord pointPicked=picked.point;
+        
         const int idx=picked.indexCollisionElement;
+        typename DataTypes::CPos pointPicked = picked.point;
         typename DataTypes::Real r=0.0;
-
-        index = this->m_mapper->addPointB(pointPicked, idx, r);
+        typename DataTypes::Coord dofPicked;
+        DataTypes::setCPos(dofPicked, pointPicked);
+        index = this->m_mapper->addPointB(dofPicked, idx, r);
         this->m_mapper->update();
 
         if (mstateCollision->getContext() != picked.body->getContext())
@@ -89,21 +90,19 @@ bool ConstraintAttachBodyPerformer<DataTypes>::startPartial(const BodyPicked& pi
     m_mstate1 = dynamic_cast<MouseContainer*>(this->m_interactor->getMouseContainer());
     m_mstate2 = mstateCollision;
 
-    type::Vec3d point1;
-    type::Vec3d point2;
-
     using sofa::component::constraint::lagrangian::model::BilateralLagrangianConstraint;
 
 
-
-    this->m_interactionObject = sofa::core::objectmodel::New<BilateralLagrangianConstraint<sofa::defaulttype::Vec3Types> >(m_mstate1, m_mstate2);
-    auto* bconstraint = dynamic_cast< BilateralLagrangianConstraint< sofa::defaulttype::Vec3Types >* >(this->m_interactionObject.get());
+    this->m_interactionObject = sofa::core::objectmodel::New<BilateralLagrangianConstraint<DataTypes> >(m_mstate1, m_mstate2);
+    auto* bconstraint = dynamic_cast< BilateralLagrangianConstraint< DataTypes >* >(this->m_interactionObject.get());
 
     bconstraint->setName("Constraint-Mouse-Contact");
 
-    type::Vec3d normal = point1-point2;
+    static const typename DataTypes::Coord point1 {};
+    static const typename DataTypes::Coord point2 {};
+    static const typename DataTypes::Deriv normal {};
 
-    bconstraint->addContact(normal, point1, point2, normal.norm(), 0, index, point2, point1);
+    bconstraint->addContact(normal, point1, point2, 0.0, 0, index, point2, point1);
 
     const core::objectmodel::TagSet &tags=mstateCollision->getTags();
     for (auto tag : tags)


### PR DESCRIPTION
adding instantiation with RigidType + removal of "hard" usage of VecTypes.

In my case, it was to support grabbing a beam (BeamAdapter) with the mouse and constraints.


https://github.com/sofa-framework/sofa/assets/11028016/8eeb22ff-396d-4d87-8d9e-22e2849eefec




Reminder: BilateralConstraint needs a GenericConstraintSolver (+FreeMotionAL), LCPConstraintSolver is not usable

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
