### PR TITLE
[Engine] Fix drawLines from ValuesFromPositions

### DIFF
--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.inl
@@ -430,8 +430,7 @@ void ValuesFromPositions<DataTypes>::draw(const core::visual::VisualParams* vpar
                 color[j] = (float)fabs (tetrahedronVectors[i][j]);
 
             colors.push_back(color);
-            colors.push_back(color);
-            
+
             vertices.push_back(point1);
             vertices.push_back(point2);
         }


### PR DESCRIPTION
Before this PR, the console was flooded of warnings (e.g. in the [ValuesFromPositions_vectorField.scn](https://github.com/sofa-framework/sofa/blob/master/examples/Component/Engine/Select/ValuesFromPositions_vectorField.scn))
```bash
[WARNING] [DrawToolGL] Sizes mismatch in drawLines method, points.size(): 1500 should be equal to colors.size()*2: 3000
```
Due to the fact that the color vector was filled twice, therefore twice longer then the point vectors.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
