### PR TITLE
[Core, Simulation.Core] Registration: (re)enable deprecation warnings

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/AugmentedLagrangianConstraint.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/AugmentedLagrangianConstraint.cpp
@@ -31,11 +31,11 @@ namespace sofa::component::constraint::lagrangian::model
 using namespace sofa::defaulttype;
 using namespace sofa::helper;
 
-int AugmentedLagrangianConstraintClass = core::RegisterObject("AugmentedLagrangianConstraint")
-        .add< AugmentedLagrangianConstraint<Vec3Types> >()
-
-        ;
-
+void registerAugmentedLagrangianConstraint(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(core::ObjectRegistrationData("AugmentedLagrangianConstraint")
+        .add< AugmentedLagrangianConstraint<Vec3Types> >());
+}
 
 template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API BaseContactLagrangianConstraint<Vec3Types,AugmentedLagrangianContactParameters>;
 template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API AugmentedLagrangianConstraint<Vec3Types>;

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/init.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/init.cpp
@@ -26,6 +26,7 @@
 namespace sofa::component::constraint::lagrangian::model
 {
 
+extern void registerAugmentedLagrangianConstraint(sofa::core::ObjectFactory* factory);
 extern void registerBilateralLagrangianConstraint(sofa::core::ObjectFactory* factory);
 extern void registerFixedLagrangianConstraint(sofa::core::ObjectFactory* factory);
 extern void registerSlidingLagrangianConstraint(sofa::core::ObjectFactory* factory);
@@ -57,6 +58,7 @@ const char* getModuleVersion()
 
 void registerObjects(sofa::core::ObjectFactory* factory)
 {
+    registerAugmentedLagrangianConstraint(factory);
     registerBilateralLagrangianConstraint(factory);
     registerFixedLagrangianConstraint(factory);
     registerSlidingLagrangianConstraint(factory);

--- a/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
@@ -69,6 +69,7 @@ public:
     {
         sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
         sofa::simpleapi::importPlugin("Sofa.Component.Visual");
+        sofa::simpleapi::importPlugin("Sofa.Component.IO.Mesh");
     }
 
     void TearDown() override
@@ -98,7 +99,6 @@ public:
                 "<?xml version='1.0'?> \n"
                 "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >       \n"
                 "   <DefaultAnimationLoop/>                                        \n"
-                "   <RequiredPlugin name='Sofa.Component.IO.Mesh' />               \n"
                 "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
                 "   <MeshOBJLoader name='loader' filename='mesh/liver-smooth.obj'/> \n"
                 "   <VisualModel src='@loader'/>                                      \n"

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -837,7 +837,7 @@ RegisterObject& RegisterObject::addCreator(std::string classname, std::string te
 
 RegisterObject::operator int() const
 {
-    msg_warning("RegisterObject") << "Implicit object registration is deprecrated since v24.12. Check #4429 for more information.";
+    msg_warning("RegisterObject") << "Implicit object registration is deprecated since v24.12. Check #4429 for more information.";
     return commitTo(ObjectFactory::getInstance());
 }
 

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -775,7 +775,8 @@ bool ObjectFactory::registerObjectsFromPlugin(const std::string& pluginName)
     // do not register if it was already done before
     if(m_registeredPluginSet.count(pluginName) > 0)
     {
-        msg_warning("ObjectFactory") << pluginName << " has already registered its components.";
+        // This warning should be generalized (i.e not only in dev mode) when runSofa will not auto-load modules/plugins by default anymore
+        dmsg_warning("ObjectFactory") << pluginName << " has already registered its components.";
         return false;
     }
 
@@ -837,7 +838,7 @@ RegisterObject& RegisterObject::addCreator(std::string classname, std::string te
 
 RegisterObject::operator int() const
 {
-    msg_warning("RegisterObject") << m_objectRegistrationdata.entry.className
+    dmsg_warning("RegisterObject") << m_objectRegistrationdata.entry.className
                                   << ": Implicit object registration is deprecated since v24.12. Check #4429 for more information.";
     return commitTo(ObjectFactory::getInstance());
 }

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -775,7 +775,7 @@ bool ObjectFactory::registerObjectsFromPlugin(const std::string& pluginName)
     // do not register if it was already done before
     if(m_registeredPluginSet.count(pluginName) > 0)
     {
-        // msg_warning("ObjectFactory") << pluginName << " has already registered its components.";
+        msg_warning("ObjectFactory") << pluginName << " has already registered its components.";
         return false;
     }
 
@@ -837,8 +837,7 @@ RegisterObject& RegisterObject::addCreator(std::string classname, std::string te
 
 RegisterObject::operator int() const
 {
-    //std::cout << "Implicit object registration is deprecrated since v24.06. Check #4429 for more information." << std::endl;
-    // msg_warning("RegisterObject") << "Implicit object registration is deprecrated since v24.06. Check #4429 for more information.";
+    msg_warning("RegisterObject") << "Implicit object registration is deprecrated since v24.12. Check #4429 for more information.";
     return commitTo(ObjectFactory::getInstance());
 }
 

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -837,7 +837,8 @@ RegisterObject& RegisterObject::addCreator(std::string classname, std::string te
 
 RegisterObject::operator int() const
 {
-    msg_warning("RegisterObject") << "Implicit object registration is deprecated since v24.12. Check #4429 for more information.";
+    msg_warning("RegisterObject") << m_objectRegistrationdata.entry.className
+                                  << ": Implicit object registration is deprecated since v24.12. Check #4429 for more information.";
     return commitTo(ObjectFactory::getInstance());
 }
 

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
@@ -377,6 +377,8 @@ public:
 
     /// This is the final operation that will actually commit the additions to the ObjectFactory.
     bool commitTo(sofa::core::ObjectFactory* objectFactory) const;
+    
+    friend class RegisterObject;
 };
 
 

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
@@ -382,7 +382,7 @@ public:
 
 // Legacy structure, to keep compatibility with olden code
 // using the singleton to get the instance of ObjectFactory
-class /* SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT() */ SOFA_CORE_API RegisterObject
+class SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT() SOFA_CORE_API RegisterObject
 {
 private:
     ObjectRegistrationData m_objectRegistrationdata;

--- a/Sofa/framework/Helper/test/system/PluginManager_test.cpp
+++ b/Sofa/framework/Helper/test/system/PluginManager_test.cpp
@@ -122,12 +122,22 @@ TEST_F(PluginManager_test, loadTestPluginAByPath)
     /// Check that existing plugins are correctly handled and returns no
     /// error/warning message.
     {
-        EXPECT_MSG_NOEMIT(Warning, Error);
-
+        EXPECT_MSG_NOEMIT(Error, Warning);
+        
         std::cout << "PluginManager_test.loadTestPluginAByPath: "
-                  << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
-                  << std::endl;
+        << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
+        << std::endl;
+    }
+    {
+        EXPECT_MSG_NOEMIT(Error);
+        // Plugin A still uses the deprecated registration mechanism
+        // and is expected to throw a warning when loaded
+        EXPECT_MSG_EMIT(Warning);
+        
         ASSERT_EQ(pm.loadPluginByPath(pluginPath), PluginManager::PluginLoadStatus::SUCCESS);
+    }
+    {
+        EXPECT_MSG_NOEMIT(Error, Warning);
         ASSERT_GT(pm.findPlugin(pluginAName).size(), 0u);
     }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
@@ -136,17 +136,16 @@ bool RequiredPlugin::loadPlugin()
                 objectFactory->registerObjectsFromPlugin(name);
 
                 // fail-safe to check if potential components have been registered (implicitly or explicitly)
-                // SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT()
                 std::vector<sofa::core::ObjectFactory::ClassEntry::SPtr> entries;
                 objectFactory->getEntriesFromTarget(entries, name);
 
                 if (entries.empty())
                 {
-//                    msg_warning() << "No component has been registered from " << name << ".\n"
-//                        << "It could be because: \n"
-//                        << " - the entrypoint registerObjects() has not been implemented;\n"
-//                        << " - (deprecated) no sofa::core::RegisterObject() has been called;\n"
-//                        << " - your plugin does not add any component (i.e BaseObject) into the factory. In that case, RequiredPlugin is not useful for this kind of plugin.";
+                    msg_warning() << "No component has been registered from " << name << ".\n"
+                        << "It could be because: \n"
+                        << " - the entrypoint registerObjects() has not been implemented;\n"
+                        << " - (deprecated since v24.12) no sofa::core::RegisterObject() has been called;\n"
+                        << " - your plugin does not add any component (i.e BaseObject) into the factory. In that case, RequiredPlugin is not useful for this kind of plugin.";
                 }
 
                 if (d_stopAfterFirstSuffixFound.getValue()) break;

--- a/Sofa/framework/Simulation/Core/test/RequiredPlugin_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/RequiredPlugin_test.cpp
@@ -85,7 +85,7 @@ struct RequiredPlugin_test : public BaseSimulationTest
     
     void testLoadPluginB()
     {
-        EXPECT_MSG_EMIT(Warning); // // TestPluginB does not register any component
+        EXPECT_MSG_EMIT(Warning); // TestPluginB does not register any component
 
         std::stringstream scene;
         scene << "<?xml version='1.0'?>"
@@ -101,7 +101,7 @@ struct RequiredPlugin_test : public BaseSimulationTest
 
     void testLoadPluginC()
     {
-        EXPECT_MSG_NOEMIT(Warning); // // TestPluginC registers its component explicitly
+        EXPECT_MSG_NOEMIT(Warning); // TestPluginC registers its component explicitly
 
         std::stringstream scene;
         scene << "<?xml version='1.0'?>"
@@ -118,8 +118,8 @@ struct RequiredPlugin_test : public BaseSimulationTest
 
 TEST_F(RequiredPlugin_test, testNotExistingPlugin ) { testNotExistingPlugin(); }
 TEST_F(RequiredPlugin_test, testNoParameter ) { testNoParameter(); }
-TEST_F(RequiredPlugin_test, DISABLED_testLoadPluginA) { testLoadPluginA(); } // disabled because testLoadPluginA() should throw a warning (but this warning is commented for the moment)
-TEST_F(RequiredPlugin_test, DISABLED_testLoadPluginB) { testLoadPluginB(); }// disabled because testLoadPluginB() should throw a warning (but this warning is commented for the moment)
+TEST_F(RequiredPlugin_test, testLoadPluginA) { testLoadPluginA(); }
+TEST_F(RequiredPlugin_test, testLoadPluginB) { testLoadPluginB(); }
 TEST_F(RequiredPlugin_test, testLoadPluginC) { testLoadPluginC(); }
 
 }

--- a/Sofa/framework/Simulation/simutest/parallel_scenes_test.cpp
+++ b/Sofa/framework/Simulation/simutest/parallel_scenes_test.cpp
@@ -29,9 +29,6 @@ using sofa::simulation::Node ;
 #include <sofa/component/sceneutility/InfoComponent.h>
 using sofa::component::sceneutility::InfoComponent;
 
-#include <sofa/helper/system/PluginManager.h>
-using sofa::helper::system::PluginManager ;
-
 #include <sofa/simulation/common/SceneLoaderXML.h>
 using sofa::simulation::SceneLoaderXML ;
 
@@ -47,10 +44,36 @@ public:
     {
     }
     
+    void SetUp() override
+    {
+        EXPECT_MSG_NOEMIT(Error, Warning);
+        
+        sofa::simpleapi::importPlugin("Sofa.Component.AnimationLoop");
+        sofa::simpleapi::importPlugin("Sofa.Component.Collision.Detection.Algorithm");
+        sofa::simpleapi::importPlugin("Sofa.Component.Collision.Detection.Intersection");
+        sofa::simpleapi::importPlugin("Sofa.Component.Collision.Geometry");
+        sofa::simpleapi::importPlugin("Sofa.Component.Collision.Response.Contact");
+        sofa::simpleapi::importPlugin("Sofa.Component.Constraint.Lagrangian.Correction");
+        sofa::simpleapi::importPlugin("Sofa.Component.Constraint.Lagrangian.Solver");
+        sofa::simpleapi::importPlugin("Sofa.Component.Constraint.Projective");
+        sofa::simpleapi::importPlugin("Sofa.Component.IO.Mesh");
+        sofa::simpleapi::importPlugin("Sofa.Component.LinearSolver.Iterative");
+        sofa::simpleapi::importPlugin("Sofa.Component.Mapping.Linear");
+        sofa::simpleapi::importPlugin("Sofa.Component.Mass");
+        sofa::simpleapi::importPlugin("Sofa.Component.ODESolver.Backward");
+        sofa::simpleapi::importPlugin("Sofa.Component.SolidMechanics.FEM.Elastic");
+        sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
+        sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Constant");
+        sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Dynamic");
+        sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Grid");
+        sofa::simpleapi::importPlugin("Sofa.Component.Visual");
+        sofa::simpleapi::importPlugin("Sofa.GL.Component.Rendering3D");
+        sofa::simpleapi::importPlugin("Sofa.Component.LinearSystem");
+    }
+    
     void executeInParallel(const char* sceneStr, const std::size_t nbScenes, const std::size_t nbSteps)
     {
-        EXPECT_MSG_NOEMIT(Error);
-        EXPECT_MSG_NOEMIT(Warning);
+        EXPECT_MSG_NOEMIT(Error, Warning);
         
         std::vector<sofa::simulation::NodeSPtr> groots;
         groots.resize(nbScenes);
@@ -104,21 +127,6 @@ public:
         const std::string sceneStr = R"(
         <?xml version="1.0" ?>
         <Node name="lroot" gravity="0 -9.81 0" dt="0.02">
-            <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
-            <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [DiscreteIntersection] -->
-            <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [SphereCollisionModel] -->
-            <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
-            <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
-            <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader MeshOBJLoader SphereLoader] -->
-            <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
-            <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [BarycentricMapping] -->
-            <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->
-            <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
-            <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedralCorotationalFEMForceField] -->
-            <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
-            <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms TetrahedronSetTopologyContainer] -->
-            <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
-
             <CollisionPipeline name="CollisionPipeline" verbose="0" />
             <DefaultAnimationLoop/>
             <BruteForceBroadPhase/>
@@ -160,29 +168,6 @@ public:
         const std::string sceneStr = R"(
         <?xml version="1.0" ?>
         <Node name="root" gravity="0 -1000 0" dt="0.04">
-            <Node name="RequiredPlugins">
-                <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
-                <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
-                <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->
-                <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [LineCollisionModel PointCollisionModel TriangleCollisionModel] -->
-                <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
-                <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [UncoupledConstraintCorrection] -->
-                <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Solver"/> <!-- Needed to use components [LCPConstraintSolver] -->
-                <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
-                <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
-                <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [BarycentricMapping] -->
-                <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
-                <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
-                <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [HexahedronFEMForceField] -->
-                <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
-                <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
-                <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [SparseGridRamificationTopology] -->
-                <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [InteractiveCamera VisualStyle] -->
-                <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
-                <RequiredPlugin name="Sofa.GL.Component.Shader"/> <!-- Needed to use components [LightManager SpotLight] -->
-                <RequiredPlugin name="Sofa.Component.LinearSystem"/> <!-- Needed to use components [MatrixLinearSystem] -->
-            </Node>
-            
             <FreeMotionAnimationLoop parallelCollisionDetectionAndFreeMotion="false" />
             <VisualStyle displayFlags="showVisual  " /> <!--showBehaviorModels showCollisionModels-->
             <LCPConstraintSolver tolerance="1e-3" maxIt="1000" initial_guess="false" build_lcp="false"  printLog="0" mu="0.2"/>

--- a/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
+++ b/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
@@ -173,11 +173,12 @@ struct SceneChecker_test : public BaseSimulationTest
         EXPECT_MSG_NOEMIT(Warning);
 
         const std::string lvl = (shouldWarn)?"17.06":"17.12";
-
+        
+        sofa::simpleapi::importPlugin("Sofa.Component.SceneUtility");
+        
         std::stringstream scene;
         scene << "<?xml version='1.0'?>                                           \n"
               << "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >    \n"
-              << "      <RequiredPlugin name='Sofa.Component.SceneUtility'/>      \n"
               << "      <APIVersion level='"<< lvl <<"'/>                         \n"
               << "      <ComponentDeprecated />                                   \n"
               << "</Node>                                                         \n";


### PR DESCRIPTION
To enforce the new registration mechanism (#4429 )
This PR:
- adds compilation deprecation warnings when using RegisterObject
- adds runtime (user) messages when using deprecated registration mechanism

⚠️ This will throw a lot of warnings on the CI (because of the plugins) so I think the log file will increase dramatically 😅

[ci-depends-on https://github.com/sofa-framework/BeamAdapter/pull/158]
[ci-depends-on https://github.com/sofa-framework/CGALPlugin/pull/20]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
