### PR TITLE
[Helper, AnimationLoop] ComponentChange: add Dealiased state

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -960,7 +960,6 @@ ConstraintProblem* ConstraintAnimationLoop::getCP()
 
 
 int ConstraintAnimationLoopClass = core::RegisterObject ( "Constraint animation loop manager" )
-        .add< ConstraintAnimationLoop >()
-        .addAlias("MasterConstraintSolver");
+        .add< ConstraintAnimationLoop >();
 
 } //namespace sofa::component::animationloop

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -406,7 +406,6 @@ void FreeMotionAnimationLoop::computeFreeMotion(const sofa::core::ExecParams* pa
 int FreeMotionAnimationLoopClass = core::RegisterObject(R"(
 The animation loop to use with constraints.
 You must add this loop at the beginning of the scene if you are using constraints.")")
-                                   .add< FreeMotionAnimationLoop >()
-                                   .addAlias("FreeMotionMasterSolver");
+                                   .add< FreeMotionAnimationLoop >();
 
 } //namespace sofa::component::animationloop

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
@@ -45,7 +45,6 @@ namespace sofa::component::animationloop
 
 int MultiStepAnimationLoopClass = core::RegisterObject("Multi steps animation loop, multi integration steps in a single animation step are managed.")
         .add< MultiStepAnimationLoop >()
-        .addAlias("MultiStepMasterSolver")
         ;
 
 MultiStepAnimationLoop::MultiStepAnimationLoop() :

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
@@ -45,7 +45,6 @@ namespace sofa::component::animationloop
 
 int MultiTagAnimationLoopClass = core::RegisterObject("Simple animation loop that given a list of tags, animate the graph one tag after another.")
         .add< MultiTagAnimationLoop >()
-        .addAlias("MultiTagMasterSolver")
         ;
 
 MultiTagAnimationLoop::MultiTagAnimationLoop()

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -235,18 +235,24 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
         using sofa::helper::lifecycle::ComponentChange;
         using sofa::helper::lifecycle::uncreatableComponents;
         using sofa::helper::lifecycle::movedComponents;
+        using sofa::helper::lifecycle::dealiasedComponents;
         if(it == registry.end())
         {
             arg->logError("The object '" + classname + "' is not in the factory.");
-            auto uuncreatableComponent = uncreatableComponents.find(classname);
+            auto uncreatableComponent = uncreatableComponents.find(classname);
             auto movedComponent = movedComponents.find(classname);
-            if( uuncreatableComponent != uncreatableComponents.end() )
+            auto dealiasedComponent = dealiasedComponents.find(classname);
+            if( uncreatableComponent != uncreatableComponents.end() )
             {
-                arg->logError( uuncreatableComponent->second.getMessage() );
+                arg->logError( uncreatableComponent->second.getMessage() );
             }
             else if (movedComponent != movedComponents.end())
             {
                 arg->logError( movedComponent->second.getMessage() );
+            }
+            else if (dealiasedComponent != dealiasedComponents.end())
+            {
+                arg->logError(dealiasedComponent->second.getMessage());
             }
             else
             {

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -763,6 +763,10 @@ const std::map< std::string, Renamed, std::less<> > renamedComponents = {
 
 
 const std::map< std::string, Dealiased, std::less<> > dealiasedComponents = {
+    {"MasterConstraintSolver", Dealiased("v24.12","ConstraintAnimationLoop")},
+    {"FreeMotionMasterSolver", Dealiased("v24.12","FreeMotionAnimationLoop")},
+    {"MultiStepMasterSolver", Dealiased("v24.12","MultiStepAnimationLoop")},
+    {"MultiTagMasterSolver", Dealiased("v24.12","MultiTagAnimationLoop")}
 };
 
 } // namespace sofa::helper::lifecycle

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -761,4 +761,8 @@ const std::map< std::string, Renamed, std::less<> > renamedComponents = {
 
 };
 
+
+const std::map< std::string, Dealiased, std::less<> > dealiasedComponents = {
+};
+
 } // namespace sofa::helper::lifecycle

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
@@ -134,9 +134,32 @@ private:
     std::string m_newName;
 };
 
+class SOFA_HELPER_API Dealiased : public ComponentChange
+{
+public:
+    Dealiased(const std::string& sinceVersion, const std::string& originalName)
+    {
+        std::stringstream output;
+        output << "This alias for the component " << originalName
+            << " was removed in SOFA " << sinceVersion << ".";
+        m_message = output.str();
+        m_changeVersion = sinceVersion;
+        m_originalName = originalName;
+    }
+
+    const std::string& getOriginalName() const
+    {
+        return m_originalName;
+    }
+
+private:
+    std::string m_originalName;
+};
+
 extern SOFA_HELPER_API const std::map< std::string, Deprecated, std::less<> > deprecatedComponents;
 extern SOFA_HELPER_API const std::map< std::string, ComponentChange, std::less<> > movedComponents;
 extern SOFA_HELPER_API const std::map< std::string, Renamed, std::less<> > renamedComponents;
 extern SOFA_HELPER_API const std::map< std::string, ComponentChange, std::less<> > uncreatableComponents;
+extern SOFA_HELPER_API const std::map< std::string, Dealiased, std::less<> > dealiasedComponents;
 
 } // namespace sofa::helper::lifecycle


### PR DESCRIPTION
Started from 
- #4858 

but decided to do a separate PR to introduce the new ComponentChange for lifecycle/user management.
and applying on Animation loop components.

[ci-depends-on https://github.com/SofaDefrost/SoftRobots/pull/296]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
