### PR TITLE
[Playback] Fix WriteStateCreator to pass period only if it has a value. Because WriteState use isSet value...

### DIFF
--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteState.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteState.cpp
@@ -109,7 +109,8 @@ void WriteStateCreator::addWriteState(sofa::core::behavior::BaseMechanicalState 
         if (!m_times.empty())
             ws->d_time.setValue(m_times);
 
-        if (m_period > 0.0) {
+        if (m_period > 0.0) 
+        {
             ws->d_period.setValue(m_period);
         }
 

--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteState.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteState.cpp
@@ -109,7 +109,9 @@ void WriteStateCreator::addWriteState(sofa::core::behavior::BaseMechanicalState 
         if (!m_times.empty())
             ws->d_time.setValue(m_times);
 
-        ws->d_period.setValue(m_period);
+        if (m_period > 0.0) {
+            ws->d_period.setValue(m_period);
+        }
 
         ws->init();
         ws->f_listening.setValue(true);  //Activated at init


### PR DESCRIPTION
Quick fix: to allow Regression to dump only last step as before. Right now it will always dump all dofs at each timestep.

WriteState init method check if d_period  is set. 
Therfor If d_period  is set to 0.0 it will activate a section of the code what will overwrite the period to the current timestep. 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
