### PR TITLE
[Core] Isolate the intrusive reference counting

### DIFF
--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/ExecParams.h
     ${SRC_ROOT}/fwd.h
     ${SRC_ROOT}/init.h
+    ${SRC_ROOT}/IntrusiveObject.h
     ${SRC_ROOT}/Mapping.h
     ${SRC_ROOT}/Mapping.inl
     ${SRC_ROOT}/MappingHelper.h
@@ -217,6 +218,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/DataTrackerCallback.cpp
     ${SRC_ROOT}/DataTrackerFunctor.cpp
     ${SRC_ROOT}/ExecParams.cpp
+    ${SRC_ROOT}/IntrusiveObject.cpp
     ${SRC_ROOT}/fwd.cpp
     ${SRC_ROOT}/init.cpp
     ${SRC_ROOT}/Mapping.cpp

--- a/Sofa/framework/Core/src/sofa/core/IntrusiveObject.cpp
+++ b/Sofa/framework/Core/src/sofa/core/IntrusiveObject.cpp
@@ -1,0 +1,38 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/IntrusiveObject.h>
+
+namespace sofa::core
+{
+void IntrusiveObject::addRef()
+{
+    ++ref_counter;
+}
+
+void IntrusiveObject::release()
+{
+    if (ref_counter.fetch_sub(1) == 1)
+    {
+        delete this;
+    }
+}
+}

--- a/Sofa/framework/Core/src/sofa/core/IntrusiveObject.h
+++ b/Sofa/framework/Core/src/sofa/core/IntrusiveObject.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/core/config.h>
+#include <atomic>
+
+namespace sofa::core
+{
+
+/**
+ * The `IntrusiveObject` class implements an internal reference counting mechanism
+ * to manage its lifetime. It is intended to work with intrusive smart pointers like
+ * `boost::intrusive_ptr`.
+ */
+class SOFA_CORE_API IntrusiveObject
+{
+    std::atomic<int> ref_counter { 0 };
+
+    void addRef();
+    void release();
+
+    friend inline void intrusive_ptr_add_ref(IntrusiveObject* p)
+    {
+        p->addRef();
+    }
+
+    friend inline void intrusive_ptr_release(IntrusiveObject* p)
+    {
+        p->release();
+    }
+};
+
+}

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
@@ -51,8 +51,7 @@ using std::string;
 static const std::string unnamed_label=std::string("unnamed");
 
 Base::Base()
-    : ref_counter(0)
-    , name(initData(&name,unnamed_label,"name","object name"))
+    : name(initData(&name,unnamed_label,"name","object name"))
     , f_printLog(initData(&f_printLog, false, "printLog", "if true, emits extra messages at runtime."))
     , f_tags(initData( &f_tags, "tags", "list of the subsets the object belongs to"))
     , f_bbox(initData( &f_bbox, "bbox", "this object bounding box"))
@@ -78,18 +77,6 @@ Base::~Base()
 {
 }
 
-void Base::addRef()
-{
-    ++ref_counter;
-}
-
-void Base::release()
-{
-    if (ref_counter.fetch_sub(1) == 1)
-    {
-        delete this;
-    }
-}
 
 
 void Base::addUpdateCallback(const std::string& name,

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -33,11 +33,11 @@
 #include <sofa/core/sptr.h>
 
 #include <deque>
-#include <atomic>
 
 #include <sofa/core/objectmodel/ComponentState.h>
 #include <sofa/core/DataTracker.h>
 #include <sofa/core/DataTrackerCallback.h>
+#include <sofa/core/IntrusiveObject.h>
 #include <sofa/type/fwd.h>
 
 #define SOFA_BASE_CAST_IMPLEMENTATION(CLASSNAME) \
@@ -55,7 +55,7 @@ namespace sofa::core::objectmodel
  *  All classes deriving from Base should use the SOFA_CLASS macro within their declaration (see BaseClass.h).
  *
  */
-class SOFA_CORE_API Base
+class SOFA_CORE_API Base : public IntrusiveObject
 {
 public:
     typedef Base* Ptr;
@@ -85,20 +85,6 @@ private:
     /// Copy constructor is not allowed
     Base(const Base& b);
     Base& operator=(const Base& b);
-
-    std::atomic<int> ref_counter;
-    void addRef();
-    void release();
-
-    friend inline void intrusive_ptr_add_ref(Base* p)
-    {
-        p->addRef();
-    }
-
-    friend inline void intrusive_ptr_release(Base* p)
-    {
-        p->release();
-    }
 
 protected:
     std::map<std::string, sofa::core::DataTrackerCallback> m_internalEngine;


### PR DESCRIPTION
I think it clarifies the distinction between what a `Base` is and the memory management.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
