### PR TITLE
[All] Fix visualisation

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.cpp
@@ -62,13 +62,13 @@ VisualStyle::VisualStyle()
     displayFlags.setOriginalData(&d_displayFlags);
 }
 
-void VisualStyle::fwdDraw(VisualParams* vparams)
+void VisualStyle::updateVisualFlags(VisualParams* vparams)
 {
     backupFlags = vparams->displayFlags();
     vparams->displayFlags() = sofa::core::visual::merge_displayFlags(backupFlags, d_displayFlags.getValue());
 }
 
-void VisualStyle::bwdDraw(VisualParams* vparams)
+void VisualStyle::applyBackupFlags(VisualParams* vparams)
 {
     vparams->displayFlags() = backupFlags;
 }

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.cpp
@@ -73,6 +73,19 @@ void VisualStyle::bwdDraw(VisualParams* vparams)
     vparams->displayFlags() = backupFlags;
 }
 
+
+bool VisualStyle::insertInNode( sofa::core::objectmodel::BaseNode* node )
+{
+    node->addVisualStyle(this);
+    return true;
+}
+
+bool VisualStyle::removeInNode( sofa::core::objectmodel::BaseNode* node )
+{
+    node->removeVisualStyle(this);
+    return true;
+}
+
 helper::WriteAccessor<sofa::core::visual::DisplayFlags> addVisualStyle( simulation::Node::SPtr node )
 {
     const VisualStyle::SPtr visualStyle = New<sofa::component::visual::VisualStyle>();

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.h
@@ -68,8 +68,8 @@ public:
 protected:
     VisualStyle();
 public:
-    void fwdDraw(VisualParams* ) override;
-    void bwdDraw(VisualParams* ) override;
+    void updateVisualFlags(VisualParams* ) override;
+    void applyBackupFlags(VisualParams* ) override;
 
     bool insertInNode( sofa::core::objectmodel::BaseNode* node );
     bool removeInNode( sofa::core::objectmodel::BaseNode* node );

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.h
@@ -61,7 +61,7 @@ namespace sofa::component::visual
 class SOFA_COMPONENT_VISUAL_API VisualStyle : public sofa::core::visual::BaseVisualStyle
 {
 public:
-    SOFA_CLASS(VisualStyle,sofa::core::visual::VisualModel);
+    SOFA_CLASS(VisualStyle,sofa::core::visual::BaseVisualStyle);
 
     typedef sofa::core::visual::VisualParams VisualParams;
     typedef sofa::core::visual::DisplayFlags DisplayFlags;

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualStyle.h
@@ -21,8 +21,10 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/component/visual/config.h>
+#include <sofa/simulation/Node.h>
 
 #include <sofa/core/visual/VisualModel.h>
+#include <sofa/core/visual/BaseVisualStyle.h>
 #include <sofa/core/visual/Data[DisplayFlags].h>
 #include <sofa/simulation/fwd.h>
 
@@ -56,7 +58,7 @@ namespace sofa::component::visual
 *   showNormals hideNormals
 *   showWireframe hideWireframe
 */
-class SOFA_COMPONENT_VISUAL_API VisualStyle : public sofa::core::visual::VisualModel
+class SOFA_COMPONENT_VISUAL_API VisualStyle : public sofa::core::visual::BaseVisualStyle
 {
 public:
     SOFA_CLASS(VisualStyle,sofa::core::visual::VisualModel);
@@ -68,6 +70,9 @@ protected:
 public:
     void fwdDraw(VisualParams* ) override;
     void bwdDraw(VisualParams* ) override;
+
+    bool insertInNode( sofa::core::objectmodel::BaseNode* node );
+    bool removeInNode( sofa::core::objectmodel::BaseNode* node );
 
     SOFA_ATTRIBUTE_DEPRECATED__RENAME_DATA_IN_VISUAL()
     sofa::core::objectmodel::RenamedData<DisplayFlags> displayFlags;

--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -187,6 +187,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/topology/TopologySubsetData.cpp
     ${SRC_ROOT}/topology/TopologySubsetIndices.h
     ${SRC_ROOT}/trait/DataTypes.h
+    ${SRC_ROOT}/visual/BaseVisualStyle.h
     ${SRC_ROOT}/visual/Data[DisplayFlags].h
     ${SRC_ROOT}/visual/DisplayFlags.h
     ${SRC_ROOT}/visual/FlagTreeItem.h

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.h
@@ -23,6 +23,7 @@
 
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/objectmodel/TypeOfInsertion.h>
+#include <sofa/core/visual/BaseVisualStyle.h>
 
 namespace sofa::core::objectmodel
 {
@@ -172,6 +173,7 @@ public:
      BASENODE_ADD_SPECIAL_COMPONENT( core::objectmodel::ConfigurationSetting, ConfigurationSetting, configurationSetting )
      BASENODE_ADD_SPECIAL_COMPONENT( core::visual::Shader, Shader, shaders )
      BASENODE_ADD_SPECIAL_COMPONENT( core::visual::VisualModel, VisualModel, visualModel )
+     BASENODE_ADD_SPECIAL_COMPONENT( core::visual::BaseVisualStyle, VisualStyle, visualStyle )
      BASENODE_ADD_SPECIAL_COMPONENT( core::visual::VisualManager, VisualManager, visualManager )
      BASENODE_ADD_SPECIAL_COMPONENT( core::CollisionModel, CollisionModel, collisionModel )
      BASENODE_ADD_SPECIAL_COMPONENT( core::collision::Pipeline, CollisionPipeline, collisionPipeline )

--- a/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/core/fwd.h>
+#include <sofa/core/visual/VisualModel.h>
+#include <string>
+#include <iostream>
+
+
+namespace sofa::core::visual
+{
+
+/**
+ * Write the graph, starting from a root Node, into a std::ostream.
+ * The format is the DOT language from Graphviz (https://graphviz.org/)
+ */
+class SOFA_CORE_API BaseVisualStyle : public sofa::core::visual::VisualModel
+{
+public:
+    SOFA_CLASS(BaseVisualStyle,sofa::core::visual::VisualModel);
+
+    typedef sofa::core::visual::VisualParams VisualParams;
+    typedef sofa::core::visual::DisplayFlags DisplayFlags;
+
+protected:
+    BaseVisualStyle() { }
+    ~BaseVisualStyle() override { }
+
+public:
+    virtual void fwdDraw(VisualParams* ) { };
+
+};
+
+} // namespace sofa::simulation::graph
+

--- a/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
@@ -33,10 +33,10 @@ namespace sofa::core::visual
  * Write the graph, starting from a root Node, into a std::ostream.
  * The format is the DOT language from Graphviz (https://graphviz.org/)
  */
-class SOFA_CORE_API BaseVisualStyle : public sofa::core::visual::VisualModel
+class SOFA_CORE_API BaseVisualStyle : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(BaseVisualStyle,sofa::core::visual::VisualModel);
+    SOFA_CLASS(BaseVisualStyle,sofa::core::objectmodel::BaseObject);
 
     typedef sofa::core::visual::VisualParams VisualParams;
     typedef sofa::core::visual::DisplayFlags DisplayFlags;
@@ -47,6 +47,7 @@ protected:
 
 public:
     virtual void fwdDraw(VisualParams* ) { };
+    virtual void bwdDraw(VisualParams* ) { };
 
 };
 

--- a/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
@@ -29,10 +29,6 @@
 namespace sofa::core::visual
 {
 
-/**
- * Write the graph, starting from a root Node, into a std::ostream.
- * The format is the DOT language from Graphviz (https://graphviz.org/)
- */
 class SOFA_CORE_API BaseVisualStyle : public sofa::core::objectmodel::BaseObject
 {
 public:

--- a/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/BaseVisualStyle.h
@@ -46,8 +46,8 @@ protected:
     ~BaseVisualStyle() override { }
 
 public:
-    virtual void fwdDraw(VisualParams* ) { };
-    virtual void bwdDraw(VisualParams* ) { };
+    virtual void updateVisualFlags(VisualParams* ) { };
+    virtual void applyBackupFlags(VisualParams* ) { };
 
 };
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -94,6 +94,7 @@ Node::Node(const std::string& name)
     , configurationSetting(initLink("configurationSetting", "The ConfigurationSetting(s) attached to this node"))
     , shaders(initLink("shaders", "The shaders attached to this node"))
     , visualModel(initLink("visualModel", "The VisualModel(s) attached to this node"))
+    , visualStyle(initLink("visualStyle", "The VisualStyle(s) attached to this node"))
     , visualManager(initLink("visualManager", "The VisualManager(s) attached to this node"))
     , collisionModel(initLink("collisionModel", "The CollisionModel(s) attached to this node"))
     , unsorted(initLink("unsorted", "The remaining objects attached to this node"))
@@ -930,6 +931,7 @@ void Node::printComponents()
     using core::objectmodel::ContextObject;
     using core::collision::Pipeline;
     using core::BaseState;
+    using core::visual::BaseVisualStyle;
 
     std::stringstream sstream;
 
@@ -986,6 +988,9 @@ void Node::printComponents()
         sstream << (*i)->getName() << " ";
     sstream << "\n" << "VisualModel: ";
     for (NodeSequence<VisualModel>::iterator i = visualModel.begin(), iend = visualModel.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "BaseVisualStyle: ";
+    for (NodeSingle<BaseVisualStyle>::iterator i = visualStyle.begin(), iend = visualStyle.end(); i != iend; ++i)
         sstream << (*i)->getName() << " ";
     sstream << "\n" << "CollisionModel: ";
     for (NodeSequence<CollisionModel>::iterator i = collisionModel.begin(), iend = collisionModel.end(); i != iend; ++i)
@@ -1045,6 +1050,7 @@ NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::objectmodel::ContextObject, ContextOb
 NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::objectmodel::ConfigurationSetting, ConfigurationSetting, configurationSetting )
 NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::visual::Shader, Shader, shaders )
 NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::visual::VisualModel, VisualModel, visualModel )
+NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::visual::BaseVisualStyle, VisualStyle, visualStyle )
 NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::visual::VisualManager, VisualManager, visualManager )
 NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::CollisionModel, CollisionModel, collisionModel )
 NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::collision::Pipeline, CollisionPipeline, collisionPipeline )
@@ -1071,6 +1077,7 @@ template class NodeSequence<sofa::core::objectmodel::BaseObject>;
 
 template class NodeSingle<sofa::core::behavior::BaseAnimationLoop>;
 template class NodeSingle<sofa::core::visual::VisualLoop>;
+template class NodeSingle<sofa::core::visual::BaseVisualStyle>;
 template class NodeSingle<sofa::core::topology::Topology>;
 template class NodeSingle<sofa::core::topology::BaseMeshTopology>;
 template class NodeSingle<sofa::core::BaseState>;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -127,6 +127,7 @@ extern template class NodeSequence<sofa::core::objectmodel::BaseObject>;
 
 extern template class NodeSingle<sofa::core::behavior::BaseAnimationLoop>;
 extern template class NodeSingle<sofa::core::visual::VisualLoop>;
+extern template class NodeSingle<sofa::core::visual::BaseVisualStyle>;
 extern template class NodeSingle<sofa::core::topology::Topology>;
 extern template class NodeSingle<sofa::core::topology::BaseMeshTopology>;
 extern template class NodeSingle<sofa::core::BaseState>;
@@ -255,6 +256,7 @@ public:
 
     NodeSingle<sofa::core::behavior::BaseAnimationLoop> animationManager;
     NodeSingle<sofa::core::visual::VisualLoop> visualLoop;
+    NodeSingle<sofa::core::visual::BaseVisualStyle> visualStyle;
     NodeSingle<sofa::core::topology::Topology> topology;
     NodeSingle<sofa::core::topology::BaseMeshTopology> meshTopology;
     NodeSingle<sofa::core::BaseState> state;
@@ -599,6 +601,7 @@ public:
     NODE_DECLARE_SEQUENCE_ACCESSOR( sofa::core::objectmodel::ConfigurationSetting, ConfigurationSetting, configurationSetting )
     NODE_DECLARE_SEQUENCE_ACCESSOR( sofa::core::visual::Shader, Shader, shaders )
     NODE_DECLARE_SEQUENCE_ACCESSOR( sofa::core::visual::VisualModel, VisualModel, visualModel )
+    NODE_DECLARE_SEQUENCE_ACCESSOR( sofa::core::visual::BaseVisualStyle, VisualStyle, visualStyle )
     NODE_DECLARE_SEQUENCE_ACCESSOR( sofa::core::visual::VisualManager, VisualManager, visualManager )
     NODE_DECLARE_SEQUENCE_ACCESSOR( sofa::core::CollisionModel, CollisionModel, collisionModel )
     NODE_DECLARE_SEQUENCE_ACCESSOR( sofa::core::collision::Pipeline, CollisionPipeline, collisionPipeline )

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
@@ -234,9 +234,6 @@ void updateVisual(Node* root)
 
     sofa::core::visual::VisualParams* vparams = sofa::core::visual::visualparams::defaultInstance();
 
-    VisualStyleVisitor act(vparams);
-    root->execute(act);
-
     if (sofa::core::visual::VisualLoop* vloop = root->getVisualLoop())
     {
         vloop->updateStep(vparams);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
@@ -230,8 +230,12 @@ void animate(Node* root, SReal dt)
 void updateVisual(Node* root)
 {
     SCOPED_TIMER("Simulation::updateVisual");
-    
+
+
     sofa::core::visual::VisualParams* vparams = sofa::core::visual::visualparams::defaultInstance();
+
+    VisualStyleVisitor act(vparams);
+    root->execute(act);
 
     if (sofa::core::visual::VisualLoop* vloop = root->getVisualLoop())
     {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
@@ -46,14 +46,28 @@ Visitor::Result VisualVisitor::processNodeTopDown(simulation::Node* node)
 }
 
 
+
+Visitor::Result VisualStyleVisitor::processNodeTopDown(simulation::Node* node)
+{
+    for_each(this, node, node->visualStyle, &VisualStyleVisitor::processVisualStyle);
+    return RESULT_CONTINUE;
+}
+
+
+void VisualStyleVisitor::processVisualStyle(simulation::Node* /*node*/, sofa::core::visual::BaseVisualStyle* o)
+{
+    o-> fwdDraw(vparams);
+}
+
+
 Visitor::Result VisualDrawVisitor::processNodeTopDown(simulation::Node* node)
 {
-
     // NB: hasShader is only used when there are visual models and getShader does a graph search when there is no shader,
     // which will most probably be the case when there are no visual models, so we skip the search unless we have visual models.
     hasShader = !node->visualModel.empty() && (node->getShader()!=nullptr);
 
     for_each(this, node, node->visualModel,     &VisualDrawVisitor::fwdVisualModel);
+
     this->VisualVisitor::processNodeTopDown(node);
 
     return RESULT_CONTINUE;
@@ -149,9 +163,20 @@ void VisualDrawVisitor::processVisualModel(simulation::Node* node, core::visual:
 
 Visitor::Result VisualUpdateVisitor::processNodeTopDown(simulation::Node* node)
 {
-    for_each(this, node, node->visualModel,              &VisualUpdateVisitor::processVisualModel);
+//    for_each(this, node, node->visualModel,     &VisualUpdateVisitor::fwdVisualModel);
+    for_each(this, node, node->visualModel,     &VisualUpdateVisitor::processVisualModel);
 
     return RESULT_CONTINUE;
+}
+
+
+void VisualUpdateVisitor::fwdVisualModel(simulation::Node* /*node*/, core::visual::VisualModel* vm)
+{
+    msg_info_when(DO_DEBUG_DRAW, vm) << " entering VisualVisitor::fwdVisualModel()" ;
+
+    vm->fwdDraw(vparams);
+
+    msg_info_when(DO_DEBUG_DRAW, vm) << " leaving VisualVisitor::fwdVisualModel()" ;
 }
 
 void VisualUpdateVisitor::processVisualModel(simulation::Node*, core::visual::VisualModel* vm)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.cpp
@@ -48,13 +48,13 @@ Visitor::Result VisualVisitor::processNodeTopDown(simulation::Node* node)
 
 void VisualVisitor::fwdProcessVisualStyle(simulation::Node* node, core::visual::BaseVisualStyle* vm)
 {
-    vm-> fwdDraw(vparams);
+    vm-> updateVisualFlags(vparams);
 }
 
 
 void VisualVisitor::bwdProcessVisualStyle(simulation::Node* node, core::visual::BaseVisualStyle* vm)
 {
-    vm-> bwdDraw(vparams);
+    vm-> applyBackupFlags(vparams);
 }
 
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.h
@@ -24,6 +24,7 @@
 
 #include <sofa/simulation/Visitor.h>
 #include <sofa/core/visual/VisualModel.h>
+#include <sofa/core/visual/BaseVisualStyle.h>
 
 
 namespace sofa::simulation
@@ -54,14 +55,36 @@ protected:
     core::visual::VisualParams* vparams;
 };
 
+class SOFA_SIMULATION_CORE_API VisualStyleVisitor : public Visitor
+{
+public:
+ VisualStyleVisitor(core::visual::VisualParams* params)
+        : Visitor(sofa::core::visual::visualparams::castToExecParams(params))
+        ,vparams(params)
+    {}
+
+    Result processNodeTopDown(simulation::Node* node) override;
+    void processVisualStyle(simulation::Node* /*node*/, sofa::core::visual::BaseVisualStyle* o);
+
+    /// Return a category name for this action.
+    /// Only used for debugging / profiling purposes
+    const char* getCategoryName() const override { return "visual"; }
+    const char* getClassName() const override { return "VisualStyleVisitor"; }
+
+    /// visual visitor must be executed as a tree, such as forward and backward orders are coherent
+    bool treeTraversal(TreeTraversalRepetition& repeat) override { repeat=NO_REPETITION; return true; }
+
+protected:
+    core::visual::VisualParams* vparams;
+};
+
 class SOFA_SIMULATION_CORE_API VisualDrawVisitor : public VisualVisitor
 {
 public:
     bool hasShader;
     VisualDrawVisitor(core::visual::VisualParams* params)
-        : VisualVisitor(params)
-    {
-    }
+    : VisualVisitor(params)
+    {};
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;
     virtual void fwdVisualModel(simulation::Node* node, core::visual::VisualModel* vm);
@@ -80,14 +103,13 @@ public:
     VisualUpdateVisitor(core::visual::VisualParams* params)
         : VisualVisitor(params)
     {}
+    virtual void fwdVisualModel(simulation::Node* node, core::visual::VisualModel* vm);
 
     virtual void processVisualModel(simulation::Node*, core::visual::VisualModel* vm) override;
     Result processNodeTopDown(simulation::Node* node) override;
 
     const char* getClassName() const override { return "VisualUpdateVisitor"; }
 
-protected:
-    core::visual::VisualParams* m_vparams;
 };
 
 class SOFA_SIMULATION_CORE_API VisualInitVisitor : public VisualVisitor

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisualVisitor.h
@@ -39,6 +39,8 @@ public:
     {}
 
     virtual void processVisualModel(simulation::Node* node, core::visual::VisualModel* vm) = 0;
+    virtual void fwdProcessVisualStyle(simulation::Node* node, core::visual::BaseVisualStyle* vm);
+    virtual void bwdProcessVisualStyle(simulation::Node* node, core::visual::BaseVisualStyle* vm);
     virtual void processObject(simulation::Node* /*node*/, core::objectmodel::BaseObject* /*o*/) {}
 
     Result processNodeTopDown(simulation::Node* node) override;
@@ -55,28 +57,6 @@ protected:
     core::visual::VisualParams* vparams;
 };
 
-class SOFA_SIMULATION_CORE_API VisualStyleVisitor : public Visitor
-{
-public:
- VisualStyleVisitor(core::visual::VisualParams* params)
-        : Visitor(sofa::core::visual::visualparams::castToExecParams(params))
-        ,vparams(params)
-    {}
-
-    Result processNodeTopDown(simulation::Node* node) override;
-    void processVisualStyle(simulation::Node* /*node*/, sofa::core::visual::BaseVisualStyle* o);
-
-    /// Return a category name for this action.
-    /// Only used for debugging / profiling purposes
-    const char* getCategoryName() const override { return "visual"; }
-    const char* getClassName() const override { return "VisualStyleVisitor"; }
-
-    /// visual visitor must be executed as a tree, such as forward and backward orders are coherent
-    bool treeTraversal(TreeTraversalRepetition& repeat) override { repeat=NO_REPETITION; return true; }
-
-protected:
-    core::visual::VisualParams* vparams;
-};
 
 class SOFA_SIMULATION_CORE_API VisualDrawVisitor : public VisualVisitor
 {
@@ -103,10 +83,10 @@ public:
     VisualUpdateVisitor(core::visual::VisualParams* params)
         : VisualVisitor(params)
     {}
-    virtual void fwdVisualModel(simulation::Node* node, core::visual::VisualModel* vm);
 
     virtual void processVisualModel(simulation::Node*, core::visual::VisualModel* vm) override;
     Result processNodeTopDown(simulation::Node* node) override;
+    void processNodeBottomUp(simulation::Node* node) override;
 
     const char* getClassName() const override { return "VisualUpdateVisitor"; }
 


### PR DESCRIPTION
Visual models where broken since this PR https://github.com/sofa-framework/sofa/pull/4827 

Actually they were not always broken, when you started the simulation, everything was ok, but then if you unchecked visualModels in the View panel, and check it back, the visual models didn't follow the mechanical one anymore. The visual models where stuck in the position when you unchecked the VisualModel (see gif). 

The problem was that the Visual params where not updated from the VisualStyle component at the right moment. It was only done in the VisualDrawVisitor, through the `fwdDraw` method. This enabled the drawing, but not the update of the visual models, because it was done before. 

Why was it working when the visual flags remained untouched ? I don't know. 

![SOFA_visual_bug](https://github.com/user-attachments/assets/06f76378-66c1-4f0f-808c-9086ed36ff81)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
