### PR TITLE
[Projective] FixedProjectiveConstraint: Remove draw specializations and compute bbox

### DIFF
--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.cpp
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.cpp
@@ -41,101 +41,11 @@ int FixedProjectiveConstraintClass = core::RegisterObject("Attach given particle
         .add< FixedProjectiveConstraint<Rigid2Types> >()
         ;
 
-
-// methods specilizations declaration
-template <> SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API
-void FixedProjectiveConstraint<defaulttype::Rigid3Types >::draw(const core::visual::VisualParams* vparams);
-template <> SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API
-void FixedProjectiveConstraint<defaulttype::Rigid2Types >::draw(const core::visual::VisualParams* vparams);
-
-
-
 template class SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API FixedProjectiveConstraint<Vec3Types>;
 template class SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API FixedProjectiveConstraint<Vec2Types>;
 template class SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API FixedProjectiveConstraint<Vec1Types>;
 template class SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API FixedProjectiveConstraint<Vec6Types>;
 template class SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API FixedProjectiveConstraint<Rigid3Types>;
 template class SOFA_COMPONENT_CONSTRAINT_PROJECTIVE_API FixedProjectiveConstraint<Rigid2Types>;
-
-
-
-// methods specilizations definition
-template <>
-void FixedProjectiveConstraint<Rigid3Types>::draw(const core::visual::VisualParams* vparams)
-{
-    if (this->d_componentState.getValue() != ComponentState::Valid) return;
-    if (!d_showObject.getValue()) return;
-    if (!this->isActive()) return;
-    if (!vparams->displayFlags().getShowBehaviorModels()) return;
-
-    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
-
-    const SetIndexArray & indices = d_indices.getValue();
-    const VecCoord& x = mstate->read(core::ConstVecCoordId::position())->getValue();
-
-    std::vector< type::Vec3 > points;
-
-    if (d_fixAll.getValue())
-    {
-        for (const auto& xi : x)
-            points.push_back(xi.getCenter());
-    }
-    else
-    {
-        if( x.size() < indices.size() )
-        {
-            for (unsigned i=0; i<x.size(); i++ )
-            {
-                points.push_back(x[indices[i]].getCenter());
-            }
-        }
-        else
-        {
-            for (const unsigned int index : indices)
-            {
-                points.push_back(x[index].getCenter());
-            }
-        }
-    }
-
-    if( d_drawSize.getValue() == 0) // old classical drawing by points
-        vparams->drawTool()->drawPoints(points, 10, sofa::type::RGBAColor(1,0.5,0.5,1));
-    else
-        vparams->drawTool()->drawSpheres(points, (float)d_drawSize.getValue(), sofa::type::RGBAColor(1.0f,0.35f,0.35f,1.0f));
-
-
-}
-
-template <>
-void FixedProjectiveConstraint<Rigid2Types>::draw(const core::visual::VisualParams* vparams)
-{
-    if (this->d_componentState.getValue() != ComponentState::Valid) return;
-    if (!d_showObject.getValue()) return;
-    if (!this->isActive()) return;
-    if (!vparams->displayFlags().getShowBehaviorModels()) return;
-
-    const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
-
-    const SetIndexArray& indices = d_indices.getValue();
-    const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
-
-    vparams->drawTool()->setLightingEnabled(false);
-    constexpr sofa::type::RGBAColor color (1,0.5,0.5,1);
-    std::vector<sofa::type::Vec3> vertices;
-
-    if(d_fixAll.getValue())
-    {
-        for (const auto& xi : x)
-            vertices.emplace_back(xi.getCenter()[0], xi.getCenter()[1], 0.0);
-    }
-    else
-    {
-        for (const unsigned int index : indices)
-            vertices.emplace_back(x[index].getCenter()[0], x[index].getCenter()[1], 0.0);
-    }
-
-    vparams->drawTool()->drawPoints(vertices, 10, color);
-
-}
 
 } // namespace sofa::component::constraint::projective

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.h
@@ -115,6 +115,7 @@ public:
 
     void applyConstraint(sofa::core::behavior::ZeroDirichletCondition* matrix) override;
 
+    void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
     void draw(const core::visual::VisualParams* vparams) override;
 
     bool fixAllDOFs() const { return d_fixAll.getValue(); }
@@ -122,6 +123,8 @@ public:
 protected :
     /// Function check values of given indices
     void checkIndices();
+
+    void computeBBoxForIndices(const type::vector<Index>& indices);
 
 };
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.inl
@@ -362,6 +362,62 @@ void FixedProjectiveConstraint<DataTypes>::applyConstraint(sofa::core::behavior:
 }
 
 template <class DataTypes>
+void FixedProjectiveConstraint<DataTypes>::computeBBoxForIndices(const type::vector<Index>& indices)
+{
+    using Real = typename DataTypes::Real;
+
+    constexpr Real max_real = std::numeric_limits<Real>::max();
+    constexpr Real min_real = std::numeric_limits<Real>::lowest();
+    Real maxBBox[3] = {min_real,min_real,min_real};
+    Real minBBox[3] = {max_real,max_real,max_real};
+
+    const auto drawSize = d_drawSize.getValue();
+
+    const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
+
+    for (const auto index : indices)
+    {
+        const auto x3d = DataTypes::getCPos(x[index]);
+
+        for (unsigned int i = 0; i < x3d.size(); ++i)
+        {
+            maxBBox[i] = std::max(x3d[i] + drawSize, maxBBox[i]);
+            minBBox[i] = std::min(x3d[i] - drawSize, minBBox[i]);
+        }
+    }
+    this->f_bbox.setValue(sofa::type::TBoundingBox<Real>(minBBox,maxBBox));
+}
+
+template <class DataTypes>
+void FixedProjectiveConstraint<DataTypes>::computeBBox(
+    const core::ExecParams* params, bool onlyVisible)
+{
+    SOFA_UNUSED(params);
+
+    if( onlyVisible && !d_showObject.getValue() )
+    {
+        return;
+    }
+
+    if(this->d_componentState.getValue() == ComponentState::Invalid)
+    {
+        return;
+    }
+
+    const auto& indices = d_indices.getValue();
+
+    if (d_fixAll.getValue())
+    {
+        const auto bbox = this->mstate->computeBBox(); //this may compute twice the mstate bbox, but there is no way to determine if the bbox has already been computed
+        this->f_bbox.setValue(std::move(bbox));
+    }
+    else if (!indices.empty())
+    {
+        computeBBoxForIndices(indices);
+    }
+}
+
+template <class DataTypes>
 void FixedProjectiveConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     if (this->d_componentState.getValue() != ComponentState::Valid) return;
@@ -389,9 +445,9 @@ void FixedProjectiveConstraint<DataTypes>::draw(const core::visual::VisualParams
         }
         else
         {
-            for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+            for (const auto index : indices)
             {
-                point = DataTypes::getCPos(x[*it]);
+                point = DataTypes::getCPos(x[index]);
                 points.push_back(point);
             }
         }
@@ -404,16 +460,18 @@ void FixedProjectiveConstraint<DataTypes>::draw(const core::visual::VisualParams
         std::vector< sofa::type::Vec3 > points;
         sofa::type::Vec3 point;
         if( d_fixAll.getValue()==true )
+        {
             for (unsigned i=0; i<x.size(); i++ )
             {
                 point = DataTypes::getCPos(x[i]);
                 points.push_back(point);
             }
+        }
         else
         {
-            for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+            for (const auto index : indices)
             {
-                point = DataTypes::getCPos(x[*it]);
+                point = DataTypes::getCPos(x[index]);
                 points.push_back(point);
             }
         }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/FixedProjectiveConstraint.inl
@@ -371,7 +371,7 @@ void FixedProjectiveConstraint<DataTypes>::computeBBoxForIndices(const type::vec
     Real maxBBox[3] = {min_real,min_real,min_real};
     Real minBBox[3] = {max_real,max_real,max_real};
 
-    const auto drawSize = d_drawSize.getValue();
+    const auto drawSize = static_cast<Real>(d_drawSize.getValue());
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 


### PR DESCRIPTION
The removed specializations were not that different from the generic `draw` method. So, I removed them. I also took the opportunity to implement bbox computation.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
