### PR TITLE
[FrameSpringForceField] Fix invalid data field's name

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/FrameSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/FrameSpringForceField.inl
@@ -43,8 +43,8 @@ template<class DataTypes>
 FrameSpringForceField<DataTypes>::FrameSpringForceField ( MechanicalState* object1, MechanicalState* object2 )
     : Inherit ( object1, object2 )
     , d_springs (initData (&d_springs, "spring", "pairs of indices, stiffness, damping, rest length" ) )
-    , d_showLawfulTorsion (initData (&d_showLawfulTorsion, false, "show lawful Torsion", "dislpay the lawful part of the joint rotation" ) )
-    , d_showExtraTorsion (initData (&d_showExtraTorsion, false, "show illicit Torsion", "dislpay the illicit part of the joint rotation" ) )
+    , d_showLawfulTorsion (initData (&d_showLawfulTorsion, false, "showLawfulTorsion", "display the lawful part of the joint rotation" ) )
+    , d_showExtraTorsion (initData (&d_showExtraTorsion, false, "showExtraTorsion", "display the illicit part of the joint rotation" ) )
 {
     springs.setOriginalData(&d_springs);
     showLawfulTorsion.setOriginalData(&d_showLawfulTorsion);


### PR DESCRIPTION
Do we allows data field's name with spaces ? 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
