### PR TITLE
[Core] ForceField: print only once about missing kfactor usage

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.inl
@@ -57,14 +57,21 @@ void ForceField<DataTypes>::addDForce(const MechanicalParams* mparams, MultiVecD
     {
 
 #ifndef NDEBUG
-            mparams->setKFactorUsed(false);
+        mparams->setKFactorUsed(false);
 #endif
 
         addDForce(mparams, *dfId[this->mstate.get()].write(), *mparams->readDx(this->mstate.get()));
 
 #ifndef NDEBUG
         if (!mparams->getKFactorUsed())
-            msg_warning()  << getClassName() << " (in ForceField<DataTypes>::addDForce): please use mparams->kFactor() in addDForce";
+        {
+            static bool displayOnce = false;
+            if (!displayOnce)
+            {
+                msg_warning() << getClassName() << " (in ForceField<DataTypes>::addDForce): please use mparams->kFactor() in addDForce";
+                displayOnce = true;
+            }
+        }
 #endif
     }
 }


### PR DESCRIPTION
I understood the first time, so don't nag me at every step 👺
It is already quite bothersome to execute in debug 😅

And it alleviates a little bit the debug  output on the CI (ubuntu-debug: 515,231 KB 🥴 on master)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
