### PR TITLE
[DefaultType] Fix RigidDeriv name

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
@@ -613,7 +613,15 @@ namespace sofa::linearalgebra
             subBlock = b[col];
         }
 
-        static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return matrix_bloc_traits<Real,IndexType>::getElementType(); }
-        static const char* Name() { return defaulttype::DataTypeName<defaulttype::RigidDeriv<N, T>>::name(); }
+        static sofa::linearalgebra::BaseMatrix::ElementType getElementType()
+        {
+            return matrix_bloc_traits<Real, IndexType>::getElementType();
+        }
+
+        static const char* Name()
+        {
+            static std::string name = defaulttype::DataTypeName<defaulttype::RigidDeriv<N, T> >::name();
+            return name.c_str();
+        }
     };
 }

--- a/Sofa/framework/DefaultType/test/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/test/CMakeLists.txt
@@ -13,8 +13,8 @@ set(SOURCE_FILES
     RigidDeriv_test.cpp
     TypeInfoRepository_test.cpp
     TypeInfoRepository_tu1_test.cpp
-    TypeInfoRepository_tu2_test.cpp
     TypeInfo_test.cpp
+    TypeInfoRepository_tu2_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})

--- a/Sofa/framework/DefaultType/test/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/test/CMakeLists.txt
@@ -9,11 +9,12 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     MapMapSparseMatrixEigenUtils_test.cpp
-    TypeInfo_test.cpp
+    QuaternionIntegration_test.cpp
+    RigidDeriv_test.cpp
     TypeInfoRepository_test.cpp
     TypeInfoRepository_tu1_test.cpp
     TypeInfoRepository_tu2_test.cpp
-    QuaternionIntegration_test.cpp
+    TypeInfo_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})

--- a/Sofa/framework/DefaultType/test/RigidDeriv_test.cpp
+++ b/Sofa/framework/DefaultType/test/RigidDeriv_test.cpp
@@ -1,0 +1,41 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/defaulttype/RigidTypes.h>
+#include <sofa/defaulttype/DataTypeInfo.h>
+
+template<sofa::Size N, typename real>
+void testName(const std::string& expectedName)
+{
+    using Deriv = sofa::defaulttype::RigidDeriv<N, real>;
+    using Bloc = sofa::linearalgebra::matrix_bloc_traits<Deriv, sofa::Index >;
+    EXPECT_EQ(std::string(Bloc::Name()), expectedName);
+}
+
+TEST(RigidDerivTest, Name)
+{
+    testName<3, float>("RigidDeriv3f");
+    testName<3, double>("RigidDeriv3d");
+
+    testName<2, float>("RigidDeriv2f");
+    testName<2, double>("RigidDeriv2d");
+}


### PR DESCRIPTION
Because of confusion between `std::string` and `const char*`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
