### PR TITLE
[Engine] Add draw method in NearestPointROI

### DIFF
--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.h
@@ -74,6 +74,7 @@ public:
     Data< sofa::type::vector<sofa::topology::Edge> > d_edges; ///< List of edge indices
     Data< type::vector<unsigned> > d_indexPairs; ///< list of couples (parent index + index in the parent)
     Data< type::vector<Real> > d_distances; ///< List of distances between pairs of points
+    Data<bool> d_drawPairs;
     ///@}
 
     explicit NearestPointROI(core::behavior::MechanicalState<DataTypes> * = nullptr, core::behavior::MechanicalState<DataTypes> *mm2 = nullptr);
@@ -82,6 +83,7 @@ public:
     void init() override;
     void reinit() override;
     void doUpdate() override;
+    void draw(const core::visual::VisualParams* vparams) override;
 
 protected:
     void computeNearestPointMaps(const VecCoord& x1, const VecCoord& x2);

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.inl
@@ -217,7 +217,7 @@ void NearestPointROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
         vertices.emplace_back(xId1[0], xId1[1], xId1[2]);
         vertices.emplace_back(xId2[0], xId2[1], xId2[2]);
         const float col = static_cast<float>(i) / nbrIds;
-        colors.emplace_back(col, 1.f, 0.5f, 1f);
+        colors.emplace_back(col, 1.f, 0.5f, 1.f);
     }
 
     vparams->drawTool()->drawLines(vertices, 1, colors);

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.inl
@@ -209,15 +209,15 @@ void NearestPointROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
     const VecCoord& x2 = this->mstate2->read(vecCoordId)->getValue();
     std::vector<sofa::type::Vec3> vertices;
     std::vector<sofa::type::RGBAColor> colors;
-    const SReal nbrIds = SReal(indices1.size());
+    const float nbrIds = static_cast<float>(indices1.size());
     for (unsigned int i = 0; i < indices1.size(); ++i)
     {
         auto xId1 = x1[indices1[i]];
         auto xId2 = x2[indices2[i]];
-        vertices.emplace_back(sofa::type::Vec3(xId1[0], xId1[1], xId1[2]));
-        vertices.emplace_back(sofa::type::Vec3(xId2[0], xId2[1], xId2[2]));
-        const SReal col = SReal(i) / nbrIds;
-        colors.emplace_back(sofa::type::RGBAColor(col, 1._sreal, 0.5_sreal, 1._sreal));
+        vertices.emplace_back(xId1[0], xId1[1], xId1[2]);
+        vertices.emplace_back(xId2[0], xId2[1], xId2[2]);
+        const float col = static_cast<float>(i) / nbrIds;
+        colors.emplace_back(col, 1.f, 0.5f, 1f);
     }
 
     vparams->drawTool()->drawLines(vertices, 1, colors);


### PR DESCRIPTION
just for quick debugging visualization


![NearestPointROI_00000001](https://github.com/user-attachments/assets/cce22e5c-263b-4ba5-8d39-050963967f30)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
