### PR TITLE
[Topology.Dynamic] Fix wrong deprecation

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/DynamicSparseGridTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/DynamicSparseGridTopologyContainer.cpp
@@ -39,10 +39,7 @@ int DynamicSparseGridTopologyContainerClass = core::RegisterObject ( "Hexahedron
         ;
 
 DynamicSparseGridTopologyContainer::DynamicSparseGridTopologyContainer()
-    : HexahedronSetTopologyContainer()
-    /// deprecated
-    , valuesIndexedInTopology(initData(&valuesIndexedInTopology, "valuesIndexedInTopology", "values indexed in the topology"))
-    , d_resolution (initData (&d_resolution, type::Vec3i (0, 0, 0 ), "resolution", "voxel grid resolution" ) )
+    : d_resolution (initData (&d_resolution, type::Vec3i (0, 0, 0 ), "resolution", "voxel grid resolution" ) )
     , d_valuesIndexedInRegularGrid(initData (&d_valuesIndexedInRegularGrid, sofa::type::vector<unsigned char>(), "valuesIndexedInRegularGrid", "values indexed in the Regular Grid" ) )
     , d_valuesIndexedInTopology(initData(&d_valuesIndexedInTopology, "valuesIndexedInTopology", "values indexed in the topology"))
     , d_idxInRegularGrid(initData (&d_idxInRegularGrid, sofa::type::vector<BaseMeshTopology::HexaID>(), "idxInRegularGrid", "indices in the Regular Grid" ) )

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/DynamicSparseGridTopologyContainer.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/DynamicSparseGridTopologyContainer.h
@@ -50,7 +50,7 @@ public:
     Data< sofa::type::vector<unsigned char> > valuesIndexedInRegularGrid;
 
     SOFA_ATTRIBUTE_DEPRECATED__RENAME_DATA_IN_TOPOLOGY_CONTAINER_DYNAMIC()
-    core::topology::HexahedronData< sofa::type::vector<unsigned char> > valuesIndexedInTopology; ///< values indexed in the topology
+    Data< sofa::type::vector<unsigned char> > valuesIndexedInTopology; ///< values indexed in the topology
 
     SOFA_ATTRIBUTE_DEPRECATED__RENAME_DATA_IN_TOPOLOGY_CONTAINER_DYNAMIC()
     Data< sofa::type::vector<BaseMeshTopology::HexaID> > idxInRegularGrid;


### PR DESCRIPTION
`valuesIndexedInTopology` should not be initialized with `initData`: it duplicates the Data name of `d_valuesIndexedInTopology`



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
