### PR TITLE
[SolidMechanics.FEM.Elastic] Fix compilation on clang{12, 13}

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BeamFEMForceField.inl
@@ -164,7 +164,7 @@ void BeamFEMForceField<DataTypes>::reinitBeam(Index i)
         return;
 
     SReal stiffness, length, radius, poisson, radiusInner;
-    const auto [a, b] = (*m_indexedElements)[i].array();
+    const auto& [a, b] = (*m_indexedElements)[i].array();
 
     const VecCoord& x0 = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
     stiffness =  d_youngModulus.getValue() ;
@@ -223,7 +223,7 @@ void BeamFEMForceField<DataTypes>::addForce(const sofa::core::MechanicalParams* 
     {
         for (unsigned int i : d_listSegment.getValue())
         {
-            const auto [a, b] = (*m_indexedElements)[i].array();
+            const auto& [a, b] = (*m_indexedElements)[i].array();
             initLarge(i, a, b);
             accumulateForceLarge(f.wref(), p, i, a, b);
         }
@@ -233,7 +233,7 @@ void BeamFEMForceField<DataTypes>::addForce(const sofa::core::MechanicalParams* 
         unsigned int i;
         for(it=m_indexedElements->begin(),i=0; it!=m_indexedElements->end(); ++it,++i)
         {
-            const auto [a, b] = it->array();
+            const auto& [a, b] = it->array();
             initLarge(i, a, b);
             accumulateForceLarge(f.wref(), p, i, a, b);
         }
@@ -256,7 +256,7 @@ void BeamFEMForceField<DataTypes>::addDForce(const sofa::core::MechanicalParams 
     {
         for (unsigned int i : d_listSegment.getValue())
         {
-            const auto [a, b] = (*m_indexedElements)[i].array();
+            const auto& [a, b] = (*m_indexedElements)[i].array();
             applyStiffnessLarge(df.wref(), dx, i, a, b, kFactor);
         }
     }
@@ -265,7 +265,7 @@ void BeamFEMForceField<DataTypes>::addDForce(const sofa::core::MechanicalParams 
         unsigned int i = 0;
         for(auto it = m_indexedElements->begin() ; it != m_indexedElements->end() ; ++it, ++i)
         {
-            const auto [a, b] = it->array();
+            const auto& [a, b] = it->array();
             applyStiffnessLarge(df.wref(), dx, i, a, b, kFactor);
         }
     }
@@ -514,7 +514,7 @@ void BeamFEMForceField<DataTypes>::addKToMatrix(const sofa::core::MechanicalPara
 
             for (unsigned int i : d_listSegment.getValue())
             {
-                const auto [a, b] = (*m_indexedElements)[i].array();
+                const auto& [a, b] = (*m_indexedElements)[i].array();
 
                 type::Quat<SReal>& q = beamQuat(i);
                 q.normalize();
@@ -548,7 +548,7 @@ void BeamFEMForceField<DataTypes>::addKToMatrix(const sofa::core::MechanicalPara
             unsigned int i {};
             for(auto it = m_indexedElements->begin() ; it != m_indexedElements->end() ; ++it, ++i)
             {
-                const auto [a, b] = it->array();
+                const auto& [a, b] = it->array();
 
                 type::Quat<SReal>& q = beamQuat(i);
                 q.normalize();
@@ -617,7 +617,7 @@ void BeamFEMForceField<DataTypes>::buildStiffnessMatrix(core::behavior::Stiffnes
     {
         for (unsigned int i : d_listSegment.getValue())
         {
-            const auto [a, b] = (*m_indexedElements)[i].array();
+            const auto& [a, b] = (*m_indexedElements)[i].array();
 
             type::Quat<SReal>& q = beamQuat(i);
             q.normalize();
@@ -651,7 +651,7 @@ void BeamFEMForceField<DataTypes>::buildStiffnessMatrix(core::behavior::Stiffnes
         unsigned int i {};
         for(auto it = m_indexedElements->begin() ; it != m_indexedElements->end() ; ++it, ++i)
         {
-            const auto [a, b] = it->array();
+            const auto& [a, b] = it->array();
 
             type::Quat<SReal>& q = beamQuat(i);
             q.normalize();
@@ -789,7 +789,7 @@ void BeamFEMForceField<DataTypes>::computeBBox(const core::ExecParams* params, b
 template<class DataTypes>
 void BeamFEMForceField<DataTypes>::drawElement(int i, std::vector< type::Vec3 >* points, const VecCoord& x)
 {
-    const auto [a, b] = (*m_indexedElements)[i].array();
+    const auto& [a, b] = (*m_indexedElements)[i].array();
     const type::Vec3d p = (x[a].getCenter() + x[b].getCenter()) * 0.5;
     type::Vec3d beamVec;
     beamVec[0]= d_beamsData.getValue()[i]._L * 0.5; beamVec[1] = 0.0; beamVec[2] = 0.0;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -702,7 +702,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::draw(const core::visual::
     {
         const core::topology::BaseMeshTopology::Tetrahedron t = m_topology->getTetrahedron(i);
 
-        const auto [a, b, c, d] = t.array();
+        const auto& [a, b, c, d] = t.array();
         Coord center = (x[a] + x[b] + x[c] + x[d])*0.125;
         Coord pa = (x[a] + center)*(Real)0.666667;
         Coord pb = (x[b] + center)*(Real)0.666667;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
@@ -631,7 +631,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::accumulateForceSmall( Vect
     const core::topology::BaseMeshTopology::Tetrahedron t=m_topology->getTetrahedron(elementIndex);
     const VecCoord& X0=this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
-    const auto [a, b, c, d] = t.array();
+    const auto& [a, b, c, d] = t.array();
 
     // displacements
     Displacement D;
@@ -1217,7 +1217,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::draw(const core::visual::V
     {
         const core::topology::BaseMeshTopology::Tetrahedron t=m_topology->getTetrahedron(i);
 
-        const auto [a, b, c, d] = t.array();
+        const auto& [a, b, c, d] = t.array();
         Coord center = (x[a]+x[b]+x[c]+x[d])*0.125;
         Coord pa = (x[a]+center)*(Real)0.666667;
         Coord pb = (x[b]+center)*(Real)0.666667;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -570,7 +570,7 @@ inline void TetrahedronFEMForceField<DataTypes>::accumulateForceSmall( Vector& f
 {
     const VecCoord &initialPoints=d_initialPoints.getValue();
     Element index = *elementIt;
-    const auto [a, b, c, d] = index.array();
+    const auto& [a, b, c, d] = index.array();
 
     // displacements
     Displacement D;
@@ -674,7 +674,7 @@ inline SReal TetrahedronFEMForceField<DataTypes>::getPotentialEnergy(const core:
         for(it=_indexedElements->begin(), i = 0 ; it!=_indexedElements->end(); ++it,++i)
         {
             Element index = *it;
-            const auto [a, b, c, d] = index.array();
+            const auto& [a, b, c, d] = index.array();
 
             // displacements
             Displacement D;
@@ -1665,7 +1665,7 @@ inline void TetrahedronFEMForceField<DataTypes>::addDForce(const core::Mechanica
     {
         for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
         {
-            const auto [a, b, c, d] = it->array();
+            const auto& [a, b, c, d] = it->array();
             applyStiffnessSmall(df, dx, i, a, b, c, d, kFactor);
         }
     }
@@ -1673,7 +1673,7 @@ inline void TetrahedronFEMForceField<DataTypes>::addDForce(const core::Mechanica
     {
         for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
         {
-            const auto [a, b, c, d] = it->array();
+            const auto& [a, b, c, d] = it->array();
             applyStiffnessCorotational(df, dx, i, a, b, c, d, kFactor);
         }
     }

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangleFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangleFEMForceField.inl
@@ -228,7 +228,7 @@ void TriangleFEMForceField<DataTypes>::computeMaterialStiffnesses()
 
     for (unsigned i = 0; i < _indexedElements->size(); ++i)
     {
-        const auto [a, b, c] = (*_indexedElements)[i].array();
+        const auto& [a, b, c] = (*_indexedElements)[i].array();
 
         const Real triangleVolume = (Real)0.5 * d_thickness.getValue() * cross(p[b] - p[a], p[c] - p[a]).norm();
 
@@ -298,7 +298,7 @@ void TriangleFEMForceField<DataTypes>::accumulateForceSmall(VecCoord& f, const V
 
     for (it = _indexedElements->begin(); it != _indexedElements->end(); ++it, ++elementIndex)
     {
-        const auto [a, b, c] = it->array();
+        const auto& [a, b, c] = it->array();
 
         const auto deforme_b = p[b] - p[a];
         const auto deforme_c = p[c] - p[a];
@@ -350,7 +350,7 @@ void TriangleFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord& v, Real h, 
     unsigned int i(0);
     for (auto it = _indexedElements->begin(); it != _indexedElements->end(); ++it, ++i)
     {
-        const auto [a, b, c] = it->array();
+        const auto& [a, b, c] = it->array();
 
         Displacement dX;
 
@@ -443,7 +443,7 @@ void TriangleFEMForceField<DataTypes>::accumulateForceLarge(VecCoord& f, const V
     for (it = _indexedElements->begin(); it != _indexedElements->end(); ++it, ++elementIndex)
     {
         // triangle vertex indices
-        const auto [a, b, c] = it->array();
+        const auto& [a, b, c] = it->array();
 
         const Coord& pA = p[a];
         const Coord& pB = p[b];
@@ -514,7 +514,7 @@ void TriangleFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord& v, Real h, 
 
     for (auto it = _indexedElements->begin(); it != _indexedElements->end(); ++it, ++i)
     {
-        const auto [a, b, c] = it->array();
+        const auto& [a, b, c] = it->array();
 
         Transformation R_0_2(type::NOINIT);
         R_0_2.transpose(_rotations[i]);
@@ -584,7 +584,7 @@ void TriangleFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vp
     typename VecElement::const_iterator it;
     for (it = _indexedElements->begin(); it != _indexedElements->end(); ++it)
     {
-        const auto [a, b, c] = it->array();
+        const auto& [a, b, c] = it->array();
 
         colorVector.push_back(sofa::type::RGBAColor::green());
         vertices.push_back(sofa::type::Vec3(x[a]));

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TriangularFEMForceField.inl
@@ -864,7 +864,7 @@ void TriangularFEMForceField<DataTypes>::computeStress(type::Vec<3, Real>& stres
     Transformation R_0_2, R_2_0;
     const VecCoord& p = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     const Triangle& tri = m_topology->getTriangle(elementIndex);
-    const auto [a, b, c] = tri.array();
+    const auto& [a, b, c] = tri.array();
 
     auto triangleInf = sofa::helper::getWriteOnlyAccessor(d_triangleInfo);
     if (method == SMALL)
@@ -983,7 +983,7 @@ template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeStressAcrossDirection(Real& stress_across_dir, Index elementIndex, const Coord& dir, const type::Vec<3, Real>& stress)
 {
     const Triangle& tri = m_topology->getTriangle(elementIndex);
-    const auto [a, b, c] = tri.array();
+    const auto& [a, b, c] = tri.array();
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     Coord n = cross(x[b] - x[a], x[c] - x[a]);
     Coord dir_t = cross(dir, n);
@@ -994,7 +994,7 @@ template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeStressAcrossDirection(Real& stress_across_dir, Index elementIndex, const Coord& dir)
 {
     const Triangle& tri = m_topology->getTriangle(elementIndex);
-    const auto [a, b, c] = tri.array();
+    const auto& [a, b, c] = tri.array();
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     Coord n = cross(x[b] - x[a], x[c] - x[a]);
     Coord dir_t = cross(dir, n);
@@ -1026,7 +1026,7 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord& v, Real h
     {
         TriangleInformation& tInfo = triangleInf[i];
         const Triangle& tri = m_topology->getTriangle(i);
-        const auto [a, b, c] = tri.array();
+        const auto& [a, b, c] = tri.array();
 
         dX[0] = x[a][0];
         dX[1] = x[a][1];
@@ -1087,7 +1087,7 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord& v, Real h
     {
         TriangleInformation& tInfo = triangleInf[i];
         const Element& tri = triangles[i];
-        const auto [a, b, c] = tri.array();
+        const auto& [a, b, c] = tri.array();
 
         Transformation R_0_2;
         R_0_2.transpose(tInfo.rotation);
@@ -1136,7 +1136,7 @@ void TriangularFEMForceField<DataTypes>::accumulateForceSmall(VecCoord& f, const
     {
         TriangleInformation& tInfo = triangleInf[i];
         const Element& tri = m_topology->getTriangle(i);
-        const auto [a, b, c] = tri.array();
+        const auto& [a, b, c] = tri.array();
 
         Coord deforme_a, deforme_b, deforme_c;
         deforme_b = p[b] - p[a];
@@ -1358,7 +1358,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         for (Size i = 0; i < nbTriangles; ++i)
         {
             const Triangle& tri = triangles[i];
-            const auto [a, b, c] = tri.array();
+            const auto& [a, b, c] = tri.array();
             Coord center = (x[a] + x[b] + x[c]) / 3;
             Coord d = triangleInf[i].principalStressDirection * 2.5; //was 0.25
             vertices.push_back(sofa::type::Vec3(center));
@@ -1378,7 +1378,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         for (Size i = 0; i < nbTriangles; ++i)
         {
             const Triangle& tri = triangles[i];
-            const auto [a, b, c] = tri.array();
+            const auto& [a, b, c] = tri.array();
 
             colorVector.push_back(evalColor(vertexInf[a].stress));
             vertices.push_back(sofa::type::Vec3(x[a]));
@@ -1419,7 +1419,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
             {
                 color = sofa::type::RGBAColor(float(0.4 + 0.4 * (triangleInf[i].differenceToCriteria - minDifference) / (maxDifference - minDifference)), 0.0f, 0.0f, 0.5f);
                 const Triangle& tri = triangles[i];
-                const auto [a, b, c] = tri.array();
+                const auto& [a, b, c] = tri.array();
 
                 colorVector.push_back(color);
                 vertices.push_back(sofa::type::Vec3(x[a]));


### PR DESCRIPTION
Compilation was failing on clang{12,13} since 
- https://github.com/sofa-framework/sofa/pull/4835

I noticed that the `.array()` method was returning a const ref.
so I tried to structure binding to a const ref (instead of a const value) and... it worked on clang12,13 🫨 (while crashing if using values)

I guess there is some bug around with clang12,13 around for this case, as clang14+ is working fine (and other compilers too)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
