### PR TITLE
[DefaultAnimationLoop] Add timer for collision begin and collision end

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -240,6 +240,7 @@ void DefaultAnimationLoop::propagateOnlyPositionAndVelocity(const SReal nextTime
 
 void DefaultAnimationLoop::propagateCollisionBeginEvent(const core::ExecParams* params) const
 {
+    SCOPED_TIMER("CollisionBeginEvent");
     CollisionBeginEvent evBegin;
     PropagateEventVisitor eventPropagation( params, &evBegin);
     eventPropagation.execute(m_node);
@@ -247,6 +248,7 @@ void DefaultAnimationLoop::propagateCollisionBeginEvent(const core::ExecParams* 
 
 void DefaultAnimationLoop::propagateCollisionEndEvent(const core::ExecParams* params) const
 {
+    SCOPED_TIMER("CollisionEndEvent");
     CollisionEndEvent evEnd;
     PropagateEventVisitor eventPropagation( params, &evEnd);
     eventPropagation.execute(m_node);


### PR DESCRIPTION
Add timers to match what is present in the FreeMotionAnimationLoop



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
