### PR TITLE
[CMake] Update all cmake_minimum_required in plugins

### DIFF
--- a/applications/plugins/BeamAdapter/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/BeamAdapter/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(BeamAdapter

--- a/applications/plugins/CGALPlugin/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/CGALPlugin/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(CGALPlugin

--- a/applications/plugins/CSparseSolvers/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/CSparseSolvers/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(CSparseSolvers

--- a/applications/plugins/CollisionAlgorithm/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/CollisionAlgorithm/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(CollisionAlgorithm

--- a/applications/plugins/ConstraintGeometry/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/ConstraintGeometry/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(ConstraintGeometry

--- a/applications/plugins/Cosserat/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/Cosserat/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(Cosserat

--- a/applications/plugins/InvertibleFVM/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/InvertibleFVM/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(InvertibleFVM

--- a/applications/plugins/ManifoldTopologies/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/ManifoldTopologies/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(ManifoldTopologies

--- a/applications/plugins/MeshSTEPLoader/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/MeshSTEPLoader/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(MeshSTEPLoader

--- a/applications/plugins/PSL/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/PSL/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(PSL

--- a/applications/plugins/PluginExample/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/PluginExample/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(PluginExample

--- a/applications/plugins/Registration/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/Registration/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(Registration

--- a/applications/plugins/STLIB/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/STLIB/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(STLIB

--- a/applications/plugins/ShapeMatchingPlugin/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/ShapeMatchingPlugin/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(ShapeMatchingPlugin

--- a/applications/plugins/SofaHighOrder/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaHighOrder/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(SofaHighOrder

--- a/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(SofaPython3

--- a/applications/plugins/SofaSphFluid/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaSphFluid/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(SofaSphFluid

--- a/applications/plugins/SofaValidation/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaValidation/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(SofaValidation

--- a/applications/plugins/SoftRobots/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SoftRobots/ExternalProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 include(ExternalProject)
 ExternalProject_Add(SoftRobots


### PR DESCRIPTION
I do not know whether some of these `cmake_minimum_required` were set to another version than SOFA for a specific reason :thinking: 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
