### PR TITLE
[GitHub] Fix python dependencies in Actions

### DIFF
--- a/.github/workflows/post-github-activity-star.yml
+++ b/.github/workflows/post-github-activity-star.yml
@@ -15,9 +15,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install python-graphql-client
-          pip install python-dateutil
-          pip install requests
+          apt install pipx
+          pipx install python-graphql-client
+          pipx install python-dateutil
+          pipx install requests
         working-directory: ${{ github.workspace }}
 
       # Star/watch related event


### PR DESCRIPTION
This is a first attempt to fix our GitHub actions now failing

Solution from : https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3

GitHub Action errors
```
Run pip install python-graphql-client
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
``` 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
