### PR TITLE
[Test] Add generic test on buildGeometricStiffnessMatrix for mappings

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseForceField.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseForceField.cpp
@@ -60,7 +60,7 @@ void BaseForceField::buildStiffnessMatrix(StiffnessMatrix* matrix)
     if (hasEmittedWarning.insert(this).second)
     {
         dmsg_warning() << "buildStiffnessMatrix not implemented: for compatibility reason, the "
-            "deprecated API (addKToMatrix) will be used. This compatibility will disapear in the "
+            "deprecated API (addKToMatrix) will be used. This compatibility will disappear in the "
             "future, and will cause issues in simulations. Please update the code of " <<
             this->getClassName() << " to ensure right behavior: the function addKToMatrix "
             "has been replaced by buildStiffnessMatrix";


### PR DESCRIPTION
This PR adds 2 generic tests for mappings:

- It tests `applyDJT` in two different contexts to cover both situtations
- It tests `buildGeometricStiffnessMatrix`



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
