### PR TITLE
[Mass] Add unit test to test rotation of inertia matrix for rigid objects

### DIFF
--- a/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
+++ b/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
@@ -1003,7 +1003,7 @@ public:
         "    <RequiredPlugin name='Sofa.Component.MechanicalLoad'/>"
         "    <DefaultAnimationLoop />"
         "    <EulerImplicitSolver rayleighStiffness='0.'  rayleighMass='0.0'/>"
-        "    <SparseLDLSolver applyPermutation='false' template='CompressedRowSparseMatrixMat3x3d'/>"
+        "    <SparseLDLSolver applyPermutation='false' template='CompressedRowSparseMatrixd'/>"
         "    <Node name='Aligned' >"
         "        <MechanicalObject  name='Mstate1' template='Rigid3' position='0 0 0 0 0 0 1' showObject='true' showObjectScale='0.1'/>"
         "        <UniformMass name='mass' vertexMass='300 0.0158 [0.0427 0.0 0.0 0.0 0.0427 0.0 0.0 0.0 0.00375]'/>"
@@ -1024,7 +1024,7 @@ public:
         return root;
     }
 
-    void nonIdentityIntertiaMatrix_DifferentRotationDirection()
+    void nonIdentityInertiaMatrix_DifferentRotationDirection()
     {
         Node::SPtr root = generateRigidScene();
         Rigid3Types::VecDeriv* CF1_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->beginEditVoidPtr());
@@ -1048,7 +1048,7 @@ public:
 
     }
 
-    void nonIdentityIntertiaMatrix_RotationOfOneRigid()
+    void nonIdentityInertiaMatrix_RotationOfOneRigid()
     {
         Node::SPtr root = generateRigidScene();
 
@@ -1295,12 +1295,12 @@ TEST_F(DiagonalMass3_test, checkAttributeLoadFromXpsMassSpring){
 }
 
 
-TEST_F(DiagonalMass3_test, nonIdentityIntertiaMatrix_DifferentRotationVector){
-    EXPECT_NO_THROW(nonIdentityIntertiaMatrix_DifferentRotationDirection());
+TEST_F(DiagonalMass3_test, nonIdentityInertiaMatrix_DifferentRotationVector){
+    EXPECT_NO_THROW(nonIdentityInertiaMatrix_DifferentRotationDirection());
 }
 
-TEST_F(DiagonalMass3_test, nonIdentityIntertiaMatrix_RotationOfTheRigid){
-    EXPECT_NO_THROW(nonIdentityIntertiaMatrix_RotationOfOneRigid());
+TEST_F(DiagonalMass3_test, nonIdentityInertiaMatrix_RotationOfTheRigid){
+    EXPECT_NO_THROW(nonIdentityInertiaMatrix_RotationOfOneRigid());
 }
 
 } // namespace sofa

--- a/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
+++ b/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
@@ -39,6 +39,7 @@ using sofa::core::ExecParams ;
 #include <sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.h>
 #include <sofa/component/topology/container/dynamic/TetrahedronSetTopologyModifier.h>
 #include <sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.h>
+#include <sofa/component/statecontainer/MechanicalObject.h>
 
 #include <sofa/simulation/Node.h>
 using sofa::simulation::Node ;
@@ -984,6 +985,97 @@ public:
         EXPECT_EQ(vMasses.size(), 0);
         EXPECT_NEAR(mass->getTotalMass(), 0, 1e-4);
     }
+
+    static Node::SPtr generateRigidScene()
+    {
+        static const string scene =
+        "<?xml version='1.0' ?>"
+        "<Node name='root' dt='0.01' gravity='0 0 0'>"
+        "    <RequiredPlugin name='Sofa.Component.Mass'/>"
+        "    <RequiredPlugin name='Sofa.Component.StateContainer'/>"
+        "    <RequiredPlugin name='Sofa.Component.Topology.Container.Grid'/>"
+        "    <RequiredPlugin name='Sofa.Component.Visual'/>"
+        "    <RequiredPlugin name='Sofa.Component.ODESolver.Backward'/>"
+        "    <RequiredPlugin name='Sofa.Component.LinearSolver.Direct'/>"
+        "    <RequiredPlugin name='Sofa.Component.Engine.Select'/>"
+        "    <RequiredPlugin name='Sofa.Component.Constraint.Projective'/>"
+        "    <RequiredPlugin name='Sofa.Component.SolidMechanics.FEM.Elastic'/>"
+        "    <RequiredPlugin name='Sofa.Component.MechanicalLoad'/>"
+        "    <DefaultAnimationLoop />"
+        "    <EulerImplicitSolver rayleighStiffness='0.'  rayleighMass='0.0'/>"
+        "    <SparseLDLSolver applyPermutation='false' template='CompressedRowSparseMatrixMat3x3d'/>"
+        "    <Node name='Aligned' >"
+        "        <MechanicalObject  name='Mstate1' template='Rigid3' position='0 0 0 0 0 0 1' showObject='true' showObjectScale='0.1'/>"
+        "        <UniformMass name='mass' vertexMass='300 0.0158 [0.0427 0.0 0.0 0.0 0.0427 0.0 0.0 0.0 0.00375]'/>"
+        "        <ConstantForceField name='ConstantForceField1' forces='0 0 0 0 0 0'/>"
+        "    </Node>"
+        "    <Node name='Rotated' >"
+        "        <MechanicalObject name='Mstate2' template='Rigid3' position='1 0 0 0 0 0 1' showObject='true' showObjectScale='0.1'/>"
+        "        <UniformMass name='mass' vertexMass='300 0.0158 [0.0427 0.0 0.0 0.0 0.0427 0.0 0.0 0.0 0.00375]'/>"
+        "        <ConstantForceField name='ConstantForceField2' forces='0 0 0 0 0 0'/>"
+        "    </Node>"
+        "</Node>";
+
+
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
+        sofa::simulation::node::initRoot(root.get());
+
+        return root;
+    }
+
+    void nonIdentityIntertiaMatrix_DifferentRotationDirection()
+    {
+        Node::SPtr root = generateRigidScene();
+        Rigid3Types::VecDeriv* CF1_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->beginEditVoidPtr());
+        Rigid3Types::VecDeriv* CF2_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->beginEditVoidPtr());
+
+        (*CF1_force)[0][5] = 1.0;
+        (*CF2_force)[0][3] = 1.0;
+
+        root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->endEditVoidPtr();
+        root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->endEditVoidPtr();
+
+        auto mstate1 = root->getChild("Aligned")->getNodeObject<MechanicalObject<Rigid3Types>>();
+        auto mstate2 = root->getChild("Rotated")->getNodeObject<MechanicalObject<Rigid3Types>>();
+
+        sofa::simulation::node::animate(root.get(),50);
+
+        //Because the inertia is smaller along z, we expect different velocity after some times with a ratio equivalent to the inverse ratio between the inertia
+        EXPECT_GT(mstate2->v.getValue()[0][3],0.0);
+        EXPECT_NEAR(mstate1->v.getValue()[0][5] / mstate2->v.getValue()[0][3], 0.0427/0.00375, 1.0e-5 );
+
+
+    }
+
+    void nonIdentityIntertiaMatrix_RotationOfOneRigid()
+    {
+        Node::SPtr root = generateRigidScene();
+
+        sofa::simulation::node::animate(root.get(),1);
+
+
+        auto mstate1 = root->getChild("Aligned")->getNodeObject<MechanicalObject<Rigid3Types>>();
+        auto mstate2 = root->getChild("Rotated")->getNodeObject<MechanicalObject<Rigid3Types>>();
+
+        //Rotate the rigid
+        mstate2->x.setValue(Rigid3Types::VecCoord{Rigid3Types::Coord(Rigid3Types::Coord::Pos(1,0,0),Rigid3Types::Coord::Rot (0.707,0,0.707,0))});
+
+        Rigid3Types::VecDeriv* CF1_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->beginEditVoidPtr());
+        Rigid3Types::VecDeriv* CF2_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->beginEditVoidPtr());
+
+        //With rotated state, we now apply rotation along the Z axis of both rigids, this should result in the same acceleration if the inertia matrix is also rotated
+        (*CF1_force)[0][5] = 1.0;
+        (*CF2_force)[0][3] = 1.0;
+
+        root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->endEditVoidPtr();
+        root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->endEditVoidPtr();
+
+        sofa::simulation::node::animate(root.get(),50);
+        EXPECT_GT(mstate1->v.getValue()[0][5],0.0);
+        EXPECT_GT(mstate2->v.getValue()[0][3],0.0);
+        EXPECT_NEAR(mstate1->v.getValue()[0][5] / mstate2->v.getValue()[0][3], 1.0, 1.0e-5 );
+    }
 };
 
 
@@ -1202,5 +1294,13 @@ TEST_F(DiagonalMass3_test, checkAttributeLoadFromXpsMassSpring){
     checkAttributeLoadFromFile("BehaviorModels/chain.xs3", 6, 0.6, false);
 }
 
+
+TEST_F(DiagonalMass3_test, nonIdentityIntertiaMatrix_DifferentRotationVector){
+    EXPECT_NO_THROW(nonIdentityIntertiaMatrix_DifferentRotationDirection());
+}
+
+TEST_F(DiagonalMass3_test, nonIdentityIntertiaMatrix_RotationOfTheRigid){
+    EXPECT_NO_THROW(nonIdentityIntertiaMatrix_RotationOfOneRigid());
+}
 
 } // namespace sofa

--- a/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
+++ b/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
@@ -39,7 +39,6 @@ using sofa::core::ExecParams ;
 #include <sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.h>
 #include <sofa/component/topology/container/dynamic/TetrahedronSetTopologyModifier.h>
 #include <sofa/component/topology/container/dynamic/TetrahedronSetGeometryAlgorithms.h>
-#include <sofa/component/statecontainer/MechanicalObject.h>
 
 #include <sofa/simulation/Node.h>
 using sofa::simulation::Node ;
@@ -1202,5 +1201,6 @@ TEST_F(DiagonalMass3_test, checkAttributeLoadFromXpsRigid){
 TEST_F(DiagonalMass3_test, checkAttributeLoadFromXpsMassSpring){
     checkAttributeLoadFromFile("BehaviorModels/chain.xs3", 6, 0.6, false);
 }
+
 
 } // namespace sofa

--- a/Sofa/Component/Mass/tests/UniformMass_test.cpp
+++ b/Sofa/Component/Mass/tests/UniformMass_test.cpp
@@ -51,6 +51,7 @@ using sofa::testing::BaseTest;
 using testing::Types;
 
 #include <sofa/core/ExecParams.h>
+#include <sofa/core/VecId.h>
 
 template <class TDataTypes, class TMassTypes>
 struct TemplateTypes
@@ -430,7 +431,7 @@ struct UniformMassTest :  public BaseTest
         "    <RequiredPlugin name='Sofa.Component.MechanicalLoad'/>"
         "    <DefaultAnimationLoop />"
         "    <EulerImplicitSolver rayleighStiffness='0.'  rayleighMass='0.0'/>"
-        "    <SparseLDLSolver applyPermutation='false' template='CompressedRowSparseMatrixd'/>"
+        "    <SparseLDLSolver template='CompressedRowSparseMatrixd'/>"
         "    <Node name='Aligned' >"
         "        <MechanicalObject  name='Mstate1' template='Rigid3' position='0 0 0 0 0 0 1' showObject='true' showObjectScale='0.1'/>"
         "        <UniformMass name='mass' vertexMass='300 0.0158 [0.0427 0.0 0.0 0.0 0.0427 0.0 0.0 0.0 0.00375]'/>"
@@ -469,8 +470,10 @@ struct UniformMassTest :  public BaseTest
         sofa::simulation::node::animate(root.get(),50);
 
         //Because the inertia is smaller along z, we expect different velocity after some times with a ratio equivalent to the inverse ratio between the inertia
-        EXPECT_GT(mstate2->v.getValue()[0][3],0.0);
-        EXPECT_NEAR(mstate1->v.getValue()[0][5] / mstate2->v.getValue()[0][3], 0.0427/0.00375, 1.0e-5 );
+        EXPECT_GT(mstate2->read(sofa::core::ConstVecDerivId::velocity())->getValue()[0][3],0.0);
+        EXPECT_NEAR(mstate1->read(sofa::core::ConstVecDerivId::velocity())->getValue()[0][5] /
+                    mstate2->read(sofa::core::ConstVecDerivId::velocity())->getValue()[0][3],
+                    0.0427/0.00375, 1.0e-5 );
 
 
     }
@@ -486,7 +489,7 @@ struct UniformMassTest :  public BaseTest
         auto mstate2 = root->getChild("Rotated")->getNodeObject<MechanicalObject<Rigid3Types>>();
 
         //Rotate the rigid
-        mstate2->x.setValue(Rigid3Types::VecCoord{Rigid3Types::Coord(Rigid3Types::Coord::Pos(1,0,0),Rigid3Types::Coord::Rot (0.707,0,0.707,0))});
+        mstate2->write(sofa::core::VecCoordId::position())->setValue({Rigid3Types::Coord(Rigid3Types::Coord::Pos(1,0,0),Rigid3Types::Coord::Rot (0.707106781,0,0.707106781,0))});
 
         Rigid3Types::VecDeriv* CF1_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->beginEditVoidPtr());
         Rigid3Types::VecDeriv* CF2_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->beginEditVoidPtr());
@@ -499,9 +502,11 @@ struct UniformMassTest :  public BaseTest
         root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->endEditVoidPtr();
 
         sofa::simulation::node::animate(root.get(),50);
-        EXPECT_GT(mstate1->v.getValue()[0][5],0.0);
-        EXPECT_GT(mstate2->v.getValue()[0][3],0.0);
-        EXPECT_NEAR(mstate1->v.getValue()[0][5] / mstate2->v.getValue()[0][3], 1.0, 1.0e-5 );
+        EXPECT_GT(mstate1->read(sofa::core::ConstVecDerivId::velocity())->getValue()[0][5],0.0);
+        EXPECT_GT(mstate2->read(sofa::core::ConstVecDerivId::velocity())->getValue()[0][3],0.0);
+        EXPECT_NEAR(mstate1->read(sofa::core::ConstVecDerivId::velocity())->getValue()[0][5] /
+                    mstate2->read(sofa::core::ConstVecDerivId::velocity())->getValue()[0][3],
+                    1.0, 1.0e-5 );
     }
 
 };

--- a/Sofa/Component/Mass/tests/UniformMass_test.cpp
+++ b/Sofa/Component/Mass/tests/UniformMass_test.cpp
@@ -412,6 +412,98 @@ struct UniformMassTest :  public BaseTest
         EXPECT_TRUE(todo == false) ;
     }
 
+
+    static Node::SPtr generateRigidScene()
+    {
+        static const string scene =
+        "<?xml version='1.0' ?>"
+        "<Node name='root' dt='0.01' gravity='0 0 0'>"
+        "    <RequiredPlugin name='Sofa.Component.Mass'/>"
+        "    <RequiredPlugin name='Sofa.Component.StateContainer'/>"
+        "    <RequiredPlugin name='Sofa.Component.Topology.Container.Grid'/>"
+        "    <RequiredPlugin name='Sofa.Component.Visual'/>"
+        "    <RequiredPlugin name='Sofa.Component.ODESolver.Backward'/>"
+        "    <RequiredPlugin name='Sofa.Component.LinearSolver.Direct'/>"
+        "    <RequiredPlugin name='Sofa.Component.Engine.Select'/>"
+        "    <RequiredPlugin name='Sofa.Component.Constraint.Projective'/>"
+        "    <RequiredPlugin name='Sofa.Component.SolidMechanics.FEM.Elastic'/>"
+        "    <RequiredPlugin name='Sofa.Component.MechanicalLoad'/>"
+        "    <DefaultAnimationLoop />"
+        "    <EulerImplicitSolver rayleighStiffness='0.'  rayleighMass='0.0'/>"
+        "    <SparseLDLSolver applyPermutation='false' template='CompressedRowSparseMatrixd'/>"
+        "    <Node name='Aligned' >"
+        "        <MechanicalObject  name='Mstate1' template='Rigid3' position='0 0 0 0 0 0 1' showObject='true' showObjectScale='0.1'/>"
+        "        <UniformMass name='mass' vertexMass='300 0.0158 [0.0427 0.0 0.0 0.0 0.0427 0.0 0.0 0.0 0.00375]'/>"
+        "        <ConstantForceField name='ConstantForceField1' forces='0 0 0 0 0 0'/>"
+        "    </Node>"
+        "    <Node name='Rotated' >"
+        "        <MechanicalObject name='Mstate2' template='Rigid3' position='1 0 0 0 0 0 1' showObject='true' showObjectScale='0.1'/>"
+        "        <UniformMass name='mass' vertexMass='300 0.0158 [0.0427 0.0 0.0 0.0 0.0427 0.0 0.0 0.0 0.00375]'/>"
+        "        <ConstantForceField name='ConstantForceField2' forces='0 0 0 0 0 0'/>"
+        "    </Node>"
+        "</Node>";
+
+
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam", scene.c_str());
+        sofa::simulation::node::initRoot(root.get());
+
+        return root;
+    }
+
+    void nonIdentityInertiaMatrix_DifferentRotationDirection()
+    {
+        Node::SPtr root = generateRigidScene();
+        Rigid3Types::VecDeriv* CF1_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->beginEditVoidPtr());
+        Rigid3Types::VecDeriv* CF2_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->beginEditVoidPtr());
+
+        (*CF1_force)[0][5] = 1.0;
+        (*CF2_force)[0][3] = 1.0;
+
+        root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->endEditVoidPtr();
+        root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->endEditVoidPtr();
+
+        auto mstate1 = root->getChild("Aligned")->getNodeObject<MechanicalObject<Rigid3Types>>();
+        auto mstate2 = root->getChild("Rotated")->getNodeObject<MechanicalObject<Rigid3Types>>();
+
+        sofa::simulation::node::animate(root.get(),50);
+
+        //Because the inertia is smaller along z, we expect different velocity after some times with a ratio equivalent to the inverse ratio between the inertia
+        EXPECT_GT(mstate2->v.getValue()[0][3],0.0);
+        EXPECT_NEAR(mstate1->v.getValue()[0][5] / mstate2->v.getValue()[0][3], 0.0427/0.00375, 1.0e-5 );
+
+
+    }
+
+    void nonIdentityInertiaMatrix_RotationOfOneRigid()
+    {
+        Node::SPtr root = generateRigidScene();
+
+        sofa::simulation::node::animate(root.get(),1);
+
+
+        auto mstate1 = root->getChild("Aligned")->getNodeObject<MechanicalObject<Rigid3Types>>();
+        auto mstate2 = root->getChild("Rotated")->getNodeObject<MechanicalObject<Rigid3Types>>();
+
+        //Rotate the rigid
+        mstate2->x.setValue(Rigid3Types::VecCoord{Rigid3Types::Coord(Rigid3Types::Coord::Pos(1,0,0),Rigid3Types::Coord::Rot (0.707,0,0.707,0))});
+
+        Rigid3Types::VecDeriv* CF1_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->beginEditVoidPtr());
+        Rigid3Types::VecDeriv* CF2_force = reinterpret_cast<Rigid3Types::VecDeriv*>(root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->beginEditVoidPtr());
+
+        //With rotated state, we now apply rotation along the Z axis of both rigids, this should result in the same acceleration if the inertia matrix is also rotated
+        (*CF1_force)[0][5] = 1.0;
+        (*CF2_force)[0][3] = 1.0;
+
+        root->getChild("Aligned")->getObject("ConstantForceField1")->findData("forces")->endEditVoidPtr();
+        root->getChild("Rotated")->getObject("ConstantForceField2")->findData("forces")->endEditVoidPtr();
+
+        sofa::simulation::node::animate(root.get(),50);
+        EXPECT_GT(mstate1->v.getValue()[0][5],0.0);
+        EXPECT_GT(mstate2->v.getValue()[0][3],0.0);
+        EXPECT_NEAR(mstate1->v.getValue()[0][5] / mstate2->v.getValue()[0][3], 1.0, 1.0e-5 );
+    }
+
 };
 
 
@@ -493,3 +585,13 @@ TYPED_TEST(UniformMassTest, checkRigidAttribute) {
 TYPED_TEST(UniformMassTest, reinitTest) {
     //ASSERT_NO_THROW(this->reinitTest()) ;
 }
+
+TYPED_TEST(UniformMassTest, nonIdentityInertiaMatrix_DifferentRotationDirection){
+    EXPECT_NO_THROW(this->nonIdentityInertiaMatrix_DifferentRotationDirection());
+}
+
+TYPED_TEST(UniformMassTest, nonIdentityInertiaMatrix_RotationOfOneRigid){
+    EXPECT_NO_THROW(this->nonIdentityInertiaMatrix_RotationOfOneRigid());
+}
+
+


### PR DESCRIPTION
This PR add a unit test that is currently failing, showing that the inertia is wrongly taken into account for rigid with different inertia along each direction. 

After rotation of a rigid, the inertia matrix is not rotated accordingly. See issue https://github.com/sofa-framework/sofa/issues/4936. 

We need to fix this ! 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
