### PR TITLE
[GUI.Common] ArgumentParser: catch exceptions when same options are added

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
@@ -40,7 +40,14 @@ ArgumentParser::~ArgumentParser(){}
 
 void ArgumentParser::addArgument(std::shared_ptr<cxxopts::Value> s, const std::string name, const std::string help)
 {
-    m_options.add_options()(name.c_str(), help.c_str(), s);
+    try
+    {
+        m_options.add_options()(name.c_str(), help.c_str(), s);
+    }
+    catch (cxxopts::exceptions::option_already_exists)
+    {
+        dmsg_warning("ArgumentParser") << "Option " << name << " has already been added to the argument parser.";
+    }
 }
 
 void ArgumentParser::addArgument(std::shared_ptr<cxxopts::Value> s, const std::string name, const std::string help, std::function<void(const ArgumentParser*, const std::string&)> callback)
@@ -51,7 +58,14 @@ void ArgumentParser::addArgument(std::shared_ptr<cxxopts::Value> s, const std::s
 
 void ArgumentParser::addArgument(const std::string name, const std::string help)
 {
-    m_options.add_options()(name.c_str(), help.c_str());
+    try
+    {
+        m_options.add_options()(name.c_str(), help.c_str());
+    }
+    catch (cxxopts::exceptions::option_already_exists)
+    {
+        dmsg_warning("ArgumentParser") << "Option " << name << " has already been added to the argument parser.";
+    }
 }
 
 void ArgumentParser::showHelp()


### PR DESCRIPTION
cxxopts throws exceptions when same names are added, which obviously crashes the whole program because they are uncaught.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
