### PR TITLE
[tools] Deactivate all plugin containing CUDA in its name

### DIFF
--- a/tools/postinstall-fixup/common.sh
+++ b/tools/postinstall-fixup/common.sh
@@ -25,7 +25,6 @@ function clean_default_plugins()
           ShapeMatchingPlugin       \
           SofaAssimp                \
           SofaCarving               \
-          SofaCUDA                  \
           SofaDistanceGrid          \
           SofaEulerianFluid         \
           SofaImplicitField         \
@@ -36,6 +35,7 @@ function clean_default_plugins()
           SofaValidation            \
           STLIB                     \
           VolumetricRendering       \
+          CUDA                      \
       ; do
       disabled_plugins=$disabled_plugins'\|'$plugin
   done


### PR DESCRIPTION
Remove all CUDA plugins from default plugin list for the release



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
