### PR TITLE
[Testing] Mitigate plugin import leakage between tests

### DIFF
--- a/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
@@ -70,11 +70,12 @@ struct BoxROITest :  public sofa::testing::BaseTest
     Node::SPtr m_node;
     typename TheBoxROI::SPtr m_boxroi;
 
-    void SetUp() override
+    void onSetUp() override
     {
-        sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
-        sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Dynamic");
-        sofa::simpleapi::importPlugin("Sofa.Component.Engine.Select");
+        this->loadPlugins({
+            "Sofa.Component.StateContainer",
+            "Sofa.Component.Topology.Container.Dynamic",
+            "Sofa.Component.Engine.Select"});
 
         m_simu = sofa::simulation::getSimulation();
         ASSERT_NE(m_simu, nullptr);
@@ -86,7 +87,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
         m_node->addObject(m_boxroi);
     }
 
-    void TearDown() override
+    void onTearDown() override
     {
         if (m_root != nullptr){
             sofa::simulation::node::unload(m_root);

--- a/Sofa/Component/LinearSolver/Direct/tests/SparseLDLSolver_test.cpp
+++ b/Sofa/Component/LinearSolver/Direct/tests/SparseLDLSolver_test.cpp
@@ -57,9 +57,10 @@ TEST(SparseLDLSolver, EmptyMState)
 
     const sofa::simulation::Node::SPtr root = sofa::simulation::getSimulation()->createNewGraph("root");
 
-    sofa::simpleapi::importPlugin("Sofa.Component.LinearSolver.Direct");
-    sofa::simpleapi::importPlugin("Sofa.Component.ODESolver.Backward");
-    sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
+    const auto plugins = sofa::testing::makeScopedPlugin({
+        "Sofa.Component.LinearSolver.Direct",
+        "Sofa.Component.ODESolver.Backward",
+        "Sofa.Component.StateContainer"});
 
     sofa::simpleapi::createObject(root, "DefaultAnimationLoop");
     sofa::simpleapi::createObject(root, "EulerImplicitSolver");
@@ -83,14 +84,15 @@ TEST(SparseLDLSolver, TopologyChangeEmptyMState)
     // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
     sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
 
-  const sofa::simulation::Node::SPtr root = sofa::simulation::getSimulation()->createNewGraph("root");
+    const sofa::simulation::Node::SPtr root = sofa::simulation::getSimulation()->createNewGraph("root");
 
-    sofa::simpleapi::importPlugin("Sofa.Component.LinearSolver.Direct");
-    sofa::simpleapi::importPlugin("Sofa.Component.Mass");
-    sofa::simpleapi::importPlugin("Sofa.Component.ODESolver.Backward");
-    sofa::simpleapi::importPlugin("Sofa.Component.StateContainer");
-    sofa::simpleapi::importPlugin("Sofa.Component.Topology.Container.Dynamic");
-    sofa::simpleapi::importPlugin("Sofa.Component.Topology.Utility");
+    const auto plugins = sofa::testing::makeScopedPlugin({
+        "Sofa.Component.LinearSolver.Direct",
+        "Sofa.Component.Mass",
+        "Sofa.Component.ODESolver.Backward",
+        "Sofa.Component.StateContainer",
+        "Sofa.Component.Topology.Container.Dynamic",
+        "Sofa.Component.Topology.Utility"});
 
     sofa::simpleapi::createObject(root, "DefaultAnimationLoop");
     sofa::simpleapi::createObject(root, "EulerImplicitSolver");

--- a/Sofa/framework/Testing/CMakeLists.txt
+++ b/Sofa/framework/Testing/CMakeLists.txt
@@ -65,6 +65,7 @@ set(HEADER_FILES
     ${SOFATESTINGSRC_ROOT}/BaseTest.h
     ${SOFATESTINGSRC_ROOT}/LinearCongruentialRandomGenerator.h
     ${SOFATESTINGSRC_ROOT}/NumericTest.h
+    ${SOFATESTINGSRC_ROOT}/ScopedPlugin.h
     ${SOFATESTINGSRC_ROOT}/TestMessageHandler.h
     ${SOFATESTINGSRC_ROOT}/BaseSimulationTest.h
 )
@@ -74,6 +75,7 @@ set(SOURCE_FILES
     ${SOFATESTINGSRC_ROOT}/BaseTest.cpp
     ${SOFATESTINGSRC_ROOT}/LinearCongruentialRandomGenerator.cpp
     ${SOFATESTINGSRC_ROOT}/NumericTest.cpp
+    ${SOFATESTINGSRC_ROOT}/ScopedPlugin.cpp
     ${SOFATESTINGSRC_ROOT}/TestMessageHandler.cpp
     ${SOFATESTINGSRC_ROOT}/BaseSimulationTest.cpp
 )

--- a/Sofa/framework/Testing/src/sofa/testing/BaseTest.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/BaseTest.cpp
@@ -93,6 +93,12 @@ BaseTest::BaseTest() :
 
 BaseTest::~BaseTest() {}
 
+void BaseTest::loadPlugins(
+    const std::initializer_list<std::string>& pluginNames)
+{
+    m_loadedPlugins = makeScopedPlugin(pluginNames);
+}
+
 void BaseTest::SetUp()
 {
     onSetUp();
@@ -100,6 +106,7 @@ void BaseTest::SetUp()
 
 void BaseTest::TearDown()
 {
+    m_loadedPlugins.reset();
     onTearDown();
 }
 

--- a/Sofa/framework/Testing/src/sofa/testing/BaseTest.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/BaseTest.cpp
@@ -96,7 +96,7 @@ BaseTest::~BaseTest() {}
 void BaseTest::loadPlugins(
     const std::initializer_list<std::string>& pluginNames)
 {
-    m_loadedPlugins = makeScopedPlugin(pluginNames);
+    m_loadedPlugins.emplace_back(pluginNames.begin(), pluginNames.end());
 }
 
 void BaseTest::SetUp()
@@ -106,7 +106,7 @@ void BaseTest::SetUp()
 
 void BaseTest::TearDown()
 {
-    m_loadedPlugins.reset();
+    m_loadedPlugins.clear();
     onTearDown();
 }
 

--- a/Sofa/framework/Testing/src/sofa/testing/BaseTest.h
+++ b/Sofa/framework/Testing/src/sofa/testing/BaseTest.h
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 #include <sofa/testing/TestMessageHandler.h>
+#include <sofa/testing/ScopedPlugin.h>
 
 namespace sofa::testing
 {
@@ -51,9 +52,13 @@ public:
     /// Seed value
     static int seed;
 
+    void loadPlugins(const std::initializer_list<std::string>& pluginNames);
+
 private:
     void SetUp() override ;
     void TearDown() override ;
+
+    std::unique_ptr<sofa::testing::ScopedPlugin> m_loadedPlugins;
 };
 
 } // namespace sofa::testing

--- a/Sofa/framework/Testing/src/sofa/testing/BaseTest.h
+++ b/Sofa/framework/Testing/src/sofa/testing/BaseTest.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <deque>
 #include <sofa/testing/config.h>
 
 #include <gtest/gtest.h>
@@ -58,7 +59,7 @@ private:
     void SetUp() override ;
     void TearDown() override ;
 
-    std::unique_ptr<sofa::testing::ScopedPlugin> m_loadedPlugins;
+    std::deque<sofa::testing::ScopedPlugin> m_loadedPlugins;
 };
 
 } // namespace sofa::testing

--- a/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.cpp
@@ -1,0 +1,71 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/testing/ScopedPlugin.h>
+
+namespace sofa::testing
+{
+
+ScopedPlugin::ScopedPlugin(const std::string& pluginName, const bool unloadAllPlugins,
+                           helper::system::PluginManager* pluginManager)
+: m_pluginManager(pluginManager), m_pluginName(pluginName), m_unloadAllPlugins(unloadAllPlugins)
+{
+    if (m_pluginManager)
+    {
+        m_status = pluginManager->loadPlugin(pluginName);
+        if(m_status == helper::system::PluginManager::PluginLoadStatus::SUCCESS)
+        {
+            sofa::core::ObjectFactory::getInstance()->registerObjectsFromPlugin(pluginName);
+        }
+    }
+}
+
+ScopedPlugin::~ScopedPlugin()
+{
+    if (m_pluginManager)
+    {
+        if (m_unloadAllPlugins)
+        {
+            for(const auto& [loadedPath, loadedPlugin] : m_pluginManager->getPluginMap())
+            {
+                m_pluginManager->unloadPlugin(loadedPath);
+            }
+        }
+        else
+        {
+            if (m_status == helper::system::PluginManager::PluginLoadStatus::SUCCESS)
+            {
+                const auto [path, isLoaded] = m_pluginManager->isPluginLoaded(m_pluginName);
+                if (isLoaded)
+                {
+                    m_pluginManager->unloadPlugin(path);
+                }
+            }
+        }
+    }
+}
+
+helper::system::PluginManager::PluginLoadStatus ScopedPlugin::getStatus() const
+{
+    return m_status;
+}
+}

--- a/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.cpp
@@ -25,9 +25,9 @@
 namespace sofa::testing
 {
 
-ScopedPlugin::ScopedPlugin(const std::string& pluginName, const bool unloadAllPlugins,
+ScopedPlugin::ScopedPlugin(const std::string& pluginName,
                            helper::system::PluginManager* pluginManager)
-: m_pluginManager(pluginManager), m_unloadAllPlugins(unloadAllPlugins)
+: m_pluginManager(pluginManager)
 {
     addPlugin(pluginName);
 }
@@ -36,22 +36,12 @@ ScopedPlugin::~ScopedPlugin()
 {
     if (m_pluginManager)
     {
-        if (m_unloadAllPlugins)
+        for (const auto& pluginName : m_loadedPlugins)
         {
-            for(const auto& [loadedPath, loadedPlugin] : m_pluginManager->getPluginMap())
+            const auto [path, isLoaded] = m_pluginManager->isPluginLoaded(pluginName);
+            if (isLoaded)
             {
-                m_pluginManager->unloadPlugin(loadedPath);
-            }
-        }
-        else
-        {
-            for (const auto& pluginName : m_loadedPlugins)
-            {
-                const auto [path, isLoaded] = m_pluginManager->isPluginLoaded(pluginName);
-                if (isLoaded)
-                {
-                    m_pluginManager->unloadPlugin(path);
-                }
+                m_pluginManager->unloadPlugin(path);
             }
         }
     }

--- a/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.h
+++ b/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.h
@@ -34,15 +34,13 @@ struct SOFA_TESTING_API ScopedPlugin
 
     explicit ScopedPlugin(
         const std::string& pluginName,
-        bool unloadAllPlugins = true,
         helper::system::PluginManager* pluginManager = &helper::system::PluginManager::getInstance());
 
     template<class InputIt>
     ScopedPlugin(
         InputIt first, InputIt last,
-        bool unloadAllPlugins = true,
         helper::system::PluginManager* pluginManager = &helper::system::PluginManager::getInstance())
-    : m_pluginManager(pluginManager), m_unloadAllPlugins(unloadAllPlugins)
+    : m_pluginManager(pluginManager)
     {
         while (first != last)
         {
@@ -54,12 +52,17 @@ struct SOFA_TESTING_API ScopedPlugin
 
 private:
     helper::system::PluginManager* m_pluginManager { nullptr };
-    bool m_unloadAllPlugins { true };
 
     std::set<std::string> m_loadedPlugins;
 
     void addPlugin(const std::string& pluginName);
 };
+
+
+inline std::unique_ptr<ScopedPlugin> makeScopedPlugin(const std::initializer_list<std::string>& pluginNames)
+{
+    return std::make_unique<ScopedPlugin>(pluginNames.begin(), pluginNames.end());
+}
 
 
 }

--- a/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.h
+++ b/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.h
@@ -1,0 +1,47 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/testing/config.h>
+#include <sofa/helper/system/PluginManager.h>
+
+namespace sofa::testing
+{
+
+struct SOFA_TESTING_API ScopedPlugin
+{
+    ScopedPlugin() = delete;
+    explicit ScopedPlugin(
+        const std::string& pluginName, bool unloadAllPlugins = true,
+        helper::system::PluginManager* pluginManager = &helper::system::PluginManager::getInstance());
+    ~ScopedPlugin();
+
+    helper::system::PluginManager::PluginLoadStatus getStatus() const;
+
+private:
+    helper::system::PluginManager* m_pluginManager { nullptr };
+    std::string m_pluginName;
+    helper::system::PluginManager::PluginLoadStatus m_status;
+    bool m_unloadAllPlugins { true };
+};
+
+
+}

--- a/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.h
+++ b/Sofa/framework/Testing/src/sofa/testing/ScopedPlugin.h
@@ -29,18 +29,36 @@ namespace sofa::testing
 struct SOFA_TESTING_API ScopedPlugin
 {
     ScopedPlugin() = delete;
-    explicit ScopedPlugin(
-        const std::string& pluginName, bool unloadAllPlugins = true,
-        helper::system::PluginManager* pluginManager = &helper::system::PluginManager::getInstance());
-    ~ScopedPlugin();
+    ScopedPlugin(const ScopedPlugin&) = delete;
+    void operator=(const ScopedPlugin&) = delete;
 
-    helper::system::PluginManager::PluginLoadStatus getStatus() const;
+    explicit ScopedPlugin(
+        const std::string& pluginName,
+        bool unloadAllPlugins = true,
+        helper::system::PluginManager* pluginManager = &helper::system::PluginManager::getInstance());
+
+    template<class InputIt>
+    ScopedPlugin(
+        InputIt first, InputIt last,
+        bool unloadAllPlugins = true,
+        helper::system::PluginManager* pluginManager = &helper::system::PluginManager::getInstance())
+    : m_pluginManager(pluginManager), m_unloadAllPlugins(unloadAllPlugins)
+    {
+        while (first != last)
+        {
+            addPlugin(*first++);
+        }
+    }
+
+    ~ScopedPlugin();
 
 private:
     helper::system::PluginManager* m_pluginManager { nullptr };
-    std::string m_pluginName;
-    helper::system::PluginManager::PluginLoadStatus m_status;
     bool m_unloadAllPlugins { true };
+
+    std::set<std::string> m_loadedPlugins;
+
+    void addPlugin(const std::string& pluginName);
 };
 
 

--- a/Sofa/framework/Testing/test/CMakeLists.txt
+++ b/Sofa/framework/Testing/test/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 3.22)
 project(Sofa.Testing_test)
 
 set(SOURCE_FILES
-	TestMessageHandler_test.cpp
+    ScopedPlugin_test.cpp
+    TestMessageHandler_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/Sofa/framework/Testing/test/ScopedPlugin_test.cpp
+++ b/Sofa/framework/Testing/test/ScopedPlugin_test.cpp
@@ -1,0 +1,59 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/testing/ScopedPlugin.h>
+#include <gtest/gtest.h>
+
+TEST(ScopedPlugin, test)
+{
+    static std::string pluginName = "Sofa.Component.AnimationLoop";
+    auto& pluginManager = sofa::helper::system::PluginManager::getInstance();
+
+    //make sure that pluginName is not already loaded
+    {
+        const auto [path, isLoaded] = pluginManager.isPluginLoaded(pluginName);
+        if (isLoaded)
+        {
+            pluginManager.unloadPlugin(path);
+        }
+    }
+
+    {
+        const auto [path, isLoaded] = pluginManager.isPluginLoaded(pluginName);
+        EXPECT_FALSE(isLoaded);
+    }
+
+    {
+        const sofa::testing::ScopedPlugin plugin(pluginName);
+
+        {
+            const auto [path, isLoaded] = pluginManager.isPluginLoaded(pluginName);
+            EXPECT_TRUE(isLoaded);
+        }
+
+        //end of scope: plugin should be unloaded
+    }
+
+    {
+        const auto [path, isLoaded] = pluginManager.isPluginLoaded(pluginName);
+        EXPECT_FALSE(isLoaded);
+    }
+}


### PR DESCRIPTION
A test must clean the environment test after it has been executed. Since some tests relies on the `PluginManager`, I suggest that tests unload the plugins that it imported. In this PR, I suggest a RAII-based method to do that.

This should be applied in all tests.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
