### PR TITLE
[FEM.Elastic] Callback on elasticity parameters to check out of bounds

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.h
@@ -44,21 +44,30 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink<BaseLinearElasticityFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_topology;
 
-    static inline const VecReal defaultYoungModulusValue = []()
-    {
-        VecReal newY;
-        newY.resize(1);
-        newY[0] = 5000;
-        return newY;
-    }();
-
     BaseLinearElasticityFEMForceField();
+
     void init() override;
 
     void setPoissonRatio(Real val);
     void setYoungModulus(Real val);
 
     Real getYoungModulusInElement(sofa::Size elementId);
+
+protected:
+
+    static constexpr Real defaultYoungModulusValue = 5000;
+    static inline const VecReal defaultVecYoungModulusValue = []()
+    {
+        VecReal newY;
+        newY.resize(1);
+        newY[0] = defaultYoungModulusValue;
+        return newY;
+    }();
+
+    static constexpr Real defaultPoissonRatioValue = 0.45;
+
+    void checkPoissonRatio();
+    void checkYoungModulus();
 };
 
 #if !defined(SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_BASELINEARELASTICITYFEMFORCEFIELD_CPP)

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl
@@ -40,13 +40,13 @@ BaseLinearElasticityFEMForceField<DataTypes>::BaseLinearElasticityFEMForceField(
     this->addUpdateCallback("checkPoissonRatio", {&d_poissonRatio}, [this](const core::DataTracker& )
     {
         checkPoissonRatio();
-        return sofa::core::objectmodel::ComponentState::Valid;
+        return this->getComponentState();
     }, {});
 
     this->addUpdateCallback("checkPositiveYoungModulus", {&d_youngModulus}, [this](const core::DataTracker& )
     {
         checkYoungModulus();
-        return sofa::core::objectmodel::ComponentState::Valid;
+        return this->getComponentState();
     }, {});
 }
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl
@@ -28,14 +28,57 @@ namespace sofa::component::solidmechanics::fem::elastic
 
 template <class DataTypes>
 BaseLinearElasticityFEMForceField<DataTypes>::BaseLinearElasticityFEMForceField()
-    : d_poissonRatio(initData(&d_poissonRatio,(Real)0.45,"poissonRatio","FEM Poisson Ratio in Hooke's law [0,0.5["))
-    , d_youngModulus(initData(&d_youngModulus, defaultYoungModulusValue, "youngModulus","FEM Young's Modulus in Hooke's law"))
+    : d_poissonRatio(initData(&d_poissonRatio, defaultPoissonRatioValue, "poissonRatio", "FEM Poisson Ratio in Hooke's law [0,0.5["))
+    , d_youngModulus(initData(&d_youngModulus, defaultVecYoungModulusValue, "youngModulus", "FEM Young's Modulus in Hooke's law"))
     , l_topology(initLink("topology", "link to the topology container"))
 {
     d_poissonRatio.setRequired(true);
     d_poissonRatio.setWidget("poissonRatio");
 
     d_youngModulus.setRequired(true);
+
+    this->addUpdateCallback("checkPoissonRatio", {&d_poissonRatio}, [this](const core::DataTracker& )
+    {
+        checkPoissonRatio();
+        return sofa::core::objectmodel::ComponentState::Valid;
+    }, {});
+
+    this->addUpdateCallback("checkPositiveYoungModulus", {&d_youngModulus}, [this](const core::DataTracker& )
+    {
+        checkYoungModulus();
+        return sofa::core::objectmodel::ComponentState::Valid;
+    }, {});
+}
+
+template <class DataTypes>
+void BaseLinearElasticityFEMForceField<DataTypes>::checkPoissonRatio()
+{
+    const auto& poissonRatio = d_poissonRatio.getValue();
+    if (poissonRatio < 0 || poissonRatio >= 0.5)
+    {
+        msg_warning() << "Poisson's ratio must be in the range [0, 0.5), "
+                "but an out-of-bounds value has been provided (" <<
+                poissonRatio << "). It is set to " << defaultPoissonRatioValue <<
+                " to ensure the correct behavior";
+        d_poissonRatio.setValue(defaultPoissonRatioValue);
+    }
+}
+
+template <class DataTypes>
+void BaseLinearElasticityFEMForceField<DataTypes>::checkYoungModulus()
+{
+    auto youngModulus = sofa::helper::getWriteAccessor(d_youngModulus);
+    for (auto& y : youngModulus)
+    {
+        if (y < 0)
+        {
+            msg_warning() << "Young's modulus must be positive, but "
+                    "a negative value has been provided (" << y <<
+                    "). It is set to " << defaultYoungModulusValue <<
+                    " to ensure the correct behavior";
+            y = defaultYoungModulusValue;
+        }
+    }
 }
 
 template <class DataTypes>
@@ -48,6 +91,9 @@ void BaseLinearElasticityFEMForceField<DataTypes>::init()
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
+
+    checkYoungModulus();
+    checkPoissonRatio();
 }
 
 template <class DataTypes>

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
@@ -492,7 +492,7 @@ void TriangularFEMForceField<DataTypes>::setPoissonArray(const type::vector<Real
         Real val = values[id];
         if (val < 0) {
             msg_warning() << "Input Poisson Coefficient at position: " << id << " is not possible: " << val << ", setting default value: 0.3";
-            val = 1000;
+            val = 0.3;
         }
         _poisson[id] = val;
     }

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedronFEMForceField_stepTest.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedronFEMForceField_stepTest.cpp
@@ -92,34 +92,7 @@ struct TetrahedronFEMForceField_stepTest : public ForceField_test<_TetrahedronFE
         Inherited::run_test( x, v, f );
     }
 
-    void checkGracefullHandlingWhenTopologyIsMissing()
-    {
-        modeling::clearScene();
 
-        // This is a RAII message.
-        EXPECT_MSG_EMIT(Error) ;
-
-        std::stringstream scene ;
-        scene << "<?xml version='1.0'?>"
-                 "<Node 	name='Root'>                                \n"
-                 "  <RequiredPlugin name=\"Sofa.Component.StateContainer\"/>"
-                 "  <RequiredPlugin name=\"Sofa.Component.SolidMechanics.FEM.Elastic\"/>"
-                 "  <DefaultAnimationLoop/>"
-                 "  <Node name='FEMnode'>                               \n"
-                 "    <MechanicalObject/>                               \n"
-                 "    <TetrahedronFEMForceField name='fem' youngModulus='5000' poissonRatio='0.07'/>\n"
-                 "  </Node>                                             \n"
-                 "</Node>                                               \n" ;
-
-        const simulation::Node::SPtr root = simulation::SceneLoaderXML::loadFromMemory ("testscene",
-                                                                                        scene.str().c_str()) ;
-        root->init(sofa::core::execparams::defaultInstance()) ;
-
-        core::objectmodel::BaseObject* fem = root->getTreeNode("FEMnode")->getObject("fem") ;
-        EXPECT_NE(fem, nullptr) ;
-
-        EXPECT_EQ(fem->getComponentState(), core::objectmodel::ComponentState::Invalid) ;
-    }
 };
 
 
@@ -145,11 +118,6 @@ TYPED_TEST(TetrahedronFEMForceField_stepTest, extension )
 
     // run test
     this->test_valueForce();
-}
-
-TYPED_TEST(TetrahedronFEMForceField_stepTest, checkGracefullHandlingWhenTopologyIsMissing)
-{
-    this->checkGracefullHandlingWhenTopologyIsMissing();
 }
 
 }

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedronFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedronFEMForceField_test.cpp
@@ -20,6 +20,8 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h>
+#include <sofa/simulation/common/SceneLoaderXML.h>
+
 #include "BaseTetrahedronFEMForceField_test.h"
 
 namespace sofa
@@ -49,6 +51,34 @@ public:
         stiffnessMat = tetraFEM->getMaterialStiffness(elementId);
         strainD = tetraFEM->getStrainDisplacement(elementId);
     }
+
+    void checkGracefullHandlingWhenTopologyIsMissing()
+    {
+        // This is a RAII message.
+        EXPECT_MSG_EMIT(Error) ;
+
+        std::stringstream scene ;
+        scene << R"scn(
+<?xml version='1.0'?>
+<Node name="root">
+    <RequiredPlugin name="Sofa.Component.StateContainer"/>
+    <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/>
+    <DefaultAnimationLoop/>
+    <Node name="FEMnode">
+        <MechanicalObject/>
+        <TetrahedronFEMForceField name="fem" youngModulus="5000" poissonRatio="0.07" printLog="true"/>
+    </Node>
+</Node>
+)scn";
+
+        m_root = simulation::SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str()) ;
+        m_root->init(sofa::core::execparams::defaultInstance());
+
+        core::objectmodel::BaseObject* fem = m_root->getTreeNode("FEMnode")->getObject("fem") ;
+        EXPECT_NE(fem, nullptr) ;
+
+        EXPECT_EQ(fem->getComponentState(), core::objectmodel::ComponentState::Invalid) ;
+    }
 };
 
 TEST_F(TetrahedronFEMForceField_test, init)
@@ -64,6 +94,11 @@ TEST_F(TetrahedronFEMForceField_test, FEMValues)
 TEST_F(TetrahedronFEMForceField_test, emptyTology)
 {
     this->checkEmptyTopology();
+}
+
+TEST_F(TetrahedronFEMForceField_test, checkGracefullHandlingWhenTopologyIsMissing)
+{
+    this->checkGracefullHandlingWhenTopologyIsMissing();
 }
 
 } // namespace sofa

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/scenes/TetrahedronFEMForceFieldRegularTetra.scn
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/scenes/TetrahedronFEMForceFieldRegularTetra.scn
@@ -4,6 +4,7 @@
 
 <RequiredPlugin name="Sofa.Component.StateContainer"/>
 <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/>
+<DefaultAnimationLoop/>
 
 <!--Mechanical Object-->
 <MechanicalObject name="DOFs" showObject="1"  showObjectScale="5"  showIndices="1"  showIndicesScale="0.0003" position="0 0 0 1 0 0 0.5 0.86602540378443864676 0 0.5 0.288675134594812882254 1" />


### PR DESCRIPTION
We check the values of Young's modulus and Poisson's ratio in the base class of all elastic FEM.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
