### PR TITLE
[Core] Deprecate typeName with parameter

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -83,3 +83,12 @@
         "v24.12", "v25.06", \
         "Data renamed according to the guidelines")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED__UNNECESSARY_PARAMETER_IN_TYPENAME()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__UNNECESSARY_PARAMETER_IN_TYPENAME() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v24.12", "v25.06", \
+        "The parameter is not necessary. Use the function without parameter.")
+#endif

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
@@ -298,7 +298,7 @@ public:
     }
 
     template<class T>
-    static SOFA_ATTRIBUTE_DEPRECATED__UNNECESSARY_PARAMETER_IN_TYPENAME() std::string typeName(const T*)
+    SOFA_ATTRIBUTE_DEPRECATED__UNNECESSARY_PARAMETER_IN_TYPENAME() static std::string typeName(const T*)
     {
         return typeName<T>();
     }

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
@@ -288,12 +288,19 @@ public:
 
     /// Helper method to get the type name of type T
     template<class T>
-    static std::string typeName(const T* = nullptr)
+    static std::string typeName()
     {
         if (defaulttype::DataTypeInfo<T>::ValidInfo)
+        {
             return defaulttype::DataTypeName<T>::name();
-        else
-            return decodeTypeName(typeid(T));
+        }
+        return decodeTypeName(typeid(T));
+    }
+
+    template<class T>
+    static SOFA_ATTRIBUTE_DEPRECATED__UNNECESSARY_PARAMETER_IN_TYPENAME() std::string typeName(const T*)
+    {
+        return typeName<T>();
     }
 
 protected:


### PR DESCRIPTION
The parameter is not used in the function. Only its type. The parameter is here probably just for template deduction. I suggest to remove the use of a parameter. Reason in https://github.com/sofa-framework/sofa/pull/4816



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
