### PR TITLE
[FEM.Elastic] remove static variable

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.h
@@ -44,13 +44,7 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink<BaseLinearElasticityFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_topology;
 
-    static inline const VecReal defaultYoungModulusValue = []()
-    {
-        VecReal newY;
-        newY.resize(1);
-        newY[0] = 5000;
-        return newY;
-    }();
+    static VecReal GetDefaultYoungModulusValue();
 
     BaseLinearElasticityFEMForceField();
     void init() override;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl
@@ -27,9 +27,19 @@ namespace sofa::component::solidmechanics::fem::elastic
 {
 
 template <class DataTypes>
+typename BaseLinearElasticityFEMForceField<DataTypes>::VecReal
+BaseLinearElasticityFEMForceField<DataTypes>::GetDefaultYoungModulusValue()
+{
+    VecReal newY;
+    newY.resize(1);
+    newY[0] = 5000;
+    return newY;
+}
+
+template <class DataTypes>
 BaseLinearElasticityFEMForceField<DataTypes>::BaseLinearElasticityFEMForceField()
     : d_poissonRatio(initData(&d_poissonRatio,(Real)0.45,"poissonRatio","FEM Poisson Ratio in Hooke's law [0,0.5["))
-    , d_youngModulus(initData(&d_youngModulus, defaultYoungModulusValue, "youngModulus","FEM Young's Modulus in Hooke's law"))
+    , d_youngModulus(initData(&d_youngModulus, GetDefaultYoungModulusValue(), "youngModulus","FEM Young's Modulus in Hooke's law"))
     , l_topology(initLink("topology", "link to the topology container"))
 {
     d_poissonRatio.setRequired(true);


### PR DESCRIPTION
The static variable is constructed as soon as the plugin is loaded. This could be a problem if the plugin initialization failed (SofaCUDA). This PR remove the variable for a static function. The code is called only when used.

Note that this PR is temporary, waiting for https://github.com/sofa-framework/sofa/pull/4852 where this variable won't be necessary.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
