### PR TITLE
[All] CMake: Remove deprecated settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,16 +48,13 @@ option(SOFA_ALLOW_FETCH_DEPENDENCIES "Allow compatible dependencies to be fetche
 # and https://cmake.org/cmake/help/v3.16/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
 
 # https://cmake.org/cmake/help/latest/policy/CMP0127.html
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.22)
-    cmake_policy(SET CMP0127 NEW)
-endif()
-cmake_dependent_option(SOFA_BUILD_WITH_PCH_ENABLED 
-    "Compile SOFA using precompiled header (to accelerate the build process)" OFF
-    "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16" OFF)
+cmake_policy(SET CMP0127 NEW)
+
+option(SOFA_BUILD_WITH_PCH_ENABLED "Compile SOFA using precompiled header (to accelerate the build process)" OFF)
 if(SOFA_BUILD_WITH_PCH_ENABLED)
     message("-- Precompiled headers: enabled (SOFA_BUILD_WITH_PCH_ENABLED is ON).")
 else()
-    message("-- Precompiled headers: disabled (SOFA_BUILD_WITH_PCH_ENABLED is OFF or CMake < 3.16).")
+    message("-- Precompiled headers: disabled (SOFA_BUILD_WITH_PCH_ENABLED is OFF).")
     set(DISABLE_PRECOMPILE_HEADERS ON)
 endif()
 
@@ -178,7 +175,6 @@ option(SOFA_ENABLE_LEGACY_HEADERS "Enable the compatibility layer (headers locat
 if(SOFA_ENABLE_LEGACY_HEADERS)
     message("Using legacy headers is enabled.")
 endif()
-sofa_add_subdirectory(library Sofa/framework/Compat Sofa.Compat ON WHEN_TO_SHOW "SOFA_ENABLE_LEGACY_HEADERS" VALUE_IF_HIDDEN OFF)
 
 ### SOFA (framework and components)
 add_subdirectory(Sofa)
@@ -294,9 +290,6 @@ if(SOFA_BUILD_RELEASE_PACKAGE)
     ################
     # Package config
     include(CPackComponent)
-    if(WIN32 AND ${CMAKE_VERSION} VERSION_LESS "3.13.0")
-        include(CPackNSIS)
-    endif()
     include(CPackIFW)
     set(CPACK_PACKAGE_VERSION "${Sofa_VERSION}")
     set(CPACK_PACKAGE_NAME "SOFA v${CPACK_PACKAGE_VERSION}")

--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -95,10 +95,6 @@ set(SOFACONFIG_BUILD_OPTIONS_SRC
     ${SOFACONFIGSRC_ROOT}/config/build_option_bbox.h.in
 )
 
-# Header-only library (not handled well by macros & stuff so commented)
-# add_library(${PROJECT_NAME} INTERFACE)
-# target_sources(${PROJECT_NAME} INTERFACE "$<BUILD_INTERFACE:${HEADER_FILES};${SOFACONFIG_BUILD_OPTIONS_SRC}>")
-
 # Library
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOFACONFIG_BUILD_OPTIONS_SRC} ${SOURCE_FILES})
 
@@ -143,18 +139,6 @@ endif()
 
 ## GCC-specific
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-    ## Find out the version of g++ (and save it in GCXX_VERSION)
-    if(CMAKE_CXX_COMPILER_ARG1) # CXX="ccache g++"
-        string(STRIP ${CMAKE_CXX_COMPILER_ARG1} CMAKE_CXX_COMPILER_ARG1_stripped)
-        execute_process(COMMAND ${CMAKE_CXX_COMPILER_ARG1_stripped} -dumpversion OUTPUT_VARIABLE GCXX_VERSION)
-    else()
-        execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCXX_VERSION)
-    endif()
-
-    ## Disable partial inlining under gcc 4.6 (Why? -> the memory was exploding)
-    if("${GCXX_VERSION}" VERSION_EQUAL 4.6)
-        list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE "-fno-partial-inlining")
-    endif()
 
     # stack-protector
     list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE "-fstack-protector;--param=ssp-buffer-size=4")
@@ -209,10 +193,9 @@ if(WIN32)
     # it happens because we put explicit instantiation in a separate translation unit
     # it is by design, so this warning is irrelevant in our project
 
-    if(MSVC_TOOLSET_VERSION GREATER 140) # > VS 2015
-        list(APPEND SOFACONFIG_COMPILE_OPTIONS "/Zc:__cplusplus")
-    endif()
-
+    # https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170
+    list(APPEND SOFACONFIG_COMPILE_OPTIONS "/Zc:__cplusplus")
+    
     # Experimental: compilation with MSVC/Clang-cl
     if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
         if( ${CMAKE_CXX_COMPILER_FRONTEND_VARIANT} STREQUAL MSVC) # something weird happens if we put the two test in one if ??
@@ -271,20 +254,6 @@ if(SOFA_ENABLE_BUILTIN_TIMER)
     set(SOFA_ENABLE_SCOPED_ADVANCED_TIMER 1)
 endif()
 
-# An important C++11 feature may be not enabled due to
-# the compiler being built without the --enable-libstdcxx-time option.
-if(CMAKE_COMPILER_IS_GNUCXX)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-        list(APPEND SOFACONFIG_COMPILE_OPTIONS "-D_GLIBCXX_USE_NANOSLEEP -D_GLIBCXX_USE_SCHED_YIELD")
-    endif()
-endif()
-
-# hack for clang on old macosx (version < 10.9, such as the dashboard servers)
-# that is using, by default at that time, a libstdc++ that did not fully implement c++11
-if(APPLE AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND CMAKE_SYSTEM_VERSION VERSION_LESS "10.9" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" )
-    list(APPEND SOFACONFIG_COMPILE_OPTIONS "-stdlib=libc++")
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT CMAKE_BUILD_TYPE MATCHES "Debug")
     target_compile_definitions(${PROJECT_NAME} PUBLIC "NDEBUG")
     # On Windows and MacOS, NDEBUG and _DEBUG are automatically
@@ -325,25 +294,9 @@ target_compile_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${SOFACONFIG_
 target_compile_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${SOFACONFIG_COMPILE_OPTIONS_DEBUG}>")
 target_compile_options(${PROJECT_NAME} PUBLIC "${SOFACONFIG_COMPILE_OPTIONS}")
 
-# target_link_option only available with cmake >= 3.13
-if(${CMAKE_VERSION} VERSION_LESS "3.13.0")
-    if(NOT SOFACONFIG_LINK_OPTIONS_RELEASE STREQUAL "")
-        string(REPLACE ";" " " SOFACONFIG_LINK_OPTIONS_RELEASE "${SOFACONFIG_LINK_OPTIONS_RELEASE}")
-        set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS_RELEASE "${SOFACONFIG_LINK_OPTIONS_RELEASE}")
-    endif()
-    if(NOT SOFACONFIG_LINK_OPTIONS_DEBUG STREQUAL "")
-        string(REPLACE ";" " " SOFACONFIG_LINK_OPTIONS_DEBUG "${SOFACONFIG_LINK_OPTIONS_DEBUG}")
-        set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS_DEBUG "${SOFACONFIG_LINK_OPTIONS_DEBUG}")
-    endif()
-    if(NOT SOFACONFIG_LINK_OPTIONS STREQUAL "")
-        string(REPLACE ";" " " SOFACONFIG_LINK_OPTIONS "${SOFACONFIG_LINK_OPTIONS}")
-        set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "${SOFACONFIG_LINK_OPTIONS}")
-    endif()
-else()
-    target_link_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${SOFACONFIG_LINK_OPTIONS_RELEASE}>")
-    target_link_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${SOFACONFIG_LINK_OPTIONS_DEBUG}>")
-    target_link_options(${PROJECT_NAME} PUBLIC "${SOFACONFIG_LINK_OPTIONS}")
-endif()
+target_link_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${SOFACONFIG_LINK_OPTIONS_RELEASE}>")
+target_link_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${SOFACONFIG_LINK_OPTIONS_DEBUG}>")
+target_link_options(${PROJECT_NAME} PUBLIC "${SOFACONFIG_LINK_OPTIONS}")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 

--- a/Sofa/framework/LinearAlgebra/CMakeLists.txt
+++ b/Sofa/framework/LinearAlgebra/CMakeLists.txt
@@ -62,7 +62,7 @@ set(SOURCE_FILES
 
 sofa_find_package(Eigen3 3.3.5 REQUIRED)
 
-if (SOFA_OPENMP AND "${EIGEN3_VERSION}" VERSION_LESS 3.2.10)
+if (SOFA_OPENMP)
     sofa_find_package(OpenMP BOTH_SCOPES) # will set/update SOFA_LINEARALGEBRA_HAVE_OPENMP
 endif()
 

--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -86,15 +86,11 @@ if(NOT Boost_FOUND)
     endif()
 endif()
 sofa_find_package(Boost QUIET REQUIRED)
-sofa_find_package(Sofa.Compat QUIET BOTH_SCOPES)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Config)
 target_link_libraries(${PROJECT_NAME} PUBLIC Boost::boost)
-if(Sofa.Compat_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Compat)
-endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 


### PR DESCRIPTION
Some cmake instructions became irrelevant as new requirement versions for cmake, gcc ,and clang have been defined.
So this PR merely remove the now-dead code

\+ Sofa.compat deletion from #4760 was not  totally finished (add a warning at cmake configure time)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
