### PR TITLE
[Core] Modern visitor creation

### DIFF
--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerExplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerExplicitSolver.cpp
@@ -85,7 +85,9 @@ void EulerExplicitSolver::solve(const core::ExecParams* params,
     computeForce(&mop, f);
 
     sofa::Size nbNonDiagonalMasses = 0;
-    MechanicalGetNonDiagonalMassesCountVisitor(&mop.mparams, &nbNonDiagonalMasses).execute(this->getContext());
+    this->getContext()->accept(
+        sofa::core::objectmodel::topDownVisitor
+        | [&nbNonDiagonalMasses](sofa::core::behavior::BaseMass* mass){nbNonDiagonalMasses++;});
 
     // Mass matrix is diagonal, solution can thus be found by computing acc = f/m
     if(nbNonDiagonalMasses == 0.)

--- a/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerExplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Forward/src/sofa/component/odesolver/forward/EulerExplicitSolver.cpp
@@ -24,6 +24,7 @@
 #include <sofa/simulation/MechanicalOperations.h>
 #include <sofa/simulation/VectorOperations.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/BaseMass.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
@@ -87,10 +88,16 @@ void EulerExplicitSolver::solve(const core::ExecParams* params,
     sofa::Size nbNonDiagonalMasses = 0;
     this->getContext()->accept(
         sofa::core::objectmodel::topDownVisitor
-        | [&nbNonDiagonalMasses](sofa::core::behavior::BaseMass* mass){nbNonDiagonalMasses++;});
+        | [&nbNonDiagonalMasses](sofa::core::behavior::BaseMass* mass)
+        {
+            if (mass && !mass->isDiagonal())
+            {
+                nbNonDiagonalMasses++;
+            }
+        });
 
     // Mass matrix is diagonal, solution can thus be found by computing acc = f/m
-    if(nbNonDiagonalMasses == 0.)
+    if(nbNonDiagonalMasses == 0)
     {
         // acc = M^-1 * f
         computeAcceleration(&mop, acc, f);

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -170,6 +170,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/objectmodel/TagSet.h
     ${SRC_ROOT}/objectmodel/vectorData.h
     ${SRC_ROOT}/objectmodel/vectorLinks.h
+    ${SRC_ROOT}/objectmodel/VisitorDirection.h
     ${SRC_ROOT}/topology/BaseMeshTopology.h
     ${SRC_ROOT}/topology/BaseTopology.h
     ${SRC_ROOT}/topology/BaseTopologyData.h

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
@@ -26,6 +26,7 @@
 #include <sofa/core/objectmodel/ClassInfo.h>
 #include <sofa/core/objectmodel/TypeOfInsertion.h>
 #include <sofa/core/ComponentNameHelper.h>
+#include <sofa/core/objectmodel/VisitorDirection.h>
 
 namespace sofa::simulation
 {
@@ -386,6 +387,10 @@ public:
 
     /// Propagate an event
     virtual void propagateEvent( const core::ExecParams* params, Event* );
+
+    virtual void accept(const TopDownVisitor& visitor) {}
+    virtual void accept(const BottomUpVisitor& visitor) {}
+    virtual void accept(const TopDownVisitor& topDownVisitor, const BottomUpVisitor& bottomUpVisitor) {}
 
     /// @}
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
@@ -388,9 +388,9 @@ public:
     /// Propagate an event
     virtual void propagateEvent( const core::ExecParams* params, Event* );
 
-    virtual void accept(const TopDownVisitor& visitor) {}
-    virtual void accept(const BottomUpVisitor& visitor) {}
-    virtual void accept(const TopDownVisitor& topDownVisitor, const BottomUpVisitor& bottomUpVisitor) {}
+    virtual void accept(const TopDownVisitor&) {}
+    virtual void accept(const BottomUpVisitor&) {}
+    virtual void accept(const TopDownVisitor&, const BottomUpVisitor&) {}
 
     /// @}
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/VisitorDirection.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/VisitorDirection.h
@@ -35,11 +35,20 @@ struct DirectionalVisitor
     virtual void operator()(sofa::core::behavior::BaseMechanicalState*) const {}
     virtual void operator()(sofa::core::behavior::BaseMass*) const {}
     virtual void operator()(sofa::core::behavior::BaseForceField*) const {}
-    virtual void operator()(sofa::core::behavior::BaseInteractionForceField*) const {}
+    virtual void operator()(sofa::core::behavior::BaseInteractionForceField* force) const
+    {
+        this->operator()((behavior::BaseForceField*)force);
+    }
     virtual void operator()(sofa::core::behavior::BaseProjectiveConstraintSet*) const {}
     virtual void operator()(sofa::core::behavior::BaseConstraintSet*) const {}
-    virtual void operator()(sofa::core::behavior::BaseInteractionProjectiveConstraintSet*) const {}
-    virtual void operator()(sofa::core::behavior::BaseInteractionConstraint*) const {}
+    virtual void operator()(sofa::core::behavior::BaseInteractionProjectiveConstraintSet* constraint) const
+    {
+        this->operator()((behavior::BaseProjectiveConstraintSet*)constraint);
+    }
+    virtual void operator()(sofa::core::behavior::BaseInteractionConstraint* constraint) const
+    {
+        this->operator()((behavior::BaseConstraintSet*)constraint);
+    }
 };
 
 struct SOFA_CORE_API TopDownVisitor : DirectionalVisitor

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/VisitorDirection.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/VisitorDirection.h
@@ -61,8 +61,8 @@ struct SpecializedVisitor : public virtual VisitorDirection
 {
     Func m_specializedFunction;
 
-    SpecializedVisitor(const VisitorDirection& visitor, const Func& massFunction)
-        : VisitorDirection(visitor), m_specializedFunction(massFunction) {}
+    SpecializedVisitor(const VisitorDirection& visitor, const Func& specializedFunction)
+        : VisitorDirection(visitor), m_specializedFunction(specializedFunction) {}
 
     void operator()(VisitedObject* object) const override
     {

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/VisitorDirection.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/VisitorDirection.h
@@ -1,0 +1,95 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/core/config.h>
+
+namespace sofa::core::objectmodel
+{
+
+struct DirectionalVisitor
+{
+    virtual ~DirectionalVisitor() = default;
+    DirectionalVisitor() = default;
+    virtual void operator()(sofa::core::behavior::OdeSolver*) const {}
+    virtual void operator()(sofa::core::behavior::ConstraintSolver*) const {}
+    virtual void operator()(sofa::core::BaseMapping*) const {}
+    virtual void operator()(sofa::core::behavior::BaseMechanicalState*) const {}
+    virtual void operator()(sofa::core::behavior::BaseMass*) const {}
+    virtual void operator()(sofa::core::behavior::BaseForceField*) const {}
+    virtual void operator()(sofa::core::behavior::BaseInteractionForceField*) const {}
+    virtual void operator()(sofa::core::behavior::BaseProjectiveConstraintSet*) const {}
+    virtual void operator()(sofa::core::behavior::BaseConstraintSet*) const {}
+    virtual void operator()(sofa::core::behavior::BaseInteractionProjectiveConstraintSet*) const {}
+    virtual void operator()(sofa::core::behavior::BaseInteractionConstraint*) const {}
+};
+
+struct SOFA_CORE_API TopDownVisitor : DirectionalVisitor
+{
+    TopDownVisitor() = default;
+};
+struct SOFA_CORE_API BottomUpVisitor : DirectionalVisitor
+{
+    BottomUpVisitor() = default;
+};
+
+inline TopDownVisitor topDownVisitor {};
+inline BottomUpVisitor bottomUpVisitor {};
+
+
+template<class VisitorDirection, class Func, class VisitedObject,
+    typename = std::enable_if_t<std::is_invocable_v<Func, VisitedObject*>>>
+struct SpecializedVisitor : public virtual VisitorDirection
+{
+    Func m_specializedFunction;
+
+    SpecializedVisitor(const VisitorDirection& visitor, const Func& massFunction)
+        : VisitorDirection(visitor), m_specializedFunction(massFunction) {}
+
+    void operator()(VisitedObject* object) const override
+    {
+        m_specializedFunction(object);
+    }
+};
+
+#define DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(ObjectType) \
+template<class VisitorDirection, class Func, \
+    typename = std::enable_if_t<std::is_invocable_v<Func, ObjectType*>>> \
+SpecializedVisitor<VisitorDirection, Func, ObjectType> operator|( \
+    const VisitorDirection& input, \
+    const Func& f) \
+{ \
+    return {input, f}; \
+}
+
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::OdeSolver)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::ConstraintSolver)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::BaseMapping)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseMechanicalState)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseMass)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseForceField)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseInteractionForceField)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseProjectiveConstraintSet)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseConstraintSet)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseInteractionProjectiveConstraintSet)
+DEFINE_PIPE_OPERATOR_FOR_OBJECT_TYPE(sofa::core::behavior::BaseInteractionConstraint)
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -912,24 +912,29 @@ void Node::visitLocalNode(const sofa::core::objectmodel::DirectionalVisitor& vis
         {
             if (obj)
             {
-                (visitor)(obj);
+                visitor(obj);
             }
         }
     };
 
     visitContainer(solver);
-    visitContainer(constraintSolver);
-    visitContainer(mapping);
+
+    if (mechanicalMapping)
+    {
+        visitor(mechanicalMapping.get());
+    }
 
     if (mechanicalState)
     {
-        (visitor)(mechanicalState.get());
-    }
-    if (mass)
-    {
-        (visitor)(mass.get());
+        visitor(mechanicalState.get());
     }
 
+    if (mass)
+    {
+        visitor(mass.get());
+    }
+
+    visitContainer(constraintSolver);
     visitContainer(forceField);
     visitContainer(interactionForceField);
     visitContainer(projectiveConstraintSet);
@@ -954,7 +959,33 @@ void Node::accept(const sofa::core::objectmodel::TopDownVisitor& visitor)
 void Node::accept(const sofa::core::objectmodel::BottomUpVisitor& visitor)
 {
     visitChildren(*this, visitor);
-    visitLocalNode(visitor);
+
+    const auto visitContainer = [&visitor](auto& container)
+    {
+        for (auto& obj : container)
+        {
+            if (obj)
+            {
+                visitor(obj);
+            }
+        }
+    };
+
+    visitContainer(projectiveConstraintSet);
+    visitContainer(constraintSet);
+    visitContainer(constraintSolver);
+
+    if (mechanicalState)
+    {
+        visitor(mechanicalState.get());
+    }
+
+    if (mechanicalMapping)
+    {
+        visitor(mechanicalMapping.get());
+    }
+
+    visitContainer(solver);
 }
 
 void Node::accept(const sofa::core::objectmodel::TopDownVisitor& topDownVisitor,

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -218,6 +218,10 @@ public:
     /// Possible optimization with traversal precomputation, not mandatory and does nothing by default
     virtual void precomputeTraversalOrder( const sofa::core::ExecParams* ) {}
 
+    void accept(const sofa::core::objectmodel::TopDownVisitor& visitor) override;
+    void accept(const sofa::core::objectmodel::BottomUpVisitor& visitor) override;
+    void accept(const sofa::core::objectmodel::TopDownVisitor& topDownVisitor, const sofa::core::objectmodel::BottomUpVisitor& bottomUpVisitor) override;
+
     /// @}
 
     template<class A, bool B=false>
@@ -553,6 +557,8 @@ private:
 
     virtual void notifyEndAddSlave(sofa::core::objectmodel::BaseObject* master, sofa::core::objectmodel::BaseObject* slave) const;
     virtual void notifyEndRemoveSlave(sofa::core::objectmodel::BaseObject* master, sofa::core::objectmodel::BaseObject* slave) const;
+
+    void visitLocalNode(const sofa::core::objectmodel::DirectionalVisitor& visitor);
 
 
 protected:

--- a/Sofa/framework/Simulation/Graph/test/Node_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Node_test.cpp
@@ -255,17 +255,17 @@ TEST(NodeVisitor_test, OneMassInChildCounterBothDirectionsVisitor)
 {
     const Node::SPtr root = sofa::simpleapi::createNode("root");
     const Node::SPtr child = sofa::simpleapi::createChild(root, "child");
-    const auto mass = core::objectmodel::New<component::mass::UniformMass<defaulttype::Vec3Types>>();
-    child->addObject(mass);
+    const auto state = core::objectmodel::New<component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+    child->addObject(state);
 
-    ASSERT_TRUE(child->mass.get() != nullptr);
+    ASSERT_TRUE(child->mechanicalState.get() != nullptr);
 
     std::size_t counter {};
     root->accept(
         sofa::core::objectmodel::topDownVisitor
-        | [&counter](core::behavior::BaseMass*){ counter++; },
+        | [&counter](core::behavior::BaseMechanicalState*){ counter++; },
         sofa::core::objectmodel::bottomUpVisitor
-        | [&counter](core::behavior::BaseMass*){ counter -= 2; });
+        | [&counter](core::behavior::BaseMechanicalState*){ counter -= 2; });
 
     EXPECT_EQ(-1, counter);
 }


### PR DESCRIPTION
This PR makes several suggestions, and should not be considered as is for a merge. A choice on the implementations must be made compared to https://github.com/sofa-framework/sofa/pull/5154.

- Implementation of the true visitor pattern (`void accept(TopDownVisitor& visitor)`) https://refactoring.guru/design-patterns/visitor/cpp/example. It is a new implementation of the visitors, independent from the old visitors.
- Modern and flexible creation of new visitor at the call site using composable callables with the pipe operator. Some old visitors can be replaced by the new mechanism, and the class can be removed.
- Some examples of use, and unit tests.

Example of the new visitors:
```cpp
ctx->accept(objectmodel::topDownVisitor
    | [this, &df](core::behavior::BaseForceField* force)
    {
        force->addMBKdx(&mparams, df);
    },
    
    objectmodel::bottomUpVisitor
    | [this, &df, accumulate](core::BaseMapping* mapping)
    {
        if (accumulate)
        {
            mapping->applyJT(&mparams, df, df);
            if( mparams.kFactor() != 0_sreal )
            {
                mapping->applyDJT(&mparams, df, df);
            }
        }
    });
```

Pros:
- The pipe operator is consistant with the design of the STL range library. 
- No more back-and-forth between the call site and the visitor file. The intention can be read clearly at the call site.
- Dozens of visitor files can be removed
- The new visitor mechanism is much clearer and closer to the visitor design pattern.

Cons:
- A bit of template meta-programming
- Some ugly macros
- The call-stack is a much clearer with the new visitors but still difficult for a novice
- More code at the call site (but it's so much clearer so it's not a con😄 )

TODO with the new visitors:

- [ ] Fix ambiguity between `BaseForceField` and `BaseInteractionForceField`
- [ ] More tests. In particular, with diamond scene graph or multiple parents
- [ ] Consistency with `BaseMechanicalVisitor` and old visitors
- [ ] Support detection of mapped states
- [ ] constexprify the visitors

The question is: which implementation of the visitors do we keep?


Future work: Implement this kind of "visitor" for the mapping graph



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
