### PR TITLE
[Core.Collision] NarrowPhaseDetection: disable lighting when displaying detection outputs

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/collision/NarrowPhaseDetection.cpp
+++ b/Sofa/framework/Core/src/sofa/core/collision/NarrowPhaseDetection.cpp
@@ -54,6 +54,9 @@ void NarrowPhaseDetection::draw(const core::visual::VisualParams* vparams)
 {
     if(! vparams->displayFlags().getShowDetectionOutputs()) return;
 
+    [[maybe_unused]] auto state = vparams->drawTool()->makeStateLifeCycle();
+    vparams->drawTool()->disableLighting();
+
     std::vector<type::Vec3> points;
 
     for (auto mapIt = m_outputsMap.begin(); mapIt!=m_outputsMap.end() ; ++mapIt)


### PR DESCRIPTION
Before:
<img src="https://github.com/user-attachments/assets/0cc909bd-b823-4e28-b3d8-b7549e240e5e" width="300" />

After:
<img src="https://github.com/user-attachments/assets/1a96d6a5-c4f1-4a34-acff-46cc667fc0bd" width="300" />

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
