### PR TITLE
[Helper] PluginManager: support loading from Non-MSVC Multi-Configuration Build

### DIFF
--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -266,12 +266,14 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${di
 set(is_release "$<CONFIG:RELEASE>")
 set(is_debug "$<CONFIG:DEBUG>")
 set(is_relwithdebinfo "$<CONFIG:RELWITHDEBINFO>")
+set(is_minsizerel "$<CONFIG:MINSIZEREL>")
 # set the type of build as preprocessor value
 target_compile_definitions(${PROJECT_NAME} PRIVATE "$<${is_release}:SOFA_BUILD_CONFIGURATION=Release>")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "$<${is_debug}:SOFA_BUILD_CONFIGURATION=Debug>")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "$<${is_relwithdebinfo}:SOFA_BUILD_CONFIGURATION=RelWithDebInfo>")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "$<${is_minsizerel}:SOFA_BUILD_CONFIGURATION=MinSizeRel>")
 ## if the type of build is something else (not supported), then SOFA_BUILD_CONFIGURATION wont be defined
-# it is also useful to know if we are using a multi-config generator
+# it could be also useful to know if we are using a multi-config generator
 if(CMAKE_CONFIGURATION_TYPES)
     target_compile_definitions(${PROJECT_NAME} PRIVATE "SOFA_BUILD_MULTI_CONFIGURATION=1")
 else()

--- a/Sofa/framework/Helper/CMakeLists.txt
+++ b/Sofa/framework/Helper/CMakeLists.txt
@@ -263,6 +263,21 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${ST
 # DiffLib (header only)
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${difflib_INCLUDE_DIR}>")
 
+set(is_release "$<CONFIG:RELEASE>")
+set(is_debug "$<CONFIG:DEBUG>")
+set(is_relwithdebinfo "$<CONFIG:RELWITHDEBINFO>")
+# set the type of build as preprocessor value
+target_compile_definitions(${PROJECT_NAME} PRIVATE "$<${is_release}:SOFA_BUILD_CONFIGURATION=Release>")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "$<${is_debug}:SOFA_BUILD_CONFIGURATION=Debug>")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "$<${is_relwithdebinfo}:SOFA_BUILD_CONFIGURATION=RelWithDebInfo>")
+## if the type of build is something else (not supported), then SOFA_BUILD_CONFIGURATION wont be defined
+# it is also useful to know if we are using a multi-config generator
+if(CMAKE_CONFIGURATION_TYPES)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "SOFA_BUILD_MULTI_CONFIGURATION=1")
+else()
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "SOFA_BUILD_MULTI_CONFIGURATION=0")
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 sofa_create_package_with_targets(

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
@@ -86,7 +86,6 @@ FileRepository PluginRepository(
     {
         Utils::getSofaPathTo("bin"),
         Utils::getSofaPathTo("plugins"),
-        Utils::getSofaPathTo("collections"),
         Utils::getExecutableDirectory(),
     }
 );
@@ -94,9 +93,8 @@ FileRepository PluginRepository(
 FileRepository PluginRepository(
     "SOFA_PLUGIN_PATH",
     {
-        Utils::getSofaPathTo("plugins"),
-        Utils::getSofaPathTo("collections"),
         Utils::getSofaPathTo("lib"),
+        Utils::getSofaPathTo("plugins"),
     }
 );
 #endif

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -43,55 +43,13 @@ using sofa::helper::system::FileSystem;
 #ifdef SOFA_BUILD_CONFIGURATION
 constexpr std::string_view SOFA_BUILD_CONFIGURATION_STR = sofa_tostring(SOFA_BUILD_CONFIGURATION);
 #else
-constexpr string_view SOFA_BUILD_CONFIGURATION_STR = "NONE";
-#endif
-#ifdef SOFA_BUILD_MULTI_CONFIGURATION
-constexpr std::string_view SOFA_BUILD_MULTI_CONFIGURATION_STR = sofa_tostring(SOFA_BUILD_MULTI_CONFIGURATION);
-#else
-constexpr string_view SOFA_BUILD_MULTI_CONFIGURATION_STR = "0";
+constexpr std::string_view SOFA_BUILD_CONFIGURATION_STR = "NONE";
 #endif
 
-enum class SofaBuildConfiguration
+constexpr std::string_view GetSofaBuildConfigurationString()
 {
-    Release,
-    RelWithDebInfo,
-    Debug,
-    MinSizeRel,
-    NonStandard
-};
-
-constexpr SofaBuildConfiguration getSofaBuildConfiguration()
-{
-    if constexpr (SOFA_BUILD_CONFIGURATION_STR == "Release")
-    {
-        return SofaBuildConfiguration::Release;
-    }
-    if constexpr (SOFA_BUILD_CONFIGURATION_STR == "RelWithDebInfo")
-    {
-        return SofaBuildConfiguration::RelWithDebInfo;
-    }
-    if constexpr (SOFA_BUILD_CONFIGURATION_STR == "Debug")
-    {
-        return SofaBuildConfiguration::Debug;
-    }
-    if constexpr (SOFA_BUILD_CONFIGURATION_STR == "MinSizeRel")
-    {
-        return SofaBuildConfiguration::MinSizeRel;
-    }
-
-    return SofaBuildConfiguration::NonStandard;
+    return SOFA_BUILD_CONFIGURATION_STR;
 }
-
-constexpr bool getSofaMultiConfiguration()
-{
-    if constexpr (SOFA_BUILD_MULTI_CONFIGURATION_STR == "1")
-    {
-        return true;
-    }
-
-    return false;
-}
-
 
 namespace sofa::helper::system
 {
@@ -533,7 +491,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
             const std::array paths =
             {
                 dir, // Non-Multi-Config build, install
-                FileSystem::append(dir, SOFA_BUILD_CONFIGURATION_STR) // Multi-Config build
+                FileSystem::append(dir, GetSofaBuildConfigurationString()) // Multi-Config build
             };
                 
             for (const auto & path : paths)

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -538,13 +538,16 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
                 
             for (const auto & path : paths)
             {
-                for (auto const& dirEntry : std::filesystem::directory_iterator{path})
+                if ( fs::exists(path) )
                 {
-                    const std::string filename = dirEntry.path().filename().string();
-                    const std::string downcaseFilename = helper::downcaseString(filename);
-                    if (downcaseFilename == downcaseLibName)
+                    for (auto const& dirEntry : std::filesystem::directory_iterator{path})
                     {
-                        return FileSystem::cleanPath(dirEntry.path().string());
+                        const std::string filename = dirEntry.path().filename().string();
+                        const std::string downcaseFilename = helper::downcaseString(filename);
+                        if (downcaseFilename == downcaseLibName)
+                        {
+                            return FileSystem::cleanPath(dirEntry.path().string());
+                        }
                     }
                 }
             }

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -525,7 +525,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
         
         for (const auto & dir : searchPaths)
         {
-            const std::array<std::string, 4> paths =
+            const std::array paths =
             {
                 dir, // Non-Multi-Config build, install
                 FileSystem::append(dir, SOFA_BUILD_CONFIGURATION_STR) // Multi-Config build

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -56,6 +56,7 @@ enum class SofaBuildConfiguration
     Release,
     RelWithDebInfo,
     Debug,
+    MinSizeRel,
     NonStandard
 };
 
@@ -72,6 +73,10 @@ constexpr SofaBuildConfiguration getSofaBuildConfiguration()
     if constexpr (SOFA_BUILD_CONFIGURATION_STR == "Debug")
     {
         return SofaBuildConfiguration::Debug;
+    }
+    if constexpr (SOFA_BUILD_CONFIGURATION_STR == "MinSizeRel")
+    {
+        return SofaBuildConfiguration::MinSizeRel;
     }
 
     return SofaBuildConfiguration::NonStandard;


### PR DESCRIPTION
My case is XCode on macOS but it should be the same problem with ninja multiconfig and other multiconfig generators.

If you compile in Release and in RelWithDebInfo, PluginManager will load the first one it can find recursively from the lib/ directory. So it can try to load Release-compiled plugins while being in RelWithDebInfo (and vice-versa)

This PR adds preprocessor definitions to the builds, and the config is known at compile-time.
For the moment, I just did it in PluginManager and the definitions are not propagated to the other dependencies as I think it may not be a good idea (is it ?).

The only other place I see it can be useful would be for SofaPython3, as the site-packages also uses the split multiconfig directories for its modules. (indeed it is not possible to load SofaPython3 scenes with XCode as it is more or less the same problem)

and I think the file organization in lib, bin, sites-packages, install should be revised...

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
