### PR TITLE
[all] Cleanings on debug symbols

### DIFF
--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -1452,7 +1452,7 @@ const Data<typename MechanicalObject<DataTypes>::VecDeriv>* MechanicalObject<Dat
     {
         const Data<typename MechanicalObject<DataTypes>::VecDeriv>* d = vectorsDeriv[v.index];
 
-#if defined(SOFA_DEBUG) || !defined(NDEBUG)
+#if !defined(NDEBUG)
         if(d!=NULL)
         {
             const typename MechanicalObject<DataTypes>::VecDeriv& val = d->getValue();
@@ -1461,7 +1461,7 @@ const Data<typename MechanicalObject<DataTypes>::VecDeriv>* MechanicalObject<Dat
                 msg_error() << "Accessing State vector " << v << " with incorrect size : " << val.size() << " != " << this->getSize();
             }
         }
-#endif // defined(SOFA_DEBUG) || !defined(NDEBUG)
+#endif // !defined(NDEBUG)
 
         return d;
     }

--- a/Sofa/framework/Core/src/sofa/core/behavior/Mass.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/Mass.inl
@@ -80,18 +80,10 @@ void Mass<DataTypes>::accFromF(const MechanicalParams* /*mparams*/, DataVecDeriv
 
 
 template<class DataTypes>
-void Mass<DataTypes>::addDForce(const MechanicalParams*
-                                #ifndef NDEBUG
-                                mparams
-                                #endif
-                                ,
+void Mass<DataTypes>::addDForce(const MechanicalParams* mparams,
                                 DataVecDeriv & /*df*/, const DataVecDeriv & /*dx*/)
 {
-#ifndef NDEBUG
-    // @TODO Remove
-    // Hack to disable warning message
-    sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
-#endif
+    SOFA_UNUSED(mparams);
 }
 
 template<class DataTypes>


### PR DESCRIPTION
Two minor cleanings:
-  clean dirty codes using `NDEBUG` to avoid warning  and use `SOFA_UNUSED`
-  remove last occurrence of SOFA_DEBUG 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
