### PR TITLE
[Core,Simulation] Inherit and link gravity from parent context if not set

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h
@@ -226,7 +226,7 @@ public:
     /// @{
     /// True if the value has been modified
     /// If this data is linked, the value of this data will be considered as modified
-    /// (even if the parent's value has not been modified)s
+    /// (even if the parent's value has not been modified)
     bool isSet() const { return m_isSet; }
 
     /// Reset the isSet flag to false, to indicate that the current value is the default for this %Data.

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Context.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Context.cpp
@@ -124,7 +124,7 @@ void Context::setAnimate(const bool val)
 }
 
 //======================
-void Context::copyContext(const Context& c)
+void Context::copyContext(Context& c)
 {
     // BUGFIX 12/01/06 (Jeremie A.): Can't use operator= on the class as it will copy other data in the BaseContext class (such as name)...
     // *this = c;
@@ -134,9 +134,15 @@ void Context::copyContext(const Context& c)
 }
 
 
-void Context::copySimulationContext(const Context& c)
+void Context::copySimulationContext(Context& c)
 {
-    worldGravity_.setValue(c.getGravity());  ///< Gravity IN THE WORLD COORDINATE SYSTEM.
+    // If not set, link the gravity to the one from the parent context
+    if (!worldGravity_.isSet())
+    {
+        worldGravity_.setParent(&c.worldGravity_);
+    }
+
+    // Copy the time step, time and animate from context
     setDt(c.getDt());
     setTime(c.getTime());
     setAnimate(c.getAnimate());

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Context.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Context.cpp
@@ -146,9 +146,7 @@ void Context::copySimulationContext(Context& c)
     setDt(c.getDt());
     setTime(c.getTime());
     setAnimate(c.getAnimate());
-
-
-
 }
+
 } // namespace sofa::core::objectmodel
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Context.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Context.h
@@ -102,10 +102,10 @@ public:
     /// @}
 
     /// Copy the context variables from the given instance
-    void copyContext(const Context& c);
+    void copyContext(Context& c);
 
     /// Copy the context variables of visualization from the given instance
-    void copySimulationContext(const Context& c);
+    void copySimulationContext(Context& c);
 
 };
 } // namespace sofa::core::objectmodel

--- a/Sofa/framework/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Core/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCE_FILES
     topology/TopologySubsetIndices_test.cpp
     DataEngine_test.cpp
     Engine_test.cpp
+    Gravity_test.cpp
     MatrixAccumulator_test.cpp
     ObjectFactory_test.cpp
     ObjectFactoryJson_test.cpp

--- a/Sofa/framework/Core/test/Gravity_test.cpp
+++ b/Sofa/framework/Core/test/Gravity_test.cpp
@@ -1,0 +1,209 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/testing/BaseSimulationTest.h>
+using sofa::testing::BaseSimulationTest;
+#include <sofa/testing/NumericTest.h>
+using sofa::testing::NumericTest;
+
+#include <sofa/simpleapi/SimpleApi.h>
+#include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
+
+namespace sofa {
+
+using namespace type;
+using namespace testing;
+using namespace defaulttype;
+using core::objectmodel::New;
+
+/// Create a stiff string
+Node::SPtr particleUnderGravity(Node::SPtr parent,
+                                std::string nodeName,
+                                Vec3d gravity,
+                                bool useGravity)
+{
+    Node::SPtr node = simpleapi::createChild(parent, nodeName);
+
+    if(useGravity)
+    {
+        Node::SPtr node = simpleapi::createChild(parent, nodeName, { {"gravity", simpleapi::str(gravity)} });
+    }
+    else
+    {
+        Node::SPtr node = simpleapi::createChild(parent, nodeName);
+    }
+
+    Vec3d startPoint(0., 0., 0.);
+
+    simpleapi::createObject(node, "EulerImplicitSolver", {});
+    simpleapi::createObject(node, "CGLinearSolver", {
+        { "iterations", simpleapi::str(25)},
+        { "tolerance", simpleapi::str(1e-5)},
+        { "threshold", simpleapi::str(1e-5)},
+    });
+
+    simpleapi::createObject(node, "MechanicalObject", {
+                                {"name", nodeName + "_DOF"},
+                                {"position", simpleapi::str(startPoint)}
+        });
+
+    simpleapi::createObject(node, "UniformMass", {
+                                {"name", nodeName + "_mass"},
+                                {"totalMass", simpleapi::str(1.)} });
+
+    return node;
+}
+
+/// Test for the gravity context data
+struct Gravity_set_at_root_node : public BaseSimulationTest, NumericTest<SReal>
+{
+    Gravity_set_at_root_node()
+    {
+        Vec3d gravity1(0., 10., 0.);
+        Vec3d gravity2(0., 20., 0.);
+        Vec3d gravity3(0., 30., 0.);
+
+        //*******
+        const auto simu = simpleapi::createSimulation();
+        const simulation::Node::SPtr root = simpleapi::createRootNode(simu, "root", { {"gravity", simpleapi::str(gravity1)} });
+        //*******
+        // load appropriate modules
+        sofa::simpleapi::importPlugin("Sofa.Component.ODESolver.Backward");
+        sofa::simpleapi::importPlugin("Sofa.Component.LinearSolver.Iterative");
+        sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
+        sofa::simpleapi::importPlugin("Sofa.Component.Mass");
+
+        // avoid warnings
+        simpleapi::createObject(root, "DefaultAnimationLoop", {});
+        simpleapi::createObject(root, "DefaultVisualManagerLoop", {});
+
+        //*********
+        // create scene
+        simulation::Node::SPtr particule1 = particleUnderGravity(root, "Node-no-gravity-set", type::Vec3(), false);
+        Node::SPtr emptyNode1 = simpleapi::createChild(root, "EmptyNode1");
+        simulation::Node::SPtr particule2 = particleUnderGravity(emptyNode1, "Node-no-gravity-set", type::Vec3(), false);
+
+        simulation::Node::SPtr particule3 = particleUnderGravity(root, "Node-gravity-set", gravity2, true);
+        Node::SPtr emptyNode2 = simpleapi::createChild(root, "EmptyNode2");
+        simulation::Node::SPtr particule4 = particleUnderGravity(emptyNode2, "Node-gravity-set", gravity2, true);
+
+        // end create scene
+        //*********
+        sofa::simulation::node::initRoot(root.get());
+        //*********
+        // run simulation
+
+        // do one time step
+        sofa::simulation::node::animate(root.get(), 1_sreal);
+
+        EXPECT_EQ(gravity1,particule1->getGravity());
+        EXPECT_EQ(gravity1,particule2->getGravity());
+        EXPECT_EQ(gravity2,particule3->getGravity());
+        EXPECT_EQ(gravity2,particule4->getGravity());
+
+        root->setGravity(gravity3);
+        emptyNode2->setGravity(gravity3);
+
+        // do another time step
+        sofa::simulation::node::animate(root.get(), 1_sreal);
+
+        EXPECT_EQ(gravity3,particule1->getGravity());
+        EXPECT_EQ(gravity3,particule2->getGravity());
+        EXPECT_EQ(gravity2,particule3->getGravity());
+        EXPECT_EQ(gravity3,particule4->getGravity());
+    }
+};
+
+
+struct Gravity_not_set_at_root_node  : public BaseSimulationTest, NumericTest<SReal>
+{
+
+    Gravity_not_set_at_root_node()
+    {
+        Vec3d default_gravity(0., -9.81, 0.);
+        Vec3d gravity2(0., 20., 0.);
+        Vec3d gravity3(0., 30., 0.);
+
+        //*******
+        const auto simu = simpleapi::createSimulation();
+        const simulation::Node::SPtr root = simpleapi::createRootNode(simu, "root");
+        //*******
+        // load appropriate modules
+        sofa::simpleapi::importPlugin("Sofa.Component.ODESolver.Backward");
+        sofa::simpleapi::importPlugin("Sofa.Component.LinearSolver.Iterative");
+        sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
+        sofa::simpleapi::importPlugin("Sofa.Component.Mass");
+
+        // avoid warnings
+        simpleapi::createObject(root, "DefaultAnimationLoop", {});
+        simpleapi::createObject(root, "DefaultVisualManagerLoop", {});
+
+        //*********
+        // create scene
+        simulation::Node::SPtr particule1 = particleUnderGravity(root, "Node-no-gravity-set", type::Vec3(), false);
+        Node::SPtr emptyNode1 = simpleapi::createChild(root, "EmptyNode1");
+        simulation::Node::SPtr particule2 = particleUnderGravity(emptyNode1, "Node-no-gravity-set", type::Vec3(), false);
+
+        simulation::Node::SPtr particule3 = particleUnderGravity(root, "Node-gravity-set", gravity2, true);
+        Node::SPtr emptyNode2 = simpleapi::createChild(root, "EmptyNode2");
+        simulation::Node::SPtr particule4 = particleUnderGravity(emptyNode2, "Node-gravity-set", gravity2, true);
+
+        // end create scene
+        //*********
+        sofa::simulation::node::initRoot(root.get());
+        //*********
+        // run simulation
+
+        // do one time step
+        sofa::simulation::node::animate(root.get(), 1_sreal);
+
+        EXPECT_EQ(default_gravity,particule1->getGravity());
+        EXPECT_EQ(default_gravity,particule2->getGravity());
+        EXPECT_EQ(gravity2,particule3->getGravity());
+        EXPECT_EQ(gravity2,particule4->getGravity());
+
+        root->setGravity(gravity3);
+        emptyNode2->setGravity(gravity3);
+
+        // do another time step
+        sofa::simulation::node::animate(root.get(), 1_sreal);
+
+        EXPECT_EQ(gravity3,particule1->getGravity());
+        EXPECT_EQ(gravity3,particule2->getGravity());
+        EXPECT_EQ(gravity2,particule3->getGravity());
+        EXPECT_EQ(gravity3,particule4->getGravity());
+    }
+
+};
+
+TEST_F( Gravity_not_set_at_root_node, check ){}
+TEST_F( Gravity_set_at_root_node, check ){}
+
+}// namespace sofa
+
+
+
+
+
+
+

--- a/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.cpp
+++ b/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.cpp
@@ -137,9 +137,9 @@ Node::SPtr createChild(Node::SPtr node, const std::string& name, const std::map<
 
 Node::SPtr createChild(Node::SPtr node, BaseObjectDescription& desc)
 {
-    Node::SPtr tmp = node->createChild(desc.getName());
-    tmp->parse(&desc);
-    return tmp;
+    Node::SPtr createdNode = node->createChild(desc.getName());
+    createdNode->parse(&desc);
+    return createdNode;
 }
 
 Node::SPtr createNode(const std::string& name)

--- a/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.cpp
+++ b/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.cpp
@@ -782,14 +782,6 @@ void DAGNode::executeVisitorTreeTraversal( simulation::Visitor* action, StatusMa
 }
 
 
-void DAGNode::initVisualContext()
-{
-    if (getNbParents())
-    {
-        this->setDisplayWorldGravity(false); //only display gravity for the root: it will be propagated at each time step
-    }
-}
-
 void DAGNode::updateContext()
 {
     sofa::core::objectmodel::BaseNode* firstParent = getFirstParent();

--- a/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.h
+++ b/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.h
@@ -108,10 +108,6 @@ public:
     /// (within it or its parents until a mapping is reached that does not preserve topologies).
     sofa::core::topology::BaseMeshTopology* getMeshTopologyLink(SearchDirection dir = SearchUp) const override;
 
-
-    /// Called during initialization to correctly propagate the visual context to the children
-    void initVisualContext() override;
-
     /// Update the whole context values, based on parent and local ContextObjects
     void updateContext() override;
 


### PR DESCRIPTION
Following #4876 (but not depending on it) this PR proposes to define a gravity-inheritance from the parent node when the data gravity is not set.

A test is added but does not work due to SimpleAPI not taking into account data set in nodes.
Currently under investigation (this is why I draft this PR)

---

Suggestion : **TODO after this PR**
- Remove the class Gravity and use one single way to play with gravity : the associated data in the nodes
- Apply the change in all scenes using the Gravity component

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
