### PR TITLE
[Helper] A static alternative to OptionsGroup: SelectableItem

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.h
@@ -66,7 +66,7 @@ protected:
     SlidingLagrangianConstraint(MechanicalState* object);
     SlidingLagrangianConstraint(MechanicalState* object1, MechanicalState* object2);
 
-    virtual ~SlidingLagrangianConstraint(){}
+    ~SlidingLagrangianConstraint() override {}
 
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -33,6 +33,8 @@
 #include <sofa/component/constraint/lagrangian/solver/visitors/MechanicalGetConstraintResolutionVisitor.h>
 
 #include <sofa/core/objectmodel/RenamedData.h>
+#include <sofa/helper/SelectableItem.h>
+
 
 namespace sofa::component::constraint::lagrangian::solver
 {
@@ -60,7 +62,13 @@ public:
     ConstraintProblem* getConstraintProblem() override;
     void lockConstraintProblem(sofa::core::objectmodel::BaseObject* from, ConstraintProblem* p1, ConstraintProblem* p2 = nullptr) override;
 
-    Data< sofa::helper::OptionsGroup > d_resolutionMethod; ///< Method used to solve the constraint problem, among: "ProjectedGaussSeidel", "UnbuiltGaussSeidel" or "for NonsmoothNonlinearConjugateGradient"
+    MAKE_SELECTABLE_ITEMS(ResolutionMethod,
+        sofa::helper::Item{"ProjectedGaussSeidel", "Projected Gauss-Seidel"},
+        sofa::helper::Item{"UnbuiltGaussSeidel", "Gauss-Seidel where the matrix is not assembled"},
+        sofa::helper::Item{"NonsmoothNonlinearConjugateGradient", "Non-smooth non-linear conjugate gradient"}
+    );
+
+    Data< ResolutionMethod > d_resolutionMethod; ///< Method used to solve the constraint problem, among: "ProjectedGaussSeidel", "UnbuiltGaussSeidel" or "for NonsmoothNonlinearConjugateGradient"
 
     SOFA_ATTRIBUTE_DEPRECATED__RENAME_DATA_IN_CONSTRAINT_LAGRANGIAN_SOLVER()
     sofa::core::objectmodel::RenamedData<int> maxIt;

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
@@ -37,8 +37,8 @@ static constexpr OglSceneFrame::Style defaultStyle("Cylinders");
 
 OglSceneFrame::OglSceneFrame()
     : d_drawFrame(initData(&d_drawFrame, true,  "draw", "Display the frame or not"))
-    , d_style(initData(&d_style, defaultStyle, "style", "Style of the frame"))
-    , d_alignment(initData(&d_alignment, defaultAlignment, "alignment", "Alignment of the frame in the view"))
+    , d_style(initData(&d_style, defaultStyle, "style", ("Style of the frame\n" + Style::dataDescription()).c_str()))
+    , d_alignment(initData(&d_alignment, defaultAlignment, "alignment", ("Alignment of the frame in the view\n" + Alignment::dataDescription()).c_str()))
     , d_viewportSize(initData(&d_viewportSize, 150, "viewportSize", "Size of the viewport where the frame is rendered"))
 {}
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
@@ -32,20 +32,15 @@ int OglSceneFrameClass = core::RegisterObject("Display a frame at the corner of 
 
 using namespace sofa::defaulttype;
 
+static constexpr OglSceneFrame::Alignment defaultAlignment("BottomRight");
+static constexpr OglSceneFrame::Style defaultStyle("Cylinders");
+
 OglSceneFrame::OglSceneFrame()
     : d_drawFrame(initData(&d_drawFrame, true,  "draw", "Display the frame or not"))
-    , d_style(initData(&d_style, "style", "Style of the frame"))
-    , d_alignment(initData(&d_alignment, "alignment", "Alignment of the frame in the view"))
+    , d_style(initData(&d_style, defaultStyle, "style", "Style of the frame"))
+    , d_alignment(initData(&d_alignment, defaultAlignment, "alignment", "Alignment of the frame in the view"))
     , d_viewportSize(initData(&d_viewportSize, 150, "viewportSize", "Size of the viewport where the frame is rendered"))
-{
-    sofa::helper::OptionsGroup styleOptions{"Arrows", "Cylinders", "CubeCones"};
-    styleOptions.setSelectedItem(1);
-    d_style.setValue(styleOptions);
-
-    sofa::helper::OptionsGroup alignmentOptions{"BottomLeft", "BottomRight", "TopRight", "TopLeft"};
-    alignmentOptions.setSelectedItem(1);
-    d_alignment.setValue(alignmentOptions);
-}
+{}
 
 void OglSceneFrame::drawArrows(const core::visual::VisualParams* vparams)
 {
@@ -112,22 +107,22 @@ void OglSceneFrame::doDrawVisual(const core::visual::VisualParams* vparams)
 
     const auto viewportSize = d_viewportSize.getValue();
 
-    switch(d_alignment.getValue().getSelectedId())
+    switch(d_alignment.getValue())
     {
-        case 0: //BottomLeft
+        case Alignment("BottomLeft"):
         default:
             glViewport(0,0,viewportSize,viewportSize);
             glScissor(0,0,viewportSize,viewportSize);
             break;
-        case 1: //BottomRight
+        case Alignment("BottomRight"):
             glViewport(viewport[2]-viewportSize,0,viewportSize,viewportSize);
             glScissor(viewport[2]-viewportSize,0,viewportSize,viewportSize);
             break;
-        case 2: //TopRight
+        case Alignment("TopRight"):
             glViewport(viewport[2]-viewportSize,viewport[3]-viewportSize,viewportSize,viewportSize);
             glScissor(viewport[2]-viewportSize,viewport[3]-viewportSize,viewportSize,viewportSize);
             break;
-        case 3: //TopLeft
+        case Alignment("TopLeft"):
             glViewport(0,viewport[3]-viewportSize,viewportSize,viewportSize);
             glScissor(0,viewport[3]-viewportSize,viewportSize,viewportSize);
             break;
@@ -157,18 +152,18 @@ void OglSceneFrame::doDrawVisual(const core::visual::VisualParams* vparams)
 
     vparams->drawTool()->disableLighting();
 
-    switch (d_style.getValue().getSelectedId())
+    switch (d_style.getValue())
     {
-    case 0:
+    case Style("Arrows"):
     default:
         drawArrows(vparams);
         break;
 
-    case 1:
+    case Style("Cylinders"):
         drawCylinders(vparams);
         break;
 
-    case 2:
+    case Style("CubeCones"):
         drawCubeCones(vparams);
         break;
     }

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
@@ -25,6 +25,8 @@
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/OptionsGroup.h>
+#include <sofa/helper/SelectableItem.h>
+
 
 namespace sofa::gl::component::rendering3d
 {
@@ -38,8 +40,23 @@ public:
     typedef core::visual::VisualParams::Viewport Viewport;
 
     Data<bool> d_drawFrame; ///< Display the frame or not
-    Data<sofa::helper::OptionsGroup> d_style; ///< Style of the frame
-    Data<sofa::helper::OptionsGroup> d_alignment; ///< Alignment of the frame in the view
+
+    MAKE_SELECTABLE_ITEMS(Style,
+        sofa::helper::Item{"Arrows", "The frame is composed of arrows"},
+        sofa::helper::Item{"Cylinders", "The frame is composed of cylinders"},
+        sofa::helper::Item{"CubeCones", "The frame is composed of cubes and cones"},
+    );
+
+    Data<Style> d_style; ///< Style of the frame
+
+    MAKE_SELECTABLE_ITEMS(Alignment,
+        sofa::helper::Item{"BottomLeft", "The scene frame is displayed in the bottom-left corner"},
+        sofa::helper::Item{"BottomRight", "The scene frame is displayed in the bottom-right corner"},
+        sofa::helper::Item{"TopRight", "The scene frame is displayed in the top-right corner"},
+        sofa::helper::Item{"TopLeft", "The scene frame is displayed in the top-left corner"}
+    );
+
+    Data<Alignment> d_alignment; ///< Alignment of the frame in the view
     Data<int> d_viewportSize; ///< Size of the viewport where the frame is rendered
 
     OglSceneFrame();

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.cpp
@@ -299,7 +299,7 @@ bool SelectableItemWidget::createWidgets()
     return true;
 }
 
-void SelectableItemWidget::setDataReadOnly(bool readOnly)
+void SelectableItemWidget::setDataReadOnly(const bool readOnly)
 {
     if (m_buttonMode)
     {
@@ -331,11 +331,11 @@ void SelectableItemWidget::writeToData()
 {
     if (m_buttonMode)
     {
-        const_cast<helper::BaseSelectableItem*>(m_selectableItem)->setSelectedId((unsigned int)m_buttonList->checkedId ());
+        const_cast<helper::BaseSelectableItem*>(m_selectableItem)->setSelectedId(static_cast<std::size_t>(m_buttonList->checkedId()));
     }
     else
     {
-        const_cast<helper::BaseSelectableItem*>(m_selectableItem)->setSelectedId((unsigned int)m_comboList->currentIndex());
+        const_cast<helper::BaseSelectableItem*>(m_selectableItem)->setSelectedId(static_cast<std::size_t>(m_comboList->currentIndex()));
     }
 }
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.cpp
@@ -222,6 +222,122 @@ void RadioDataWidget::writeToData()
     this->getData()->setValue(m_radiotrick);
 }
 
+Creator<DataWidgetFactory, SelectableItemWidget> DWClass_SelectableItem("default",true);
+
+SelectableItemWidget::SelectableItemWidget(QWidget* parent, const char* name,
+    core::BaseData* m_data, const helper::BaseSelectableItem* item)
+: TDataWidget(parent, name, m_data, item)
+, m_selectableItem(item)
+{}
+
+bool SelectableItemWidget::createWidgets()
+{
+    if (Tdata && Tdata->getValueTypeString() != "SelectableItem" ||
+        baseData && baseData->getValueTypeString() != "SelectableItem")
+    {
+        return false;
+    }
+
+    QVBoxLayout* layout = new QVBoxLayout(this);
+    static constexpr unsigned int LIMIT_NUM_BUTTON = 4;
+
+    assert(m_selectableItem);
+    const std::size_t nbItems = m_selectableItem->getNumberOfItems();
+    m_buttonMode = nbItems < LIMIT_NUM_BUTTON;
+    const auto* items = m_selectableItem->getItemsData();
+
+    const auto getItem = [](const sofa::helper::Item* item)
+    {
+        std::stringstream ss;
+        ss << item->key;
+        if (!item->description.empty())
+        {
+            ss << " (" << item->description << ")";
+        }
+        return ss.str();
+    };
+
+    if (m_buttonMode)
+    {
+        m_buttonList = new QButtonGroup(this);
+
+        for (std::size_t i = 0; i < nbItems; i++)
+        {
+            const helper::Item* item_i = items + i;
+
+            QRadioButton * m_radiobutton = new QRadioButton(QString(getItem(item_i).c_str()), this);
+            if (i == m_selectableItem->getSelectedId())
+            {
+                m_radiobutton->setChecked(true);
+            }
+            layout->addWidget(m_radiobutton);
+            m_buttonList->addButton(m_radiobutton, i);
+        }
+        connect(m_buttonList, SIGNAL(buttonClicked(int)), this, SLOT(setWidgetDirty())) ;
+    }
+    else
+    {
+        m_comboList=new QComboBox(this);
+        m_comboList->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+
+        QStringList list;
+        for (std::size_t i = 0; i < nbItems; i++)
+        {
+            const helper::Item* item_i = items + i;
+            list << getItem(item_i).c_str();
+        }
+
+        m_comboList->insertItems(0, list);
+
+        m_comboList->setCurrentIndex(m_selectableItem->getSelectedId());
+
+        connect(m_comboList, SIGNAL(activated(int)), this, SLOT(setWidgetDirty()));
+        layout->addWidget(m_comboList);
+
+    }
+
+    return true;
+}
+
+void SelectableItemWidget::setDataReadOnly(bool readOnly)
+{
+    if (m_buttonMode)
+    {
+        const QList<QAbstractButton *> buttons = m_buttonList->buttons();
+        for (auto& button : buttons)
+        {
+            button->setEnabled(!readOnly);
+        }
+    }
+    else
+    {
+        m_comboList->setEnabled(!readOnly);
+    }
+}
+
+void SelectableItemWidget::readFromData()
+{
+    if (m_buttonMode)
+    {
+        m_buttonList->button(m_selectableItem->getSelectedId())->setChecked(true);
+    }
+    else
+    {
+        m_comboList->setCurrentIndex(m_selectableItem->getSelectedId());
+    }
+}
+
+void SelectableItemWidget::writeToData()
+{
+    if (m_buttonMode)
+    {
+        const_cast<helper::BaseSelectableItem*>(m_selectableItem)->setSelectedId((unsigned int)m_buttonList->checkedId ());
+    }
+    else
+    {
+        const_cast<helper::BaseSelectableItem*>(m_selectableItem)->setSelectedId((unsigned int)m_comboList->currentIndex());
+    }
+}
 
 
 } //namespace sofa::gui::qt

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.h
@@ -946,7 +946,7 @@ public :
     ///a widget for a that particular data type.
     RadioDataWidget(QWidget* parent, const char* name,
             core::objectmodel::Data<sofa::helper::OptionsGroup >* m_data)
-        : TDataWidget<sofa::helper::OptionsGroup >(parent,name,m_data) {};
+        : TDataWidget<sofa::helper::OptionsGroup >(parent,name,m_data) {}
 
     ///In this method we  create the widgets and perform the signal / slots connections.
     virtual bool createWidgets();
@@ -962,6 +962,34 @@ protected:
     QButtonGroup *buttonList;
     QComboBox    *comboList;
     bool buttonMode;
+};
+
+class SelectableItemWidget : public TDataWidget<helper::BaseSelectableItem>
+{
+    Q_OBJECT
+public :
+
+    ///The class constructor takes a TData<RadioTrick> since it creates
+    ///a widget for a that particular data type.
+    SelectableItemWidget(QWidget* parent, const char* name,
+            core::BaseData* m_data, const helper::BaseSelectableItem* item);
+
+    ///In this method we  create the widgets and perform the signal / slots connections.
+    virtual bool createWidgets();
+    virtual void setDataReadOnly(bool readOnly);
+
+protected:
+    ///Implements how update the widgets knowing the data value.
+    virtual void readFromData();
+
+    ///Implements how to update the data, knowing the widget value.
+    virtual void writeToData();
+
+    QButtonGroup *m_buttonList { nullptr };
+    QComboBox    *m_comboList { nullptr };
+    bool m_buttonMode;
+
+    const helper::BaseSelectableItem* m_selectableItem { nullptr };
 };
 
 

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.h
@@ -964,30 +964,25 @@ protected:
     bool buttonMode;
 };
 
-class SelectableItemWidget : public TDataWidget<helper::BaseSelectableItem>
+class SelectableItemWidget final : public TDataWidget<helper::BaseSelectableItem>
 {
     Q_OBJECT
 public :
 
-    ///The class constructor takes a TData<RadioTrick> since it creates
-    ///a widget for a that particular data type.
     SelectableItemWidget(QWidget* parent, const char* name,
             core::BaseData* m_data, const helper::BaseSelectableItem* item);
 
-    ///In this method we  create the widgets and perform the signal / slots connections.
-    virtual bool createWidgets();
-    virtual void setDataReadOnly(bool readOnly);
+    bool createWidgets() override;
+    void setDataReadOnly(bool readOnly) override;
 
 protected:
-    ///Implements how update the widgets knowing the data value.
-    virtual void readFromData();
+    void readFromData() override;
 
-    ///Implements how to update the data, knowing the widget value.
-    virtual void writeToData();
+    void writeToData() override;
 
     QButtonGroup *m_buttonList { nullptr };
     QComboBox    *m_comboList { nullptr };
-    bool m_buttonMode;
+    bool m_buttonMode { false };
 
     const helper::BaseSelectableItem* m_selectableItem { nullptr };
 };

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
@@ -264,7 +264,7 @@ std::string GetSofaTypeTemplateName(const std::string prefix)
     if constexpr (HasName<T>::value )
             return prefix + T::Name();
     else if constexpr (HasDataTypeInfo<T>::value )
-            return prefix + sofa::defaulttype::DataTypeInfo<T>::name();
+            return prefix + sofa::defaulttype::DataTypeInfo<T, void>::name();
     else
         return prefix + sofa::helper::NameDecoder::decodeTypeName(typeid(T));
 }

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
@@ -78,8 +78,8 @@ class HasDataTypeInfo
     typedef char YesType[1];
     typedef char NoType[2];
 
-    template<typename C, typename Enable> static YesType& test( decltype (&sofa::defaulttype::DataTypeInfo<C, Enable>::name) );
-    template<typename C, typename Enable> static NoType& test(...);
+    template<typename C> static YesType& test( decltype (&sofa::defaulttype::DataTypeInfo<C, void>::name) );
+    template<typename C> static NoType& test(...);
 
 public:
     enum { value = sizeof(test<T>(0)) == sizeof(YesType) };

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
@@ -27,7 +27,7 @@
 
 namespace sofa::defaulttype
 {
-    template<class T> struct DataTypeInfo;
+    template<class T, typename Enable> struct DataTypeInfo;
 }
 
 namespace sofa::core::objectmodel
@@ -78,8 +78,8 @@ class HasDataTypeInfo
     typedef char YesType[1];
     typedef char NoType[2];
 
-    template<typename C> static YesType& test( decltype (&sofa::defaulttype::DataTypeInfo<C>::name) );
-    template<typename C> static NoType& test(...);
+    template<typename C, typename Enable> static YesType& test( decltype (&sofa::defaulttype::DataTypeInfo<C, Enable>::name) );
+    template<typename C, typename Enable> static NoType& test(...);
 
 public:
     enum { value = sizeof(test<T>(0)) == sizeof(YesType) };

--- a/Sofa/framework/DefaultType/CMakeLists.txt
+++ b/Sofa/framework/DefaultType/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/typeinfo/TypeInfo_RGBAColor.h
     ${SRC_ROOT}/typeinfo/TypeInfo_Set.h
     ${SRC_ROOT}/typeinfo/TypeInfo_Scalar.h
+    ${SRC_ROOT}/typeinfo/TypeInfo_SelectableItem.h
     ${SRC_ROOT}/typeinfo/TypeInfo_Text.h
     ${SRC_ROOT}/typeinfo/TypeInfo_Vector.h
     ${SRC_ROOT}/typeinfo/TypeInfo_Vec.h

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfo.h
@@ -67,7 +67,7 @@ namespace sofa::defaulttype
     \see AbstractTypeInfo provides similar mechanisms to manipulate Data objects
     generically in non-template code.
 */
-template<class TDataType>
+template<class TDataType, typename Enable = void>
 struct DataTypeInfo;
 
 template<class TDataType>
@@ -140,7 +140,7 @@ struct DefaultDataTypeInfo
     static const std::string GetTypeName() { return sofa::helper::NameDecoder::decodeTypeName(typeid(DataType)); }
 };
 
-template<class TDataType>
+template<class TDataType, typename Enable>
 struct DataTypeInfo : public DefaultDataTypeInfo<TDataType>
 {
 };

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_SelectableItem.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_SelectableItem.h
@@ -20,38 +20,31 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-
-#include <vector>
-#include <sofa/type/fixed_array.h>
-#include <sofa/type/vector.h>
-#include <sofa/helper/set.h>
-#include <sofa/type/RGBAColor.h>
-#include <typeinfo>
-#include <sofa/defaulttype/AbstractTypeInfo.h>
-#include <sofa/defaulttype/typeinfo/DataTypeInfoDynamicWrapper.h>
+#include <sofa/helper/SelectableItem.h>
 #include <sofa/defaulttype/typeinfo/DataTypeInfo.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Bool.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Integer.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Mat.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Quat.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Scalar.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_SelectableItem.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Set.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Text.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Vec.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_FixedArray.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_BoundingBox.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_RGBAColor.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Vector.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_RigidTypes.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_VecTypes.h>
-#include <sofa/defaulttype/typeinfo/TypeInfo_Topology.h>
 
 namespace sofa::defaulttype
 {
 
-/// We make an alias to wrap around the old name to the new one.
-template<class T>
-using VirtualTypeInfo = DataTypeInfoDynamicWrapper<DataTypeInfo<T>>;
+template<class TDataType>
+struct SelectableItemDataTypeInfo : defaulttype::DefaultDataTypeInfo<TDataType>
+{
+    enum { ValidInfo       = 1 /**< 1 if this type has valid infos*/ };
+    static const std::string name()
+    {
+        return "SelectableItem";
+    }
+    static const std::string GetTypeName()
+    {
+        return "SelectableItem";
+    }
+};
 
-} /// namespace sofa::defaulttype
+
+template<class T>
+struct DataTypeInfo<T, std::enable_if_t<std::is_base_of_v<helper::BaseSelectableItem, T>>> :
+    SelectableItemDataTypeInfo<T>
+{
+};
+
+}

--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -42,6 +42,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/RandomGenerator.h
     ${SRC_ROOT}/SimpleTimer.h
     ${SRC_ROOT}/ScopedAdvancedTimer.h
+    ${SRC_ROOT}/SelectableItem.h
     ${SRC_ROOT}/SortedPermutation.h
     ${SRC_ROOT}/StringUtils.h
     ${SRC_ROOT}/TagFactory.h

--- a/Sofa/framework/Helper/src/sofa/helper/SelectableItem.h
+++ b/Sofa/framework/Helper/src/sofa/helper/SelectableItem.h
@@ -304,7 +304,7 @@ private:
 
     void setSelectedId(std::size_t id) final
     {
-        m_selected_id = 0;
+        m_selected_id = id;
     }
 };
 

--- a/Sofa/framework/Helper/src/sofa/helper/SelectableItem.h
+++ b/Sofa/framework/Helper/src/sofa/helper/SelectableItem.h
@@ -1,0 +1,329 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <ostream>
+#include <string>
+#include <sofa/helper/StringUtils.h>
+#include <sofa/helper/logging/ComponentInfo.h>
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/type/fixed_array.h>
+#include <sofa/core/objectmodel/Data.h>
+#include <sofa/defaulttype/DataTypeInfo.h>
+
+
+namespace sofa::helper
+{
+
+struct Item
+{
+    std::string_view key;
+    std::string_view description;
+};
+
+/**
+ * Type used to define the replacement key of a deprecated key
+ */
+struct DeprecatedItem
+{
+    std::string_view replacementKey;
+    std::string_view deprecationMessage;
+};
+
+
+#define MAKE_SELECTABLE_ITEMS_BEGIN(ClassName, ...) \
+    struct ClassName final : sofa::helper::SelectableItem<ClassName> \
+    { \
+        using sofa::helper::SelectableItem<ClassName>::SelectableItem; \
+        using sofa::helper::SelectableItem<ClassName>::operator=; \
+        using sofa::helper::SelectableItem<ClassName>::operator==; \
+        static constexpr std::array s_items { \
+            __VA_ARGS__ \
+        }; \
+        static_assert(std::is_same_v<decltype(s_items)::value_type, sofa::helper::Item>); \
+
+/**
+ * Helper macro to ease the creation of a class derived from SelectableItem
+ *
+ * @param ClassName Name to give to the class derived from SelectableItem
+ *
+ * Example:
+ * MAKE_SELECTABLE_ITEMS(ResolutionMethod,
+ *      sofa::helper::Item{"ProjectedGaussSeidel", "Projected Gauss-Seidel"},
+ *      sofa::helper::Item{"UnbuiltGaussSeidel", "Gauss-Seidel no matrix assembly"},
+ *      sofa::helper::Item{"NonsmoothNonlinearConjugateGradient", "Non-smooth non-linear conjugate gradient"}
+ *  );
+ */
+#define MAKE_SELECTABLE_ITEMS(ClassName, ...) \
+    MAKE_SELECTABLE_ITEMS_BEGIN(ClassName, __VA_ARGS__) }
+
+/**
+ * Version of the helper macro where a deprecation map is declared. Warning: It is not defined
+ */
+#define MAKE_SELECTABLE_ITEMS_WITH_DEPRECATION(ClassName, ...) \
+    MAKE_SELECTABLE_ITEMS_BEGIN(ClassName, __VA_ARGS__) \
+    static const std::map<std::string_view, sofa::helper::DeprecatedItem> s_deprecationMap; \
+    }
+
+struct BaseSelectableItem
+{
+    [[nodiscard]] virtual std::size_t getNumberOfItems() const { return 0; }
+    [[nodiscard]] virtual const Item* getItemsData() const { return nullptr; }
+    [[nodiscard]] virtual std::size_t getSelectedId() const { return 0; }
+    virtual void setSelectedId(std::size_t id) {}
+    virtual void print(std::ostream& out) const {}
+    virtual void readFromStream(std::istream& stream) {}
+};
+
+inline std::ostream& operator<<(std::ostream& out, const BaseSelectableItem& selectableItem)
+{
+    selectableItem.print(out);
+    return out;
+}
+
+inline std::istream& operator>>(std::istream& in, BaseSelectableItem& selectableItem)
+{
+    selectableItem.readFromStream(in);
+    return in;
+}
+
+template<class Derived, typename IdType>
+class SelectableItem;
+
+namespace logging
+{
+
+template<class Derived, typename IdType>
+bool notMuted(const SelectableItem<Derived, IdType>* );
+
+template<class Derived, typename IdType>
+ComponentInfo::SPtr getComponentInfo(const SelectableItem<Derived, IdType>* );
+
+}
+
+/**
+ * Selection of an item among a fixed list of items.
+ *
+ * The class is designed to have the list of items static, so the class can be
+ * used in a constexpr context. In particular, it can be used in a switch
+ * statement.
+ *
+ * The helper macro @MAKE_SELECTABLE_ITEMS can be used to make the code more concise.
+ *
+ * @tparam Derived The class derived from SelectableItem. The CRTP must be used.
+ * @tparam IdType A type for the indices
+ */
+template<class Derived, typename IdType = std::size_t>
+class SelectableItem : public BaseSelectableItem
+{
+public:
+
+    static constexpr std::size_t numberOfItems()
+    {
+        return std::tuple_size<decltype(Derived::s_items)>{};
+    }
+
+    static constexpr const auto &items()
+    {
+        return Derived::s_items;
+    }
+
+    using id_type = IdType;
+
+    constexpr SelectableItem() = default;
+    constexpr SelectableItem(const std::string_view key) : m_selected_id(findId(key))
+    {
+        if (m_selected_id >= numberOfItems())
+        {
+            keyError(key);
+        }
+    }
+
+    [[nodiscard]] std::string_view key() const
+    {
+        return Derived::s_items[m_selected_id].key;
+    }
+
+    [[nodiscard]] std::string_view description() const
+    {
+        return Derived::s_items[m_selected_id].description;
+    }
+
+    explicit operator std::string_view() const
+    {
+        return key();
+    }
+
+    constexpr operator id_type() const
+    {
+        return m_selected_id;
+    }
+
+    [[nodiscard]] bool operator==(const std::string_view key)
+    {
+        return key == Derived::s_items[m_selected_id].key;
+    }
+
+    [[nodiscard]] bool operator==(const SelectableItem& other) const
+    {
+        return m_selected_id == other.m_selected_id;
+    }
+
+    [[nodiscard]] bool operator!=(const SelectableItem& other) const
+    {
+        return m_selected_id != other.m_selected_id;
+    }
+
+    constexpr SelectableItem& operator=(const std::string_view key)
+    {
+        m_selected_id = findId(key);
+        if (m_selected_id >= numberOfItems())
+        {
+            keyError(key);
+        }
+        return *this;
+    }
+
+    [[nodiscard]] static const std::string& allKeysAsString()
+    {
+        static std::string allKeys = ::sofa::helper::join(Derived::s_items.begin(), Derived::s_items.end(),
+            [](const Item& item){ return item.key;}, ',');
+        return allKeys;
+    }
+
+    static const std::string& dataDescription()
+    {
+        static const std::string dataDescription =
+            sofa::helper::join(Derived::s_items.begin(), Derived::s_items.end(),
+            [](const Item& item)
+            {
+                return "- " + std::string{item.key} + ": " + std::string{item.description};
+            }, '\n');
+        return dataDescription;
+    }
+
+    void print(std::ostream& out) const final
+    {
+        out << key();
+    }
+
+    void readFromStream(std::istream& stream) final
+    {
+        std::string tmp;
+        std::getline(stream, tmp);
+        m_selected_id = findId(tmp);
+        if (m_selected_id >= numberOfItems())
+        {
+            keyError(tmp);
+        }
+    }
+
+protected:
+    id_type m_selected_id {};
+
+    static constexpr id_type findId(const std::string_view key)
+    {
+        return findId_impl(key, std::make_index_sequence<numberOfItems()>{});
+    }
+
+    template<id_type... Is>
+    static constexpr id_type findId_impl(const std::string_view key, std::index_sequence<Is...>)
+    {
+        id_type result = static_cast<id_type>(-1);
+        ((Derived::s_items[Is].key == key ? (result = Is, true) : false) || ...);
+        return result;
+    }
+
+    template <typename, typename = std::void_t<>>
+    struct has_deprecation_map : std::false_type {};
+
+    // Specialization when T has a static member s_foo
+    template <typename T>
+    struct has_deprecation_map<T, std::void_t<decltype(T::s_deprecationMap)>> : std::true_type {};
+
+    void keyError(const std::string_view key)
+    {
+        if constexpr (has_deprecation_map<Derived>::value)
+        {
+            static_assert(std::is_same_v<std::remove_cv_t<decltype(Derived::s_deprecationMap)>, std::map<std::string_view, DeprecatedItem>>);
+            const auto it = Derived::s_deprecationMap.find(key);
+            if (it != Derived::s_deprecationMap.end())
+            {
+                if (it->second.replacementKey == key)
+                {
+                    dmsg_fatal() << "Item '" << key << "' is deprecated, but new key is also '" << it->second.replacementKey << "'.";
+                }
+                else
+                {
+                    msg_warning() << "Item '" << key << "' is deprecated. New key to use instead is '" << it->second.replacementKey << "'. " << it->second.deprecationMessage;
+                    this->operator=(it->second.replacementKey);
+                    return;
+                }
+            }
+        }
+
+        static_assert(numberOfItems() > 0);
+        msg_error() << "Item '" << key << "' does not exist in the list ["
+                << this->allKeysAsString() << "]. Fall back to item '"
+                << items().front().key << "'";
+        m_selected_id = 0;
+    }
+
+private:
+    [[nodiscard]] std::size_t getNumberOfItems() const final
+    {
+        return numberOfItems();
+    }
+
+    [[nodiscard]] const Item* getItemsData() const final
+    {
+        return Derived::s_items.data();
+    }
+
+    [[nodiscard]] std::size_t getSelectedId() const final
+    {
+        return m_selected_id;
+    }
+
+    void setSelectedId(std::size_t id) final
+    {
+        m_selected_id = 0;
+    }
+};
+
+namespace logging
+{
+
+template<class Derived, typename IdType>
+bool notMuted(const SelectableItem<Derived, IdType>* )
+{
+    return true;
+}
+
+template<class Derived, typename IdType>
+ComponentInfo::SPtr getComponentInfo(const SelectableItem<Derived, IdType>* )
+{
+    return std::make_shared<ComponentInfo>("SelectableItem");
+}
+}
+
+}
+

--- a/Sofa/framework/Helper/src/sofa/helper/SelectableItem.h
+++ b/Sofa/framework/Helper/src/sofa/helper/SelectableItem.h
@@ -26,8 +26,7 @@
 #include <sofa/helper/logging/ComponentInfo.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/type/fixed_array.h>
-#include <sofa/core/objectmodel/Data.h>
-#include <sofa/defaulttype/DataTypeInfo.h>
+#include <map>
 
 
 namespace sofa::helper

--- a/Sofa/framework/Helper/test/CMakeLists.txt
+++ b/Sofa/framework/Helper/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCE_FILES
     KdTree_test.cpp
     NameDecoder_test.cpp
     OptionsGroup_test.cpp
+    SelectableItem_test.cpp
     StringUtils_test.cpp
     TagFactory_test.cpp
     Utils_test.cpp

--- a/Sofa/framework/Helper/test/OptionsGroup_test.cpp
+++ b/Sofa/framework/Helper/test/OptionsGroup_test.cpp
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #include <sofa/helper/OptionsGroup.h>
 #include <gtest/gtest.h>
+#include <sofa/defaulttype/typeinfo/DataTypeInfo.h>
+
 
 namespace sofa
 {
@@ -48,6 +50,11 @@ TEST(OptionsGroup, constructors)
     EXPECT_EQ(opt3.getSelectedItem(), "optionB");
     EXPECT_EQ(opt4.getSelectedItem(), "optionA");
     EXPECT_EQ(opt5.getSelectedItem(), "optionB");
+}
+
+TEST(OptionsGroup, DataTypeInfo)
+{
+    EXPECT_EQ(defaulttype::DataTypeInfo<OptionsGroup>::GetTypeName(), "OptionsGroup");
 }
 
 }

--- a/Sofa/framework/Helper/test/SelectableItem_test.cpp
+++ b/Sofa/framework/Helper/test/SelectableItem_test.cpp
@@ -168,7 +168,7 @@ TEST(SelectableItem, data)
 
 TEST(SelectableItem, DataTypeInfo_BaseSelectableItems)
 {
-    EXPECT_EQ(sofa::defaulttype::DataTypeInfo<sofa::helper::BaseSelectableItem>::GetTypeName(), "BaseSelectableItem");
+    EXPECT_EQ(sofa::defaulttype::DataTypeInfo<sofa::helper::BaseSelectableItem>::GetTypeName(), "SelectableItem");
 }
 
 TEST(SelectableItem, DataTypeInfoValidInfo_SelectableItem)

--- a/Sofa/framework/Helper/test/SelectableItem_test.cpp
+++ b/Sofa/framework/Helper/test/SelectableItem_test.cpp
@@ -22,6 +22,7 @@
 #include <sofa/helper/SelectableItem.h>
 #include <gtest/gtest.h>
 #include <sofa/testing/TestMessageHandler.h>
+#include <sofa/core/objectmodel/Data.h>
 
 
 struct TestSelectableItem final : sofa::helper::SelectableItem<TestSelectableItem>

--- a/Sofa/framework/Helper/test/SelectableItem_test.cpp
+++ b/Sofa/framework/Helper/test/SelectableItem_test.cpp
@@ -163,7 +163,7 @@ TEST(SelectableItem, wrong_key)
 TEST(SelectableItem, data)
 {
     const sofa::Data<TestSelectableItem> data;
-    EXPECT_EQ(data.getValueTypeString(), "TestSelectableItem");
+    EXPECT_EQ(data.getValueTypeString(), "SelectableItem");
 }
 
 TEST(SelectableItem, DataTypeInfo_BaseSelectableItems)
@@ -171,9 +171,19 @@ TEST(SelectableItem, DataTypeInfo_BaseSelectableItems)
     EXPECT_EQ(sofa::defaulttype::DataTypeInfo<sofa::helper::BaseSelectableItem>::GetTypeName(), "BaseSelectableItem");
 }
 
+TEST(SelectableItem, DataTypeInfoValidInfo_SelectableItem)
+{
+    EXPECT_TRUE(sofa::defaulttype::DataTypeInfo<TestSelectableItem>::ValidInfo);
+}
+
 TEST(SelectableItem, DataTypeInfo_SelectableItem)
 {
-    EXPECT_EQ(sofa::defaulttype::DataTypeInfo<TestSelectableItem>::GetTypeName(), "TestSelectableItem");
+    EXPECT_EQ(sofa::defaulttype::DataTypeInfo<TestSelectableItem>::GetTypeName(), "SelectableItem");
+}
+
+TEST(SelectableItem, BaseData_typeName)
+{
+    EXPECT_EQ(sofa::core::objectmodel::BaseData::typeName<TestSelectableItem>(), "SelectableItem");
 }
 
 TEST(SelectableItem, dynamic_cast_base)

--- a/Sofa/framework/Helper/test/SelectableItem_test.cpp
+++ b/Sofa/framework/Helper/test/SelectableItem_test.cpp
@@ -1,0 +1,203 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/SelectableItem.h>
+#include <gtest/gtest.h>
+#include <sofa/testing/TestMessageHandler.h>
+
+
+struct TestSelectableItem final : sofa::helper::SelectableItem<TestSelectableItem>
+{
+    using Inherited = sofa::helper::SelectableItem<TestSelectableItem>;
+    using Inherited::SelectableItem;
+    using Inherited::operator=;
+
+    static constexpr std::array s_items {
+        sofa::helper::Item{"small", "small displacements"},
+        sofa::helper::Item{"large", "large displacements"},
+    };
+
+    inline static const std::map<std::string_view, sofa::helper::DeprecatedItem> s_deprecationMap {
+        {"deprecated_key", sofa::helper::DeprecatedItem{"large", "Now use 'large'"}}
+    };
+
+    [[nodiscard]] id_type selectedId() const
+    {
+        return m_selected_id;
+    }
+};
+
+MAKE_SELECTABLE_ITEMS(TestSelectableItemNoDeprecation,
+    sofa::helper::Item{"small", "small displacements"},
+    sofa::helper::Item{"large", "large displacements"});
+
+MAKE_SELECTABLE_ITEMS_WITH_DEPRECATION(TestSelectableItemWithDeprecation,
+    sofa::helper::Item{"small", "small displacements"},
+    sofa::helper::Item{"large", "large displacements"});
+
+const std::map<std::string_view, sofa::helper::DeprecatedItem> TestSelectableItemWithDeprecation::s_deprecationMap{
+    {"deprecated_key", sofa::helper::DeprecatedItem{"large", "Now use 'large'"}}
+};
+
+TEST(SelectableItem, numberOfItems)
+{
+    static constexpr auto size = TestSelectableItem::numberOfItems();
+    EXPECT_EQ(size, 2);
+}
+
+TEST(SelectableItem, allKeysAsString)
+{
+    static const auto& allKeys = TestSelectableItem::allKeysAsString();
+    EXPECT_EQ(allKeys, "small,large");
+}
+
+TEST(SelectableItem, operator_equal_string_view)
+{
+    static constexpr std::string_view key_small = "small";
+
+    TestSelectableItem foo;
+    foo = key_small;
+
+    EXPECT_EQ(foo.selectedId(), 0);
+}
+
+TEST(SelectableItem, operator_equal_string)
+{
+    static std::string key_large = "large";
+
+    TestSelectableItem foo;
+    foo = key_large;
+
+    EXPECT_EQ(foo.selectedId(), 1);
+}
+
+TEST(SelectableItem, description)
+{
+    TestSelectableItem foo;
+    foo = "large";
+
+    EXPECT_EQ(foo.description(), "large displacements");
+}
+
+TEST(SelectableItem, operator_equal_to)
+{
+    TestSelectableItem foo;
+    foo = "large";
+
+    const bool is_equal = (foo == "large");
+    EXPECT_TRUE(is_equal);
+}
+
+TEST(SelectableItem, convertion_string_view)
+{
+    TestSelectableItem foo;
+    foo = "large";
+
+    const auto key = static_cast<std::string_view>(foo);
+    EXPECT_EQ(key, "large");
+}
+
+TEST(SelectableItem, stream_out)
+{
+    TestSelectableItem foo;
+    foo = "large";
+
+    std::stringstream ss;
+    ss << foo;
+
+    EXPECT_EQ(ss.str(), "large");
+}
+
+TEST(SelectableItem, stream_in)
+{
+    TestSelectableItem foo;
+
+    std::istringstream input_stream("large");
+    input_stream >> foo;
+
+    EXPECT_EQ(foo.selectedId(), 1);
+}
+
+TEST(SelectableItem, constexpr_constructor)
+{
+    static constexpr TestSelectableItem foo("large");
+    EXPECT_EQ(foo.selectedId(), 1);
+
+    // static constexpr TestSelectableItem bar("bar"); //does not compile because "bar" does not exist in the list
+}
+
+TEST(SelectableItem, wrong_key)
+{
+    // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+
+    TestSelectableItem foo;
+
+    {
+        EXPECT_MSG_EMIT(Error);
+        foo = "foo";
+    }
+
+    EXPECT_EQ(foo.selectedId(), 0);
+}
+
+TEST(SelectableItem, data)
+{
+    const sofa::Data<TestSelectableItem> data;
+    EXPECT_EQ(data.getValueTypeString(), "TestSelectableItem");
+}
+
+TEST(SelectableItem, DataTypeInfo_BaseSelectableItems)
+{
+    EXPECT_EQ(sofa::defaulttype::DataTypeInfo<sofa::helper::BaseSelectableItem>::GetTypeName(), "BaseSelectableItem");
+}
+
+TEST(SelectableItem, DataTypeInfo_SelectableItem)
+{
+    EXPECT_EQ(sofa::defaulttype::DataTypeInfo<TestSelectableItem>::GetTypeName(), "TestSelectableItem");
+}
+
+TEST(SelectableItem, dynamic_cast_base)
+{
+    TestSelectableItem foo;
+    EXPECT_NE(nullptr, dynamic_cast<sofa::helper::BaseSelectableItem*>(&foo));
+}
+
+template<class T>
+void testDeprecatedKey()
+{
+    // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+
+    T foo;
+
+    EXPECT_MSG_EMIT(Warning);
+    foo = "deprecated_key";
+
+    const auto key = static_cast<std::string_view>(foo);
+    EXPECT_EQ(key, "large");
+}
+
+TEST(SelectableItem, deprecated_key)
+{
+    testDeprecatedKey<TestSelectableItem>();
+    testDeprecatedKey<TestSelectableItemWithDeprecation>();
+}


### PR DESCRIPTION
`SelectableItem` is a new type that can replace `OptionsGroup` in some cases. The idea is the same: a list of keys + a selection of a key among the list. In `OptionsGroup`, everything is dynamic, whereas `SelectableItem` is designed to be static.

Disadvantages of `OptionsGroup`:

```cpp
OptionsGroup foo{{"optionA", "optionB"}};
foo.setSelectedItem(12); //out of bounds
foo.setSelectedItem("optionC"); //this key does not exist

if (foo.getSelectedId() == 0) // 0 has no meaning here. We don't know what 0
    // refers to. In addition, the order of the options can change
{
    
}
```

In `SelectableItem`:

- The list of items is included in the type and cannot change:

```cpp
struct TestSelectableItem final : sofa::helper::SelectableItem<TestSelectableItem>
{
    static constexpr std::array s_items {
        sofa::helper::Item{"small", "small displacements"},
        sofa::helper::Item{"large", "large displacements"},
    };
};
```

The consequences:

- Constant number of items: 

```cpp
static constexpr auto size = TestSelectableItem::numberOfItems();
```

- List of keys is static:

```cpp
static const auto& allKeys = TestSelectableItem::allKeysAsString();
```

- Constructor can be `constexpr`:

```cpp
static constexpr TestSelectableItem foo("large");
```

It allows to use the type in a `constexpr` context. For example:

```cpp
  switch ( d_resolutionMethod.getValue() )
  {
      case ResolutionMethod("ProjectedGaussSeidel"):
      case ResolutionMethod("NonsmoothNonlinearConjugateGradient"):
      {
          buildSystem_matrixAssembly(cParams);
          break;
      }
      case ResolutionMethod("UnbuiltGaussSeidel"):
      {
          buildSystem_matrixFree(numConstraints);
          break;
      }
      default:
          msg_error() << "Wrong \"resolutionMethod\" given";
  }
```

There is compile-time check that any of the `ResolutionMethod("ProjectedGaussSeidel"), ResolutionMethod("NonsmoothNonlinearConjugateGradient"), ResolutionMethod("UnbuiltGaussSeidel")` exist. If it does not exist, it does not compile.

It is preferable to force the `constexpr` context:

```cpp
static constexpr ResolutionMethod NonsmoothNonlinearConjugateGradient("NonsmoothNonlinearConjugateGradient");
if (d_resolutionMethod.getValue() != NonsmoothNonlinearConjugateGradient)
{
```

The compiler may not choose to use `constexpr` in:

```cpp
if (d_resolutionMethod.getValue() != ResolutionMethod("NonsmoothNonlinearConjugateGradient"))
{
```

Therefore, no `constexpr` check if `NonsmoothNonlinearConjugateGradient` is not in the list. There is a runtime check though.

The type allows to deprecate a key if desired (I am thinking about the Data `method` in the FEM force fields).

There is also a description of each key. And the whole list (key + description) can be added easily in the description of the Data, hence in the documentation.

The major problem is about the GUI. More particularly, when a Data is read to be displayed in the GUI. Here, each of the `SelectableItem` is a new strong type. So there is no `DataTypeName`, `DataTypeInfo` etc for the new type. I tried to factorize with a common base class (`BaseSelectableItem`) but without success. I tried to define `DataTypeName`, `DataTypeInfo` etc for `SelectedItem` but without success. The consequence is that I cannot specialize a widget for this type of Data.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
