### PR TITLE
[SofaCUDA] Simplify definition of CudaVector type

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -60,19 +60,7 @@ struct DataTypeInfoManager
 };
 
 template<class T>
-class CudaVector : public type::vector_device<T,CudaMemoryManager<T>, DataTypeInfoManager<T> >
-{
-public :
-    using Inherit = type::vector_device<T, CudaMemoryManager<T>, DataTypeInfoManager<T> >;
-    typedef size_t Size;
-
-    CudaVector() : Inherit() {}
-
-    CudaVector(Size n) : Inherit(n) {}
-
-    CudaVector(const Inherit& v) : Inherit(v) {}
-
-};
+using CudaVector = type::vector_device<T,CudaMemoryManager<T>, DataTypeInfoManager<T> >;
 
 template<class TCoord, class TDeriv, class TReal = typename TCoord::value_type>
 class CudaVectorTypes


### PR DESCRIPTION
In addition to a simplification, it allows also to automatically use the newly introduced constructors from `vector_device`



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
