### PR TITLE
[CollisionOBBCapsule] Fix Capsule destructor

### DIFF
--- a/applications/plugins/CollisionOBBCapsule/CollisionOBBCapsule_test/CMakeLists.txt
+++ b/applications/plugins/CollisionOBBCapsule/CollisionOBBCapsule_test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADER_FILES
 )
 
 set(SOURCE_FILES
+    CapsuleModel_test.cpp
     OBB_test.cpp
 )
 

--- a/applications/plugins/CollisionOBBCapsule/CollisionOBBCapsule_test/CapsuleModel_test.cpp
+++ b/applications/plugins/CollisionOBBCapsule/CollisionOBBCapsule_test/CapsuleModel_test.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -19,24 +19,15 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_COMPONENT_COLLISION_CAPSULECOLLISIONMODEL_CPP
-#include <CollisionOBBCapsule/geometry/CapsuleModel.inl>
+#include <gtest/gtest.h>
+#include <CollisionOBBCapsule/geometry/CapsuleModel.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace collisionobbcapsule::geometry
+TEST(CapsuleModel, creationFromFactory)
 {
+    const auto entry = sofa::core::ObjectFactory::getInstance()->getEntry("CapsuleCollisionModel");
+    const auto creatorRigid = entry.creatorMap.at("Rigid3d");
 
-using namespace sofa::defaulttype;
-
-int CapsuleCollisionModelClass = core::RegisterObject("Collision model which represents a set of Capsules")
-    .add< CapsuleCollisionModel<sofa::defaulttype::Vec3Types> >()
-    .add< CapsuleCollisionModel<sofa::defaulttype::Rigid3Types> >()
-        ;
-
-template class COLLISIONOBBCAPSULE_API TCapsule<defaulttype::Vec3Types>;
-template class COLLISIONOBBCAPSULE_API CapsuleCollisionModel<defaulttype::Vec3Types>;
-
-template class COLLISIONOBBCAPSULE_API TCapsule<defaulttype::Rigid3Types>;
-template class COLLISIONOBBCAPSULE_API CapsuleCollisionModel<defaulttype::Rigid3Types>;
-
-} // namespace collisionobbcapsule::geometry
+    sofa::core::objectmodel::BaseObjectDescription desc;
+    const auto object = creatorRigid->createInstance(nullptr, &desc);
+}

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.h
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.h
@@ -103,6 +103,8 @@ protected:
 
     CapsuleCollisionModel();
     CapsuleCollisionModel(core::behavior::MechanicalState<TDataTypes>* mstate );
+
+    ~CapsuleCollisionModel() override;
 public:
     void init() override;
 
@@ -153,11 +155,14 @@ public:
     template<class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
     {
-        if (dynamic_cast<core::behavior::MechanicalState<TDataTypes>*>(context->getMechanicalState()) == nullptr && context->getMechanicalState() != nullptr)
+        if (context)
         {
-            arg->logError(std::string("No mechanical state with the datatype '") + DataTypes::Name() +
-                          "' found in the context node.");
-            return false;
+            if (dynamic_cast<core::behavior::MechanicalState<TDataTypes>*>(context->getMechanicalState()) == nullptr && context->getMechanicalState() != nullptr)
+            {
+                arg->logError(std::string("No mechanical state with the datatype '") + DataTypes::Name() +
+                              "' found in the context node.");
+                return false;
+            }
         }
 
         return BaseObject::canCreate(obj, context, arg);

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.inl
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.inl
@@ -47,6 +47,10 @@ CapsuleCollisionModel<DataTypes>::CapsuleCollisionModel(core::behavior::Mechanic
     enum_type = CAPSULE_TYPE;
 }
 
+template <class TDataTypes>
+CapsuleCollisionModel<TDataTypes>::~CapsuleCollisionModel()
+{}
+
 template<class DataTypes>
 void CapsuleCollisionModel<DataTypes>::resize(sofa::Size size)
 {


### PR DESCRIPTION
The test introduced in this PR was crashing because of the absence of destructor in `CapsuleCollisionModel`.

I also added the template `Rigid`  in the factory. It was compiled, but not registered.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
