### PR TITLE
[Helper] Retrieve the current user local configuration directory

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
@@ -313,22 +313,11 @@ const std::string& Utils::getUserLocalDirectory()
 
 const std::string& Utils::getSofaUserLocalDirectory()
 {
-    auto computeSofaLocalDirectory = []()
-    {
-        const auto localDirPath = FileSystem::append(getUserLocalDirectory(), "SOFA");
-        if(!FileSystem::exists(localDirPath))
-        {
-            if(!FileSystem::createDirectory(localDirPath))
-            {
-                // error while trying to create the computed path
-                // most likely because of permissions errors
-                return std::string("");
-            }
-        }
-        return localDirPath;
-    };
+    constexpr std::string_view sofaLocalDirSuffix = "SOFA";
 
-    static std::string sofaLocalDirectory = FileSystem::cleanPath(computeSofaLocalDirectory());
+    static std::string sofaLocalDirectory = FileSystem::cleanPath(FileSystem::findOrCreateAValidPath(
+        FileSystem::append(getUserLocalDirectory(), sofaLocalDirSuffix)));
+
     return sofaLocalDirectory;
 }
 

--- a/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
@@ -253,13 +253,7 @@ const std::string& Utils::getUserLocalDirectory()
             CoTaskMemFree(path);
         }
 
-        // convert wide string (unicode) to standard string
-        std::string result(wresult.length(), 0);
-        std::transform(wresult.begin(), wresult.end(), result.begin(), [](wchar_t c) {
-            return (char)c;
-        });
-
-        return result;
+        return Utils::narrowString(wresult);
 
 #elif defined(__APPLE__) // macOS : ${HOME}/Library/Application Support
         // https://stackoverflow.com/questions/5123361/finding-library-application-support-from-c

--- a/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
@@ -315,17 +315,17 @@ const std::string& Utils::getSofaUserLocalDirectory()
 {
     auto computeSofaLocalDirectory = []()
     {
-        const std::filesystem::path localDirPath = getUserLocalDirectory() + "/SOFA";
-        if(!std::filesystem::exists(localDirPath))
+        const auto localDirPath = FileSystem::append(getUserLocalDirectory(), "SOFA");
+        if(!FileSystem::exists(localDirPath))
         {
-            if(!std::filesystem::create_directories(localDirPath))
+            if(!FileSystem::createDirectory(localDirPath))
             {
                 // error while trying to create the computed path
                 // most likely because of permissions errors
                 return std::string("");
             }
         }
-        return localDirPath.string();
+        return localDirPath;
     };
 
     static std::string sofaLocalDirectory = FileSystem::cleanPath(computeSofaLocalDirectory());

--- a/Sofa/framework/Helper/src/sofa/helper/Utils.h
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.h
@@ -75,6 +75,13 @@ static const std::string& getExecutablePath();
 /// @brief Get the path to the directory of the executable that is currently running.
 static const std::string& getExecutableDirectory();
 
+/// @brief Get the path to the current user local config directory.
+static const std::string& getUserLocalDirectory();
+
+/// @brief Get the path to the SOFA directory into the current user local config directory.
+static const std::string& getSofaUserLocalDirectory();
+
+
 /// @brief Get the path to the "root" path of Sofa (i.e. the build directory or
 /// the installation prefix).
 ///

--- a/Sofa/framework/Helper/test/Utils_test.cpp
+++ b/Sofa/framework/Helper/test/Utils_test.cpp
@@ -48,6 +48,39 @@ TEST(UtilsTest, getSofaPathPrefix)
     EXPECT_TRUE(FileSystem::exists(prefix + "/bin"));
 }
 
+// Following tests can fail (or not really relevant)
+// if the user has a custom/non-standard home directory
+// (moreso if the user does not have a home directory or is being disabled for security reason)
+bool testGetUserLocalDirectory()
+{
+    bool result = true;
+
+    const std::string path = Utils::getUserLocalDirectory();
+#if defined(WIN32)
+    result = result && (path.find("AppData") != std::string::npos);
+    result = result && (path.find("Local") != std::string::npos);
+#elif defined (__APPLE__)
+    result = result && (path.find("Library") != std::string::npos);
+    result = result && (path.find("Application Support") != std::string::npos);
+#else // Linux
+    result = result && (path.find(".config") != std::string::npos);
+#endif
+
+    return result;
+}
+
+TEST(UtilsTest, getUserLocalDirectory)
+{
+    EXPECT_TRUE(testGetUserLocalDirectory());
+}
+
+TEST(UtilsTest, getSofaUserLocalDirectory)
+{
+    const std::string path = Utils::getSofaUserLocalDirectory();
+    EXPECT_TRUE(testGetUserLocalDirectory());
+    EXPECT_TRUE(path.find("SOFA") != std::string::npos);
+}
+
 TEST(UtilsTest, readBasicIniFile_nonexistentFile)
 {
     // this test will raise an error on purpose


### PR DESCRIPTION
First steps for a consistent, uniformed and centralized configuration storage.

This PR adds the ability to retrieve the current local config folder for the user. 

These return respectively (local account is `fred`):
 - Linux:
```
getUserLocalDirectory(): /home/fred/.config
getSofaUserLocalDirectory(): /home/fred/.config/SOFA
```

 - macOS:
 ```
getUserLocalDirectory(): /Users/fred/Library/Application Support
getSofaUserLocalDirectory(): /Users/fred/Library/Application Support/SOFA
```
 - Windows:
 ```
getUserLocalDirectory(): C:/Users/Fred/AppData/Local
getSofaUserLocalDirectory(): C:/Users/Fred/AppData/Local/SOFA
```

`getSofaUserLocalDirectory()` creates also the directory if it is not created yet

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
