### PR TITLE
[CMake] Add QGLViewer2 name in FindQGLViewer.cmake

### DIFF
--- a/cmake/Modules/FindQGLViewer.cmake
+++ b/cmake/Modules/FindQGLViewer.cmake
@@ -21,7 +21,7 @@ if(NOT TARGET QGLViewer)
 
   if(NOT QGLViewer_LIBRARY)
   find_library(QGLViewer_LIBRARY
-    NAMES QGLViewer QGLViewer-qt5
+    NAMES QGLViewer QGLViewer2 QGLViewer-qt5
     PATH_SUFFIXES lib
   )
   endif()


### PR DESCRIPTION
This is a task for the conda-forge packaging.

Add QGLViewer2 name as Conda installs this name instead of QGLViewer on Windows





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
