### PR TITLE
[Lagrangian] Remove unused data numericalTolerance in BLC

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.cpp
@@ -90,7 +90,7 @@ public:
     static void getConstraintResolution(BilateralLagrangianConstraint<T>& self,
                                         const ConstraintParams* cParams,
                                         std::vector<ConstraintResolution*>& resTab,
-                                        unsigned int& offset, SReal tolerance)
+                                        unsigned int& offset)
     {
         SOFA_UNUSED(cParams);
         const unsigned minp = std::min(self.d_m1.getValue().size(),
@@ -100,7 +100,6 @@ public:
             resTab[offset] = new BilateralConstraintResolution3Dof();
             offset += 3;
             BilateralConstraintResolution3Dof* temp = new BilateralConstraintResolution3Dof();
-            temp->setTolerance(tolerance);	// specific (smaller) tolerance for the rotation
             resTab[offset] = temp;
             offset += 3;
         }
@@ -276,8 +275,7 @@ void BilateralLagrangianConstraint<Rigid3Types>::getConstraintResolution(
     unsigned int& offset)
 {
     RigidBilateralLagrangianConstraint::getConstraintResolution(*this,
-        cParams, resTab, offset,
-        d_numericalTolerance.getValue());
+        cParams, resTab, offset);
 }
 
 template <> SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
@@ -114,7 +114,8 @@ protected:
     Data<VecDeriv> d_restVector; ///< Relative position to maintain between attached points (optional)
     VecCoord initialDifference;
 
-    Data<SReal> d_numericalTolerance; ///< a real value specifying the tolerance during the constraint solving. (default=0.0001
+    SOFA_ATTRIBUTE_DEPRECATED__BILATERALREMOVEUNUSEDTOLERANCE() DeprecatedAndRemoved d_numericalTolerance; ///< a real value specifying the tolerance during the constraint solving. (default=0.0001
+
     Data<bool> d_activate; ///< control constraint activation (true by default)
     Data<bool> d_keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
@@ -44,8 +44,6 @@ BilateralLagrangianConstraint<DataTypes>::BilateralLagrangianConstraint(Mechanic
     , d_m1(initData(&d_m1, "first_point","index of the constraint on the first model (object1)"))
     , d_m2(initData(&d_m2, "second_point","index of the constraint on the second model (object2)"))
     , d_restVector(initData(&d_restVector, "rest_vector","Relative position to maintain between attached points (optional)"))
-    , d_numericalTolerance(initData(&d_numericalTolerance, 1e-4_sreal, "numericalTolerance",
-                                    "a real value specifying the tolerance during the constraint solving.") )
     , d_activate( initData(&d_activate, true, "activate", "control constraint activation (true by default)"))
     , d_keepOrientDiff(initData(&d_keepOrientDiff, false, "keepOrientationDifference", "keep the initial difference in orientation (only for rigids)"))
     , l_topology1(initLink("topology1", "link to the first topology container"))

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/config.h.in
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/config.h.in
@@ -45,3 +45,13 @@ namespace sofa::component::constraint::lagrangian::model
         "v24.06", "v24.12", \
         "Data renamed according to the guidelines")
 #endif
+
+
+#ifdef SOFA_BUILD_SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL
+#define SOFA_ATTRIBUTE_DEPRECATED__BILATERALREMOVEUNUSEDTOLERANCE()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__BILATERALREMOVEUNUSEDTOLERANCE() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v25.06", "v25.12", \
+        "Data \'d_numericalTolerance\' has been removed since it was actually not taken into account")
+#endif


### PR DESCRIPTION
During peregrination in constraints, we noticed that this Data is actually not taken into account.
The API is there for the `ConstraintResolution` but the tolerance is actually never used later.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
