### PR TITLE
[GUI.Qt] Fix invalid color of the warning sign on object

### DIFF
--- a/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.cpp
+++ b/Sofa/GUI/Qt/src/sofa/gui/qt/GraphListenerQListView.cpp
@@ -154,7 +154,6 @@ QPixmap* getPixmap(core::objectmodel::Base* obj, bool haveInfo, bool haveWarning
         if(haveErrors)
             flags |= 1 << (4) ;
 
-
         static std::map<unsigned int, QPixmap*> pixmaps;
         if (!pixmaps.count(flags))
         {
@@ -236,10 +235,10 @@ QPixmap* getPixmap(core::objectmodel::Base* obj, bool haveInfo, bool haveWarning
         flags |= 1 << (ALLCOLORS+1) ;
 
     if(haveWarning)
-        flags |= 1 << (ALLCOLORS+1) ;
+        flags |= 1 << (ALLCOLORS+2) ;
 
     if(haveErrors)
-        flags |= 1 << (ALLCOLORS+1) ;
+        flags |= 1 << (ALLCOLORS+3) ;
 
     static std::map<unsigned int, QPixmap*> pixmaps;
     if (!pixmaps.count(flags))
@@ -249,10 +248,8 @@ QPixmap* getPixmap(core::objectmodel::Base* obj, bool haveInfo, bool haveWarning
             if (flags & (1<<i))
                 ++nc;
         const int nx = 2+iconWidth*nc+iconMargin;
-        //QImage * img = new QImage(nx,iconHeight,32);
         QImage * img = new QImage(nx,iconHeight,QImage::Format_ARGB32);
 
-        //img->setAlphaBuffer(true);
         img->fill(qRgba(0,0,0,0));
         // Workaround for qt 3.x where fill() does not set the alpha channel
         for (int y=0 ; y < iconHeight ; y++)


### PR DESCRIPTION
The following scene: 
```python
import Sofa

def createScene(root):
	root.addObject("MechanicalObject", name="mo1")
	Sofa.msg_info(root.mo1,"INFO MESSAGE")

	root.addObject("MechanicalObject", name="mo2")
	Sofa.msg_warning(root.mo2,"WARNING MESSAGE")
	
	root.addObject("MechanicalObject", name="mo3")
	Sofa.msg_error(root.mo3,"ERROR MESSAGE")
	
	root.addObject("MechanicalObject", name="mo4")
	Sofa.msg_deprecated(root.mo4,"DEPRECATION MESSAGE")
```
Leads to the following rendering in the scenegraph (with all the warning sign in green instead of one reflecting the level or message)

![Capture d’écran du 2025-01-06 14-40-45](https://github.com/user-attachments/assets/8b64e94e-ab33-4472-9d66-319d083c9f0a)

The PR fix it leading to the following display:
![Capture d’écran du 2025-01-06 14-44-33](https://github.com/user-attachments/assets/3f797968-0b51-4e4f-9443-2acf2e3dccd7)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
