### PR TITLE
[all] Various changes relative to the constraint matrix

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
@@ -112,7 +112,7 @@ public:
 protected:
     DeprecatedAndRemoved J; ///< use m_constraintMatrix instead
 
-    linearalgebra::SparseMatrix<Real> m_constraintMatrix;
+    linearalgebra::SparseMatrix<Real> m_constraintJacobian;
 
     SOFA_ATTRIBUTE_DEPRECATED__FORCES_IN_LINEARSOLVERCONSTRAINTCORRECTION()
     linearalgebra::FullVector<SReal> F; ///< forces computed from the constraints

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
@@ -62,7 +62,7 @@ public:
 protected:
     LinearSolverConstraintCorrection(sofa::core::behavior::MechanicalState<DataTypes> *mm = nullptr);
 
-    virtual ~LinearSolverConstraintCorrection();
+    ~LinearSolverConstraintCorrection() override;
 public:
     void init() override;
 
@@ -110,13 +110,22 @@ public:
     void getBlockDiagonalCompliance(linearalgebra::BaseMatrix* W, int begin, int end) override;
 
 protected:
-    linearalgebra::SparseMatrix<SReal> J; ///< constraint matrix
+    DeprecatedAndRemoved J; ///< use m_constraintMatrix instead
+
+    linearalgebra::SparseMatrix<Real> m_constraintMatrix;
+
+    SOFA_ATTRIBUTE_DEPRECATED__FORCES_IN_LINEARSOLVERCONSTRAINTCORRECTION()
     linearalgebra::FullVector<SReal> F; ///< forces computed from the constraints
 
     /**
-    * @brief Compute the compliance matrix
+    * @brief Convert the constraint matrix
     */
-    virtual void computeJ(sofa::linearalgebra::BaseMatrix* W, const MatrixDeriv& j);
+    void convertConstraintMatrix(sofa::SignedIndex numberOfConstraints, const MatrixDeriv& inputConstraintMatrix);
+
+    virtual void computeJ(sofa::linearalgebra::BaseMatrix* W, const MatrixDeriv& j)
+    {
+        convertConstraintMatrix(W->rowSize(), j);
+    }
 
 
     ////////////////////////// Inherited attributes ////////////////////////////

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -145,7 +145,7 @@ void LinearSolverConstraintCorrection<TDataTypes>::convertConstraintMatrix(const
     static constexpr unsigned int N = Deriv::size();
     const unsigned int numDOFReals = numDOFs * N;
 
-    m_constraintMatrix.resize(numberOfConstraints, numDOFReals);
+    m_constraintJacobian.resize(numberOfConstraints, numDOFReals);
 
     MatrixDerivRowConstIterator rowItEnd = inputConstraintMatrix.end();
 
@@ -162,7 +162,7 @@ void LinearSolverConstraintCorrection<TDataTypes>::convertConstraintMatrix(const
 
             for (unsigned int r = 0; r < N; ++r)
             {
-                m_constraintMatrix.add(cid, dof * N + r, n[r]);
+                m_constraintJacobian.add(cid, dof * N + r, n[r]);
             }
         }
     }
@@ -201,7 +201,7 @@ void LinearSolverConstraintCorrection<DataTypes>::addComplianceInConstraintSpace
 
     // use the Linear solver to compute J*inv(M)*Jt, where M is the mechanical linear system matrix
     l_linearSolver->setSystemLHVector(sofa::core::MultiVecDerivId::null());
-    l_linearSolver->addJMInvJt(W, &m_constraintMatrix, factor);
+    l_linearSolver->addJMInvJt(W, &m_constraintJacobian, factor);
 }
 
 
@@ -702,7 +702,7 @@ void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(lin
     const MatrixDeriv& constraints = mstate->read(core::ConstMatrixDerivId::constraintJacobian())->getValue();
     const sofa::SignedIndex totalNumConstraints = W->rowSize();
 
-    m_constraintMatrix.resize(totalNumConstraints, numDOFReals);
+    m_constraintJacobian.resize(totalNumConstraints, numDOFReals);
 
     for (int i = begin; i <= end; i++)
     {
@@ -723,7 +723,7 @@ void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(lin
                 const Deriv n = colIt.val();
 
                 for (unsigned int r = 0; r < N; ++r)
-                    m_constraintMatrix.add(i, dof * N + r, n[r]);
+                    m_constraintJacobian.add(i, dof * N + r, n[r]);
 
                 if (debug!=0)
                 {
@@ -738,7 +738,7 @@ void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(lin
     }
 
     // use the Linear solver to compute J*inv(M)*Jt, where M is the mechanical linear system matrix
-    l_linearSolver->addJMInvJt(W, &m_constraintMatrix, factor);
+    l_linearSolver->addJMInvJt(W, &m_constraintJacobian, factor);
 
     // construction of  Vec_I_list_dof : vector containing, for each constraint block, the list of dof concerned
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/config.h.in
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/config.h.in
@@ -45,3 +45,12 @@ namespace sofa::component::constraint::lagrangian::correction
         "v24.06", "v24.12", \
         "Data renamed according to the guidelines")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_CORRECTION
+#define SOFA_ATTRIBUTE_DEPRECATED__FORCES_IN_LINEARSOLVERCONSTRAINTCORRECTION()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__FORCES_IN_LINEARSOLVERCONSTRAINTCORRECTION() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v24.12", "v25.06", \
+        "Class member 'LinearSolverConstraintCorrection::F' is not used.")
+#endif

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.inl
@@ -528,10 +528,10 @@ bool MatrixLinearSolver<Matrix, Vector>::singleThreadAddJMInvJtLocal(Matrix* M, 
 template<class Matrix, class Vector>
 bool MatrixLinearSolver<Matrix,Vector>::addMInvJtLocal(Matrix * /*M*/,ResMatrixType * result,const JMatrixType * J, SReal fact)
 {
-    for (typename JMatrixType::Index row=0; row<J->rowSize(); row++)
+    for (typename JMatrixType::Index row = 0; row < J->rowSize(); ++row)
     {
         // STEP 1 : put each line of matrix Jt in the right hand term of the system
-        for (typename JMatrixType::Index i=0; i<J->colSize(); i++)
+        for (typename JMatrixType::Index i = 0; i < J->colSize(); ++i)
         {
             getSystemRHVector()->set(i, J->element(row, i)); // linearSystem.systemMatrix->rowSize()
         }
@@ -540,7 +540,7 @@ bool MatrixLinearSolver<Matrix,Vector>::addMInvJtLocal(Matrix * /*M*/,ResMatrixT
         solveSystem();
 
         // STEP 3 : project the result using matrix J
-        for (typename JMatrixType::Index i=0; i<J->colSize(); i++)
+        for (typename JMatrixType::Index i = 0; i < J->colSize(); ++i)
         {
             result->add(row, i, getSystemRHVector()->element(i) * fact);
         }
@@ -552,7 +552,10 @@ bool MatrixLinearSolver<Matrix,Vector>::addMInvJtLocal(Matrix * /*M*/,ResMatrixT
 template<class Matrix, class Vector>
 bool MatrixLinearSolver<Matrix,Vector>::addJMInvJt(linearalgebra::BaseMatrix* result, linearalgebra::BaseMatrix* J, SReal fact)
 {
-    if (J->rowSize()==0) return true;
+    if (J->rowSize() == 0)
+    {
+        return true;
+    }
 
     const JMatrixType * j_local = internalData.getLocalJ(J);
     ResMatrixType * res_local = internalData.getLocalRes(result);
@@ -585,9 +588,9 @@ bool MatrixLinearSolver<Matrix,Vector>::buildComplianceMatrix(const sofa::core::
         return true;
     }
 
-    executeVisitor(MechanicalGetConstraintJacobianVisitor(cparams,j_local));
+    executeVisitor(MechanicalGetConstraintJacobianVisitor(cparams, j_local));
 
-    return addJMInvJt(result,j_local,fact);
+    return addJMInvJt(result, j_local, fact);
 }
 
 template<class Matrix, class Vector>

--- a/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LinearSolver.h
@@ -130,6 +130,12 @@ public:
 
     /// Multiply the inverse of the system matrix by the transpose of the given matrix, and multiply the result with the given matrix J
     ///
+    /// This method can compute the Schur complement of the constrained system:
+    /// W = H A^{-1} H^T, where:
+    /// - A is the mechanical matrix
+    /// - H is the constraints matrix
+    /// - W is the compliance matrix projected in the constraints space
+    ///
     /// @param result the variable where the result will be added
     /// @param J the matrix J to use
     /// @param fact integrator parameter

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
@@ -25,6 +25,8 @@
 #include <sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h>
 
 #include <numeric>
+#include <sofa/helper/StringUtils.h>
+
 
 namespace sofa::linearalgebra
 {
@@ -82,6 +84,12 @@ public:
     typedef typename CRSMatrix::Real Real;
     typedef typename CRSMatrix::Index KeyType;
     typedef typename CRSMatrix::IndexedBlock IndexedBlock;
+
+    static constexpr sofa::Index NL = CRSMatrix::NL;  ///< Number of rows of a block
+    static constexpr sofa::Index NC = CRSMatrix::NC;  ///< Number of columns of a block
+
+    template<class TBlock2>
+    using rebind_to = CompressedRowSparseMatrixConstraint< TBlock2, Policy >;
 
 public:
     CompressedRowSparseMatrixConstraint()
@@ -167,54 +175,72 @@ public:
             return m_internal == CompressedRowSparseMatrixConstraint::s_invalidIndex;
         }
 
-        void operator++() // prefix
+        ColConstIterator& operator++() // prefix
         {
-            m_internal++;
+            ++m_internal;
+            return *this;
         }
 
-        void operator++(int) // postfix
+        ColConstIterator operator++(difference_type) // postfix
         {
-            m_internal++;
+            ColConstIterator tmp = *this;
+            ++(*this);
+            return tmp;
         }
 
-        void operator--() // prefix
+        ColConstIterator& operator--() // prefix
         {
-            m_internal--;
+            --m_internal;
+            return *this;
         }
 
-        void operator--(int) // postfix
+        ColConstIterator operator--(difference_type) // postfix
         {
-            m_internal--;
+            ColConstIterator tmp = *this;
+            --(*this);
+            return tmp;
         }
 
-        void operator+=(int i)
+        ColConstIterator& operator+=(difference_type i)
         {
             m_internal += i;
+            return *this;
         }
 
-        void operator-=(int i)
+        ColConstIterator& operator-=(difference_type i)
         {
             m_internal -= i;
+            return *this;
         }
 
-        bool operator==(const ColConstIterator& it2) const
+        bool operator==(const ColConstIterator& other) const
         {
-            return (m_internal == it2.m_internal);
+            return (m_internal == other.m_internal);
         }
 
-        bool operator!=(const ColConstIterator& it2) const
+        bool operator!=(const ColConstIterator& other) const
         {
-            return (m_internal != it2.m_internal);
+            return m_internal != other.m_internal;
         }
 
-        bool operator<(const ColConstIterator& it2) const
+        bool operator<(const ColConstIterator& other) const
         {
-            return m_internal < it2.m_internal;
+            return m_internal < other.m_internal;
         }
 
-        bool operator>(const ColConstIterator& it2) const
+        bool operator>(const ColConstIterator& other) const
         {
-            return m_internal > it2.m_internal;
+            return other < *this;
+        }
+
+        bool operator<=(const ColConstIterator& other) const
+        {
+            return !(other < *this);
+        }
+
+        bool operator>=(const ColConstIterator& other) const
+        {
+            return !(*this < other);
         }
 
     private :
@@ -249,10 +275,9 @@ public:
             , m_matrix(it2.m_matrix)
         {}
 
-        RowConstIterator()
-        {}
+        RowConstIterator() = default;
 
-        RowConstIterator&  operator=(const RowConstIterator& other)
+        RowConstIterator& operator=(const RowConstIterator& other)
         {
             if (this != &other)
             {
@@ -262,28 +287,28 @@ public:
             return *this;
         }
 
-        Index index() const
+        [[nodiscard]] Index index() const
         {
             return m_matrix->rowIndex[m_internal];
         }
 
-        Index getInternal() const
+        [[nodiscard]] Index getInternal() const
         {
             return m_internal;
         }
 
-        bool isInvalid() const
+        [[nodiscard]] bool isInvalid() const
         {
             return m_internal == CompressedRowSparseMatrixConstraint::s_invalidIndex;
         }
 
-        ColConstIterator begin() const
+        [[nodiscard]] ColConstIterator begin() const
         {
             if (isInvalid())
             {
                 return ColConstIterator(m_internal, s_invalidIndex, m_matrix);
             }
-            Range r = m_matrix->getRowRange(m_internal);
+            const Range r = m_matrix->getRowRange(m_internal);
             return ColConstIterator(m_internal, r.begin(), m_matrix);
         }
 
@@ -293,51 +318,59 @@ public:
             {
                 return ColConstIterator(m_internal, s_invalidIndex, m_matrix);
             }
-            Range r = m_matrix->getRowRange(m_internal);
+            const Range r = m_matrix->getRowRange(m_internal);
             return ColConstIterator(m_internal, r.end(), m_matrix);
         }
 
-        RowType row() const
+        [[nodiscard]] RowType row() const
         {
-            Range r = m_matrix->getRowRange(m_internal);
+            const Range r = m_matrix->getRowRange(m_internal);
             return RowType(ColConstIterator(m_internal, r.begin(), m_matrix),
                            ColConstIterator(m_internal, r.end(), m_matrix));
         }
 
-        bool empty() const
+        [[nodiscard]] bool empty() const
         {
-            Range r = m_matrix->getRowRange(m_internal);
+            const Range r = m_matrix->getRowRange(m_internal);
             return r.empty();
         }
 
-        void operator++() // prefix
+        RowConstIterator& operator++() // prefix
         {
-            m_internal++;
+            ++m_internal;
+            return *this;
         }
 
-        void operator++(int) // postfix
+        RowConstIterator operator++(difference_type) // postfix
         {
-            m_internal++;
+            RowConstIterator tmp = *this;
+            ++(*this);
+            return tmp;
         }
 
-        void operator--() // prefix
+        RowConstIterator& operator--() // prefix
         {
-            m_internal--;
+            --m_internal;
+            return *this;
         }
 
-        void operator--(int) // postfix
+        RowConstIterator operator--(difference_type) // postfix
         {
-            m_internal--;
+            RowConstIterator tmp = *this;
+            --(*this);
+            return tmp;
         }
 
-        void operator+=(int i)
+        RowConstIterator& operator+=(difference_type i)
         {
             m_internal += i;
+            return *this;
         }
 
-        void operator-=(int i)
+        RowConstIterator& operator-=(difference_type i)
         {
             m_internal -= i;
+            return *this;
         }
 
         int operator-(const RowConstIterator& it2) const
@@ -345,38 +378,48 @@ public:
             return m_internal - it2.m_internal;
         }
 
-        RowConstIterator operator+(int i) const
+        RowConstIterator operator+(difference_type i) const
         {
             RowConstIterator res = *this;
             res += i;
             return res;
         }
 
-        RowConstIterator operator-(int i) const
+        RowConstIterator operator-(difference_type i) const
         {
             RowConstIterator res = *this;
             res -= i;
             return res;
         }
 
-        bool operator==(const RowConstIterator& it2) const
+        bool operator==(const RowConstIterator& other) const
         {
-            return m_internal == it2.m_internal;
+            return m_internal == other.m_internal;
         }
 
-        bool operator!=(const RowConstIterator& it2) const
+        bool operator!=(const RowConstIterator& other) const
         {
-            return !(m_internal == it2.m_internal);
+            return !(m_internal == other.m_internal);
         }
 
-        bool operator<(const RowConstIterator& it2) const
+        bool operator<(const RowConstIterator& other) const
         {
-            return m_internal < it2.m_internal;
+            return m_internal < other.m_internal;
         }
 
-        bool operator>(const RowConstIterator& it2) const
+        bool operator>(const RowConstIterator& other) const
         {
-            return m_internal > it2.m_internal;
+            return other < *this;
+        }
+
+        bool operator<=(const RowConstIterator& other) const
+        {
+            return !(other < *this);
+        }
+
+        bool operator>=(const RowConstIterator& other) const
+        {
+            return !(*this < other);
         }
 
         template <class VecDeriv, typename Real>
@@ -581,10 +624,24 @@ public:
         {
             out << "Constraint ID : ";
             out << rowIt.index();
-            for (ColConstIterator colIt = rowIt.begin(); colIt !=  rowIt.end(); ++colIt)
+            const auto colToString = [](const ColConstIterator& colIt)
             {
-                out << "  dof ID : " << colIt.index() << "  value : " << colIt.val() << "  ";
+                std::stringstream ss;
+                ss << "dof ID : " << colIt.index() << "  value : " << colIt.val();
+                return ss.str();
+            };
+
+            ColConstIterator colIt = rowIt.begin();
+            const ColConstIterator colItEnd = rowIt.end();
+            if (colIt != colItEnd)
+            {
+                out << "  " << colToString(colIt++);
+                while(colIt != colItEnd)
+                {
+                    out << "  " << colToString(colIt++);
+                }
             }
+
             out << "\n";
         }
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraintEigenUtils.h
@@ -40,15 +40,19 @@ struct CompressedRowSparseMatrixToEigenSparse
 template <typename TVec>
 struct CompressedRowSparseMatrixToEigenSparseVec
 {
-    typedef typename TVec::Real Real;
     typedef CompressedRowSparseMatrixConstraint< TVec > TCompressedRowSparseMatrix;
+    typedef typename TCompressedRowSparseMatrix::Real Real;
     typedef Eigen::SparseMatrix<Real, Eigen::RowMajor> EigenSparseMatrix;
 
-
-    EigenSparseMatrix operator() (const TCompressedRowSparseMatrix& mat, std::size_t size)
+    EigenSparseMatrix operator() (const TCompressedRowSparseMatrix& mat, std::size_t size) const
     {
-        const std::size_t eigenMatSize = size * TVec::size();
-        EigenSparseMatrix eigenMat(eigenMatSize, eigenMatSize);
+        SOFA_UNUSED(size);
+        return operator()(mat);
+    }
+
+    EigenSparseMatrix operator() (const TCompressedRowSparseMatrix& mat) const
+    {
+        EigenSparseMatrix eigenMat(mat.nBlockRow * NL, mat.nBlockCol * NC);
 
         sofa::type::vector<Eigen::Triplet<Real> > triplets;
 
@@ -57,25 +61,45 @@ struct CompressedRowSparseMatrixToEigenSparseVec
             for (auto col = row.begin(), colend = row.end(); col !=colend; ++col)
             {
                 const TVec& vec = col.val();
-                const int   colIndex  = col.index() * TVec::size();
+                const int colIndex  = col.index() * NC;
 
                 for (std::size_t i = 0; i < TVec::size(); ++i)
                 {
-                    triplets.emplace_back(row.index(), colIndex + i, vec[i]);
+                    if (row.index() < eigenMat.rows())
+                    {
+                        const auto colInsertion = colIndex + i;
+                        if (colInsertion < eigenMat.cols())
+                        {
+                            triplets.emplace_back(row.index(), colInsertion, vec[i]);
+                        }
+                        else
+                        {
+                            msg_error("CompressedRowSparseMatrixToEigenSparseVec") << "Trying to insert in col " << colInsertion << " whereas matrix size is " << eigenMat.rows() << "x" << eigenMat.cols();
+                        }
+                    }
+                    else
+                    {
+                        msg_error("CompressedRowSparseMatrixToEigenSparseVec") << "Trying to insert in row " << row.index() << " whereas matrix size is " << eigenMat.rows() << "x" << eigenMat.cols();
+                    }
                 }
 
             }
         }
 
-        eigenMat.setFromTriplets(triplets.begin(), triplets.end());;
+        eigenMat.setFromTriplets(triplets.begin(), triplets.end());
 
         return eigenMat;
     }
 
+private:
+
+    static constexpr sofa::Index NL = TCompressedRowSparseMatrix::NL;  ///< Number of rows of a block
+    static constexpr sofa::Index NC = TCompressedRowSparseMatrix::NC;  ///< Number of columns of a block
+
 };
 
 template< int N, typename Real >
-class CompressedRowSparseMatrixToEigenSparse< sofa::type::Vec<N,Real> >
+struct CompressedRowSparseMatrixToEigenSparse< sofa::type::Vec<N,Real> >
     : public  CompressedRowSparseMatrixToEigenSparseVec< sofa::type::Vec<N, Real> >
 {
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
@@ -105,6 +105,9 @@ public:
     typedef typename traits::BlockTranspose BlockTranspose;
     typedef typename traits::Real Real;
 
+    template<class TBlock2>
+    using rebind_to = CompressedRowSparseMatrixGeneric< TBlock2, Policy >;
+
     typedef Matrix Expr;
     enum { category = MATRIX_SPARSE };
     enum { operand = 1 };

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
@@ -71,13 +71,16 @@ public:
     typedef typename CRSMatrix::IndexedBlock IndexedBlock;
     typedef typename CRSMatrix::VecIndexedBlock VecIndexedBlock;
 
+    template<class TBlock2>
+    using rebind_to = CompressedRowSparseMatrixMechanical< TBlock2, Policy >;
+
     typedef Matrix Expr;
     typedef CompressedRowSparseMatrixMechanical<double> matrix_type;
     enum { category = MATRIX_SPARSE };
     enum { operand = 1 };
 
-    enum { NL = CRSMatrix::NL };  ///< Number of rows of a block
-    enum { NC = CRSMatrix::NC };  ///< Number of columns of a block
+    static constexpr sofa::Index NL = traits::NL;  ///< Number of rows of a block
+    static constexpr sofa::Index NC = traits::NC;  ///< Number of columns of a block
 
     /// Size
     Index nRow,nCol;         ///< Mathematical size of the matrix, in scalars

--- a/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrix_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrix_test.cpp
@@ -99,16 +99,15 @@ void generateMatrix(sofa::linearalgebra::CompressedRowSparseMatrixConstraint<TBl
     using Real = typename Matrix::Real;
     const auto nbNonZero = static_cast<sofa::SignedIndex>(sparsity * static_cast<Real>(nbRows*nbCols));
 
-    sofa::helper::RandomGenerator randomGenerator;
-    randomGenerator.initSeed(seed);
+    sofa::testing::LinearCongruentialRandomGenerator lcg(seed);
 
     matrix.resizeBlock(nbRows / Matrix::NL, nbCols / Matrix::NC);
 
     for (sofa::SignedIndex i = 0; i < nbNonZero; ++i)
     {
-        const auto value = static_cast<Real>(sofa::helper::drand(1));
-        const auto row = randomGenerator.random<sofa::Index>(0, nbRows);
-        const auto col = randomGenerator.random<sofa::Index>(0, nbCols);
+        const auto value = lcg.generateInUnitRange<Real>();
+        const auto row = static_cast<sofa::Index>(lcg.generateInRange(0., nbRows));
+        const auto col = static_cast<sofa::Index>(lcg.generateInRange(0., nbCols));
 
         auto line = matrix.writeLine(row);
         TBlock block;
@@ -421,10 +420,10 @@ TEST(CompressedRowSparseMatrixConstraint, ostream)
     ss << A;
 
     static const std::string expectedOutput =
-R"(Constraint ID : 0  dof ID : 1  value : 0 0.170019 0  dof ID : 10  value : 0 0.617481 0
-Constraint ID : 1  dof ID : 1  value : 0 0.127171 0  dof ID : 10  value : 0 -0.997497 0
-Constraint ID : 2  dof ID : 4  value : 0 -0.613392 0  dof ID : 13  value : 0 -0.299417 0
-Constraint ID : 3  dof ID : 13  value : 0 -0.0402539 0
+R"(Constraint ID : 0  dof ID : 1  value : 0 0.360985 0  dof ID : 12  value : 0.926981 0 0
+Constraint ID : 2  dof ID : 9  value : 0.451858 0 0
+Constraint ID : 3  dof ID : 6  value : 0.777417 0 0
+Constraint ID : 4  dof ID : 5  value : 0 0 0.474108  dof ID : 7  value : 0 0.983937 0  dof ID : 9  value : 0.238781 0 0
 )";
 
     EXPECT_EQ(ss.str(), expectedOutput);

--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -36,6 +36,7 @@ set(HEADER_FILES
     ${SOFATYPESRC_ROOT}/stable_vector.h
     ${SOFATYPESRC_ROOT}/trait/Rebind.h
     ${SOFATYPESRC_ROOT}/trait/is_container.h
+    ${SOFATYPESRC_ROOT}/trait/is_specialization_of.h
     ${SOFATYPESRC_ROOT}/trait/is_vector.h
     ${SOFATYPESRC_ROOT}/vector.h
     ${SOFATYPESRC_ROOT}/vector_Integral.h

--- a/Sofa/framework/Type/src/sofa/type/trait/is_specialization_of.h
+++ b/Sofa/framework/Type/src/sofa/type/trait/is_specialization_of.h
@@ -1,0 +1,81 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <type_traits>
+
+namespace sofa::type::trait
+{
+/**
+ * @brief Trait to check if a type `T` is a specialization of a given template class `Template`.
+ *
+ * The `is_specialization_of` trait is a compile-time check to determine if a type `T`
+ * is a specialization of a particular template class `Template`. This trait works with
+ * template classes that accept any number of template parameters.
+ *
+ * Example usage:
+ * @code
+ * template <typename T1, typename T2>
+ * class Foo {};
+ *
+ * template <typename T>
+ * class Bar {};
+ *
+ * class Baz {};
+ *
+ * static_assert(is_specialization_of<Foo<int, double>, Foo>::value, "Foo<int, double> is a Foo!");
+ * static_assert(is_specialization_of<Bar<int>, Bar>::value, "Bar<int> is a Bar!");
+ * static_assert(!is_specialization_of<int, Foo>::value, "int is not a Foo specialization.");
+ * static_assert(!is_specialization_of<Baz, Bar>::value, "Baz is not a Bar specialization.");
+ * @endcode
+ *
+ * @tparam T The type to be checked. This is the type that you want to determine whether it is a specialization of `Template`.
+ * @tparam Template The template class to check against. This can be any template class that accepts one or more template parameters.
+ */
+template <typename T, template <typename...> class Template>
+struct is_specialization_of : std::false_type {};
+
+/**
+ * @brief Partial specialization for the case where `T` is an instance of `Template<Args...>`.
+ *
+ * This specialization checks if `T` matches the form `Template<Args...>`, meaning `T` is a specialization
+ * of the template class `Template` with specific template parameters `Args...`.
+ *
+ * @tparam Template The template class that `T` is expected to be an instance of.
+ * @tparam Args The actual template parameters used in the instantiation of `Template`.
+ */
+template <template <typename...> class Template, typename... Args>
+struct is_specialization_of<Template<Args...>, Template> : std::true_type {};
+
+/**
+ * @brief Helper variable template to simplify the syntax for checking if `T` is a specialization of `Template`.
+ *
+ * This variable template provides a cleaner and more concise way to use the `is_specialization_of` trait.
+ * Instead of writing `is_specialization_of<T, Template>::value`, you can use `is_specialization_of_v<T, Template>`.
+ *
+ * @tparam T The type to be checked.
+ * @tparam Template The template class to check against.
+ * @see is_specialization_of
+ */
+template <typename T, template <typename...> class Template>
+inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
+
+}


### PR DESCRIPTION
- `LinearSolverConstraintCorrection::F` is deprecated because it is not used. I believe it stopped to be used here: https://github.com/sofa-framework/sofa/commit/50fe60f28306912e0e853c0a9493bccdd9735ff7#diff-b0264445a2a81f648e146f0b1d59d5d197cf3a935f3b7cbb24af11a38b8e6e68L433
- `override` keyword was missing in `~LinearSolverConstraintCorrection`
- `LinearSolverConstraintCorrection::J` is renamed to `m_constraintMatrix`. Its floating-type is no longer `SReal`, but `Real`. In theory, it's breaking.
- `computeJ` is no longer used. Instead, I introduce the method `convertConstraintMatrix`, which is IMO clearer. `computeJ` could be removed I think. But for some reasons it is virtual. Anyone overrides it?
- Added a timer in `convertConstraintMatrix`. This must be used for benchmark to evaluate the cost of the conversion. I believe that we can think of a way to avoid the conversions (only if it costs too much).
- `MatrixLinearSolverInternalData::copyJmatrix` is renamed to `convertMatrix` and it is now protected.
- Made `getLocalJ` clearer.
- Added details for `addJMInvJt`
- Introduced rebind types for `CompressedRowSparseMatrixConstraint`, `CompressedRowSparseMatrixGeneric` and `CompressedRowSparseMatrixMechanical`
- `CompressedRowSparseMatrixConstraint`: added test for the stream operator. The operator no longer adds trailing spaces on each line.
- Better iterators in `CompressedRowSparseMatrixConstraint`
- Missing header guard in `CompressedRowSparseMatrixConstraintEigenUtils.h`
- Fixed `operator()` in `CompressedRowSparseMatrixToEigenSparseVec`. Also added error message if out-of-bounds. Required for https://github.com/sofa-framework/SofaPython3/pull/459
- Introduction of `is_specialization_of`. Used in [a SofaPython3 PR](https://github.com/sofa-framework/SofaPython3/pull/459)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
