### PR TITLE
[Core] Explicit type instead of calling function with side effect

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Data.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Data.h
@@ -287,7 +287,7 @@ std::string Data<T>::getDefaultValueString() const
 template<class T>
 std::string Data<T>::getValueTypeString() const
 {
-    return BaseData::typeName(&getValue());
+    return BaseData::typeName<T>();
 }
 
 template <class T>


### PR DESCRIPTION
`getValue` has a side effect. `BaseData::typeName` allows to use only the type, without a parameter. So, by expliciting the type, we can remove the call to `getValue`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
