### PR TITLE
[Core] Fix VisualState.h compilation on windows

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/VisualState.h
@@ -33,7 +33,7 @@ template< typename DataTypes >
 class VisualState : public core::State< DataTypes >
 {
 public:
-    SOFA_CLASS(VisualState, SOFA_TEMPLATE(core::State, defaulttype::Vec3Types));
+    SOFA_CLASS(SOFA_TEMPLATE(VisualState, DataTypes), SOFA_TEMPLATE(core::State, DataTypes));
 
     using VecCoord = typename DataTypes::VecCoord;
     using VecDeriv = typename DataTypes::VecCoord;


### PR DESCRIPTION
After updating the code I had this error of compilation:
```
11>VisualState.cpp
11>C:\projects\sofa-src\Sofa\framework\Core\src\sofa/core/visual/VisualState.h(36,5): fatal error C1001: Internal compiler error.
11>(compiler file 'D:\a_work\1\s\src\vctools\Compiler\CxxFE\sl\p1\c\symbols.c', line 6202)
11> To work around this problem, try simplifying or changing the program near the locations listed above.
```

Fixing the SOFA_CLASS macro solved the issue


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
