### PR TITLE
[Type] Deprecate is_container trait

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
+++ b/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
@@ -28,7 +28,6 @@
 
 #include <sofa/type/vector.h>
 #include <sofa/helper/config.h>
-#include <sofa/type/trait/is_container.h>
 
 namespace sofa::helper
 {
@@ -58,7 +57,7 @@ public :
     explicit OptionsGroup(int nbofRadioButton,...);
 
     ///generic constructor taking other string container like list<string>, set<string>, vector<string>
-    template <class T, typename = std::enable_if_t<type::trait::is_container<T>::value> >
+    template <std::ranges::range T>
     explicit OptionsGroup(const T& list);
 
     template <class T> OptionsGroup(const std::initializer_list<T>& list);
@@ -114,7 +113,7 @@ protected:
     type::vector<std::string> textItems    ;
     unsigned int                selectedItem ;
 
-    template <class T> void buildFromContainer(const T& list);
+    template <std::ranges::range T> void buildFromContainer(const T& list);
 
 public:
 
@@ -137,7 +136,7 @@ inline std::istream & operator >>(std::istream& in, OptionsGroup& m_trick)
     return in;
 }
 
-template <class T, typename>
+template <std::ranges::range T>
 OptionsGroup::OptionsGroup(const T& list)
 {
     buildFromContainer(list);
@@ -159,7 +158,7 @@ void OptionsGroup::setNames(const std::initializer_list<T>& list)
     selectedItem=0;
 }
 
-template <class T>
+template <std::ranges::range T>
 void OptionsGroup::buildFromContainer(const T& list)
 {
     textItems.reserve(list.size());

--- a/Sofa/framework/Type/src/sofa/type/config.h.in
+++ b/Sofa/framework/Type/src/sofa/type/config.h.in
@@ -50,3 +50,12 @@
         "v24.12", "v25.06", \
         "Use isNegligible instead.")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_TYPE
+#define SOFA_ATTRIBUTE_DEPRECATED__IS_CONTAINER()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__IS_CONTAINER() \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v25.06", "v25.12", \
+        "Use std::ranges::ranges concept instead.")
+#endif

--- a/Sofa/framework/Type/src/sofa/type/trait/is_container.h
+++ b/Sofa/framework/Type/src/sofa/type/trait/is_container.h
@@ -21,12 +21,17 @@
 ******************************************************************************/
 #pragma once
 #include <type_traits>
+#include <sofa/type/config.h>
+
+SOFA_HEADER_DEPRECATED_NOT_REPLACED("v25.06", "v25.12")
+
 
 namespace sofa::type::trait
 {
 
 /// Detect if a type T has iterator/const iterator function.
 template<typename T>
+SOFA_ATTRIBUTE_DEPRECATED__IS_CONTAINER()
 struct is_container
 {
     typedef typename std::remove_const<T>::type test_type;


### PR DESCRIPTION
Because the concept `std::ranges::range` can be used instead



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
