### PR TITLE
 [Core] Fix check and use of componentState in SingleStateAccessor 

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.h
@@ -47,10 +47,18 @@ public:
         {
             mstate.set(dynamic_cast< MechanicalState<DataTypes>* >(getContext()->getMechanicalState()));
 
-            msg_error_when(!mstate) << "No compatible MechanicalState found in the current context. "
-                "This may be because there is no MechanicalState in the local context, "
-                "or because the type is not compatible.";
-            d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+            if(!mstate)
+            {
+
+                msg_error() << "No compatible MechanicalState found in the current context. "
+                    "This may be because there is no MechanicalState in the local context, "
+                    "or because the type is not compatible";
+                d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+            }
+            else
+            {
+                msg_info() << "No link given for mstate, but it has been found in the context";
+            }
         }
 
         l_mechanicalStates.clear();


### PR DESCRIPTION
I noticed that SingleStateAccessor was printing an error if mstate pointer is null which was not differentiating the following cases:
- mstate not linked but found in the context
- mstate not linked AND not found in the context

Commit of interest: https://github.com/sofa-framework/sofa/commit/172ec0028e0e1a25ff12a8eb5521499c9520afcc
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
