### PR TITLE
[All] Add scoped timers for tracy profiler

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -270,17 +270,25 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
             l_constraintSolver->solveConstraint(&cparams, pos, vel);
         }
 
-        MultiVecDeriv cdx(&vop, l_constraintSolver->getDx());
-        mop.projectResponse(cdx);
-        mop.propagateDx(cdx, true);
+        {
+            SCOPED_TIMER("ProjectAndPropagateDx");
+
+            MultiVecDeriv cdx(&vop, l_constraintSolver->getDx());
+            mop.projectResponse(cdx);
+            mop.propagateDx(cdx, true);
+        }
     }
 
     MechanicalEndIntegrationVisitor endVisitor(params, dt);
     node->execute(&endVisitor);
 
-    mop.projectPositionAndVelocity(pos, vel);
-    mop.propagateXAndV(pos, vel);
-    
+    {
+        SCOPED_TIMER("ProjectAndPropagateXAndV");
+
+        mop.projectPositionAndVelocity(pos, vel);
+        mop.propagateXAndV(pos, vel);
+    }
+
     node->setTime ( startTime + dt );
     node->execute<UpdateSimulationContextVisitor>(params);  // propagate time
 

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -163,11 +163,14 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
     {
         SCOPED_TIMER("setSystemMBKMatrix");
         SReal mFact, kFact, bFact;
-        if (firstOrder) {
+        if (firstOrder)
+        {
             mFact = 1;
             bFact = 0;
             kFact = -h * tr;
-        } else {
+        }
+        else
+        {
             mFact = 1 + tr * h * d_rayleighMass.getValue();
             bFact = -tr * h;
             kFact = -tr * h * (h + d_rayleighStiffness.getValue());

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -161,7 +161,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
     }
 
     {
-        SCOPED_TIMER("MBKBuild");
+        SCOPED_TIMER("setSystemMBKMatrix");
         SReal mFact, kFact, bFact;
         if (firstOrder) {
             mFact = 1;

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -128,54 +128,57 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         msg_info() << "EulerImplicitSolver, initial f = " << f;
     }
 
-    sofa::helper::AdvancedTimer::stepBegin("ComputeRHTerm");
-    if( firstOrder )
     {
-        b.eq(f);
+        SCOPED_TIMER("ComputeRHTerm");
+
+        if (firstOrder)
+        {
+            b.eq(f);
+        }
+        else
+        {
+            // new more powerful visitors
+
+            // force in the current configuration
+            b.eq(f, 1.0 / tr);                                                                    // b = f
+
+            msg_info() << "EulerImplicitSolver, f = " << f;
+
+            // add the change of force due to stiffness + Rayleigh damping
+            mop.addMBKv(b, -d_rayleighMass.getValue(), 0,
+                        h + d_rayleighStiffness.getValue()); // b =  f + ( rm M + (h+rs) K ) v
+
+            // integration over a time step
+            b.teq(h *
+                  tr);                                                                       // b = h(f + ( rm M + (h+rs) K ) v )
+        }
+
+        msg_info() << "EulerImplicitSolver, b = " << b;
+
+        mop.projectResponse(b);          // b is projected to the constrained space
+
+        msg_info() << "EulerImplicitSolver, projected b = " << b;
     }
-    else
+
     {
-        // new more powerful visitors
-
-        // force in the current configuration
-        b.eq(f,1.0/tr);                                                                    // b = f
-
-        msg_info() << "EulerImplicitSolver, f = " << f;
-
-        // add the change of force due to stiffness + Rayleigh damping
-        mop.addMBKv(b, -d_rayleighMass.getValue(), 0, h + d_rayleighStiffness.getValue()); // b =  f + ( rm M + (h+rs) K ) v
-
-        // integration over a time step
-        b.teq(h*tr);                                                                       // b = h(f + ( rm M + (h+rs) K ) v )
-    }
-
-    msg_info() << "EulerImplicitSolver, b = " << b;
-
-    mop.projectResponse(b);          // b is projected to the constrained space
-
-    msg_info() << "EulerImplicitSolver, projected b = " << b;
-
-    sofa::helper::AdvancedTimer::stepNext ("ComputeRHTerm", "MBKBuild");
-
-    SReal mFact, kFact, bFact;
-    if (firstOrder)
-    {
-        mFact = 1;
-        bFact = 0;
-        kFact = -h * tr;
-    }
-    else
-    {
-        mFact = 1 + tr * h * d_rayleighMass.getValue();
-        bFact = -tr * h;
-        kFact = -tr * h * (h + d_rayleighStiffness.getValue());
-    }
-    mop.setSystemMBKMatrix(mFact, bFact, kFact, l_linearSolver.get());
+        SCOPED_TIMER("MBKBuild");
+        SReal mFact, kFact, bFact;
+        if (firstOrder) {
+            mFact = 1;
+            bFact = 0;
+            kFact = -h * tr;
+        } else {
+            mFact = 1 + tr * h * d_rayleighMass.getValue();
+            bFact = -tr * h;
+            kFact = -tr * h * (h + d_rayleighStiffness.getValue());
+        }
+        mop.setSystemMBKMatrix(mFact, bFact, kFact, l_linearSolver.get());
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    simulation::Visitor::printNode("SystemSolution");
+        simulation::Visitor::printNode("SystemSolution");
 #endif
-    sofa::helper::AdvancedTimer::stepEnd ("MBKBuild");
+    }
+
     {
         SCOPED_TIMER("MBKSolve");
 


### PR DESCRIPTION
In the process of building the performance regression scripts I needed a timer basis working for both FreeMotionAnimaitonLoop and DefaultAnimationLoop with Tracy.

For this I needed to add timers around the mechanical mapping application in the FreeMotionAnimationLoop and scoped timers for RH side computation and MBKBuild in the EulerImplicit. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
