### PR TITLE
[Sofa.GL] OglModel: Deprecate/Remove isEnabled Data

### DIFF
--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -53,7 +53,6 @@ OglModel::OglModel()
     , pointSize(initData(&pointSize, 1.0f, "pointSize", "Point size (set if != 1, only for points rendering)"))
     , lineSmooth(initData(&lineSmooth, false, "lineSmooth", "Enable smooth line rendering"))
     , pointSmooth(initData(&pointSmooth, false, "pointSmooth", "Enable smooth point rendering"))
-    , isEnabled( initData(&isEnabled, true, "isEnabled", "Activate/deactive the component."))
     , primitiveType( initData(&primitiveType, "primitiveType", "Select types of primitives to send (necessary for some shader types such as geometry or tesselation)"))
     , blendEquation( initData(&blendEquation, "blendEquation", "if alpha blending is enabled this specifies how source and destination colors are combined") )
     , sourceFactor( initData(&sourceFactor, "sfactor", "if alpha blending is enabled this specifies how the red, green, blue, and alpha source blending factors are computed") )
@@ -71,6 +70,18 @@ OglModel::OglModel()
     sourceFactor.setValue(helper::OptionsGroup{"GL_ZERO", "GL_ONE", "GL_SRC_ALPHA", "GL_ONE_MINUS_SRC_ALPHA"}.setSelectedItem(2));
     destFactor.setValue(helper::OptionsGroup{"GL_ZERO", "GL_ONE", "GL_SRC_ALPHA", "GL_ONE_MINUS_SRC_ALPHA"}.setSelectedItem(3));
     primitiveType.setValue(helper::OptionsGroup{"DEFAULT", "LINES_ADJACENCY", "PATCHES", "POINTS"}.setSelectedItem(0));
+}
+
+void OglModel::parse(core::objectmodel::BaseObjectDescription* arg)
+{
+    if (arg->getAttribute("isEnabled"))
+    {
+        msg_warning() << "isEnabled field has been renamed to \'enabled\' since v23.12 (#3931).";
+
+        this->d_enable.setValue(std::strcmp(arg->getAttribute("isEnabled"), "true") == 0 || arg->getAttributeAsInt("isEnabled"));
+    }
+
+    Inherit::parse(arg);
 }
 
 void OglModel::deleteTextures()
@@ -329,9 +340,6 @@ void copyVector(const InType& src, OutType& dst)
 void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool transparent)
 {
     if (!vparams->displayFlags().getShowVisualModels())
-        return;
-
-    if(!isEnabled.getValue())
         return;
 
     /// Checks that the VBO's are ready.

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
@@ -61,8 +61,9 @@ protected:
     Data<GLfloat> pointSize; ///< Point size (set if != 1, only for points rendering)
     Data<bool> lineSmooth; ///< Enable smooth line rendering
     Data<bool> pointSmooth; ///< Enable smooth point rendering
-    /// Suppress field for save as function
-    Data < bool > isEnabled;
+
+    // SOFA_ATTRIBUTE_DISABLED("v24.12", "v25.06")
+    DeprecatedAndRemoved isEnabled;
 
     // primitive types
     Data<sofa::helper::OptionsGroup> primitiveType; ///< Select types of primitives to send (necessary for some shader types such as geometry or tesselation)
@@ -102,6 +103,7 @@ protected:
 
     ~OglModel() override;
 public:
+    void parse(core::objectmodel::BaseObjectDescription* arg) override;
 
     bool loadTexture(const std::string& filename) override;
     bool loadTextures() override;


### PR DESCRIPTION
- #3931 

added  a `enabled` data for all VisualModels

OglModel already had a data with the same feature (`isEnabled`) so this PR removes it.
Breaking because of the removal of the Data isEnabled (change of type) so the code using it as a Data will break,



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
