### PR TITLE
[examples] Change rendering option in the TetrahedronFEMForceField.scn

### DIFF
--- a/examples/Component/SolidMechanics/FEM/TetrahedronFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/TetrahedronFEMForceField.scn
@@ -29,7 +29,7 @@
 
         <DiagonalMass massDensity="0.2" />
         <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
-                                  method="small" computeVonMisesStress="2" showVonMisesStressPerElement="true"/>
+                                  method="small" computeVonMisesStress="2" showVonMisesStressPerNodeColorMap="true"/>
 
         <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedProjectiveConstraint template="Vec3" indices="@box_roi.indices" />
@@ -50,7 +50,7 @@
 
         <DiagonalMass massDensity="0.2" />
         <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
-                                  method="large" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+                                  method="large" computeVonMisesStress="1" showVonMisesStressPerNodeColorMap="true"/>
 
         <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedProjectiveConstraint template="Vec3" indices="@box_roi.indices" />
@@ -70,7 +70,7 @@
 
         <DiagonalMass massDensity="0.2" />
         <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
-                                  method="polar" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+                                  method="polar" computeVonMisesStress="1" showVonMisesStressPerNodeColorMap="true"/>
 
         <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedProjectiveConstraint template="Vec3" indices="@box_roi.indices" />
@@ -90,7 +90,7 @@
 
         <DiagonalMass massDensity="0.2" />
         <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
-                                  method="svd" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+                                  method="svd" computeVonMisesStress="1" showVonMisesStressPerNodeColorMap="true"/>
 
         <BoxROI template="Vec3" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedProjectiveConstraint template="Vec3" indices="@box_roi.indices" />


### PR DESCRIPTION
Let's make is sexier 

Before: 
![TetrahedronFEMForceField_00000000](https://github.com/user-attachments/assets/1a69a1f7-4799-4db0-8fe9-e6d4b4c4a7d8)


After:
![TetrahedronFEMForceField_00000001](https://github.com/user-attachments/assets/3b34d328-af75-41fa-8e26-c91fb8d309ce)





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
