### PR TITLE
[Core] Test for nullptr in force field creation

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
@@ -191,23 +191,26 @@ public:
     {
         const std::string attributeName {"mstate"};
         std::string mstateLink = arg->getAttribute(attributeName,"");
-        if (mstateLink.empty())
+        if (context)
         {
-            if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr)
+            if (mstateLink.empty())
             {
-                arg->logError("Since the attribute '" + attributeName + "' has not been specified, a mechanical state "
-                    "with the datatype '" + DataTypes::Name() + "' has been searched in the current context, but not found.");
-                return false;
+                if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr)
+                {
+                    arg->logError("Since the attribute '" + attributeName + "' has not been specified, a mechanical state "
+                        "with the datatype '" + DataTypes::Name() + "' has been searched in the current context, but not found.");
+                    return false;
+                }
             }
-        }
-        else
-        {
-            MechanicalState<DataTypes>* mstate = nullptr;
-            context->findLinkDest(mstate, mstateLink, nullptr);
-            if (!mstate)
+            else
             {
-                arg->logError("Data attribute '" + attributeName + "' does not point to a valid mechanical state of datatype '" + std::string(DataTypes::Name()) + "'.");
-                return false;
+                MechanicalState<DataTypes>* mstate = nullptr;
+                context->findLinkDest(mstate, mstateLink, nullptr);
+                if (!mstate)
+                {
+                    arg->logError("Data attribute '" + attributeName + "' does not point to a valid mechanical state of datatype '" + std::string(DataTypes::Name()) + "'.");
+                    return false;
+                }
             }
         }
         return BaseObject::canCreate(obj, context, arg);

--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
@@ -189,31 +189,43 @@ public:
     template<class T>
     static bool canCreate(T*& obj, objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg)
     {
-        const std::string attributeName {"mstate"};
-        std::string mstateLink = arg->getAttribute(attributeName,"");
         if (context)
         {
-            if (mstateLink.empty())
+            if (arg)
             {
-                if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr)
+                static const std::string attributeName {"mstate"};
+                const std::string mstateLink = arg->getAttribute(attributeName,"");
+                if (mstateLink.empty())
                 {
-                    arg->logError("Since the attribute '" + attributeName + "' has not been specified, a mechanical state "
-                        "with the datatype '" + DataTypes::Name() + "' has been searched in the current context, but not found.");
-                    return false;
+                    if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr)
+                    {
+                        arg->logError("Since the attribute '" + attributeName + "' has not been specified, a mechanical state "
+                            "with the datatype '" + DataTypes::Name() + "' has been searched in the current context, but not found.");
+                        return false;
+                    }
+                }
+                else
+                {
+                    MechanicalState<DataTypes>* mstate = nullptr;
+                    context->findLinkDest(mstate, mstateLink, nullptr);
+                    if (!mstate)
+                    {
+                        arg->logError("Data attribute '" + attributeName + "' does not point to a valid mechanical state of datatype '" + std::string(DataTypes::Name()) + "'.");
+                        return false;
+                    }
                 }
             }
             else
             {
-                MechanicalState<DataTypes>* mstate = nullptr;
-                context->findLinkDest(mstate, mstateLink, nullptr);
-                if (!mstate)
+                if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr)
                 {
-                    arg->logError("Data attribute '" + attributeName + "' does not point to a valid mechanical state of datatype '" + std::string(DataTypes::Name()) + "'.");
                     return false;
                 }
             }
+
+            return BaseObject::canCreate(obj, context, arg);
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return false;
     }
 
     template<class T>


### PR DESCRIPTION
It crashed if `context` was `nullptr`.

Not sure what to return if `context` is `nullptr`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
