### PR TITLE
[GenericConstraintSolver] FIX Generic constraint solver timer

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -531,8 +531,6 @@ void GenericConstraintSolver::applyMotionCorrection(
 
 void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::ConstraintParams* cParams, MultiVecId res1, MultiVecId res2) const
 {
-    SCOPED_TIMER("Compute And Apply Motion Correction");
-
     static constexpr auto supportedCorrections = {
         sofa::core::ConstraintOrder::POS_AND_VEL,
         sofa::core::ConstraintOrder::POS,
@@ -544,11 +542,11 @@ void GenericConstraintSolver::computeAndApplyMotionCorrection(const core::Constr
         for (const auto& constraintCorrection : filteredConstraintCorrections())
         {
             {
-                SCOPED_TIMER("ComputeCorrection");
+                SCOPED_TIMER("doComputeCorrection");
                 constraintCorrection->computeMotionCorrectionFromLambda(cParams, this->getDx(), &current_cp->f);
             }
 
-            SCOPED_TIMER("ApplyCorrection");
+            SCOPED_TIMER("doApplyCorrection");
             applyMotionCorrection(cParams, res1, res2, constraintCorrection);
         }
     }


### PR DESCRIPTION
The timer "ApplyCorrection" is already in the mother class in applyCorrectionTask which is the method that actually call applyCorrection. "Compute And Apply Motion Correction" was thus redondant and the second "ApplyCorrection" was misleading.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
