### PR TITLE
[All] Remove compat layer for Intersection methods

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/CollisionPM.h
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/CollisionPM.h
@@ -200,7 +200,7 @@ namespace sofa::component::collision::detection::algorithm
                         for(umap_collision::iterator it = _coll_pairs[i][j].begin() ; it != _coll_pairs[i][j].end() ; ++it){
                             core::collision::DetectionOutputVector*& output = phase->getDetectionOutputs(it->second.elem1.getCollisionModel(),it->second.elem2.getCollisionModel());
                             ei->beginIntersect(it->second.elem1.getCollisionModel(),it->second.elem2.getCollisionModel(),output);
-                            ei->intersect(it->second.elem1,it->second.elem2,output);
+                            ei->intersect(it->second.elem1,it->second.elem2,output, phase->getIntersectionMethod());
                         }
                     }
                 }

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/DirectSAPNarrowPhase.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/DirectSAPNarrowPhase.cpp
@@ -363,7 +363,7 @@ void DirectSAPNarrowPhase::narrowCollisionDetectionForPair(core::collision::Elem
 {
     sofa::core::collision::DetectionOutputVector*& outputs = this->getDetectionOutputs(collisionModel0, collisionModel1);
     intersector->beginIntersect(collisionModel0, collisionModel1, outputs);//creates outputs if null
-    intersector->intersect(collisionModelIterator0, collisionModelIterator1, outputs);
+    intersector->intersect(collisionModelIterator0, collisionModelIterator1, outputs, this->intersectionMethod);
 }
 
 void DirectSAPNarrowPhase::draw(const core::visual::VisualParams* vparams)

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/MirrorIntersector.h
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/MirrorIntersector.h
@@ -67,18 +67,10 @@ public:
         return intersector->name() + std::string("<SWAP>");
     }
 
-    SOFA_ATTRIBUTE_DEPRECATED__CORE_INTERSECTION_AS_PARAMETER()
-    bool canIntersect(core::CollisionElementIterator elem1, core::CollisionElementIterator elem2) override
-    {
-        assert(intersector != nullptr);
-        return intersector->canIntersect(elem2, elem1);
-    }
-    SOFA_ATTRIBUTE_DEPRECATED__CORE_INTERSECTION_AS_PARAMETER()
-    int intersect(core::CollisionElementIterator elem1, core::CollisionElementIterator elem2, core::collision::DetectionOutputVector* contacts) override
-    {
-        assert(intersector != nullptr);
-        return intersector->intersect(elem2, elem1, contacts);
-    }
+    SOFA_ATTRIBUTE_DISABLED__CORE_INTERSECTION_AS_PARAMETER()
+    bool canIntersect(core::CollisionElementIterator elem1, core::CollisionElementIterator elem2) override = delete;
+    SOFA_ATTRIBUTE_DISABLED__CORE_INTERSECTION_AS_PARAMETER()
+    int intersect(core::CollisionElementIterator elem1, core::CollisionElementIterator elem2, core::collision::DetectionOutputVector* contacts) override = delete;
 };
 
 } // namespace sofa::component::collision::detection::algorithm

--- a/Sofa/framework/Core/src/sofa/core/collision/Intersection.h
+++ b/Sofa/framework/Core/src/sofa/core/collision/Intersection.h
@@ -82,10 +82,10 @@ public:
 
     virtual std::string name() const = 0;
 
-    SOFA_ATTRIBUTE_DEPRECATED__CORE_INTERSECTION_AS_PARAMETER()
-    virtual bool canIntersect(core::CollisionElementIterator, core::CollisionElementIterator) { return false; };
-    SOFA_ATTRIBUTE_DEPRECATED__CORE_INTERSECTION_AS_PARAMETER()
-    virtual int intersect(core::CollisionElementIterator, core::CollisionElementIterator, DetectionOutputVector*) { return 0; };
+    SOFA_ATTRIBUTE_DISABLED__CORE_INTERSECTION_AS_PARAMETER()
+    virtual bool canIntersect(core::CollisionElementIterator, core::CollisionElementIterator) = delete;
+    SOFA_ATTRIBUTE_DISABLED__CORE_INTERSECTION_AS_PARAMETER()
+    virtual int intersect(core::CollisionElementIterator, core::CollisionElementIterator, DetectionOutputVector*) = delete;
 };
 
 /// Table storing associations between types of collision models and intersectors implementing intersection tests

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -62,10 +62,10 @@
 #endif
 
 #ifdef SOFA_BUILD_SOFA_CORE
-#define SOFA_ATTRIBUTE_DEPRECATED__CORE_INTERSECTION_AS_PARAMETER()
+#define SOFA_ATTRIBUTE_DISABLED__CORE_INTERSECTION_AS_PARAMETER()
 #else
-#define SOFA_ATTRIBUTE_DEPRECATED__CORE_INTERSECTION_AS_PARAMETER() \
-    SOFA_ATTRIBUTE_DEPRECATED("v24.06", "v24.12", "Intersection detection methods now needs the Intersection method as a parameter.")
+#define SOFA_ATTRIBUTE_DISABLED__CORE_INTERSECTION_AS_PARAMETER() \
+    SOFA_ATTRIBUTE_DISABLED("v24.06", "v24.12", "Intersection detection methods now needs the Intersection method as a parameter.")
 #endif
 
 #ifdef SOFA_BUILD_SOFA_CORE

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/CapsuleIntersection.cpp
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/CapsuleIntersection.cpp
@@ -43,8 +43,7 @@ using namespace collisionobbcapsule::geometry;
 IntersectorCreator<DiscreteIntersection, CapsuleDiscreteIntersection> CapsuleDiscreteIntersectors("Capsule");
 IntersectorCreator<NewProximityIntersection, CapsuleMeshDiscreteIntersection> CapsuleMeshDiscreteIntersectors("CapsuleMesh");
 
-CapsuleDiscreteIntersection::CapsuleDiscreteIntersection(DiscreteIntersection* object)
-    : intersection(object)
+CapsuleDiscreteIntersection::CapsuleDiscreteIntersection(DiscreteIntersection* intersection)
 {
     intersection->intersectors.add<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>, CapsuleCollisionModel<sofa::defaulttype::Vec3Types>, CapsuleDiscreteIntersection>(this);
     intersection->intersectors.add<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, CapsuleDiscreteIntersection>(this);
@@ -60,8 +59,7 @@ CapsuleDiscreteIntersection::CapsuleDiscreteIntersection(DiscreteIntersection* o
     intersection->intersectors.ignore<RayCollisionModel, CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>>();
 }
 
-CapsuleMeshDiscreteIntersection::CapsuleMeshDiscreteIntersection(NewProximityIntersection* object)
-    : intersection(object)
+CapsuleMeshDiscreteIntersection::CapsuleMeshDiscreteIntersection(NewProximityIntersection* intersection)
 {
 
     intersection->intersectors.add<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>, TriangleCollisionModel<sofa::defaulttype::Vec3Types>, CapsuleMeshDiscreteIntersection>(this);

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/CapsuleIntersection.h
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/CapsuleIntersection.h
@@ -45,21 +45,18 @@ public:
     CapsuleDiscreteIntersection(DiscreteIntersection* object);
 
     template <class Elem1, class Elem2>
-    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts) {
-        return BaseIntTool::computeIntersection(e1, 
+    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* currentIntersection) {
+        return BaseIntTool::computeIntersection(e1,
             e2, 
-            e1.getProximity() + e2.getProximity() + intersection->getAlarmDistance(), 
-            e1.getProximity() + e2.getProximity() + intersection->getContactDistance(),
+            e1.getProximity() + e2.getProximity() + currentIntersection->getAlarmDistance(),
+            e1.getProximity() + e2.getProximity() + currentIntersection->getContactDistance(),
             contacts);
     }
 
     template <class Elem1, class Elem2>
-    bool testIntersection(Elem1& e1, Elem2& e2) {
-        return BaseIntTool::testIntersection(e1, e2, intersection->getAlarmDistance());
+    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* currentIntersection) {
+        return BaseIntTool::testIntersection(e1, e2, currentIntersection->getAlarmDistance());
     }
-
-protected:
-    DiscreteIntersection* intersection;
 
 };
 
@@ -72,24 +69,21 @@ public:
     CapsuleMeshDiscreteIntersection(NewProximityIntersection* object);
 
     template <class Elem1, class Elem2>
-    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts) {
+    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* currentIntersection) {
         return MeshIntTool::computeIntersection(e1,
             e2,
-            e1.getProximity() + e2.getProximity() + intersection->getAlarmDistance(),
-            e1.getProximity() + e2.getProximity() + intersection->getContactDistance(),
+            e1.getProximity() + e2.getProximity() + currentIntersection->getAlarmDistance(),
+            e1.getProximity() + e2.getProximity() + currentIntersection->getContactDistance(),
             contacts);
     }
 
     template <class Elem1, class Elem2>
-    bool testIntersection(Elem1& e1, Elem2& e2) {
-        return BaseIntTool::testIntersection(e1, e2, intersection->getAlarmDistance());
+    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* currentIntersection) {
+        return BaseIntTool::testIntersection(e1, e2, currentIntersection->getAlarmDistance());
     }
 
-    bool testIntersection(Capsule&, Triangle&) { return true; }
-    bool testIntersection(Capsule&, Line&) { return true; }
-
-protected:
-    NewProximityIntersection* intersection;
+    bool testIntersection(Capsule&, Triangle&, const core::collision::Intersection*) { return true; }
+    bool testIntersection(Capsule&, Line&, const core::collision::Intersection*) { return true; }
 
 };
 

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/CapsuleIntersection.h
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/CapsuleIntersection.h
@@ -42,20 +42,20 @@ class COLLISIONOBBCAPSULE_API CapsuleDiscreteIntersection : public core::collisi
     typedef DiscreteIntersection::OutputVector OutputVector;
 
 public:
-    CapsuleDiscreteIntersection(DiscreteIntersection* object);
+    CapsuleDiscreteIntersection(DiscreteIntersection* intersection);
 
     template <class Elem1, class Elem2>
-    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* currentIntersection) {
+    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* intersection) {
         return BaseIntTool::computeIntersection(e1,
             e2, 
-            e1.getProximity() + e2.getProximity() + currentIntersection->getAlarmDistance(),
-            e1.getProximity() + e2.getProximity() + currentIntersection->getContactDistance(),
+            e1.getProximity() + e2.getProximity() + intersection->getAlarmDistance(),
+            e1.getProximity() + e2.getProximity() + intersection->getContactDistance(),
             contacts);
     }
 
     template <class Elem1, class Elem2>
-    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* currentIntersection) {
-        return BaseIntTool::testIntersection(e1, e2, currentIntersection->getAlarmDistance());
+    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* intersection) {
+        return BaseIntTool::testIntersection(e1, e2, intersection->getAlarmDistance());
     }
 
 };
@@ -66,20 +66,20 @@ class COLLISIONOBBCAPSULE_API CapsuleMeshDiscreteIntersection : public core::col
     typedef DiscreteIntersection::OutputVector OutputVector;
 
 public:
-    CapsuleMeshDiscreteIntersection(NewProximityIntersection* object);
+    CapsuleMeshDiscreteIntersection(NewProximityIntersection* intersection);
 
     template <class Elem1, class Elem2>
-    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* currentIntersection) {
+    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* intersection) {
         return MeshIntTool::computeIntersection(e1,
             e2,
-            e1.getProximity() + e2.getProximity() + currentIntersection->getAlarmDistance(),
-            e1.getProximity() + e2.getProximity() + currentIntersection->getContactDistance(),
+            e1.getProximity() + e2.getProximity() + intersection->getAlarmDistance(),
+            e1.getProximity() + e2.getProximity() + intersection->getContactDistance(),
             contacts);
     }
 
     template <class Elem1, class Elem2>
-    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* currentIntersection) {
-        return BaseIntTool::testIntersection(e1, e2, currentIntersection->getAlarmDistance());
+    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* intersection) {
+        return BaseIntTool::testIntersection(e1, e2, intersection->getAlarmDistance());
     }
 
     bool testIntersection(Capsule&, Triangle&, const core::collision::Intersection*) { return true; }

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/OBBIntersection.cpp
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/OBBIntersection.cpp
@@ -43,8 +43,7 @@ using namespace collisionobbcapsule::geometry;
 IntersectorCreator<DiscreteIntersection, RigidDiscreteIntersection> RigidDiscreteIntersectors("Rigid");
 IntersectorCreator<NewProximityIntersection, RigidMeshDiscreteIntersection> RigidMeshDiscreteIntersectors("RigidMesh");
 
-RigidDiscreteIntersection::RigidDiscreteIntersection(DiscreteIntersection* object)
-    : intersection(object)
+RigidDiscreteIntersection::RigidDiscreteIntersection(DiscreteIntersection* intersection)
 {
     intersection->intersectors.add<OBBCollisionModel<sofa::defaulttype::Rigid3Types>, OBBCollisionModel<sofa::defaulttype::Rigid3Types>, RigidDiscreteIntersection>(this);
     intersection->intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, OBBCollisionModel<sofa::defaulttype::Rigid3Types>, RigidDiscreteIntersection>(this);
@@ -53,13 +52,12 @@ RigidDiscreteIntersection::RigidDiscreteIntersection(DiscreteIntersection* objec
     intersection->intersectors.add<RayCollisionModel, OBBCollisionModel<sofa::defaulttype::Rigid3Types>, RigidDiscreteIntersection>(this);
 }
 
-RigidMeshDiscreteIntersection::RigidMeshDiscreteIntersection(NewProximityIntersection* object)
-    : intersection(object)
+RigidMeshDiscreteIntersection::RigidMeshDiscreteIntersection(NewProximityIntersection* intersection)
 {
     intersection->intersectors.add<TriangleCollisionModel<sofa::defaulttype::Vec3Types>, OBBCollisionModel<sofa::defaulttype::Rigid3Types>, RigidMeshDiscreteIntersection>(this);
 }
 
-bool RigidDiscreteIntersection::testIntersection(Ray& /*rRay*/, OBB& /*rOBB*/)
+bool RigidDiscreteIntersection::testIntersection(Ray& /*rRay*/, OBB& /*rOBB*/, const core::collision::Intersection*)
 {
     return false;
 }
@@ -68,7 +66,7 @@ static float const c_fMin = -3.402823466e+38f;
 static float const c_fMax = 3.402823466e+38f;
 typedef Mat<3, 3, SReal> Mat33;
 
-int  RigidDiscreteIntersection::computeIntersection(Ray& rRay, OBB& rObb, OutputVector* contacts)
+int  RigidDiscreteIntersection::computeIntersection(Ray& rRay, OBB& rObb, OutputVector* contacts, const core::collision::Intersection*)
 {
     //Near intersection: ray to closest plat of slab
     float fNear = c_fMin;

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/OBBIntersection.h
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/detection/intersection/OBBIntersection.h
@@ -42,10 +42,10 @@ class COLLISIONOBBCAPSULE_API RigidDiscreteIntersection : public core::collision
     typedef DiscreteIntersection::OutputVector OutputVector;
 
 public:
-    RigidDiscreteIntersection(DiscreteIntersection* object);
+    RigidDiscreteIntersection(DiscreteIntersection* intersection);
 
     template <class Elem1, class Elem2>
-    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts) {
+    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* intersection) {
         return BaseIntTool::computeIntersection(e1,
             e2,
             e1.getProximity() + e2.getProximity() + intersection->getAlarmDistance(),
@@ -54,16 +54,12 @@ public:
     }
 
     template <class Elem1, class Elem2>
-    bool testIntersection(Elem1& e1, Elem2& e2) {
+    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* intersection) {
         return BaseIntTool::testIntersection(e1, e2, intersection->getAlarmDistance());
     }
 
-    bool testIntersection(Ray& /*rRay*/, OBB& /*rOBB*/);
-    int computeIntersection(Ray& rRay, OBB& rObb, OutputVector* contacts);
-
-protected:
-    DiscreteIntersection* intersection;
-
+    bool testIntersection(Ray& /*rRay*/, OBB& /*rOBB*/, const core::collision::Intersection* intersection);
+    int computeIntersection(Ray& rRay, OBB& rObb, OutputVector* contacts, const core::collision::Intersection* intersection);
 };
 
 
@@ -72,10 +68,10 @@ class COLLISIONOBBCAPSULE_API RigidMeshDiscreteIntersection : public core::colli
     typedef DiscreteIntersection::OutputVector OutputVector;
 
 public:
-    RigidMeshDiscreteIntersection(NewProximityIntersection* object);
+    RigidMeshDiscreteIntersection(NewProximityIntersection* intersection);
 
     template <class Elem1, class Elem2>
-    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts) {
+    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts, const core::collision::Intersection* intersection) {
         return MeshIntTool::computeIntersection(e1,
             e2,
             e1.getProximity() + e2.getProximity() + intersection->getAlarmDistance(),
@@ -84,13 +80,9 @@ public:
     }
 
     template <class Elem1, class Elem2>
-    bool testIntersection(Elem1& e1, Elem2& e2) {
+    bool testIntersection(Elem1& e1, Elem2& e2, const core::collision::Intersection* intersection) {
         return BaseIntTool::testIntersection(e1, e2, intersection->getAlarmDistance());
     }
-
-protected:
-    NewProximityIntersection* intersection;
-
 };
 
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBruteForceBroadPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/collision/detection/algorithm/ParallelBruteForceBroadPhase.cpp
@@ -183,7 +183,7 @@ sofa::simulation::Task::MemoryAlloc BruteForcePairTest::run()
         }
 
         // Here we assume a single root element is present in both models
-        if (intersector->canIntersect(cm_1->begin(), cm_2->begin()))
+        if (intersector->canIntersect(cm_1->begin(), cm_2->begin(), m_intersectionMethod))
         {
             m_intersectingPairs.emplace_back(cm_1, cm_2);
         }

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
@@ -44,8 +44,7 @@ using namespace sofa::component::collision::detection::intersection;
 
 IntersectorCreator<DiscreteIntersection, FFDDistanceGridDiscreteIntersection> FFDDistanceGridDiscreteIntersectors("FFDDistanceGrid");
 
-FFDDistanceGridDiscreteIntersection::FFDDistanceGridDiscreteIntersection(DiscreteIntersection* object)
-    : intersection(object)
+FFDDistanceGridDiscreteIntersection::FFDDistanceGridDiscreteIntersection(DiscreteIntersection* intersection)
 {
     intersection->intersectors.add<FFDDistanceGridCollisionModel, PointCollisionModel<sofa::defaulttype::Vec3Types>,                        FFDDistanceGridDiscreteIntersection>  (this);
     intersection->intersectors.add<FFDDistanceGridCollisionModel, SphereCollisionModel<sofa::defaulttype::Vec3Types>,                       FFDDistanceGridDiscreteIntersection>  (this);
@@ -55,12 +54,12 @@ FFDDistanceGridDiscreteIntersection::FFDDistanceGridDiscreteIntersection(Discret
     intersection->intersectors.add<FFDDistanceGridCollisionModel,   FFDDistanceGridCollisionModel,   FFDDistanceGridDiscreteIntersection> (this);
 }
 
-bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&)
+bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, const core::collision::Intersection*)
 {
     return true;
 }
 
-int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, RigidDistanceGridCollisionElement& e2, OutputVector* contacts)
+int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, RigidDistanceGridCollisionElement& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     int nc = 0;
     DistanceGrid* grid1 = e1.getGrid();
@@ -231,12 +230,12 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
 }
 
 
-bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, FFDDistanceGridCollisionElement&)
+bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, FFDDistanceGridCollisionElement&, const core::collision::Intersection*)
 {
     return true;
 }
 
-int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, FFDDistanceGridCollisionElement& e2, OutputVector* contacts)
+int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, FFDDistanceGridCollisionElement& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     int nc = 0;
     DistanceGrid* grid1 = e1.getGrid();
@@ -428,12 +427,12 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
     return nc;
 }
 
-bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, Point&)
+bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, Point&, const core::collision::Intersection*)
 {
     return true;
 }
 
-int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, Point& e2, OutputVector* contacts)
+int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, Point& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
 
     DistanceGrid* grid1 = e1.getGrid();
@@ -517,12 +516,12 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
     return nc;
 }
 
-bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, Triangle&)
+bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, Triangle&, const core::collision::Intersection*)
 {
     return true;
 }
 
-int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, Triangle& e2, OutputVector* contacts)
+int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, Triangle& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     const int f2 = e2.flags();
     if (!(f2&TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS)) return 0; // no points associated with this triangle
@@ -611,12 +610,12 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
     return nc;
 }
 
-bool FFDDistanceGridDiscreteIntersection::testIntersection(Ray& /*e1*/, FFDDistanceGridCollisionElement& /*e2*/)
+bool FFDDistanceGridDiscreteIntersection::testIntersection(Ray& /*e1*/, FFDDistanceGridCollisionElement& /*e2*/, const core::collision::Intersection*)
 {
     return true;
 }
 
-int FFDDistanceGridDiscreteIntersection::computeIntersection(Ray& e2, FFDDistanceGridCollisionElement& e1, OutputVector* contacts)
+int FFDDistanceGridDiscreteIntersection::computeIntersection(Ray& e2, FFDDistanceGridCollisionElement& e1, OutputVector* contacts, const core::collision::Intersection*)
 {
     type::Vec3 rayOrigin(e2.origin());
     type::Vec3 rayDirection(e2.direction());

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.h
@@ -50,23 +50,19 @@ class SOFA_SOFADISTANCEGRID_API FFDDistanceGridDiscreteIntersection : public cor
 public:
     FFDDistanceGridDiscreteIntersection(detection::intersection::DiscreteIntersection* object);
 
-    bool testIntersection(FFDDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&);
-    bool testIntersection(FFDDistanceGridCollisionElement&, FFDDistanceGridCollisionElement&);
-    bool testIntersection(FFDDistanceGridCollisionElement&, geometry::Point&);
-    template<class T> bool testIntersection(FFDDistanceGridCollisionElement&, geometry::TSphere<T>&);
-    bool testIntersection(FFDDistanceGridCollisionElement&, geometry::Triangle&);
-    bool testIntersection(geometry::Ray&, FFDDistanceGridCollisionElement&);
+    bool testIntersection(FFDDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, const core::collision::Intersection*);
+    bool testIntersection(FFDDistanceGridCollisionElement&, FFDDistanceGridCollisionElement&, const core::collision::Intersection*);
+    bool testIntersection(FFDDistanceGridCollisionElement&, geometry::Point&, const core::collision::Intersection*);
+    template<class T> bool testIntersection(FFDDistanceGridCollisionElement&, geometry::TSphere<T>&, const core::collision::Intersection*);
+    bool testIntersection(FFDDistanceGridCollisionElement&, geometry::Triangle&, const core::collision::Intersection*);
+    bool testIntersection(geometry::Ray&, FFDDistanceGridCollisionElement&, const core::collision::Intersection*);
 
-    int computeIntersection(FFDDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, OutputVector*);
-    int computeIntersection(FFDDistanceGridCollisionElement&, FFDDistanceGridCollisionElement&, OutputVector*);
-    int computeIntersection(FFDDistanceGridCollisionElement&, geometry::Point&, OutputVector*);
-    template<class T> int computeIntersection(FFDDistanceGridCollisionElement&, geometry::TSphere<T>&, OutputVector*);
-    int computeIntersection(FFDDistanceGridCollisionElement&, geometry::Triangle&, OutputVector*);
-    int computeIntersection(geometry::Ray&, FFDDistanceGridCollisionElement&, OutputVector*);
-
-protected:
-
-    detection::intersection::DiscreteIntersection* intersection;
+    int computeIntersection(FFDDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(FFDDistanceGridCollisionElement&, FFDDistanceGridCollisionElement&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(FFDDistanceGridCollisionElement&, geometry::Point&, OutputVector*, const core::collision::Intersection*);
+    template<class T> int computeIntersection(FFDDistanceGridCollisionElement&, geometry::TSphere<T>&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(FFDDistanceGridCollisionElement&, geometry::Triangle&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(geometry::Ray&, FFDDistanceGridCollisionElement&, OutputVector*, const core::collision::Intersection*);
 
 };
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.inl
@@ -42,13 +42,13 @@ namespace collision
 
 
 template<class T>
-bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, geometry::TSphere<T>&)
+bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollisionElement&, geometry::TSphere<T>&, const core::collision::Intersection*)
 {
     return true;
 }
 
 template<class T>
-int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, geometry::TSphere<T>& e2, OutputVector* contacts)
+int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, geometry::TSphere<T>& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
 
     DistanceGrid* grid1 = e1.getGrid();

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
@@ -45,8 +45,7 @@ using namespace sofa::component::collision::geometry;
 
 IntersectorCreator<DiscreteIntersection, RigidDistanceGridDiscreteIntersection> RigidDistanceGridDiscreteIntersectors("RigidDistanceGrid");
 
-RigidDistanceGridDiscreteIntersection::RigidDistanceGridDiscreteIntersection(DiscreteIntersection* object)
-    : intersection(object)
+RigidDistanceGridDiscreteIntersection::RigidDistanceGridDiscreteIntersection(DiscreteIntersection* intersection)
 {
     intersection->intersectors.add<RigidDistanceGridCollisionModel, PointCollisionModel<sofa::defaulttype::Vec3Types>,                      RigidDistanceGridDiscreteIntersection>  (this);
     intersection->intersectors.add<RigidDistanceGridCollisionModel, SphereCollisionModel<sofa::defaulttype::Vec3Types>,                     RigidDistanceGridDiscreteIntersection>  (this);
@@ -56,14 +55,14 @@ RigidDistanceGridDiscreteIntersection::RigidDistanceGridDiscreteIntersection(Dis
     intersection->intersectors.add<RigidDistanceGridCollisionModel, RigidDistanceGridCollisionModel, RigidDistanceGridDiscreteIntersection> (this);
 }
 
-bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&)
+bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, const core::collision::Intersection*)
 {
     return true;
 }
 
 //#define DEBUG_XFORM
 
-int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, RigidDistanceGridCollisionElement& e2, OutputVector* contacts)
+int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, RigidDistanceGridCollisionElement& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     int nc = 0;
     DistanceGrid* grid1 = e1.getGrid();
@@ -550,12 +549,12 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
     return nc;
 }
 
-bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, Point&)
+bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, Point&, const core::collision::Intersection* )
 {
     return true;
 }
 
-int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, Point& e2, OutputVector* contacts)
+int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, Point& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     DistanceGrid* grid1 = e1.getGrid();
     bool useXForm = e1.isTransformed();
@@ -613,12 +612,12 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
     return 1;
 }
 
-bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, Triangle&)
+bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, Triangle&, const core::collision::Intersection*)
 {
     return true;
 }
 
-int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, Triangle& e2, OutputVector* contacts)
+int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, Triangle& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     const int f2 = e2.flags();
     if (!(f2&(TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS|TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_BEDGES))) return 0; // no points associated with this triangle
@@ -722,12 +721,12 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
     return nc;
 }
 
-bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, Line&)
+bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, Line&, const core::collision::Intersection*)
 {
     return true;
 }
 
-int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, Line& e2, OutputVector* contacts)
+int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, Line& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     const int f2 = e2.flags();
     if (!(f2&LineCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS)) return 0; // no points associated with this line
@@ -786,12 +785,12 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
     return nresult;
 }
 
-bool RigidDistanceGridDiscreteIntersection::testIntersection(Ray& /*e2*/, RigidDistanceGridCollisionElement& /*e1*/)
+bool RigidDistanceGridDiscreteIntersection::testIntersection(Ray& /*e2*/, RigidDistanceGridCollisionElement& /*e1*/, const core::collision::Intersection*)
 {
     return true;
 }
 
-int RigidDistanceGridDiscreteIntersection::computeIntersection(Ray& e2, RigidDistanceGridCollisionElement& e1, OutputVector* contacts)
+int RigidDistanceGridDiscreteIntersection::computeIntersection(Ray& e2, RigidDistanceGridCollisionElement& e1, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     type::Vec3 rayOrigin(e2.origin());
     type::Vec3 rayDirection(e2.direction());

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.h
@@ -48,25 +48,21 @@ class SOFA_SOFADISTANCEGRID_API RigidDistanceGridDiscreteIntersection : public c
     typedef detection::intersection::DiscreteIntersection::OutputVector OutputVector;
 
 public:
-    RigidDistanceGridDiscreteIntersection(detection::intersection::DiscreteIntersection* object);
+    RigidDistanceGridDiscreteIntersection(detection::intersection::DiscreteIntersection* intersection);
 
-    bool testIntersection(RigidDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&);
-    bool testIntersection(RigidDistanceGridCollisionElement&, geometry::Point&);
-    template<class T> bool testIntersection(RigidDistanceGridCollisionElement&, geometry::TSphere<T>&);
-    bool testIntersection(RigidDistanceGridCollisionElement&, geometry::Line&);
-    bool testIntersection(RigidDistanceGridCollisionElement&, geometry::Triangle&);
-    bool testIntersection(geometry::Ray&, RigidDistanceGridCollisionElement&);
+    bool testIntersection(RigidDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, const core::collision::Intersection* );
+    bool testIntersection(RigidDistanceGridCollisionElement&, geometry::Point&, const core::collision::Intersection* );
+    template<class T> bool testIntersection(RigidDistanceGridCollisionElement&, geometry::TSphere<T>&, const core::collision::Intersection* );
+    bool testIntersection(RigidDistanceGridCollisionElement&, geometry::Line&, const core::collision::Intersection* );
+    bool testIntersection(RigidDistanceGridCollisionElement&, geometry::Triangle&, const core::collision::Intersection* );
+    bool testIntersection(geometry::Ray&, RigidDistanceGridCollisionElement&, const core::collision::Intersection*);
 
-    int computeIntersection(RigidDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, OutputVector*);
-    int computeIntersection(RigidDistanceGridCollisionElement&, geometry::Point&, OutputVector*);
-    template<class T> int computeIntersection(RigidDistanceGridCollisionElement&, geometry::TSphere<T>&, OutputVector*);
-    int computeIntersection(RigidDistanceGridCollisionElement&, geometry::Line&, OutputVector*);
-    int computeIntersection(RigidDistanceGridCollisionElement&, geometry::Triangle&, OutputVector*);
-    int computeIntersection(geometry::Ray&, RigidDistanceGridCollisionElement&, OutputVector*);
-
-protected:
-
-    detection::intersection::DiscreteIntersection* intersection;
+    int computeIntersection(RigidDistanceGridCollisionElement&, RigidDistanceGridCollisionElement&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(RigidDistanceGridCollisionElement&, geometry::Point&, OutputVector*, const core::collision::Intersection*);
+    template<class T> int computeIntersection(RigidDistanceGridCollisionElement&, geometry::TSphere<T>&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(RigidDistanceGridCollisionElement&, geometry::Line&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(RigidDistanceGridCollisionElement&, geometry::Triangle&, OutputVector*, const core::collision::Intersection*);
+    int computeIntersection(geometry::Ray&, RigidDistanceGridCollisionElement&, OutputVector*, const core::collision::Intersection*);
 
 };
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
@@ -40,13 +40,13 @@ namespace collision
 {
 
 template<class T>
-bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, geometry::TSphere<T>&)
+bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCollisionElement&, geometry::TSphere<T>&, const core::collision::Intersection*)
 {
     return true;
 }
 
 template<class T>
-int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, geometry::TSphere<T>& e2, OutputVector* contacts)
+int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, geometry::TSphere<T>& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     DistanceGrid* grid1 = e1.getGrid();
     bool useXForm = e1.isTransformed();


### PR DESCRIPTION
Isolate the piece of code from 
- #4787 

where the change of versions forces to use the new API for intersection, introduced in 
- #4583

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
