### PR TITLE
[Plugin] Add Cosserat as a fetchable plugin

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -46,6 +46,7 @@ sofa_add_subdirectory(plugin SofaMatrix SofaMatrix ON) # Depends on image, CImgP
 sofa_add_subdirectory(plugin BeamAdapter BeamAdapter EXTERNAL GIT_REF master)
 sofa_add_subdirectory(plugin STLIB STLIB EXTERNAL GIT_REF master)
 sofa_add_subdirectory(plugin SoftRobots SoftRobots EXTERNAL GIT_REF master)
+sofa_add_subdirectory(plugin Cosserat Cosserat EXTERNAL GIT_REF master) # Cosserat has an optional dependency on SoftRobots
 sofa_add_subdirectory(plugin CollisionAlgorithm CollisionAlgorithm EXTERNAL GIT_REF master)
 sofa_add_subdirectory(plugin ConstraintGeometry ConstraintGeometry EXTERNAL GIT_REF master)
 sofa_add_subdirectory(plugin ShapeMatchingPlugin ShapeMatchingPlugin EXTERNAL GIT_REF master)

--- a/applications/plugins/Cosserat/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/Cosserat/ExternalProjectConfig.cmake.in
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.11)
+
+include(ExternalProject)
+ExternalProject_Add(Cosserat
+    GIT_REPOSITORY https://github.com/SofaDefrost/Cosserat
+    GIT_TAG origin/@ARG_GIT_REF@
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/Cosserat"
+    BINARY_DIR ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+    GIT_CONFIG "remote.origin.fetch=+refs/pull/*:refs/remotes/origin/pr/*"
+)


### PR DESCRIPTION
But needs to wait for
[ci-depends-on https://github.com/SofaDefrost/Cosserat/pull/119]

to be merged before enabling it on the CI



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
