### PR TITLE
[DefaultType] Aliases defined twice

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/fwd.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/fwd.h
@@ -57,15 +57,6 @@ typedef RigidMass<3,float> Rigid3fMass;
 typedef StdRigidTypes<3,SReal> Rigid3Types;  ///< un-defined precision type
 typedef RigidMass<3,SReal>     Rigid3Mass;   ///< un-defined precision type
 
-typedef StdRigidTypes<2,double> Rigid2dTypes;
-typedef RigidMass<2,double> Rigid2dMass;
-
-typedef StdRigidTypes<2,float> Rigid2fTypes;
-typedef RigidMass<2,float> Rigid2fMass;
-
-typedef StdRigidTypes<2,SReal> Rigid2Types;
-typedef RigidMass<2,SReal> Rigid2Mass;
-
 template<class TCoord, class TDeriv, class TReal = typename TCoord::value_type>
 class StdVectorTypes;
 


### PR DESCRIPTION
The aliases are declared twice. Not sure if it the intention was to declare them for another dimension or not... (@damienmarchal ?)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
