### PR TITLE
[ODESOlver] Fix RHS computation of the backward Euler implicit solver

### DIFF
--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -123,7 +123,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         SCOPED_TIMER("ComputeForce");
         mop->setImplicit(true); // this solver is implicit
         // compute the net forces at the beginning of the time step
-        mop.computeForce(f);
+        mop.computeForce(f);                                                               //f = Kx + Bv
 
         msg_info() << "EulerImplicitSolver, initial f = " << f;
     }
@@ -138,15 +138,15 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         // new more powerful visitors
 
         // force in the current configuration
-        b.eq(f,1.0/tr);                                                                         // b = f0
+        b.eq(f,1.0/tr);                                                                    // b = f
 
         msg_info() << "EulerImplicitSolver, f = " << f;
 
         // add the change of force due to stiffness + Rayleigh damping
-        mop.addMBKv(b, -d_rayleighMass.getValue(), 1, h + d_rayleighStiffness.getValue()); // b =  f0 + ( rm M + B + (h+rs) K ) v
+        mop.addMBKv(b, -d_rayleighMass.getValue(), 0, h + d_rayleighStiffness.getValue()); // b =  f + ( rm M + (h+rs) K ) v
 
         // integration over a time step
-        b.teq(h*tr);                                                                        // b = h(f0 + ( rm M + B + (h+rs) K ) v )
+        b.teq(h*tr);                                                                       // b = h(f + ( rm M + (h+rs) K ) v )
     }
 
     msg_info() << "EulerImplicitSolver, b = " << b;

--- a/Sofa/Component/ODESolver/Backward/tests/CMakeLists.txt
+++ b/Sofa/Component/ODESolver/Backward/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ project(Sofa.Component.ODESolver.Backward_test)
 set(SOURCE_FILES
     EulerImplicitSolverDynamic_test.cpp
     EulerImplicitSolverStatic_test.cpp
+    EulerImplicitSolver_withDamping_test.cpp
     NewmarkImplicitSolverDynamic_test.cpp
     StaticSolver_test.cpp
     SpringSolverDynamic_test.cpp

--- a/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
@@ -61,6 +61,7 @@ struct EulerImplicit_with_damping_forcefield : public BaseSimulationTest, Numeri
         sofa::simpleapi::importPlugin("Sofa.Component.LinearSolver.Iterative");
         sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
         sofa::simpleapi::importPlugin("Sofa.Component.Mass");
+        sofa::simpleapi::importPlugin("Sofa.Component.MechanicalLoad");
 
         // avoid warnings
         simpleapi::createObject(root, "DefaultAnimationLoop", {});
@@ -78,6 +79,7 @@ struct EulerImplicit_with_damping_forcefield : public BaseSimulationTest, Numeri
             { "threshold", simpleapi::str(1e-15)},
             });
         simpleapi::createObject(dampedParticule, "MechanicalObject", {
+            { "template", simpleapi::str("Vec3")},
             { "position", simpleapi::str(zeroVec3)},
             { "velocity", simpleapi::str(oneVec3)},
             { "force", simpleapi::str(zeroVec3)},
@@ -101,10 +103,11 @@ struct EulerImplicit_with_damping_forcefield : public BaseSimulationTest, Numeri
         for(int i=0; i<2500; i++)
             sofa::simulation::node::animate(root.get(), 0.02);
 
-        std::vector<MechanicalObject<sofa::defaulttype::Vec3dTypes>*> meca;
-        root->get<MechanicalObject<sofa::defaulttype::Vec3dTypes>>(&meca,std::string("mecaConstraint"),root->SearchDown);
+        // access the MechanicalObect (access position of the dampedParticule)
+        typename MechanicalObject<sofa::defaulttype::Vec3dTypes>::SPtr dofs = dampedParticule->get<MechanicalObject<sofa::defaulttype::Vec3dTypes>>(root->SearchDown);
+        sofa::defaulttype::Vec3dTypes::Coord position = dofs.get()->read(sofa::core::ConstVecCoordId::position())->getValue()[0];
 
-        sofa::defaulttype::Vec3dTypes::Coord position = meca[0]->read(core::ConstVecCoordId::position())->getValue()[0];
+        // save it as Vec3d for comparison with expected result
         Vec3d finalPosition(position[0], position[1], position[2]);
 
         // Position at t∞ is (10,10,10), see https://github.com/sofa-framework/sofa/pull/4848#issuecomment-2263947900

--- a/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
@@ -1,0 +1,126 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/testing/BaseSimulationTest.h>
+using sofa::testing::BaseSimulationTest;
+#include <sofa/testing/NumericTest.h>
+using sofa::testing::NumericTest;
+
+#include <sofa/simpleapi/SimpleApi.h>
+#include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/component/statecontainer/MechanicalObject.h>
+#include <sofa/defaulttype/VecTypes.h>
+
+namespace sofa {
+
+using namespace type;
+using namespace testing;
+using namespace defaulttype;
+using core::objectmodel::New;
+using namespace sofa::component::statecontainer;
+
+
+/// Test for the gravity context data
+struct EulerImplicit_with_damping_forcefield : public BaseSimulationTest, NumericTest<SReal>
+{
+    EulerImplicit_with_damping_forcefield()
+    {
+        //*******
+        const auto simu = simpleapi::createSimulation();
+        const simulation::Node::SPtr root = simpleapi::createRootNode(simu, "root");
+
+        Vec3d zeroVec3(0., 0., 0.);
+        Vec3d oneVec3(1., 1., 1.);
+        Vec3d expectedPosition(10., 10., 10.);
+        Vec3d threshold(0.1, 0.1, 0.1);
+        root->setGravity(zeroVec3);
+
+        //*******
+        // load appropriate modules
+        sofa::simpleapi::importPlugin("Sofa.Component.ODESolver.Backward");
+        sofa::simpleapi::importPlugin("Sofa.Component.LinearSolver.Iterative");
+        sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
+        sofa::simpleapi::importPlugin("Sofa.Component.Mass");
+
+        // avoid warnings
+        simpleapi::createObject(root, "DefaultAnimationLoop", {});
+        simpleapi::createObject(root, "DefaultVisualManagerLoop", {});
+
+        //*********
+        // create scene
+        Node::SPtr dampedParticule = simpleapi::createChild(root, "dampedParticule");
+
+        simpleapi::createObject(dampedParticule, "EulerImplicitSolver", {{ "rayleighStiffness", simpleapi::str(0.)},
+                                                                         { "rayleighMass", simpleapi::str(0.)}, });
+        simpleapi::createObject(dampedParticule, "CGLinearSolver", {
+            { "iterations", simpleapi::str(25)},
+            { "tolerance", simpleapi::str(1e-15)},
+            { "threshold", simpleapi::str(1e-15)},
+            });
+        simpleapi::createObject(dampedParticule, "MechanicalObject", {
+            { "position", simpleapi::str(zeroVec3)},
+            { "velocity", simpleapi::str(oneVec3)},
+            { "force", simpleapi::str(zeroVec3)},
+            { "externalForce", simpleapi::str(zeroVec3)},
+            { "derivX", simpleapi::str(zeroVec3)},
+            });
+        simpleapi::createObject(dampedParticule, "UniformMass", {
+            { "totalMass", simpleapi::str(1.0)},
+            });
+        simpleapi::createObject(dampedParticule, "UniformVelocityDampingForceField", {
+            { "template", simpleapi::str("Vec3")},
+            });
+
+        // end create scene
+        //*********
+        sofa::simulation::node::initRoot(root.get());
+        //*********
+        // run simulation
+
+        // compute 2500 time steps
+        for(int i=0; i<2500; i++)
+            sofa::simulation::node::animate(root.get(), 0.02);
+
+        std::vector<MechanicalObject<sofa::defaulttype::Vec3dTypes>*> meca;
+        root->get<MechanicalObject<sofa::defaulttype::Vec3dTypes>>(&meca,std::string("mecaConstraint"),root->SearchDown);
+
+        sofa::defaulttype::Vec3dTypes::Coord position = meca[0]->read(core::ConstVecCoordId::position())->getValue()[0];
+        Vec3d finalPosition(position[0], position[1], position[2]);
+
+        // Position at t∞ is (10,10,10), see https://github.com/sofa-framework/sofa/pull/4848#issuecomment-2263947900
+        EXPECT_LT(expectedPosition-finalPosition,threshold);
+    }
+};
+
+
+
+TEST_F( EulerImplicit_with_damping_forcefield, check ){}
+
+}// namespace sofa
+
+
+
+
+
+
+


### PR DESCRIPTION
Remove damping correction to the RHS because it is already added in the computeForce.

In a Euler implicit integration scheme, the right hand side expression only contains terms coming for the internal and external forces taken at the begining of the timestep, and an inertial term constituted of the stiffness matrix, but no term coming from the constitutive damping.  (see [Christian Duriez HDR](https://theses.hal.science/tel-00785118) for ref)

The contribution of the damping forcefield is already taken into account through the `computeForce` call line 126, so the `b` coefficient should be put to 0 here otherwise the behavior is not correct. 

This can bee reproduced by launching the scene `examples/Component/SolidMechanics/FEM/DampingForceField.scn` and putting the data `implicit` of the damping forcefield to true. This data might have been introduced to fix this error, because here we are in an implicit scheme, and setting this parameter to true when the `b` coef is equal to 1 changes the behavior. 

This was introduced here : https://github.com/sofa-framework/sofa/commit/fe0ee6248971383daa4e488e80f5fe480ee85988

[ci-depends-on https://github.com/sofa-framework/Regression/pull/67]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
