### PR TITLE
[runSofa] Centralize configuration into the user local directory

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -170,6 +170,8 @@ int main(int argc, char** argv)
 
     string colorsStatus = "unset";
     string messageHandler = "auto";
+    string configPath = "";
+
     int width = 800;
     int height = 600;
 
@@ -289,6 +291,13 @@ int main(int argc, char** argv)
         "msaa",
         "Number of samples for MSAA (Multi Sampling Anti Aliasing ; value < 2 means disabled"
     );
+    
+    argParser->addArgument(
+        cxxopts::value<std::string>(configPath)
+        ->default_value(Utils::getSofaUserLocalDirectory()),
+        "config",
+       "change the configuration path."
+    );
 
     // first option parsing to see if the user requested to show help
     argParser->parse();
@@ -362,8 +371,14 @@ int main(int argc, char** argv)
     msg_info("runSofa") << "GuiDataRepository paths = " << GuiDataRepository.getPathsJoined();
 
     // Initialise paths
-    BaseGUI::setConfigDirectoryPath(Utils::getSofaPathPrefix() + "/config", true);
-    BaseGUI::setScreenshotDirectoryPath(Utils::getSofaPathPrefix() + "/screenshots", true);
+    if(!FileSystem::exists(FileSystem::cleanPath(configPath)))
+    {
+        msg_warning("runSofa") << "The configuration path " << configPath << " is not accessible or is invalid, using default " << Utils::getSofaUserLocalDirectory();
+        configPath = Utils::getSofaUserLocalDirectory();
+    }
+
+    BaseGUI::setConfigDirectoryPath(configPath + "/config", true);
+    BaseGUI::setScreenshotDirectoryPath(configPath + "/screenshots", true);
 
     // Add Batch GUI (runSofa without any GUIs wont be useful)
     sofa::gui::batch::init();

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -33,7 +33,7 @@ using std::vector;
 
 #include <sofa/simulation/Node.h>
 #include <sofa/helper/system/PluginManager.h>
-#include <sofa/simulation/config.h> // #defines SOFA_HAVE_DAG (or not)
+#include <sofa/simulation/config.h>
 #include <sofa/simulation/common/init.h>
 #include <sofa/simulation/graph/init.h>
 #include <sofa/simulation/graph/DAGSimulation.h>
@@ -166,18 +166,11 @@ int main(int argc, char** argv)
     string gui = "";
     string verif = "";
 
-#if defined(SOFA_HAVE_DAG)
-    string simulationType = "dag";
-#else
-    string simulationType = "tree";
-#endif
-
     vector<string> plugins;
     vector<string> files;
 
     string colorsStatus = "unset";
     string messageHandler = "auto";
-    bool enableInteraction = false ;
     int width = 800;
     int height = 600;
 
@@ -262,11 +255,6 @@ int main(int argc, char** argv)
         "load most recently opened file"
     );
     argParser->addArgument(
-        cxxopts::value<std::string>(simulationType),
-        "s,simu", 
-        "select the type of simulation (bgl, dag, tree)"
-    );
-    argParser->addArgument(
         cxxopts::value<bool>(temporaryFile)
         ->default_value("false")->implicit_value("true"),
         "tmp",
@@ -298,13 +286,6 @@ int main(int argc, char** argv)
         "select the message formatting to use (auto, clang, sofa, rich, test)"
     );
     argParser->addArgument(
-        cxxopts::value<bool>(enableInteraction)
-        ->default_value("false")
-        ->implicit_value("true"),
-        "i,interactive",
-        "enable interactive mode for the GUI which includes idle and mouse events (EXPERIMENTAL)"
-    );
-    argParser->addArgument(
         cxxopts::value<std::vector<std::string> >(sofa::gui::common::ArgumentParser::extra),
         "argv",
         "forward extra args to the python interpreter"
@@ -329,8 +310,6 @@ int main(int argc, char** argv)
     // even if everything is ok e.g. asking for help
     sofa::simulation::graph::init();
 
-    if (simulationType == "tree")
-        msg_warning("runSofa") << "Tree based simulation, switching back to graph simulation.";
     assert(sofa::simulation::getSimulation());
 
     if (colorsStatus == "unset") {

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -155,7 +155,6 @@ int main(int argc, char** argv)
     bool        printFactory = false;
     bool        loadRecent = false;
     bool        temporaryFile = false;
-    bool        testMode = false;
     bool        noAutoloadPlugins = false;
     bool        noSceneCheck = false;
     unsigned int nbMSSASamples = 1;
@@ -259,12 +258,6 @@ int main(int argc, char** argv)
         ->default_value("false")->implicit_value("true"),
         "tmp",
         "the loaded scene won't appear in history of opened files"
-    );
-    argParser->addArgument(
-        cxxopts::value<bool>(testMode)
-        ->default_value("false")->implicit_value("true"),
-        "test",
-        "select test mode with xml output after N iteration"
     );
     argParser->addArgument(
         cxxopts::value<std::string>(verif)
@@ -518,13 +511,6 @@ int main(int argc, char** argv)
     if (int err = GUIManager::MainLoop(groot,fileName.c_str()))
         return err;
     groot = dynamic_cast<Node*>( GUIManager::CurrentSimulation() );
-
-    if (testMode)
-    {
-        string xmlname = fileName.substr(0,fileName.length()-4)+"-scene.scn";
-        msg_info("") << "Exporting to XML " << xmlname ;
-        sofa::simulation::node::exportInXML(groot.get(), xmlname.c_str());
-    }
 
     if (groot!=nullptr)
         sofa::simulation::node::unload(groot);


### PR DESCRIPTION
Based on 
- #4925 

This PR sets the `ConfigDirectoryPath` with the value of getSofaLocalUserDir (see https://github.com/sofa-framework/sofa/pull/4875) instead of the current directory (could be the binary dir, install dir, etc)

This PR also adds the option to change this directory path to a custom path, set with a new cmd line option

---
Note (not the object of the PR 🙂‍↕️)
A bit weird that the config directory path getter is from the GUI, which means one needs a dep on Sofa.GUI to get the config dir path 🤔

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
