### PR TITLE
[GL.Component] Fix min max computation in DataDisplay

### DIFF
--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
@@ -56,8 +56,8 @@ DataDisplay::DataDisplay()
     , state(nullptr)
     , m_topology(nullptr)
     , l_topology(initLink("topology", "link to the topology container"))
-    , oldMin(std::numeric_limits<Real>::max())
-    , oldMax(std::numeric_limits<Real>::lowest())
+    , m_oldMin(std::numeric_limits<Real>::max())
+    , m_oldMax(std::numeric_limits<Real>::lowest())
 {
     this->addAlias(&f_triangleData,"cellData"); // backward compatibility
     d_currentMin.setReadOnly(true);
@@ -211,12 +211,12 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
     }
 
 
-    if (max > oldMax) oldMax = max;
-    if (min < oldMin) oldMin = min;
+    if (max > m_oldMax) m_oldMax = max;
+    if (min < m_oldMin) m_oldMin = min;
 
     if (f_maximalRange.getValue()) {
-        max = oldMax;
-        min = oldMin;
+        max = m_oldMax;
+        min = m_oldMin;
     }
     d_currentMin.setValue(min);
     d_currentMax.setValue(max);

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.cpp
@@ -56,8 +56,8 @@ DataDisplay::DataDisplay()
     , state(nullptr)
     , m_topology(nullptr)
     , l_topology(initLink("topology", "link to the topology container"))
-    , oldMin(0)
-    , oldMax(0)
+    , oldMin(std::numeric_limits<Real>::max())
+    , oldMax(std::numeric_limits<Real>::lowest())
 {
     this->addAlias(&f_triangleData,"cellData"); // backward compatibility
     d_currentMin.setReadOnly(true);
@@ -141,9 +141,8 @@ void DataDisplay::doDrawVisual(const core::visual::VisualParams* vparams)
     }
 
     // Range for points
-    Real min ;
-    Real max ;
-    min = max = 0;
+    Real min = std::numeric_limits<Real>::max();
+    Real max = std::numeric_limits<Real>::lowest();
     if (bDrawPointData) {
         VecPointData::const_iterator i = ptData.begin();
         min = *i;

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/DataDisplay.h
@@ -66,8 +66,6 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink <DataDisplay, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
-    Real oldMin, oldMax;
-
     void init() override;
     void doDrawVisual(const core::visual::VisualParams* vparams) override;
     void doUpdateVisual(const core::visual::VisualParams* vparams) override;
@@ -80,6 +78,9 @@ protected:
     type::vector<type::Vec3f> m_normals;
 
     DataDisplay();
+
+    Real m_oldMin, m_oldMax;
+
 };
 
 } // namespace sofa::gl::component::rendering3d


### PR DESCRIPTION
Only positive values would keep `min` to 0, so it needs to be set to the highest possible value.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
