### PR TITLE
[Core] Remove m_cId deprecation warning spam

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.cpp
@@ -25,6 +25,19 @@
 namespace sofa::core::behavior
 {
 
+BaseConstraintSet::BaseConstraintSet()
+    : group(initData(&group, 0, "group", "ID of the group containing this constraint. This ID is used to specify which constraints are solved by which solver, by specifying in each solver which groups of constraints it should handle."))
+    , d_constraintIndex(initData(&d_constraintIndex, 0u, "constraintIndex", "Constraint index (first index in the right hand term resolution vector)"))
+{
+    m_constraintIndex.setParent(&d_constraintIndex);
+}
+
+
+BaseConstraintSet::~BaseConstraintSet()
+{
+
+}
+
 bool BaseConstraintSet::insertInNode( objectmodel::BaseNode* node )
 {
     node->addConstraintSet(this);

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraintSet.h
@@ -37,14 +37,8 @@ public:
     SOFA_BASE_CAST_IMPLEMENTATION(BaseConstraintSet)
 
 protected:
-    BaseConstraintSet()
-        : group(initData(&group, 0, "group", "ID of the group containing this constraint. This ID is used to specify which constraints are solved by which solver, by specifying in each solver which groups of constraints it should handle."))
-        , d_constraintIndex(initData(&d_constraintIndex, 0u, "constraintIndex", "Constraint index (first index in the right hand term resolution vector)"))
-    {
-        m_constraintIndex.setParent(&d_constraintIndex);
-    }
-
-    ~BaseConstraintSet() override { }
+    BaseConstraintSet();
+    ~BaseConstraintSet() override;
 
 private:
     BaseConstraintSet(const BaseConstraintSet& n) = delete;
@@ -103,8 +97,8 @@ public:
     bool insertInNode( objectmodel::BaseNode* node ) override;
     bool removeInNode( objectmodel::BaseNode* node ) override;
 
-    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Use d_constraintIndex instead")
-    DeprecatedAndRemoved m_cId;
+    SOFA_ATTRIBUTE_DEPRECATED__REMOVED_CID()
+    DeprecatedAndRemoved m_cId{};
 
 };
 

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -99,3 +99,12 @@
 #define SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT() \
     SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.12", "RegisterObject and the associated implicit registration is being phased out. Use ObjectRegistrationData and explicit registration from now on. See #4429 for more information.")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED__REMOVED_CID()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__REMOVED_CID() \
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.06", "Use d_constraintIndex instead.")
+#endif
+
+


### PR DESCRIPTION
Appearing when other files includes BaseConstraintSet.h.

It appeared because:
 - the declaration itself was not guarded
 - the constructor and the destructor body were in the h, triggering the warning.

Actually the last cause is the reason why there are a lot of deprecation warnings due to the Data renaming, even if "macro-guarded"; there are a lot of components where the body of the ctor and/or the dtor (even only with `=default`) are in the header file.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
