### PR TITLE
[Topology.Container] Add new method computeSegmentTriangleIntersectionInPlane in TriangleSetGeometryAlgorithm

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
@@ -231,14 +231,26 @@ public:
      * @param baryCoef : barycoef of the intersection point on the edge
      * @param coord_kmin : barycoef of the intersection point on the vecteur AB.
      */
-
-
     bool computeSegmentTriangleIntersection(bool is_entered, 
         const sofa::type::Vec<3, Real>& a,
         const sofa::type::Vec<3, Real>& b,
         const TriangleID ind_t,
         sofa::type::vector<PointID>& indices,
         Real& baryCoef, Real& coord_kmin) const;
+
+    /** \brief Computes the intersection between the edges of the Triangle triId and the vector [AB] projected into this Triangle frame.
+     * @param ptA : first input point
+     * @param ptB : last input point
+     * @param triId : index of the triangle whose edges will be checked
+     * @param intersectedEdges : output list of Edge global Ids that are intersected by vector AB (size could be 0, 1 or 2)
+     * @param baryCoefs : output list of barycoef corresponding to the relative position of the intersection on the edge (same size and order as @sa intersectedEdges)
+    */
+    bool computeSegmentTriangleIntersectionInPlane(
+        const sofa::type::Vec<3, Real>& ptA,
+        const sofa::type::Vec<3, Real>& ptB,
+        const TriangleID triId,
+        sofa::type::vector<EdgeID>& intersectedEdges,
+        sofa::type::vector<Real>& baryCoefs) const;
 
     /** \brief Computes the intersections of the vector from point a to point b and the triangle indexed by t
     *

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
@@ -1299,6 +1299,62 @@ void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const 
     }
 }
 
+
+template<class DataTypes>
+bool TriangleSetGeometryAlgorithms< DataTypes >::computeSegmentTriangleIntersectionInPlane(
+    const sofa::type::Vec<3, Real>& ptA,
+    const sofa::type::Vec<3, Real>& ptB,
+    const TriangleID triId,
+    sofa::type::vector<EdgeID>& intersectedEdges,
+    sofa::type::vector<Real>& baryCoefs) const
+{
+    // Get coordinates of each vertex of the triangle
+    const typename DataTypes::VecCoord& coords = (this->object->read(core::ConstVecCoordId::position())->getValue());
+    const Triangle& tri = this->m_topology->getTriangle(triId);
+
+    const typename DataTypes::Coord& c0 = coords[tri[0]];
+    const typename DataTypes::Coord& c1 = coords[tri[1]];
+    const typename DataTypes::Coord& c2 = coords[tri[2]];
+    type::fixed_array<Vec3, 3> triP = { Vec3(c0[0], c0[1], c0[2]), Vec3(c1[0], c1[1], c1[2]), Vec3(c2[0], c2[1], c2[2]) };
+
+    // Project A and B into triangle plan
+    Vec3 v_normal = (triP[2] - triP[0]).cross(triP[1] - triP[0]);
+    v_normal.normalize();
+    const Vec3 pa_proj = ptA - v_normal * dot(ptA - triP[0], v_normal);
+    const Vec3 pb_proj = ptB - v_normal * dot(ptB - triP[0], v_normal);
+
+    // check intersection between AB and each edge of the triangle
+    const sofa::type::fixed_array<EdgeID, 3>& edgesInTri = this->m_topology->getEdgesInTriangle(triId);
+    for (const EdgeID& edgeId : edgesInTri)
+    {
+        const Edge& edge = this->m_topology->getEdge(edgeId);
+        Edge localIds;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 3; j++) 
+            {
+                if (edge[i] == tri[j])
+                {
+                    localIds[i] = j;
+                    break;
+                }
+            }
+        }
+
+        type::Vec2 baryCoords(type::NOINIT);
+        bool res = geometry::Edge::intersectionWithEdge(triP[localIds[0]], triP[localIds[1]], pa_proj, pb_proj, baryCoords);
+
+        if (res)
+        {
+            intersectedEdges.push_back(edgeId);
+            baryCoefs.push_back(baryCoords[0]);
+        }
+    }
+
+    return !intersectedEdges.empty();
+}
+
+
 // Computes the intersection of the segment from point a to point b and the triangle indexed by t
 template<class DataTypes>
 bool TriangleSetGeometryAlgorithms< DataTypes >::computeSegmentTriangleIntersection(bool is_entered,

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
@@ -32,12 +32,23 @@ using namespace sofa::testing;
 class TriangleSetTopology_test : public BaseTest
 {
 public:
+    /// Test on TriangleSetTopologyContainer creation without Data. All container should be empty.
     bool testEmptyContainer();
+
+    /// Test on TriangleSetTopologyContainer creation with a triangular mesh as input. Check Triangle container size and content against know values.
     bool testTriangleBuffers();
+
+    /// Test on TriangleSetTopologyContainer creation with a triangular mesh as input. Check Edge container size and content against know values.
     bool testEdgeBuffers();
+
+    /// Test on TriangleSetTopologyContainer creation with a triangular mesh as input. Check Vertex container size and content against know values.
     bool testVertexBuffers();
+
+    /// Test on TriangleSetTopologyContainer creation with a triangular mesh as input. Call member method CheckTopology which check all buffers concistency.
     bool checkTopology();
 
+private:
+    // Ground truth values for mesh 'square1.obj'
     int nbrTriangle = 26;
     int nbrEdge = 45;
     int nbrVertex = 20;

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
@@ -49,13 +49,13 @@ public:
     bool checkTopology();
 
 
-    /// Test on @sa EdgeSetTopologyModifier::removeVertices method and check edge buffers.
+    /// Test on @sa TriangleSetTopologyModifier::removeVertices method and check triangle buffers.
     bool testRemovingVertices();
 
-    /// Test on @sa EdgeSetTopologyModifier::removeTriangles method with isolated vertices and check triangle buffers.
+    /// Test on @sa TriangleSetTopologyModifier::removeTriangles method with isolated vertices and check triangle buffers.
     bool testRemovingTriangles();
 
-    /// Test on @sa EdgeSetTopologyModifier::addTriangles method and check triangle buffers.
+    /// Test on @sa TriangleSetTopologyModifier::addTriangles method and check triangle buffers.
     bool testAddingTriangles();
 
 private:

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
@@ -358,7 +358,7 @@ bool TriangleSetTopology_test::testRemovingTriangles()
     EXPECT_EQ(triangles.size(), nbrTriangle);
 
     // 1. Check first the swap + pop_back method
-    const Triangle lastTri = triangles.back();
+    const TriangleSetTopologyContainer::Triangle lastTri = triangles.back();
     sofa::type::vector< TriangleSetTopologyContainer::TriangleID > triIds = { 0 };
 
     // Remove first edge from the buffer

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
@@ -485,8 +485,8 @@ bool TriangleSetTopology_test::testTriangleSegmentIntersectionInPlane(const sofa
     if (triangleGeo == nullptr)
         return false;
 
-    const TriangleID tId = 0;
-    const Triangle tri0 = m_topoCon->getTriangle(tId);
+    const TriangleSetTopologyContainer::TriangleID tId = 0;
+    const TriangleSetTopologyContainer::Triangle tri0 = m_topoCon->getTriangle(tId);
     const auto edgeIds = m_topoCon->getEdgesInTriangle(tId); // as a reminder localEdgeId 0 is the opposite edge of triangle vertex[0]
 
     const auto& p0 = triangleGeo->getPointPosition(tri0[0]);
@@ -504,7 +504,7 @@ bool TriangleSetTopology_test::testTriangleSegmentIntersectionInPlane(const sofa
     ptA = ptA + (ptA - ptB) + bufferZ;
     ptB = ptB + (ptB - ptA) - bufferZ;
 
-    sofa::type::vector<EdgeID> intersectedEdges;
+    sofa::type::vector<TriangleSetTopologyContainer::EdgeID> intersectedEdges;
     sofa::type::vector<Real> baryCoefs;
     triangleGeo->computeSegmentTriangleIntersectionInPlane(ptA, ptB, tId, intersectedEdges, baryCoefs);
     

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
@@ -437,8 +437,8 @@ bool TriangleSetTopology_test::testAddingTriangles()
     const auto triAV0 = m_topoCon->getTrianglesAroundVertex(tri1[0]);
     const auto triAV1 = m_topoCon->getTrianglesAroundVertex(tri1[2]);
 
-    const TriangleSetTopologyContainer::Triangle newTri0 = Triangle(tri0[0], tri0[1], tri1[2]);
-    const TriangleSetTopologyContainer::Triangle newTri1 = Triangle(tri1[0], tri0[2], tri1[2]);
+    const TriangleSetTopologyContainer::Triangle newTri0 = TriangleSetTopologyContainer::Triangle(tri0[0], tri0[1], tri1[2]);
+    const TriangleSetTopologyContainer::Triangle newTri1 = TriangleSetTopologyContainer::Triangle(tri1[0], tri0[2], tri1[2]);
 
     sofa::type::vector< TriangleSetTopologyContainer::Triangle > triangesToAdd = { newTri0 , newTri1 };
     

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSetTopology_test.cpp
@@ -352,14 +352,14 @@ bool TriangleSetTopology_test::testRemovingTriangles()
         return false;
 
     // Check triangle buffer before changes
-    const sofa::type::vector<Triangle>& triangles = m_topoCon->getTriangleArray();
+    const sofa::type::vector<TriangleSetTopologyContainer::Triangle>& triangles = m_topoCon->getTriangleArray();
     EXPECT_EQ(m_topoCon->getNbPoints(), nbrVertex);
     EXPECT_EQ(m_topoCon->getNbEdges(), nbrEdge);
     EXPECT_EQ(triangles.size(), nbrTriangle);
 
     // 1. Check first the swap + pop_back method
     const Triangle lastTri = triangles.back();
-    sofa::type::vector< TriangleID > triIds = { 0 };
+    sofa::type::vector< TriangleSetTopologyContainer::TriangleID > triIds = { 0 };
 
     // Remove first edge from the buffer
     triangleModifier->removeTriangles(triIds, true, true);
@@ -373,7 +373,7 @@ bool TriangleSetTopology_test::testRemovingTriangles()
     EXPECT_EQ(m_topoCon->getNbPoints(), newNbrVertex);
 
     // Check that first triangle is now the previous last triangle
-    const Triangle& newTri = m_topoCon->getTriangle(0);
+    const TriangleSetTopologyContainer::Triangle& newTri = m_topoCon->getTriangle(0);
     EXPECT_EQ(lastTri[0], newTri[0]);
     EXPECT_EQ(lastTri[1], newTri[1]);
     EXPECT_EQ(lastTri[2], newTri[2]);
@@ -430,17 +430,17 @@ bool TriangleSetTopology_test::testAddingTriangles()
         return false;
 
     // construct triangles based on vertices of 2 triangles which do not have vertices in commun
-    const sofa::type::vector<Triangle>& triangles = m_topoCon->getTriangleArray();
-    const Triangle tri0 = triangles[0];
-    const Triangle tri1 = triangles[10];
+    const sofa::type::vector<TriangleSetTopologyContainer::Triangle>& triangles = m_topoCon->getTriangleArray();
+    const TriangleSetTopologyContainer::Triangle tri0 = triangles[0];
+    const TriangleSetTopologyContainer::Triangle tri1 = triangles[10];
 
     const auto triAV0 = m_topoCon->getTrianglesAroundVertex(tri1[0]);
     const auto triAV1 = m_topoCon->getTrianglesAroundVertex(tri1[2]);
 
-    const Triangle newTri0 = Triangle(tri0[0], tri0[1], tri1[2]);
-    const Triangle newTri1 = Triangle(tri1[0], tri0[2], tri1[2]);
+    const TriangleSetTopologyContainer::Triangle newTri0 = Triangle(tri0[0], tri0[1], tri1[2]);
+    const TriangleSetTopologyContainer::Triangle newTri1 = Triangle(tri1[0], tri0[2], tri1[2]);
 
-    sofa::type::vector< Triangle > triangesToAdd = { newTri0 , newTri1 };
+    sofa::type::vector< TriangleSetTopologyContainer::Triangle > triangesToAdd = { newTri0 , newTri1 };
     
     // Add triangles
     // TODO @epernod (2025-01-28): Adding the triangle create a segmentation fault. Need to investigate why
@@ -449,8 +449,8 @@ bool TriangleSetTopology_test::testAddingTriangles()
 
     // Check buffers on new triangle just added
     EXPECT_EQ(m_topoCon->getNbTriangles(), nbrTriangle + triangesToAdd.size());
-    const Triangle& checkTri0 = m_topoCon->getTriangle(nbrTriangle);
-    const Triangle& checkTri1 = m_topoCon->getTriangle(nbrTriangle + 1);
+    const TriangleSetTopologyContainer::Triangle& checkTri0 = m_topoCon->getTriangle(nbrTriangle);
+    const TriangleSetTopologyContainer::Triangle& checkTri1 = m_topoCon->getTriangle(nbrTriangle + 1);
 
     for (int i = 0; i < 3; i++)
     {


### PR DESCRIPTION
Edit: PR based on #5246 

This method compute the intersection between a Triangle from the current topology and a Segment [AB] which will be projected in Triangle Frame. Using Segment-Segment intersection from `geometry::Edge::intersectionWithEdge`

Return true if there is an intersection otherwise false.

Will fill input variables `sofa::type::vector<EdgeID>& intersectedEdges` and `sofa::type::vector<Real>& baryCoefs` with the list of intersected edges (Id in global topology, not relative to the triangle) and the barycoef of the intersection relative to the first vertex of the edge. I.e coordinate of the intersection is:   Edge[0] * barycoef  + Edge[1] * (1-barycoef )

This method will replace `computeSegmentTriangleIntersection`  when all the work regarding new incision in triangle using TriangleSubvider is finished. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
