### PR TITLE
[LinearAlgebra] CompressedRowSparseMatrixConstraint: make consistent the serialization/deserialization process

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.cpp
@@ -130,6 +130,15 @@ Creator<DataWidgetFactory, SimpleDataWidget< Mat<6,6,double> > > DWClass_Mat66d(
 Creator<DataWidgetFactory, SimpleDataWidget< sofa::core::objectmodel::TagSet > > DWClass_TagSet("default",true);
 
 
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<1,float>> > > DWClass_CRSCVec1f("default",true);
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<2,float>> > > DWClass_CRSCVec2f("default",true);
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<3,float>> > > DWClass_CRSCVec3f("default",true);
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<6,float>> > > DWClass_CRSCVec6f("default",true);
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<1,double>> > > DWClass_CRSCVec1d("default",true);
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<2,double>> > > DWClass_CRSCVec2d("default",true);
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<3,double>> > > DWClass_CRSCVec3d("default",true);
+Creator<DataWidgetFactory, SimpleDataWidget< sofa::linearalgebra::CompressedRowSparseMatrixConstraint<Vec<6,double>> > > DWClass_CRSCVec6d("default",true);
+
 ////////////////////////////////////////////////////////////////
 /// OptionsGroup support
 ////////////////////////////////////////////////////////////////

--- a/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.h
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/SimpleDataWidget.h
@@ -27,6 +27,7 @@
 //#include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/type/fixed_array.h>
 #include <sofa/core/topology/Topology.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h>
 #include "WDoubleLineEdit.h"
 #include <climits>
 
@@ -931,6 +932,45 @@ public:
 template<sofa::Size L, sofa::Size C, class T>
 class data_widget_container < sofa::type::Mat<L, C, T> > : public fixed_grid_data_widget_container < sofa::type::Mat<L, C, T> >
 {};
+
+////////////////////////////////////////////////////////////////
+/// sofa::linearalgebra::CompressedRowSparseMatrixConstraint support
+////////////////////////////////////////////////////////////////
+
+template<typename TBlock>
+class data_widget_trait <sofa::linearalgebra::CompressedRowSparseMatrixConstraint<TBlock>>
+{
+public:
+    typedef sofa::linearalgebra::CompressedRowSparseMatrixConstraint<TBlock> data_type;
+    typedef QLineEdit Widget;
+    static Widget* create(QWidget* parent, const data_type& /*d*/)
+    {
+        Widget* w = new Widget(parent);
+        w->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        return w;
+    }
+    static void readFromData(Widget* w, const data_type& d)
+    {
+        std::ostringstream oss;
+        d.prettyPrint(oss);
+        w->setText(QString(oss.str().c_str()));
+    }
+    static void writeToData(Widget* /* w */, const data_type& /* d */)
+    {
+        // not supported by this type
+        // TODO: CompressedRowSparseMatrixConstraint needs a parser for its pretty output
+    }
+    static void setReadOnly(Widget* w, bool readOnly)
+    {
+        w->setEnabled(!readOnly);
+        w->setReadOnly(readOnly);
+    }
+    static void connectChanged(Widget* w, DataWidget* datawidget)
+    {
+        datawidget->connect(w, SIGNAL( textChanged(const QString&) ), datawidget, SLOT(setWidgetDirty()) );
+    }
+    
+};
 
 ////////////////////////////////////////////////////////////////
 /// OptionsGroup support

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
@@ -685,7 +685,7 @@ public:
     }
     
     /// write into output stream (default is standard output)
-    void prettyPrint(std::ostream& out = std::cout)
+    void prettyPrint(std::ostream& out = std::cout) const
     {
         for (RowConstIterator rowIt = this->begin(); rowIt !=  this->end(); ++rowIt)
         {

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
@@ -683,6 +683,35 @@ public:
 
         return in;
     }
+    
+    /// write into output stream (default is standard output)
+    void prettyPrint(std::ostream& out = std::cout)
+    {
+        for (RowConstIterator rowIt = this->begin(); rowIt !=  this->end(); ++rowIt)
+        {
+            out << "Constraint ID : ";
+            out << rowIt.index();
+            const auto colToString = [](const ColConstIterator& colIt)
+            {
+                std::stringstream ss;
+                ss << "dof ID : " << colIt.index() << "  value : " << colIt.val();
+                return ss.str();
+            };
+
+            ColConstIterator colIt = rowIt.begin();
+            const ColConstIterator colItEnd = rowIt.end();
+            if (colIt != colItEnd)
+            {
+                out << "  " << colToString(colIt++);
+                while(colIt != colItEnd)
+                {
+                    out << "  " << colToString(colIt++);
+                }
+            }
+
+            out << "\n";
+        }
+    }
 
     static const char* Name()
     {

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
@@ -677,7 +677,7 @@ public:
             currentNbLines++;
         }
 
-        assert(nbLines != currentNbLines);
+        assert(nbLines == currentNbLines);
 
         sc.compress();
 

--- a/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrixConstraint_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrixConstraint_test.cpp
@@ -2172,4 +2172,23 @@ R"(4 0 2 1 0 0.360985 0 12 0.926981 0 0 2 1 9 0.451858 0 0 3 1 6 0.777417 0 0 4 
     EXPECT_EQ(ss.str(), expectedOutput);
 }
 
+TEST(CompressedRowSparseMatrixConstraint, prettyPrint)
+{
+    sofa::linearalgebra::CompressedRowSparseMatrixConstraint<sofa::type::Vec3> A;
+
+    generateMatrix(A, 5, 15, 0.1, 7);
+
+    static const std::string expectedOutput =
+R"(Constraint ID : 0  dof ID : 1  value : 0 0.360985 0  dof ID : 12  value : 0.926981 0 0
+Constraint ID : 2  dof ID : 9  value : 0.451858 0 0
+Constraint ID : 3  dof ID : 6  value : 0.777417 0 0
+Constraint ID : 4  dof ID : 5  value : 0 0 0.474108  dof ID : 7  value : 0 0.983937 0  dof ID : 9  value : 0.238781 0 0
+)";
+    
+    std::ostringstream oss;
+    A.prettyPrint(oss);
+
+    EXPECT_EQ(oss.str(), expectedOutput);
+}
+
 } // namespace sofa

--- a/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrixConstraint_test.cpp
+++ b/Sofa/framework/LinearAlgebra/test/CompressedRowSparseMatrixConstraint_test.cpp
@@ -281,6 +281,51 @@ TYPED_TEST(SparseMatrixTest, CheckThatTheSizeOfASparseMatrixIsOneAfterTryingToWr
     EXPECT_EQ(1u, matrix.size());
 }
 
+
+//////////////////////////////////////////////////
+TYPED_TEST(SparseMatrixTest, CheckOutInSerialization)
+{
+    typedef TypeParam Matrix;
+    Matrix outMatrix;
+    auto lineIndices = TestHelpers::Populate(outMatrix, 3u, 3u);
+    EXPECT_EQ(3u, outMatrix.size());
+
+    std::ostringstream oss;
+    oss << outMatrix;
+
+    Matrix inMatrix;
+    std::istringstream iss(oss.str());
+    iss >> inMatrix;
+
+    EXPECT_TRUE(!lineIndices.empty());
+
+    for (const auto& lineIndex : lineIndices)
+    {
+        auto inRowIt = inMatrix.readLine(lineIndex);
+        auto outRowIt = outMatrix.readLine(lineIndex);
+
+        EXPECT_TRUE(inRowIt == outRowIt);
+
+        if (inRowIt != inMatrix.end() && outRowIt != outMatrix.end())
+        {
+            auto inColItEnd = inRowIt.end();
+            auto outColItEnd = outRowIt.end();
+
+            auto inColIt = inRowIt.begin();
+            auto outColIt = outRowIt.begin();
+
+            for (; 
+                inColIt != inColItEnd && outColIt != outColItEnd;
+                ++inColIt, ++outColIt)
+            {
+                EXPECT_TRUE(inColIt.index() == outColIt.index());
+                EXPECT_TRUE(inColIt.val() == outColIt.val());
+            }
+        }
+    }
+
+}
+
 //////////////////////////////////////////////////
 TYPED_TEST(SparseMatrixTest, CheckThatAMatrixIsConsideredEmptyAfterIsHasBeenCleared)
 {
@@ -2122,11 +2167,7 @@ TEST(CompressedRowSparseMatrixConstraint, ostream)
     ss << A;
 
     static const std::string expectedOutput =
-R"(Constraint ID : 0  dof ID : 1  value : 0 0.360985 0  dof ID : 12  value : 0.926981 0 0
-Constraint ID : 2  dof ID : 9  value : 0.451858 0 0
-Constraint ID : 3  dof ID : 6  value : 0.777417 0 0
-Constraint ID : 4  dof ID : 5  value : 0 0 0.474108  dof ID : 7  value : 0 0.983937 0  dof ID : 9  value : 0.238781 0 0
-)";
+R"(4 0 2 1 0 0.360985 0 12 0.926981 0 0 2 1 9 0.451858 0 0 3 1 6 0.777417 0 0 4 3 5 0 0 0.474108 7 0 0.983937 0 9 0.238781 0 0 )";
 
     EXPECT_EQ(ss.str(), expectedOutput);
 }


### PR DESCRIPTION
For now, the serialization of a CSR cannot be used a deserialization as the format are different.
In a nutshell, it is not possible to do:
```
    std::ostringstream oss;
    oss << outMatrix;

    CSR inMatrix;
    std::istringstream iss(oss.str());
    iss >> inMatrix;
```

So this PR tries to fix it by changing the output format of the serialization.
\+ more concise (faster to serialize, less space)
\- much less human-readable

Other/complimentary solutions:
\- adding a nice printing (same as the deserialization now)
\- dont change the serialization but the deserialization

EDIT:
- restoration of the pretty output in a function (`prettyPrint()`)
- use this print in a specialization for its Qt Widget (so no change of behavior with the Qt GUI)
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
