### PR TITLE
[Visual] BaseCamera: Fix return value when saving a view file

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/BaseCamera.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/BaseCamera.cpp
@@ -831,7 +831,7 @@ bool BaseCamera::exportParametersInFile(const std::string& viewFilename)
     BaseCameraXMLExportSingleParameter(root, d_zFar, "Real");
     BaseCameraXMLExportSingleParameter(root, d_type, "Int (0 -> Perspective, 1 -> Orthographic)");
 
-    return doc.SaveFile( viewFilename.c_str() );
+    return (doc.SaveFile(viewFilename.c_str()) == tinyxml2::XML_SUCCESS);
 }
 
 bool BaseCameraXMLImportSingleParameter(tinyxml2::XMLElement* root, core::objectmodel::BaseData& data, BaseCamera* c)


### PR DESCRIPTION
SofaGLFW was throwing me error when saving a camera view while effectively writting the file....
It appeared that SaveFile return XML_SUCCESS (underlying value of 0) when successful....


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
