### PR TITLE
[Config] Add CMake option for memory sanitizer

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -166,8 +166,14 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
 
     option(SOFA_ENABLE_THREAD_SANITIZER "Enable thread sanitizer (only gcc or clang)" OFF)
     if(SOFA_ENABLE_THREAD_SANITIZER)
-        list(APPEND SOFACONFIG_COMPILE_OPTIONS "-fsanitize=thread")
+        list(APPEND SOFACONFIG_COMPILE_OPTIONS "-fsanitize=thread;-fno-omit-frame-pointer")
         list(APPEND SOFACONFIG_LINK_OPTIONS "-fsanitize=thread")
+    endif()
+
+    option(SOFA_ENABLE_MEMORY_SANITIZER "Enable memory sanitizer (only gcc or clang)" OFF)
+    if(SOFA_ENABLE_MEMORY_SANITIZER)
+        list(APPEND SOFACONFIG_COMPILE_OPTIONS "-fsanitize=address;-fno-omit-frame-pointer")
+        list(APPEND SOFACONFIG_LINK_OPTIONS "-fsanitize=address")
     endif()
 endif()
 


### PR DESCRIPTION
Started from the PR #4838 

Similar to the Thread Sanitizer.
Only for GCC/Clang and Unix (seems even GCC-win/Clang-win are not supported)

This A(L)SAN adds leaks and memory detection.
More info:
 - https://github.com/google/sanitizers/wiki/AddressSanitizer
 - https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer (leak is included into the addresssanitizer)

The `-fno-omit-frame-pointer`adds also a better reporting (nicer stack traces)








______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
