### PR TITLE
[Mapping] Implement tetrahedral-topological changes in SubsetTopologicalMapping

### DIFF
--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/SubsetTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/SubsetTopologicalMapping.cpp
@@ -420,7 +420,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
     EdgeSetTopologyModifier *toEdgeMod = nullptr;
     TriangleSetTopologyModifier *toTriangleMod = nullptr;
     //QuadSetTopologyModifier *toQuadMod = nullptr;
-    //TetrahedronSetTopologyModifier *toTetrahedronMod = nullptr;
+    TetrahedronSetTopologyModifier *toTetrahedronMod = nullptr;
     //HexahedronSetTopologyModifier *toHexahedronMod = nullptr;
 
     toModel->getContext()->get(toPointMod);
@@ -936,6 +936,106 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                         --last;
                     }
                     tD2S.resize( tD2S.size() - tab2.size() );
+                }
+            }
+            break;
+        }
+
+        case core::topology::TETRAHEDRAADDED:
+        {
+        }
+
+        case core::topology::TETRAHEDRAREMOVED:
+        {
+            if (!d_handleTetrahedra.getValue()) break;
+            if (!toTetrahedronMod) toModel->getContext()->get(toTetrahedronMod);
+            if (!toTetrahedronMod) break;
+
+            // tRem is a pointer to the tetra elements that should be removed
+            // this change comes from the topology container in the source topology.
+            // So here, we have to update our data that maps between source and destination
+            // tD2S and tS2D, and also update the topology container of this model (the destination)
+            const TetrahedraRemoved *tRem = static_cast< const TetrahedraRemoved * >( topoChange );
+
+            // each tetra is an integer that specifies it's index in the source topology
+            sofa::type::vector<Index> tetra_array_buffer_source = tRem->getArray();
+
+            // we want to remove the elements in both source and destination
+            sofa::type::vector<Index> tetra_array_buffer_destination;
+            tetra_array_buffer_destination.reserve(tetra_array_buffer_source.size());
+
+            // for each tetra that should be removed, look up the correct tetra in the destination topology
+            for (auto &tetra_source : tetra_array_buffer_source)
+            {
+                Index tetra_destination = tS2D[tetra_source];
+                if (tetra_destination == sofa::InvalidID)
+                    continue;
+                tetra_array_buffer_destination.push_back(tetra_destination);
+            }
+
+            msg_info() << "[" << count << "]TETRAHEDRAREMOVED : "
+                << tetra_array_buffer_source.size() << " -> "
+                << tetra_array_buffer_destination.size() << " : "
+                << tetra_array_buffer_source << " -> "
+                << tetra_array_buffer_destination;
+
+            // remove the tetra in the tS2D data (the mapping from source to destination topology)
+            // removal is done by looking up the tetra that should be removed,
+            // replacing the tetra with the tetra that is the last one in the data,
+            // and finally resizing the data so that the last tetra is dropped.
+            // So essentially placing the last tetra in the data to overwrite the tetra that should
+            // be removed from the data.
+            {
+                Index last_index =tS2D.size() -1;
+                for (auto &tetra_source : tetra_array_buffer_source)
+                {
+                    Index tetra_destination = tS2D[tetra_source];
+
+                    // we set the source tetra to invalid in the destination to source mapping,
+                    // because we now remove it.
+                    if (tetra_destination != sofa::InvalidID)
+                        tD2S[tetra_destination] = sofa::InvalidID;
+
+                    // get the tetra of the destination topology, that corresponds to the last tetra
+                    // in the source topology
+                    Index new_tetra_destination = tS2D[last_index];
+
+                    // replace the destination tetra at the position where we remove a tetra
+                    // in the source topology
+                    tS2D[tetra_source] = new_tetra_destination;
+
+                    // if that destination tetra is valid, and correctly maps back to the last
+                    // tetra in the source topology, update the mapping from destination to source.
+                    if (new_tetra_destination != sofa::InvalidID && tD2S[new_tetra_destination] == last_index)
+                        tD2S[new_tetra_destination] = tetra_source;
+                    --last_index;
+                }
+                tS2D.resize(tS2D.size() - tetra_array_buffer_source.size() );
+            }
+
+            // the same for the D2S data, but also update the topology container of this model
+            if (!tetra_array_buffer_destination.empty())
+            {
+                toTetrahedronMod->removeTetrahedra(tetra_array_buffer_destination, false);
+                {
+                    Index last_index = tD2S.size() -1;
+
+                    for (auto &tetra_destination : tetra_array_buffer_destination)
+                    {
+                        Index tetra_source = tD2S[tetra_destination];
+
+                        // now as a sanity check, we check that the source tetra is INVALID, because
+                        // we set it to invalid when we updated the tS2D data
+                        if (tetra_source != sofa::InvalidID)
+                                msg_error() << "Invalid Tetra Remove";
+
+                        Index new_tetra_source = tD2S[last_index];
+                        tD2S[tetra_destination] = new_tetra_source;
+                        if (new_tetra_source != sofa::InvalidID && tS2D[new_tetra_source] == last_index)
+                            tS2D[new_tetra_source] = tetra_destination;
+                        --last_index;
+                    }
+                    tD2S.resize(tD2S.size() - tetra_array_buffer_destination.size());
                 }
             }
             break;

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/SubsetTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/SubsetTopologicalMapping.cpp
@@ -951,14 +951,14 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             if (!toTetrahedronMod) toModel->getContext()->get(toTetrahedronMod);
             if (!toTetrahedronMod) break;
 
-            // tRem is a pointer to the tetra elements that should be removed
+            // teRem is a pointer to the tetra elements that should be removed
             // this change comes from the topology container in the source topology.
             // So here, we have to update our data that maps between source and destination
-            // tD2S and tS2D, and also update the topology container of this model (the destination)
-            const TetrahedraRemoved *tRem = static_cast< const TetrahedraRemoved * >( topoChange );
+            // teD2S and teS2D, and also update the topology container of this model (the destination)
+            const TetrahedraRemoved *teRem = static_cast< const TetrahedraRemoved * >( topoChange );
 
             // each tetra is an integer that specifies it's index in the source topology
-            sofa::type::vector<Index> tetra_array_buffer_source = tRem->getArray();
+            sofa::type::vector<Index> tetra_array_buffer_source = teRem->getArray();
 
             // we want to remove the elements in both source and destination
             sofa::type::vector<Index> tetra_array_buffer_destination;
@@ -967,7 +967,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             // for each tetra that should be removed, look up the correct tetra in the destination topology
             for (auto &tetra_source : tetra_array_buffer_source)
             {
-                Index tetra_destination = tS2D[tetra_source];
+                Index tetra_destination = teS2D[tetra_source];
                 if (tetra_destination == sofa::InvalidID)
                     continue;
                 tetra_array_buffer_destination.push_back(tetra_destination);
@@ -986,31 +986,31 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             // So essentially placing the last tetra in the data to overwrite the tetra that should
             // be removed from the data.
             {
-                Index last_index =tS2D.size() -1;
+                Index last_index = teS2D.size() -1;
                 for (auto &tetra_source : tetra_array_buffer_source)
                 {
-                    Index tetra_destination = tS2D[tetra_source];
+                    Index tetra_destination = teS2D[tetra_source];
 
                     // we set the source tetra to invalid in the destination to source mapping,
                     // because we now remove it.
                     if (tetra_destination != sofa::InvalidID)
-                        tD2S[tetra_destination] = sofa::InvalidID;
+                        teD2S[tetra_destination] = sofa::InvalidID;
 
                     // get the tetra of the destination topology, that corresponds to the last tetra
                     // in the source topology
-                    Index new_tetra_destination = tS2D[last_index];
+                    Index new_tetra_destination = teS2D[last_index];
 
                     // replace the destination tetra at the position where we remove a tetra
                     // in the source topology
-                    tS2D[tetra_source] = new_tetra_destination;
+                    teS2D[tetra_source] = new_tetra_destination;
 
                     // if that destination tetra is valid, and correctly maps back to the last
                     // tetra in the source topology, update the mapping from destination to source.
-                    if (new_tetra_destination != sofa::InvalidID && tD2S[new_tetra_destination] == last_index)
-                        tD2S[new_tetra_destination] = tetra_source;
+                    if (new_tetra_destination != sofa::InvalidID && teD2S[new_tetra_destination] == last_index)
+                        teD2S[new_tetra_destination] = tetra_source;
                     --last_index;
                 }
-                tS2D.resize(tS2D.size() - tetra_array_buffer_source.size() );
+                teS2D.resize(teS2D.size() - tetra_array_buffer_source.size());
             }
 
             // the same for the D2S data, but also update the topology container of this model
@@ -1018,24 +1018,24 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             {
                 toTetrahedronMod->removeTetrahedra(tetra_array_buffer_destination, false);
                 {
-                    Index last_index = tD2S.size() -1;
+                    Index last_index = teD2S.size() -1;
 
                     for (auto &tetra_destination : tetra_array_buffer_destination)
                     {
-                        Index tetra_source = tD2S[tetra_destination];
+                        Index tetra_source = teD2S[tetra_destination];
 
                         // now as a sanity check, we check that the source tetra is INVALID, because
-                        // we set it to invalid when we updated the tS2D data
+                        // we set it to invalid when we updated the teS2D data
                         if (tetra_source != sofa::InvalidID)
                                 msg_error() << "Invalid Tetra Remove";
 
-                        Index new_tetra_source = tD2S[last_index];
-                        tD2S[tetra_destination] = new_tetra_source;
-                        if (new_tetra_source != sofa::InvalidID && tS2D[new_tetra_source] == last_index)
-                            tS2D[new_tetra_source] = tetra_destination;
+                        Index new_tetra_source = teD2S[last_index];
+                        teD2S[tetra_destination] = new_tetra_source;
+                        if (new_tetra_source != sofa::InvalidID && teS2D[new_tetra_source] == last_index)
+                            teS2D[new_tetra_source] = tetra_destination;
                         --last_index;
                     }
-                    tD2S.resize(tD2S.size() - tetra_array_buffer_destination.size());
+                    teD2S.resize(teD2S.size() - tetra_array_buffer_destination.size());
                 }
             }
             break;


### PR DESCRIPTION
Bonjour,
I am currently adding TETRA topology changes in SubsetTopologicalMapping.

This first commit is just a WIP commit for the REMOVE case to get your feedback.
If the style and content is ok, I will also implement the ADD case.
In particular, I am unsure about the line
`toTetrahedronMod->removeTetrahedra(tetra_array_buffer_destination, false);`
The `removeTriangle` distinguishes between different topology types of isolated items, while `removeTetrahedra` does not.
Should this thus just set to be false?

I also think that the naive implementation of following the TRIANGLESREMOVED is invalid.
```
[ERROR]   [SubsetTopologicalMapping(SubsetTopologicalMapping)] Invalid d_triangleS2D size : 13943 != 13944
[ERROR]   [SubsetTopologicalMapping(SubsetTopologicalMapping)] Invalid d_triangleS2D size : 13942 != 13944
[ERROR]   [SubsetTopologicalMapping(SubsetTopologicalMapping)] Invalid d_tetrahedronS2D size : 6315 != 6314
[ERROR]   [SubsetTopologicalMapping(SubsetTopologicalMapping)] Invalid d_triangleS2D size : 13942 != 13943
[ERROR]   [SubsetTopologicalMapping(SubsetTopologicalMapping)] Invalid d_tetrahedronS2D size : 6315 != 6314
[ERROR]   [SubsetTopologicalMapping(SubsetTopologicalMapping)] Invalid d_triangleS2D size : 13942 != 13943
[ERROR]   [SubsetTopologicalMapping(SubsetTopologicalMapping)] Invalid d_tetrahedronS2D size : 6315 != 6314
```


Cheers,
Paul