### PR TITLE
[All] VisualModel: implement NVI for init/updateVisual()

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/LineAxis.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/LineAxis.cpp
@@ -45,15 +45,20 @@ LineAxis::LineAxis()
 void LineAxis::init()
 {
     Inherit1::init();
-    updateVisual();
+    updateLine();
 }
 
 void LineAxis::reinit()
 {
-    updateVisual();
+    updateLine();
 }
 
-void LineAxis::updateVisual()
+void LineAxis::doUpdateVisual(const core::visual::VisualParams*)
+{
+    updateLine();
+}
+
+void LineAxis::updateLine()
 {
     const std::string a = d_axis.getValue();
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/LineAxis.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/LineAxis.h
@@ -42,10 +42,10 @@ public:
     void init() override;
     void reinit() override;
     void doDrawVisual(const core::visual::VisualParams*) override;
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams*) override;
+    void updateLine();
 
 protected:
-
     bool m_drawX;
     bool m_drawY;
     bool m_drawZ;

--- a/Sofa/Component/Visual/src/sofa/component/visual/Visual3DText.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/Visual3DText.cpp
@@ -50,8 +50,6 @@ void Visual3DText::init()
     VisualModel::init();
 
     reinit();
-
-    updateVisual();
 }
 
 void Visual3DText::reinit()

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
@@ -64,7 +64,7 @@ void VisualGrid::reinit()
     updateGrid();
 }
 
-void VisualGrid::doUpdateVisual(const core::visual::VisualParams* vparams)
+void VisualGrid::doUpdateVisual(const core::visual::VisualParams*)
 {
     updateGrid();
 }

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
@@ -46,7 +46,7 @@ VisualGrid::VisualGrid()
     addUpdateCallback("buildGrid", {&d_plane, &d_size, &d_nbSubdiv}, [this](const core::DataTracker& t)
     {
         SOFA_UNUSED(t);
-        updateVisual();
+        updateGrid();
         return sofa::core::objectmodel::ComponentState::Valid;
     }, {});
 }
@@ -54,17 +54,22 @@ VisualGrid::VisualGrid()
 void VisualGrid::init()
 {
     Inherit1::init();
-    updateVisual();
+    updateGrid();
 
     d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 void VisualGrid::reinit()
 {
-    updateVisual();
+    updateGrid();
 }
 
-void VisualGrid::updateVisual()
+void VisualGrid::doUpdateVisual(const core::visual::VisualParams* vparams)
+{
+    updateGrid();
+}
+
+void VisualGrid::updateGrid()
 {
     const auto planeValue = d_plane.getValue();
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.h
@@ -64,7 +64,8 @@ public:
     void init() override;
     void reinit() override;
     void doDrawVisual(const core::visual::VisualParams*) override;
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams*) override;
+    void updateGrid();
     void buildGrid();
 
 protected:

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -754,6 +754,8 @@ void VisualModelImpl::applyUVScale(const Real scaleU, const Real scaleV)
         vtexcoords[i][1] *= scaleVf;
     }
     d_vtexcoords.endEdit();
+
+    updateVisual(sofa::core::visual::visualparams::defaultInstance());
 }
 
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -256,7 +256,7 @@ void VisualModelImpl::doDrawVisual(const core::visual::VisualParams* vparams)
             loadTexture(d_texturename.getFullPath());
             m_textureChanged = false;
         }
-        initVisual();
+        
         updateBuffers();
         d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
     }
@@ -661,8 +661,8 @@ void VisualModelImpl::applyTranslation(const SReal dx, const SReal dy, const SRe
         m_restPositions.endEdit();
     }
 
-
-    updateVisual();
+    const sofa::core::visual::VisualParams* vparams = sofa::core::visual::VisualParams::defaultInstance();
+    doUpdateVisual(vparams);
 }
 
 void VisualModelImpl::applyRotation(const SReal rx, const SReal ry, const SReal rz)
@@ -695,7 +695,8 @@ void VisualModelImpl::applyRotation(const Quat<SReal> q)
         m_restPositions.endEdit();
     }
 
-    updateVisual();
+    const sofa::core::visual::VisualParams* vparams = sofa::core::visual::VisualParams::defaultInstance();
+    doUpdateVisual(vparams);
 }
 
 void VisualModelImpl::applyScale(const SReal sx, const SReal sy, const SReal sz)
@@ -726,7 +727,8 @@ void VisualModelImpl::applyScale(const SReal sx, const SReal sy, const SReal sz)
         m_restPositions.endEdit();
     }
 
-    updateVisual();
+    const sofa::core::visual::VisualParams* vparams = sofa::core::visual::VisualParams::defaultInstance();
+    doUpdateVisual(vparams);
 }
 
 void VisualModelImpl::applyUVTranslation(const Real dU, const Real dV)
@@ -814,8 +816,6 @@ void VisualModelImpl::init()
     d_translation.setValue(Vec3Real());
     d_rotation.setValue(Vec3Real());
     d_scale.setValue(Vec3Real(1, 1, 1));
-
-    updateVisual();
 }
 
 
@@ -1310,7 +1310,7 @@ void VisualModelImpl::setColor(std::string color)
 }
 
 
-void VisualModelImpl::updateVisual()
+void VisualModelImpl::doUpdateVisual(const core::visual::VisualParams* vparams)
 {
     if (modified && !getVertices().empty())
     {
@@ -1496,11 +1496,6 @@ void VisualModelImpl::computeMesh()
         quads[i][3] = visual_index_type(inputQuads[i][3]);
     }
     d_quads.endEdit();
-}
-
-
-void VisualModelImpl::initVisual()
-{
 }
 
 void VisualModelImpl::exportOBJ(std::string name, std::ostream* out, std::ostream* mtl, sofa::Index& vindex, sofa::Index& nindex, sofa::Index& tindex, int& count)

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -256,7 +256,7 @@ void VisualModelImpl::doDrawVisual(const core::visual::VisualParams* vparams)
             loadTexture(d_texturename.getFullPath());
             m_textureChanged = false;
         }
-        
+        initVisual(vparams);
         updateBuffers();
         d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
     }
@@ -661,8 +661,7 @@ void VisualModelImpl::applyTranslation(const SReal dx, const SReal dy, const SRe
         m_restPositions.endEdit();
     }
 
-    const sofa::core::visual::VisualParams* vparams = sofa::core::visual::VisualParams::defaultInstance();
-    doUpdateVisual(vparams);
+    updateVisual(sofa::core::visual::visualparams::defaultInstance());
 }
 
 void VisualModelImpl::applyRotation(const SReal rx, const SReal ry, const SReal rz)
@@ -695,8 +694,7 @@ void VisualModelImpl::applyRotation(const Quat<SReal> q)
         m_restPositions.endEdit();
     }
 
-    const sofa::core::visual::VisualParams* vparams = sofa::core::visual::VisualParams::defaultInstance();
-    doUpdateVisual(vparams);
+    updateVisual(sofa::core::visual::visualparams::defaultInstance());
 }
 
 void VisualModelImpl::applyScale(const SReal sx, const SReal sy, const SReal sz)
@@ -727,8 +725,7 @@ void VisualModelImpl::applyScale(const SReal sx, const SReal sy, const SReal sz)
         m_restPositions.endEdit();
     }
 
-    const sofa::core::visual::VisualParams* vparams = sofa::core::visual::VisualParams::defaultInstance();
-    doUpdateVisual(vparams);
+    updateVisual(sofa::core::visual::visualparams::defaultInstance());
 }
 
 void VisualModelImpl::applyUVTranslation(const Real dU, const Real dV)
@@ -742,6 +739,8 @@ void VisualModelImpl::applyUVTranslation(const Real dU, const Real dV)
         vtexcoords[i][1] += dVf;
     }
     d_vtexcoords.endEdit();
+
+    updateVisual(sofa::core::visual::visualparams::defaultInstance());
 }
 
 void VisualModelImpl::applyUVScale(const Real scaleU, const Real scaleV)

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.h
@@ -449,16 +449,14 @@ public:
     virtual void updateBuffers() {}
     virtual void deleteBuffers() {}
     virtual void deleteTextures() {}
-
-    void updateVisual() override;
+    
+    void doUpdateVisual(const core::visual::VisualParams*) override;
 
     void init() override;
     void initFromTopology();
     void initPositionFromVertices();
     void initFromFileMesh();
-
-    void initVisual() override;
-
+    
     /// Append this mesh to an OBJ format stream.
     /// The number of vertices position, normal, and texture coordinates already written is given as parameters
     /// This method should update them

--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.cpp
@@ -118,7 +118,7 @@ void OglLabel::reinit()
     }
 }
 
-void OglLabel::updateVisual()
+void OglLabel::doUpdateVisual(const core::visual::VisualParams*)
 {
     if (!d_updateLabelEveryNbSteps.getValue()) m_internalLabel = d_label.getValue();
 }

--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.h
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglLabel.h
@@ -54,7 +54,7 @@ public:
 
     void init() override;
     void reinit() override;
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams*) override;
     void doDrawVisual(const core::visual::VisualParams* vparams) override;
 
     void handleEvent(core::objectmodel::Event *) override;

--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglViewport.cpp
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglViewport.cpp
@@ -77,7 +77,7 @@ void OglViewport::init()
     }
 }
 
-void OglViewport::initVisual()
+void OglViewport::doInitVisual(const core::visual::VisualParams*)
 {
     if (p_useFBO.getValue())
     {

--- a/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglViewport.h
+++ b/Sofa/GL/Component/Rendering2D/src/sofa/gl/component/rendering2d/OglViewport.h
@@ -63,7 +63,7 @@ protected:
 public:
     void init() override;
     void draw(const core::visual::VisualParams* vparams) override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams*) override;
     void preDrawScene(core::visual::VisualParams* vp) override;
     bool drawScene(core::visual::VisualParams* vp) override;
     void postDrawScene(core::visual::VisualParams* vp) override;

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
@@ -86,7 +86,7 @@ void DataDisplay::init()
 }
 
 
-void DataDisplay::updateVisual()
+void DataDisplay::doUpdateVisual(const core::visual::VisualParams*)
 {
     computeNormals();
 }

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.h
@@ -70,7 +70,7 @@ public:
 
     void init() override;
     void doDrawVisual(const core::visual::VisualParams* vparams) override;
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams* vparams) override;
 
     bool insertInNode( core::objectmodel::BaseNode* node ) override { Inherit1::insertInNode(node); Inherit2::insertInNode(node); return true; }
     bool removeInNode( core::objectmodel::BaseNode* node ) override { Inherit1::removeInNode(node); Inherit2::removeInNode(node); return true; }

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglCylinderModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglCylinderModel.cpp
@@ -55,12 +55,6 @@ void OglCylinderModel::init()
     VisualModel::init();
 
     reinit();
-
-    updateVisual();
-}
-
-void OglCylinderModel::reinit()
-{
 }
 
 void OglCylinderModel::doDrawVisual(const core::visual::VisualParams* vparams)

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglCylinderModel.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglCylinderModel.h
@@ -56,8 +56,6 @@ protected:
 public:
     void init() override;
 
-    void reinit() override;
-
     void doDrawVisual(const core::visual::VisualParams* vparams) override;
 
     void exportOBJ(std::string /*name*/, std::ostream* /*out*/, std::ostream* /*mtl*/, Index& /*vindex*/, Index& /*nindex*/, Index& /*tindex*/, int& /*count*/) override;

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -641,7 +641,7 @@ bool OglModel::loadTextures()
     return result;
 }
 
-void OglModel::initVisual()
+void OglModel::doInitVisual(const core::visual::VisualParams*)
 {
     initTextures();
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
@@ -109,7 +109,7 @@ public:
     bool loadTextures() override;
 
     void initTextures();
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
 
     void init() override { VisualModelImpl::init(); }
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
@@ -47,17 +47,6 @@ OglSceneFrame::OglSceneFrame()
     d_alignment.setValue(alignmentOptions);
 }
 
-void OglSceneFrame::init()
-{
-    Inherit1::init();
-    updateVisual();
-}
-
-void OglSceneFrame::reinit()
-{
-    updateVisual();
-}
-
 void OglSceneFrame::drawArrows(const core::visual::VisualParams* vparams)
 {
     for (unsigned int i = 0; i < 3; ++i)
@@ -113,7 +102,7 @@ void OglSceneFrame::drawCubeCones(const core::visual::VisualParams* vparams)
     }
 }
 
-void OglSceneFrame::draw(const core::visual::VisualParams* vparams)
+void OglSceneFrame::doDrawVisual(const core::visual::VisualParams* vparams)
 {
     if (!d_drawFrame.getValue()) return;
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
@@ -44,9 +44,7 @@ public:
 
     OglSceneFrame();
 
-    void init() override;
-    void reinit() override;
-    void draw(const core::visual::VisualParams*) override;
+    void doDrawVisual(const core::visual::VisualParams*) override;
 
 private:
     static void drawArrows(const core::visual::VisualParams* vparams);

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/PointSplatModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/PointSplatModel.cpp
@@ -98,8 +98,6 @@ void PointSplatModel::init()
     }
 
     reinit();
-
-    updateVisual();
 }
 
 void PointSplatModel::reinit()

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/SlicedVolumetricModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/SlicedVolumetricModel.cpp
@@ -134,8 +134,6 @@ void SlicedVolumetricModel::init()
     }
 
     reinit();
-
-    updateVisual();
 }
 
 void SlicedVolumetricModel::reinit()

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/CompositingVisualLoop.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/CompositingVisualLoop.cpp
@@ -43,9 +43,6 @@ CompositingVisualLoop::CompositingVisualLoop()
 CompositingVisualLoop::~CompositingVisualLoop()
 {}
 
-void CompositingVisualLoop::initVisual()
-{}
-
 void CompositingVisualLoop::init()
 {
     if (!l_node)

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/CompositingVisualLoop.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/CompositingVisualLoop.h
@@ -61,7 +61,6 @@ protected:
 public:
 
     void init() override;
-    void initVisual() override;
     void drawStep(sofa::core::visual::VisualParams* vparams) override;
 };
 

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.cpp
@@ -223,10 +223,10 @@ void Light::reinit()
     b_needUpdate = true;
 }
 
-void Light::drawLight()
+void Light::drawLight(const core::visual::VisualParams* vparams)
 {
     if (b_needUpdate)
-        updateVisual(sofa::core::visual::visualparams::defaultInstance());
+        updateVisual(vparams);
     glLightf(GL_LIGHT0+m_lightID, GL_SPOT_CUTOFF, 180.0);
     const GLfloat c[4] = { (GLfloat)d_color.getValue()[0], (GLfloat)d_color.getValue()[1], (GLfloat)d_color.getValue()[2], 1.0 };
     glLightfv(GL_LIGHT0+m_lightID, GL_AMBIENT, c);
@@ -236,10 +236,10 @@ void Light::drawLight()
 
 }
 
-void Light::preDrawShadow(core::visual::VisualParams* /* vp */)
+void Light::preDrawShadow(core::visual::VisualParams* vp)
 {
     if (b_needUpdate)
-        updateVisual(sofa::core::visual::visualparams::defaultInstance());
+        updateVisual(vp);
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glMatrixMode(GL_MODELVIEW);
@@ -407,9 +407,9 @@ DirectionalLight::~DirectionalLight()
 
 }
 
-void DirectionalLight::drawLight()
+void DirectionalLight::drawLight(const core::visual::VisualParams* vparams)
 {
-    Light::drawLight();
+    Light::drawLight(vparams);
     GLfloat dir[4];
 
     dir[0]=(GLfloat)(d_direction.getValue()[0]);
@@ -612,9 +612,9 @@ PositionalLight::~PositionalLight()
 
 }
 
-void PositionalLight::drawLight()
+void PositionalLight::drawLight(const core::visual::VisualParams* vparams)
 {
-    Light::drawLight();
+    Light::drawLight(vparams);
 
     GLfloat pos[4];
     pos[0]=(GLfloat)(d_position.getValue()[0]);
@@ -682,9 +682,9 @@ SpotLight::~SpotLight()
 
 }
 
-void SpotLight::drawLight()
+void SpotLight::drawLight(const core::visual::VisualParams* vparams)
 {
-    PositionalLight::drawLight();
+    PositionalLight::drawLight(vparams);
     type::Vec3 d = d_direction.getValue();
     if (d_lookat.getValue()) d -= d_position.getValue();
     d.normalize();

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.cpp
@@ -183,7 +183,7 @@ void Light::init()
     }
 }
 
-void Light::initVisual()
+void Light::doInitVisual(const core::visual::VisualParams* vparams)
 {
     //init Shadow part
     computeShadowMapSize();
@@ -204,14 +204,14 @@ void Light::initVisual()
     m_depthShader->vertFilename.addPath(PATH_TO_GENERATE_DEPTH_TEXTURE_VERTEX_SHADER,true);
     m_depthShader->fragFilename.addPath(PATH_TO_GENERATE_DEPTH_TEXTURE_FRAGMENT_SHADER,true);
     m_depthShader->init();
-    m_depthShader->initVisual();
+    m_depthShader->initVisual(vparams);
     m_blurShader->vertFilename.addPath(PATH_TO_BLUR_TEXTURE_VERTEX_SHADER,true);
     m_blurShader->fragFilename.addPath(PATH_TO_BLUR_TEXTURE_FRAGMENT_SHADER,true);
     m_blurShader->init();
-    m_blurShader->initVisual();
+    m_blurShader->initVisual(vparams);
 }
 
-void Light::updateVisual()
+void Light::doUpdateVisual(const core::visual::VisualParams*)
 {
     if (!b_needUpdate) return;
     computeShadowMapSize();
@@ -226,7 +226,7 @@ void Light::reinit()
 void Light::drawLight()
 {
     if (b_needUpdate)
-        updateVisual();
+        updateVisual(sofa::core::visual::visualparams::defaultInstance());
     glLightf(GL_LIGHT0+m_lightID, GL_SPOT_CUTOFF, 180.0);
     const GLfloat c[4] = { (GLfloat)d_color.getValue()[0], (GLfloat)d_color.getValue()[1], (GLfloat)d_color.getValue()[2], 1.0 };
     glLightfv(GL_LIGHT0+m_lightID, GL_AMBIENT, c);
@@ -239,7 +239,7 @@ void Light::drawLight()
 void Light::preDrawShadow(core::visual::VisualParams* /* vp */)
 {
     if (b_needUpdate)
-        updateVisual();
+        updateVisual(sofa::core::visual::visualparams::defaultInstance());
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glMatrixMode(GL_MODELVIEW);

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.h
@@ -95,7 +95,7 @@ public:
     //VisualModel
     void doInitVisual(const core::visual::VisualParams* vparams) override;
     void init() override;
-    virtual void drawLight();
+    virtual void drawLight(const core::visual::VisualParams* vparams);
     void reinit() override;
     void doUpdateVisual(const core::visual::VisualParams* vparams) override;
 
@@ -137,7 +137,7 @@ public:
     DirectionalLight();
     ~DirectionalLight() override;
     void preDrawShadow(core::visual::VisualParams* vp) override;
-    void drawLight() override;
+    void drawLight(const core::visual::VisualParams* vparams) override;
     void draw(const core::visual::VisualParams* vparams) override;
     void drawSource(const core::visual::VisualParams* vparams) override;
     GLuint getDepthTexture() override;
@@ -162,7 +162,7 @@ public:
 
     PositionalLight();
     ~PositionalLight() override;
-    void drawLight() override;
+    void drawLight(const core::visual::VisualParams* vparams) override;
     void draw(const core::visual::VisualParams* vparams) override;
     void drawSource(const core::visual::VisualParams*) override;
     const sofa::type::Vec3 getPosition() override { return d_position.getValue(); }
@@ -181,7 +181,7 @@ public:
 
     SpotLight();
     ~SpotLight() override;
-    void drawLight() override;
+    void drawLight(const core::visual::VisualParams* vparams) override;
     void draw(const core::visual::VisualParams* vparams) override;
     void drawSource(const core::visual::VisualParams* vparams) override;
 

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/Light.h
@@ -93,11 +93,11 @@ public:
     void setID(const GLint& id);
 
     //VisualModel
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
     void init() override;
     virtual void drawLight();
     void reinit() override;
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams* vparams) override;
 
     /// Draw the light source from an external point of view.
     virtual void drawSource(const sofa::core::visual::VisualParams*) = 0;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/LightManager.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/LightManager.cpp
@@ -206,7 +206,7 @@ void LightManager::fwdDraw(core::visual::VisualParams* vp)
     for (std::vector<Light::SPtr>::iterator itl = m_lights.begin(); itl != m_lights.end() ; ++itl)
     {
         glEnable(GL_LIGHT0+id);
-        (*itl)->drawLight();
+        (*itl)->drawLight(vp);
         ++id;
     }
 

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/LightManager.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/LightManager.cpp
@@ -93,10 +93,10 @@ void LightManager::bwdInit()
     }
 }
 
-void LightManager::initVisual()
+void LightManager::doInitVisual(const core::visual::VisualParams* vparams)
 {
     for(unsigned int i=0 ; i<m_shadowShaders.size() ; ++i)
-        m_shadowShaders[i]->initVisual();
+        m_shadowShaders[i]->initVisual(vparams);
 
     ///TODO: keep trace of all active textures at the same time, with a static factory
     ///or something like that to avoid conflics with color texture declared in the scene file.
@@ -115,7 +115,7 @@ void LightManager::initVisual()
 
     for (std::vector<Light::SPtr>::iterator itl = m_lights.begin(); itl != m_lights.end() ; ++itl)
     {
-        (*itl)->initVisual();
+        (*itl)->initVisual(vparams);
         const unsigned short shadowTextureUnit = (*itl)->getShadowTextureUnit();
 
         /// if given unit is available and correct
@@ -499,13 +499,13 @@ void LightManager::handleEvent(sofa::core::objectmodel::Event* event)
                     for (unsigned int i=0 ; i < m_shadowShaders.size() ; ++i)
                     {
                         m_shadowShaders[i]->setCurrentIndex(d_shadowsEnabled.getValue() ? 1 : 0);
-                        m_shadowShaders[i]->updateVisual();
+                        m_shadowShaders[i]->updateVisual(sofa::core::visual::visualparams::defaultInstance());
                     }
                     for (std::vector<Light::SPtr>::iterator itl = m_lights.begin(); itl != m_lights.end() ; ++itl)
                     {
-                        (*itl)->updateVisual();
+                        (*itl)->updateVisual(sofa::core::visual::visualparams::defaultInstance());
                     }
-                    this->updateVisual();
+                    this->updateVisual(sofa::core::visual::visualparams::defaultInstance());
                 }
 
                 msg_info() << "Shadows : "<<(d_shadowsEnabled.getValue()?"ENABLED":"DISABLED");

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/LightManager.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/LightManager.h
@@ -71,7 +71,7 @@ public:
     void init() override;
     void bwdInit() override;
     void reinit() override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
 
     void preDrawScene(core::visual::VisualParams* vp) override;
     bool drawScene(core::visual::VisualParams* vp) override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglAttribute.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglAttribute.h
@@ -44,13 +44,13 @@ public:
     typedef TDataTypes DataType;
 
     void init() override;
-
-    void initVisual() override;
+    
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
 
     void reinit() override;
 
     /// if attributes are not static, update the buffer
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams* vparams) override;
 
     type::vector<TDataTypes>* beginEdit();
     void endEdit();

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglAttribute.inl
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglAttribute.inl
@@ -71,7 +71,7 @@ void OglAttribute< size, type, DataTypes>::init()
 }
 
 template < int size, unsigned int type, class DataTypes>
-void OglAttribute< size, type, DataTypes>::initVisual ()
+void OglAttribute< size, type, DataTypes>::doInitVisual (const core::visual::VisualParams* )
 {
     if ( _abo == GLuint(-1) ) glGenBuffers ( 1, &_abo );
     const type::vector<DataTypes>& data = value.getValue();
@@ -106,7 +106,7 @@ void OglAttribute< size, type, DataTypes>::initVisual ()
 }
 
 template < int size, unsigned int type, class DataTypes>
-void OglAttribute< size, type, DataTypes>::updateVisual()
+void OglAttribute< size, type, DataTypes>::doUpdateVisual(const core::visual::VisualParams* )
 {
      if ( _abo == GLuint(-1) )
          return; // initVisual not yet called

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShader.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShader.cpp
@@ -140,7 +140,7 @@ void OglShader::reinit()
 
 }
 
-void OglShader::initVisual()
+void OglShader::doInitVisual(const core::visual::VisualParams*)
 {
 
     if (!sofa::gl::GLSLShader::InitGLSL())
@@ -278,11 +278,6 @@ void OglShader::start()
 bool OglShader::isActive()
 {
     return !passive.getValue();
-}
-
-void OglShader::updateVisual()
-{
-
 }
 
 unsigned int OglShader::getNumberOfShaders()

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShader.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShader.h
@@ -101,10 +101,9 @@ protected:
     OglShader();
     ~OglShader() override;
 public:
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams*) override;
     void init() override;
     void reinit() override;
-    void updateVisual() override;
     void parse(core::objectmodel::BaseObjectDescription* arg) override;
 
     void start() override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.cpp
@@ -133,14 +133,14 @@ void OglShaderVisualModel::init()
 }
 
 
-void OglShaderVisualModel::initVisual()
+void OglShaderVisualModel::doInitVisual(const core::visual::VisualParams* vparams)
 {
-    OglModel::initVisual();
+    OglModel::initVisual(vparams);
 }
 
-void OglShaderVisualModel::updateVisual()
+void OglShaderVisualModel::doUpdateVisual(const core::visual::VisualParams* vparams)
 {
-    OglModel::updateVisual();
+    OglModel::updateVisual(vparams);
     computeRestPositions();
 }
 

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.cpp
@@ -132,15 +132,10 @@ void OglShaderVisualModel::init()
     }
 }
 
-
-void OglShaderVisualModel::doInitVisual(const core::visual::VisualParams* vparams)
-{
-    OglModel::initVisual(vparams);
-}
-
 void OglShaderVisualModel::doUpdateVisual(const core::visual::VisualParams* vparams)
 {
-    OglModel::updateVisual(vparams);
+    OglModel::doUpdateVisual(vparams);
+
     computeRestPositions();
 }
 

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.h
@@ -53,11 +53,9 @@ protected:
     ~OglShaderVisualModel() override;
 public:
     void init() override;
-    void initVisual() override;
-
-    void updateVisual() override;
-
-    //void putRestPositions(const Vec3fTypes::VecCoord& positions);
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
+    
+    void doUpdateVisual(const core::visual::VisualParams* vparams) override;
 
     void bwdDraw(core::visual::VisualParams*) override;
     void fwdDraw(core::visual::VisualParams*) override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglShaderVisualModel.h
@@ -53,8 +53,6 @@ protected:
     ~OglShaderVisualModel() override;
 public:
     void init() override;
-    void doInitVisual(const core::visual::VisualParams* vparams) override;
-    
     void doUpdateVisual(const core::visual::VisualParams* vparams) override;
 
     void bwdDraw(core::visual::VisualParams*) override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexture.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexture.cpp
@@ -198,7 +198,7 @@ void OglTexture::init()
     OglShaderElement::init();
 }
 
-void OglTexture::doInitVisual(const core::visual::VisualParams* vparams)
+void OglTexture::doInitVisual(const core::visual::VisualParams*)
 {
     if (img == nullptr)
     {

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexture.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexture.cpp
@@ -198,7 +198,7 @@ void OglTexture::init()
     OglShaderElement::init();
 }
 
-void OglTexture::initVisual()
+void OglTexture::doInitVisual(const core::visual::VisualParams* vparams)
 {
     if (img == nullptr)
     {
@@ -265,7 +265,11 @@ void OglTexture::bwdDraw(core::visual::VisualParams*)
 
 void OglTexture::bind()
 {
-    if (!texture) initVisual();
+    if (!texture) 
+    {
+        initVisual(sofa::core::visual::visualparams::defaultInstance());
+    }
+    
     texture->bind();
     glEnable(texture->getTarget());
 }

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexture.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexture.h
@@ -78,7 +78,7 @@ protected:
     ~OglTexture() override;
 public:
     void init() override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
     void reinit() override;
     void fwdDraw(core::visual::VisualParams*) override;
     void bwdDraw(core::visual::VisualParams*) override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexturePointer.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexturePointer.cpp
@@ -53,16 +53,6 @@ void OglTexturePointer::init()
     OglShaderElement::init();
 }
 
-void OglTexturePointer::initVisual()
-{
-
-}
-
-void OglTexturePointer::reinit()
-{
-
-}
-
 void OglTexturePointer::fwdDraw(core::visual::VisualParams*)
 {
     if (enabled.getValue() && !l_oglTexture.empty())

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexturePointer.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglTexturePointer.h
@@ -59,8 +59,6 @@ protected:
 
 public:
     void init() override;
-    void initVisual() override;
-    void reinit() override;
     void fwdDraw(core::visual::VisualParams*) override;
     void bwdDraw(core::visual::VisualParams*) override;
 

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglVariable.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglVariable.cpp
@@ -177,7 +177,7 @@ OglInt4Variable::OglInt4Variable()
 
 }
 
-void OglIntVariable::initVisual()
+void OglIntVariable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -187,7 +187,7 @@ void OglIntVariable::initVisual()
 }
 
 
-void OglInt2Variable::initVisual()
+void OglInt2Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -196,7 +196,7 @@ void OglInt2Variable::initVisual()
         (*it)->setInt2(idShader, idstr.c_str(), v[0], v[1]);
 }
 
-void OglInt3Variable::initVisual()
+void OglInt3Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -205,7 +205,7 @@ void OglInt3Variable::initVisual()
         (*it)->setInt3(idShader, idstr.c_str(), v[0], v[1], v[2]);
 }
 
-void OglInt4Variable::initVisual()
+void OglInt4Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -235,7 +235,7 @@ OglFloat4Variable::OglFloat4Variable()
 
 }
 
-void OglFloatVariable::initVisual()
+void OglFloatVariable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -245,7 +245,7 @@ void OglFloatVariable::initVisual()
 }
 
 
-void OglFloat2Variable::initVisual()
+void OglFloat2Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -254,7 +254,7 @@ void OglFloat2Variable::initVisual()
         (*it)->setFloat2(idShader, idstr.c_str(), v[0], v[1]);
 }
 
-void OglFloat3Variable::initVisual()
+void OglFloat3Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -263,7 +263,7 @@ void OglFloat3Variable::initVisual()
         (*it)->setFloat3(idShader, idstr.c_str(), v[0], v[1], v[2]);
 }
 
-void OglFloat4Variable::initVisual()
+void OglFloat4Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -340,7 +340,7 @@ void OglIntVector4Variable::init()
     }
 }
 
-void OglIntVectorVariable::initVisual()
+void OglIntVectorVariable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -351,7 +351,7 @@ void OglIntVectorVariable::initVisual()
         (*it)->setIntVector(idShader, idstr.c_str(), count, vptr);
 }
 
-void OglIntVector2Variable::initVisual()
+void OglIntVector2Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -362,7 +362,7 @@ void OglIntVector2Variable::initVisual()
         (*it)->setIntVector2(idShader, idstr.c_str(), count, vptr);
 }
 
-void OglIntVector3Variable::initVisual()
+void OglIntVector3Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -373,7 +373,7 @@ void OglIntVector3Variable::initVisual()
         (*it)->setIntVector3(idShader, idstr.c_str(), count, vptr);
 }
 
-void OglIntVector4Variable::initVisual()
+void OglIntVector4Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -426,7 +426,7 @@ void OglFloatVector4Variable::init()
     OglVariable<type::vector<type::Vec4f> >::init();
 }
 
-void OglFloatVectorVariable::initVisual()
+void OglFloatVectorVariable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -437,7 +437,7 @@ void OglFloatVectorVariable::initVisual()
         (*it)->setFloatVector(idShader, idstr.c_str(), count, vptr);
 }
 
-void OglFloatVector2Variable::initVisual()
+void OglFloatVector2Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -448,7 +448,7 @@ void OglFloatVector2Variable::initVisual()
         (*it)->setFloatVector2(idShader, idstr.c_str(), count, vptr);
 }
 
-void OglFloatVector3Variable::initVisual()
+void OglFloatVector3Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -459,7 +459,7 @@ void OglFloatVector3Variable::initVisual()
         (*it)->setFloatVector3(idShader, idstr.c_str(), count, vptr);
 }
 
-void OglFloatVector4Variable::initVisual()
+void OglFloatVector4Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -493,7 +493,7 @@ void OglMatrix2Variable::init()
     }
 }
 
-void OglMatrix2Variable::initVisual()
+void OglMatrix2Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -526,7 +526,7 @@ void OglMatrix3Variable::init()
     }
 }
 
-void OglMatrix3Variable::initVisual()
+void OglMatrix3Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -559,7 +559,7 @@ void OglMatrix4Variable::init()
     }
 }
 
-void OglMatrix4Variable::initVisual()
+void OglMatrix4Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -592,7 +592,7 @@ void OglMatrix2x3Variable::init()
     }
 }
 
-void OglMatrix2x3Variable::initVisual()
+void OglMatrix2x3Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -626,7 +626,7 @@ void OglMatrix3x2Variable::init()
     }
 }
 
-void OglMatrix3x2Variable::initVisual()
+void OglMatrix3x2Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -659,7 +659,7 @@ void OglMatrix2x4Variable::init()
     }
 }
 
-void OglMatrix2x4Variable::initVisual()
+void OglMatrix2x4Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -692,7 +692,7 @@ void OglMatrix4x2Variable::init()
     }
 }
 
-void OglMatrix4x2Variable::initVisual()
+void OglMatrix4x2Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -725,7 +725,7 @@ void OglMatrix3x4Variable::init()
     }
 }
 
-void OglMatrix3x4Variable::initVisual()
+void OglMatrix3x4Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -758,7 +758,7 @@ void OglMatrix4x3Variable::init()
     }
 }
 
-void OglMatrix4x3Variable::initVisual()
+void OglMatrix4x3Variable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
@@ -779,7 +779,7 @@ void OglMatrix4VectorVariable::init()
 {
     OglVariable<type::vector<type::Mat4x4f> >::init();
 }
-void OglMatrix4VectorVariable::initVisual()
+void OglMatrix4VectorVariable::pushValue()
 {
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglVariable.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglVariable.h
@@ -61,12 +61,17 @@ protected:
     ~OglVariable() override {}
 public:
     virtual void setValue( const DataTypes& v ) { value.setValue(v); }
+    virtual void pushValue() = 0;
+    
     void init() override { OglShaderElement::init(); }
-    void initVisual() override { core::visual::VisualModel::initVisual(); }
-    void pushValue() { initVisual(); }
-    void reinit() override { init();	initVisual(); }
-	void updateVisual() override { initVisual(); }
-
+    void doInitVisual(const core::visual::VisualParams* vparams) override
+    {
+        pushValue();
+    }
+    void reinit() override { init();	pushValue(); }
+    void doUpdateVisual(const core::visual::VisualParams* ) override { pushValue(); }
+    
+    
     /// Returns the type of shader element (texture, macro, variable, or attribute)
     ShaderElementType getSEType() const override { return core::visual::ShaderElement::SE_VARIABLE; }
     // Returns the value of the shader element
@@ -85,7 +90,7 @@ public:
     OglIntVariable();
     virtual ~OglIntVariable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglInt2Variable : public OglVariable<type::Vec<2, int> >
@@ -97,7 +102,7 @@ public:
     OglInt2Variable();
     virtual ~OglInt2Variable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglInt3Variable : public OglVariable<type::Vec<3, int> >
@@ -108,7 +113,7 @@ public:
     OglInt3Variable();
     virtual ~OglInt3Variable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglInt4Variable : public OglVariable<type::Vec<4, int> >
@@ -119,7 +124,7 @@ public:
     OglInt4Variable();
     virtual ~OglInt4Variable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 /** SINGLE FLOAT VARIABLE **/
@@ -132,7 +137,7 @@ public:
     OglFloatVariable();
     virtual ~OglFloatVariable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglFloat2Variable : public OglVariable<type::Vec2f>
@@ -143,7 +148,7 @@ public:
     OglFloat2Variable();
     virtual ~OglFloat2Variable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglFloat3Variable : public OglVariable<type::Vec3f>
@@ -154,7 +159,7 @@ public:
     OglFloat3Variable();
     virtual ~OglFloat3Variable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglFloat4Variable : public OglVariable<type::Vec4f>
@@ -165,7 +170,7 @@ public:
     OglFloat4Variable();
     virtual ~OglFloat4Variable() { }
 
-    void initVisual() override;
+    void pushValue() override;
 };
 
 /** INT VECTOR VARIABLE **/
@@ -178,7 +183,7 @@ public:
     virtual ~OglIntVectorVariable() { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglIntVector2Variable : public OglIntVectorVariable
@@ -191,7 +196,7 @@ public:
     ~OglIntVector2Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglIntVector3Variable : public OglIntVectorVariable
@@ -203,7 +208,7 @@ public:
     ~OglIntVector3Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglIntVector4Variable : public OglIntVectorVariable
@@ -215,7 +220,7 @@ public:
     ~OglIntVector4Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 /** FLOAT VECTOR VARIABLE **/
@@ -228,7 +233,7 @@ public:
     virtual ~OglFloatVectorVariable() { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglFloatVector2Variable : public OglVariable<type::vector<type::Vec2f> >
@@ -240,7 +245,7 @@ public:
     virtual ~OglFloatVector2Variable() { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglFloatVector3Variable : public OglVariable<type::vector<type::Vec3f> >
@@ -252,7 +257,7 @@ public:
     virtual ~OglFloatVector3Variable() { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglFloatVector4Variable : public OglVariable<type::vector<type::Vec4f> >
@@ -264,7 +269,7 @@ public:
     virtual ~OglFloatVector4Variable() { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 /** Matrix VARIABLE **/
@@ -281,7 +286,7 @@ public:
     virtual void setTranspose( const bool& v ) { transpose.setValue(v); }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix3Variable : public OglMatrix2Variable
@@ -293,7 +298,7 @@ public:
     ~OglMatrix3Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix4Variable : public OglMatrix2Variable
@@ -305,7 +310,7 @@ public:
     ~OglMatrix4Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix2x3Variable : public OglMatrix2Variable
@@ -317,7 +322,7 @@ public:
     ~OglMatrix2x3Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix3x2Variable : public OglMatrix2Variable
@@ -329,7 +334,7 @@ public:
     ~OglMatrix3x2Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix2x4Variable : public OglMatrix2Variable
@@ -341,7 +346,7 @@ public:
     ~OglMatrix2x4Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix4x2Variable : public OglMatrix2Variable
@@ -353,7 +358,7 @@ public:
     ~OglMatrix4x2Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix3x4Variable : public OglMatrix2Variable
@@ -365,7 +370,7 @@ public:
     ~OglMatrix3x4Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix4x3Variable : public OglMatrix2Variable
@@ -377,7 +382,7 @@ public:
     ~OglMatrix4x3Variable() override { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 };
 
 class SOFA_GL_COMPONENT_SHADER_API OglMatrix4VectorVariable : public OglVariable<type::vector<type::Mat4x4f> >
@@ -389,7 +394,7 @@ public:
     virtual ~OglMatrix4VectorVariable() { }
 
     void init() override;
-    void initVisual() override;
+    void pushValue() override;
 
     Data<bool> transpose; ///< Transpose the matrix (e.g. to use row-dominant matrices in OpenGL
     virtual void setTranspose( const bool& v ) { transpose.setValue(v); }

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglVariable.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OglVariable.h
@@ -64,7 +64,7 @@ public:
     virtual void pushValue() = 0;
     
     void init() override { OglShaderElement::init(); }
-    void doInitVisual(const core::visual::VisualParams* vparams) override
+    void doInitVisual(const core::visual::VisualParams*) override
     {
         pushValue();
     }

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OrderIndependentTransparencyManager.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OrderIndependentTransparencyManager.cpp
@@ -79,7 +79,7 @@ void OrderIndependentTransparencyManager::bwdInit()
 
 }
 
-void OrderIndependentTransparencyManager::initVisual()
+void OrderIndependentTransparencyManager::doInitVisual(const core::visual::VisualParams*)
 {
     GLSLShader::InitGLSL();
 

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OrderIndependentTransparencyManager.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/OrderIndependentTransparencyManager.h
@@ -78,7 +78,7 @@ public:
     void init() override;
     void bwdInit() override;
     void reinit() override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vp) override;
 
     void preDrawScene(core::visual::VisualParams* vp) override;
     bool drawScene(core::visual::VisualParams* vp) override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/PostProcessManager.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/PostProcessManager.cpp
@@ -66,7 +66,7 @@ void PostProcessManager::init()
     }
 }
 
-void PostProcessManager::initVisual()
+void PostProcessManager::doInitVisual(const core::visual::VisualParams*)
 {
     if (postProcessEnabled)
     {

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/PostProcessManager.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/PostProcessManager.h
@@ -57,7 +57,7 @@ protected:
 public:
     void init() override;
     void reinit() override { };
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
 
     void preDrawScene(core::visual::VisualParams* vp) override;
     bool drawScene(core::visual::VisualParams* vp) override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerPass.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerPass.cpp
@@ -78,7 +78,7 @@ void VisualManagerPass::init()
 }
 
 /* herited from VisualModel */
-void VisualManagerPass::doInitVisual(const core::visual::VisualParams* vparams)
+void VisualManagerPass::doInitVisual(const core::visual::VisualParams*)
 {
     GLint viewport[4];
     glGetIntegerv(GL_VIEWPORT, viewport);

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerPass.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerPass.cpp
@@ -78,7 +78,7 @@ void VisualManagerPass::init()
 }
 
 /* herited from VisualModel */
-void VisualManagerPass::initVisual()
+void VisualManagerPass::doInitVisual(const core::visual::VisualParams* vparams)
 {
     GLint viewport[4];
     glGetIntegerv(GL_VIEWPORT, viewport);

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerPass.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerPass.h
@@ -61,7 +61,7 @@ public:
 
 
     void init() override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams*) override;
 
     void preDrawScene(core::visual::VisualParams* vp) override;
     bool drawScene(core::visual::VisualParams* vp) override;

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerSecondaryPass.cpp
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerSecondaryPass.cpp
@@ -55,7 +55,7 @@ void VisualManagerSecondaryPass::init()
     multiPassEnabled=checkMultipass(context);
 }
 
-void VisualManagerSecondaryPass::initVisual()
+void VisualManagerSecondaryPass::doInitVisual(const core::visual::VisualParams* vparams)
 {
     if (l_shader.get())
     {
@@ -79,7 +79,7 @@ void VisualManagerSecondaryPass::initVisual()
             m_shaderPostproc->fragFilename.addPath(fragFilename.getFullPath(),true);
 
         m_shaderPostproc->init();
-        m_shaderPostproc->initVisual();
+        m_shaderPostproc->initVisual(vparams);
     }
 
     initShaderInputTexId();

--- a/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerSecondaryPass.h
+++ b/Sofa/GL/Component/Shader/src/sofa/gl/component/shader/VisualManagerSecondaryPass.h
@@ -54,7 +54,7 @@ protected:
 
 public:
     void init() override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams*) override;
 
     void preDrawScene(core::visual::VisualParams* vp) override;
     bool drawScene(core::visual::VisualParams* vp) override;

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualLoop.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualLoop.h
@@ -44,10 +44,10 @@ protected:
     ~VisualLoop() override { }
 public:
     /// Initialize the textures
-    virtual void initStep(sofa::core::ExecParams* /*params*/) {}
+    virtual void initStep(sofa::core::visual::VisualParams* /*vparams*/) {}
 
     /// Update the Visual Models: triggers the Mappings
-    virtual void updateStep(sofa::core::ExecParams* /*params*/) {}
+    virtual void updateStep(sofa::core::visual::VisualParams* /*vparams*/) {}
 
     /// Update contexts. Required before drawing the scene if root flags are modified.
     virtual void updateContextStep(sofa::core::visual::VisualParams* /*vparams*/) {}

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualModel.cpp
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualModel.cpp
@@ -71,6 +71,11 @@ void VisualModel::updateVisual(const VisualParams* vparams)
     doUpdateVisual(vparams);
 }
 
+void VisualModel::updateVisual()
+{
+    updateVisual(sofa::core::visual::visualparams::defaultInstance());
+}
+
 void VisualModel::initVisual(const VisualParams* vparams)
 {
     // don't init visual things if the component is not in valid state
@@ -78,6 +83,11 @@ void VisualModel::initVisual(const VisualParams* vparams)
         return;
 
     doInitVisual(vparams);
+}
+
+void VisualModel::initVisual()
+{
+    initVisual(sofa::core::visual::visualparams::defaultInstance());
 }
 
 bool VisualModel::insertInNode( objectmodel::BaseNode* node )

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualModel.cpp
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualModel.cpp
@@ -54,6 +54,32 @@ void VisualModel::drawVisual(const VisualParams* vparams)
     doDrawVisual(vparams);
 }
 
+void VisualModel::updateVisual(const VisualParams* vparams)
+{
+    // don't update if specified not to do so in the user interface
+    if (!vparams->displayFlags().getShowVisualModels())
+        return;
+
+    // don't update if this component is specifically configured to be disabled
+    if (!d_enable.getValue())
+        return;
+
+    // don't update if the component is not in valid state
+    if (d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
+        return;
+
+    doUpdateVisual(vparams);
+}
+
+void VisualModel::initVisual(const VisualParams* vparams)
+{
+    // don't init visual things if the component is not in valid state
+    if (d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
+        return;
+
+    doInitVisual(vparams);
+}
+
 bool VisualModel::insertInNode( objectmodel::BaseNode* node )
 {
     node->addVisualModel(this);

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualModel.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualModel.h
@@ -63,19 +63,18 @@ public:
      *
      *  Called once before the first frame is drawn, and if the graphical
      *  context has been recreated.
-     *  TODO for v25.12: Deprecate VI and use NVI design pattern: In one year, remove the virtual keyword so that everyone
-     *  will have to override doInitVisual;
      */
-    virtual void initVisual(const VisualParams* /*vparams*/) final;
+    void initVisual(const VisualParams* /*vparams*/);
+    // SOFA_ATTRIBUTE_DISABLED("v24.12", "v25.12", "Implement doInitVisual(const VisualParams*) instead")
+    virtual void initVisual() = delete;
 
     /**
      *  \brief used to update the model if necessary.
-     * 
-     *  TODO for v25.12: Deprecate VI and use NVI design pattern: In one year, remove the virtual keyword so that everyone
-     *  will have to override doUpdateVisual;
+     *
      */
-    virtual void updateVisual(const VisualParams* /*vparams*/) final;
-
+    void updateVisual(const VisualParams* /*vparams*/);
+    // SOFA_ATTRIBUTE_DISABLED("v24.12", "v25.12", "Implement doUpdateVisual(const VisualParams*) instead")
+    virtual void updateVisual() = delete;
 
 protected:
     VisualModel();

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualModel.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualModel.h
@@ -65,16 +65,21 @@ public:
      *  context has been recreated.
      */
     void initVisual(const VisualParams* /*vparams*/);
-    // SOFA_ATTRIBUTE_DISABLED("v24.12", "v25.12", "Implement doInitVisual(const VisualParams*) instead")
-    virtual void initVisual() = delete;
+
+    // Deprecate the usage of initVisual()
+    // But the final keyword will break the compilation if one does override initVisual anyway.
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Use initVisual(const VisualParams*) instead")
+    virtual void initVisual() final;
 
     /**
      *  \brief used to update the model if necessary.
      *
      */
     void updateVisual(const VisualParams* /*vparams*/);
-    // SOFA_ATTRIBUTE_DISABLED("v24.12", "v25.12", "Implement doUpdateVisual(const VisualParams*) instead")
-    virtual void updateVisual() = delete;
+    // Deprecate the usage of updateVisual()
+    // But the final keyword will break the compilation if one does override updateVisual() anyway.
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Use updateVisual(const VisualParams*) instead")
+    virtual void updateVisual() final;
 
 protected:
     VisualModel();

--- a/Sofa/framework/Core/src/sofa/core/visual/VisualModel.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualModel.h
@@ -57,6 +57,24 @@ public:
      *  will have to override doDrawVisual;
      */
     virtual void drawVisual(const VisualParams* /*vparams*/) final;
+    
+    /**
+     *  \brief Initialize the textures, or other graphical resources.
+     *
+     *  Called once before the first frame is drawn, and if the graphical
+     *  context has been recreated.
+     *  TODO for v25.12: Deprecate VI and use NVI design pattern: In one year, remove the virtual keyword so that everyone
+     *  will have to override doInitVisual;
+     */
+    virtual void initVisual(const VisualParams* /*vparams*/) final;
+
+    /**
+     *  \brief used to update the model if necessary.
+     * 
+     *  TODO for v25.12: Deprecate VI and use NVI design pattern: In one year, remove the virtual keyword so that everyone
+     *  will have to override doUpdateVisual;
+     */
+    virtual void updateVisual(const VisualParams* /*vparams*/) final;
 
 
 protected:
@@ -65,16 +83,10 @@ protected:
 
 private:
     virtual void doDrawVisual(const VisualParams* /*vparams*/) {}
+    virtual void doInitVisual(const VisualParams* /*vparams*/) {}
+    virtual void doUpdateVisual(const VisualParams* /*vparams*/) {}
 
 public:
-    /**
-     *  \brief Initialize the textures, or other graphical resources.
-     *
-     *  Called once before the first frame is drawn, and if the graphical
-     *  context has been recreated.
-     */
-    virtual void initVisual() {  }
-
     /**
      *  \brief clear some graphical resources (generaly called before the deleteVisitor).
      *  \note: for more general usage you can use the cleanup visitor
@@ -111,10 +123,6 @@ public:
         doDrawVisual(vparams);
     }
 
-    /**
-     *  \brief used to update the model if necessary.
-     */
-    virtual void updateVisual() {  }
     /**
     *  \brief used to update the model if necessary.
     */

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultVisualManagerLoop.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultVisualManagerLoop.cpp
@@ -56,23 +56,23 @@ void DefaultVisualManagerLoop::init()
 }
 
 
-void DefaultVisualManagerLoop::initStep(sofa::core::ExecParams* params)
+void DefaultVisualManagerLoop::initStep(sofa::core::visual::VisualParams* vparams)
 {
     if ( !l_node ) return;
-    l_node->execute<VisualInitVisitor>(params);
+    l_node->execute<VisualInitVisitor>(vparams);
     // Do a visual update now as it is not done in load() anymore
     /// \todo Separate this into another method?
-    l_node->execute<VisualUpdateVisitor>(params);
+    l_node->execute<VisualUpdateVisitor>(vparams);
 }
 
-void DefaultVisualManagerLoop::updateStep(sofa::core::ExecParams* params)
+void DefaultVisualManagerLoop::updateStep(sofa::core::visual::VisualParams* vparams)
 {
     if ( !l_node ) return;
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printNode("UpdateVisual");
 #endif
 
-    l_node->execute<VisualUpdateVisitor>(params);
+    l_node->execute<VisualUpdateVisitor>(vparams);
     
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printCloseNode("UpdateVisual");

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultVisualManagerLoop.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultVisualManagerLoop.h
@@ -54,10 +54,10 @@ public:
     void init() override;
 
     /// Initialize the textures
-    void initStep(sofa::core::ExecParams* params) override;
+    void initStep(sofa::core::visual::VisualParams* vparams) override;
 
     /// Update the Visual Models: triggers the Mappings
-    void updateStep(sofa::core::ExecParams* params) override;
+    void updateStep(sofa::core::visual::VisualParams* vparams) override;
 
     /// Update contexts. Required before drawing the scene if root flags are modified.
     void updateContextStep(sofa::core::visual::VisualParams* vparams) override;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
@@ -230,12 +230,12 @@ void animate(Node* root, SReal dt)
 void updateVisual(Node* root)
 {
     SCOPED_TIMER("Simulation::updateVisual");
-
-    sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance();
+    
+    sofa::core::visual::VisualParams* vparams = sofa::core::visual::visualparams::defaultInstance();
 
     if (sofa::core::visual::VisualLoop* vloop = root->getVisualLoop())
     {
-        vloop->updateStep(params);
+        vloop->updateStep(vparams);
     }
     else
     {
@@ -271,18 +271,17 @@ void reset(Node* root)
     root->execute<MechanicalProjectPositionAndVelocityVisitor>(&mparams);
     root->execute<MechanicalPropagateOnlyPositionAndVelocityVisitor>(&mparams);
     root->execute<UpdateMappingVisitor>(params);
-    root->execute<VisualUpdateVisitor>(params);
 }
 
 void initTextures(Node* root)
 {
     if (!root)
         return;
-    sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance();
+    sofa::core::visual::VisualParams* vparams = sofa::core::visual::visualparams::defaultInstance();
 
     if (sofa::core::visual::VisualLoop* vloop = root->getVisualLoop())
     {
-        vloop->initStep(params);
+        vloop->initStep(vparams);
     }
     else
     {
@@ -291,7 +290,7 @@ void initTextures(Node* root)
     }
 
     SimulationInitTexturesDoneEvent endInit;
-    PropagateEventVisitor pe{params, &endInit};
+    PropagateEventVisitor pe{vparams, &endInit};
     root->execute(pe);
 }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
@@ -157,7 +157,7 @@ Visitor::Result VisualUpdateVisitor::processNodeTopDown(simulation::Node* node)
 void VisualUpdateVisitor::processVisualModel(simulation::Node*, core::visual::VisualModel* vm)
 {
     helper::ScopedAdvancedTimer timer("VisualUpdateVisitor process: " + vm->getName());
-    vm->updateVisual();
+    vm->updateVisual(vparams);
 }
 
 
@@ -169,7 +169,7 @@ Visitor::Result VisualInitVisitor::processNodeTopDown(simulation::Node* node)
 }
 void VisualInitVisitor::processVisualModel(simulation::Node*, core::visual::VisualModel* vm)
 {
-    vm->initVisual();
+    vm->initVisual(vparams);
 }
 
 VisualComputeBBoxVisitor::VisualComputeBBoxVisitor(const core::ExecParams* params)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.h
@@ -74,23 +74,30 @@ public:
 #endif
 };
 
-class SOFA_SIMULATION_CORE_API VisualUpdateVisitor : public Visitor
+class SOFA_SIMULATION_CORE_API VisualUpdateVisitor : public VisualVisitor
 {
 public:
-    VisualUpdateVisitor(const core::ExecParams* params) : Visitor(params) {}
+    VisualUpdateVisitor(core::visual::VisualParams* params)
+        : VisualVisitor(params)
+    {}
 
-    virtual void processVisualModel(simulation::Node*, core::visual::VisualModel* vm);
+    virtual void processVisualModel(simulation::Node*, core::visual::VisualModel* vm) override;
     Result processNodeTopDown(simulation::Node* node) override;
 
     const char* getClassName() const override { return "VisualUpdateVisitor"; }
+
+protected:
+    core::visual::VisualParams* m_vparams;
 };
 
-class SOFA_SIMULATION_CORE_API VisualInitVisitor : public Visitor
+class SOFA_SIMULATION_CORE_API VisualInitVisitor : public VisualVisitor
 {
 public:
-    VisualInitVisitor(const core::ExecParams* params):Visitor(params) {}
-
-    virtual void processVisualModel(simulation::Node*, core::visual::VisualModel* vm);
+    VisualInitVisitor(core::visual::VisualParams* params)
+        : VisualVisitor(params)
+    {}
+    
+    virtual void processVisualModel(simulation::Node*, core::visual::VisualModel* vm) override;
     Result processNodeTopDown(simulation::Node* node) override;
     const char* getClassName() const override { return "VisualInitVisitor"; }
 };

--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicVisualModel.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicVisualModel.cpp
@@ -122,8 +122,8 @@ void GeomagicVisualModel::initDisplay(sofa::simulation::Node::SPtr node, const s
         visualNode[i].visu->d_vtexcoords.setParent(&visualNode[i].loader->d_texCoords);
         
         visualNode[i].visu->init();
-        visualNode[i].visu->initVisual();
-        visualNode[i].visu->updateVisual();
+        visualNode[i].visu->initVisual(sofa::core::visual::visualparams::defaultInstance());
+        visualNode[i].visu->updateVisual(sofa::core::visual::visualparams::defaultInstance());
 
         // create the visual mapping and at it to the graph //
         visualNode[i].mapping = sofa::core::objectmodel::New< sofa::component::mapping::nonlinear::RigidMapping< Rigid3Types, Vec3Types > >();

--- a/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
+++ b/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
@@ -376,8 +376,8 @@ void OmniDriverEmu::draw(const core::visual::VisualParams *)
         visu_base->d_scale.setValue(type::Vec3(scale.getValue(),scale.getValue(),scale.getValue()));
         visu_base->setColor(1.0f,1.0f,1.0f,1.0f);
         visu_base->init();
-        visu_base->initVisual();
-        visu_base->updateVisual();
+        visu_base->initVisual(sofa::core::visual::visualparams::defaultInstance());
+        visu_base->updateVisual(sofa::core::visual::visualparams::defaultInstance());
         visu_base->applyRotation(orientationBase.getValue());
         visu_base->applyTranslation( positionBase.getValue()[0],positionBase.getValue()[1], positionBase.getValue()[2]);
 
@@ -386,8 +386,8 @@ void OmniDriverEmu::draw(const core::visual::VisualParams *)
         visu_end->d_scale.setValue(type::Vec3(scale.getValue(),scale.getValue(),scale.getValue()));
         visu_end->setColor(1.0f,0.3f,0.0f,1.0f);
         visu_end->init();
-        visu_end->initVisual();
-        visu_end->updateVisual();
+        visu_end->initVisual(sofa::core::visual::visualparams::defaultInstance());
+        visu_end->updateVisual(sofa::core::visual::visualparams::defaultInstance());
         visu_end->applyRotation(world_H_endOmni.getOrientation());
         visu_end->applyTranslation(world_H_endOmni.getOrigin()[0],world_H_endOmni.getOrigin()[1],world_H_endOmni.getOrigin()[2]);
         isInited=true;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.h
@@ -107,9 +107,10 @@ public:
     virtual void doDrawVisual(const core::visual::VisualParams*) override;
     virtual void drawTransparent(const core::visual::VisualParams*) override;
     virtual void drawShadow(const core::visual::VisualParams*) override;
-    virtual void updateVisual() override;
+    virtual void doUpdateVisual(const core::visual::VisualParams* vparams) override;
     virtual void updateTopology();
     virtual void updateNormals();
+    virtual void updateTopologyAndNormals();
     virtual void handleTopologyChange() override;
 
     virtual void computeBBox(const core::ExecParams* params, bool=false) override;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
@@ -132,13 +132,13 @@ void CudaVisualModel< TDataTypes >::init()
     {
         topology = this->getContext()->getMeshTopology();
     }
-    updateVisual();
+    updateTopologyAndNormals();
 }
 
 template<class TDataTypes>
 void CudaVisualModel< TDataTypes >::reinit()
 {
-    updateVisual();
+    updateTopologyAndNormals();
 }
 
 template<class TDataTypes>
@@ -284,11 +284,17 @@ void CudaVisualModel< TDataTypes >::updateNormals()
 }
 
 template<class TDataTypes>
-void CudaVisualModel< TDataTypes >::updateVisual()
+void CudaVisualModel< TDataTypes >::updateTopologyAndNormals()
 {
     updateTopology();
     if (computeNormals.getValue())
         updateNormals();
+}
+
+template<class TDataTypes>
+void CudaVisualModel< TDataTypes >::doUpdateVisual(const core::visual::VisualParams* vparams)
+{
+    updateTopologyAndNormals();
 }
 
 template<class TDataTypes>

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.h
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.h
@@ -81,11 +81,11 @@ protected:
     ~OglTetrahedralModel() override;
 public:
     void init() override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
     void drawTransparent(const core::visual::VisualParams* vparams) override;
     void computeBBox(const core::ExecParams *, bool onlyVisible=false) override;
 
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams* vparams) override;
     virtual void computeMesh();
 };
 

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
@@ -136,12 +136,11 @@ void OglTetrahedralModel<DataTypes>::init()
     useTopology = true;
     modified = true;
     VisualModel::init();
-    updateVisual();
 
 }
 
 template<class DataTypes>
-void OglTetrahedralModel<DataTypes>::initVisual()
+void OglTetrahedralModel<DataTypes>::doInitVisual(const sofa::core::visual::VisualParams* vparams)
 {
     const type::vector<Coord> tmpvertices = m_positions.getValue();
     type::vector<type::Vec3f> vertices;
@@ -151,8 +150,8 @@ void OglTetrahedralModel<DataTypes>::initVisual()
         vertices.push_back(type::Vec3f(tmpvertices[i][0], tmpvertices[i][1], tmpvertices[i][2]));
     }
 
-    m_mappingTableValues->initVisual();
-    m_runSelectTableValues->initVisual();
+    m_mappingTableValues->initVisual(vparams);
+    m_runSelectTableValues->initVisual(vparams);
 
     glGenBuffersARB(1, &m_vbo);
     unsigned positionsBufferSize;
@@ -173,10 +172,9 @@ void OglTetrahedralModel<DataTypes>::initVisual()
 }
 
 template<class DataTypes>
-void OglTetrahedralModel<DataTypes>::updateVisual()
+void OglTetrahedralModel<DataTypes>::doUpdateVisual(const core::visual::VisualParams* vparams)
 {
     // Workaround if updateVisual() is called without an opengl context
-    const auto* vparams = core::visual::VisualParams::defaultInstance();
     if (!vparams->isSupported(core::visual::API_OpenGL))
     {
         return;

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
@@ -158,12 +158,12 @@ void OglVolumetricModel::init()
 
 }
 
-void OglVolumetricModel::initVisual()
+void OglVolumetricModel::doInitVisual(const core::visual::VisualParams* vparams)
 {
     const type::vector<Coord>& positions = m_positions.getValue();
 
-    m_mappingTableValues->initVisual();
-    m_runSelectTableValues->initVisual();
+    m_mappingTableValues->initVisual(vparams);
+    m_runSelectTableValues->initVisual(vparams);
 
     glGenBuffersARB(1, &m_vbo);
     unsigned positionsBufferSize;
@@ -218,14 +218,13 @@ void OglVolumetricModel::initVisual()
 
     getContext()->addObject(m_vertexColors);
     m_vertexColors->init();
-    m_vertexColors->initVisual();
+    m_vertexColors->initVisual(vparams);
 
 }
 
-void OglVolumetricModel::updateVisual()
+void OglVolumetricModel::doUpdateVisual(const core::visual::VisualParams* vparams)
 {
     // Workaround if updateVisual() is called without an opengl context
-    const auto* vparams = core::visual::VisualParams::defaultInstance();
     if (!vparams->isSupported(core::visual::API_OpenGL))
     {
         return;

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.h
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.h
@@ -95,13 +95,13 @@ private:
 
 public:
     void init() override;
-    void initVisual() override;
+    void doInitVisual(const core::visual::VisualParams* vparams) override;
     void drawTransparent(const core::visual::VisualParams* vparams) override;
     void computeBBox(const core::ExecParams *, bool onlyVisible=false) override;
 
     void handleTopologyChange() override;
 
-    void updateVisual() override;
+    void doUpdateVisual(const core::visual::VisualParams* vparams) override;
     void computeMeshFromTopology();
 
     bool insertInNode(core::objectmodel::BaseNode* node) override { Inherit1::insertInNode(node); Inherit2::insertInNode(node); return true; }


### PR DESCRIPTION
... and add VisualParameters  as a parameter to their signature.

Based on 
- #4822 

Continue on what has been introduced by:
- #3931 

Little difference, this PR does not only do the NVI thing but it adds the visualparameters as input.
This seems consistent (to me) with the fact that init/update visual as supposed to be called when there is a draw context (like drawVisual). 
The nice side effect (and it was the intent at the beginning) is that updatevisual wont be called anymore if the component state is wrong, showVisualModels flag is not set or not enabled.

\+ cleanings here and there in the visual/gl components

Unfortunately, breaking ⚠️

[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/423]
[ci-depends-on https://github.com/sofa-framework/SofaSphFluid/pull/1]

TEMP: 
[ci-depends-on https://github.com/sofa-framework/BeamAdapter/pull/153]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
