### PR TITLE
[Core] Fix string comparison in factory

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
@@ -367,7 +367,7 @@ public:
         }
 
         auto objectCreator = std::make_shared<ObjectCreator<RealObject> >();
-        if (objectCreator->getTarget() == "")
+        if (strcmp(objectCreator->getTarget(), "") == 0)
         {
             dmsg_warning("ObjectFactory") << "Module name cannot be found when registering "
                 << RealObject::GetClass()->className << "<" << RealObject::GetClass()->templateName << "> into the object factory";


### PR DESCRIPTION
Fix wrong string comparison that displayed a lot of warning at compilation. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
