### PR TITLE
[all] Remove last deprecated VecId and use constexpr vecids

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/FixedLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/FixedLagrangianConstraint.inl
@@ -70,8 +70,8 @@ void FixedLagrangianConstraint<DataTypes>::getConstraintViolation(const core::Co
     SOFA_UNUSED(cParams);
     SOFA_UNUSED(x);
     SOFA_UNUSED(v);
-    const DataVecCoord * freePos = this->getMState()->read(sofa::core::VecId::freePosition());
-    const DataVecCoord * restPos = this->getMState()->read(sofa::core::VecId::restPosition());
+    const DataVecCoord * freePos = this->getMState()->read(sofa::core::vec_id::read_access::freePosition);
+    const DataVecCoord * restPos = this->getMState()->read(sofa::core::vec_id::read_access::restPosition);
 
     for(unsigned i=0; i<m_cid.size(); ++i)
     {

--- a/Sofa/Component/Playback/src/sofa/component/playback/CompareState.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/CompareState.cpp
@@ -150,7 +150,7 @@ void CompareState::processCompareState()
         if (cmd.compare("X=") == 0)
         {
             last_X = *it;
-            currentError = mmodel->compareVec(core::VecId::position(), str);
+            currentError = mmodel->compareVec(sofa::core::vec_id::read_access::position, str);
 
 
             totalError_X +=currentError;
@@ -162,7 +162,7 @@ void CompareState::processCompareState()
         else if (cmd.compare("V=") == 0)
         {
             last_V = *it;
-            currentError = mmodel->compareVec(core::VecId::velocity(), str);
+            currentError = mmodel->compareVec(sofa::core::vec_id::read_access::velocity, str);
             totalError_V +=currentError;
 
             const double dsize = (double)this->mmodel->getSize();

--- a/Sofa/Component/Playback/src/sofa/component/playback/ReadState.inl
+++ b/Sofa/Component/Playback/src/sofa/component/playback/ReadState.inl
@@ -248,7 +248,7 @@ void ReadState::processReadState()
         str >> cmd;
         if (cmd == "X=")
         {
-            mmodel->readVec(core::VecId::position(), str);
+            mmodel->readVec(sofa::core::vec_id::write_access::position, str);
             mmodel->applyScale(scale,scale,scale);
             mmodel->applyRotation(rotation[0],rotation[1],rotation[2]);
             mmodel->applyTranslation(translation[0],translation[1],translation[2]);
@@ -257,7 +257,7 @@ void ReadState::processReadState()
         }
         else if (cmd == "V=")
         {
-            mmodel->readVec(core::VecId::velocity(), str);
+            mmodel->readVec(sofa::core::vec_id::write_access::velocity, str);
             updated = true;
         }
     }

--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteState.inl
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteState.inl
@@ -327,20 +327,20 @@ void WriteState::handleEvent(sofa::core::objectmodel::Event* event)
                 if (d_writeX.getValue())
                 {
                     str << "  X= ";
-                    mmodel->writeVec(core::VecId::position(), str);
+                    mmodel->writeVec(sofa::core::vec_id::read_access::position, str);
                     str << "\n";
                 }
                 if (d_writeX0.getValue())
                 {
                     str << "  X0= ";
-                    mmodel->writeVec(core::VecId::restPosition(), str);
+                    mmodel->writeVec(sofa::core::vec_id::read_access::restPosition, str);
                     str << "\n";
                 }
                 //write the V state
                 if (d_writeV.getValue())
                 {
                     str << "  V= ";
-                    mmodel->writeVec(core::VecId::velocity(), str);
+                    mmodel->writeVec(sofa::core::vec_id::read_access::velocity, str);
                     str << "\n";
                 }
                 gzputs(gzfile, str.str().c_str());
@@ -355,27 +355,27 @@ void WriteState::handleEvent(sofa::core::objectmodel::Event* event)
                     if (d_writeX.getValue())
                     {
                         (*outfile) << "  X= ";
-                        mmodel->writeVec(core::VecId::position(), *outfile);
+                        mmodel->writeVec(sofa::core::vec_id::read_access::position, *outfile);
                         (*outfile) << "\n";
                     }
                     if (d_writeX0.getValue())
                     {
                         (*outfile) << "  X0= ";
-                        mmodel->writeVec(core::VecId::restPosition(), *outfile);
+                        mmodel->writeVec(sofa::core::vec_id::read_access::restPosition, *outfile);
                         (*outfile) << "\n";
                     }
                     //write the V state
                     if (d_writeV.getValue())
                     {
                         (*outfile) << "  V= ";
-                        mmodel->writeVec(core::VecId::velocity(), *outfile);
+                        mmodel->writeVec(sofa::core::vec_id::read_access::velocity, *outfile);
                         (*outfile) << "\n";
                     }
                     //write the F state
                     if (d_writeF.getValue())
                     {
                         (*outfile) << "  F= ";
-                        mmodel->writeVec(core::VecId::force(), *outfile);
+                        mmodel->writeVec(sofa::core::vec_id::read_access::force, *outfile);
                         (*outfile) << "\n";
                     }
                     outfile->flush();

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
@@ -1228,7 +1228,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::computeVonMisesStress()
 {
     typename core::behavior::MechanicalState<DataTypes>* mechanicalObject;
     this->getContext()->get(mechanicalObject);
-    const VecCoord& X = mechanicalObject->read(core::ConstVecCoordId::position())->getValue();
+    const VecCoord& X = mechanicalObject->read(core::vec_id::read_access::position)->getValue();
 
     const sofa::core::topology::BaseMeshTopology::SeqTetrahedra& tetras = this->l_topology->getTetrahedra();
     const type::vector<typename TetrahedralCorotationalFEMForceField<DataTypes>::TetrahedronInformation>& tetrahedronInf = tetrahedronInfo.getValue();

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -1134,7 +1134,7 @@ void MechanicalObject<DataTypes>::storeResetState()
     if( !isIndependent() ) return;
 
     // Save initial state for reset button
-    vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::restPosition, sofa::core::vec_id::read_access::position);
+    vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::resetPosition, sofa::core::vec_id::read_access::position);
 
     // we only store a resetVelocity if the velocity is not zero
     helper::ReadAccessor< Data<VecDeriv> > v = *this->read(core::vec_id::read_access::velocity);

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -1032,7 +1032,7 @@ void MechanicalObject<DataTypes>::init()
     //case if X0 has been set but not X
     if (read(core::vec_id::read_access::restPosition)->getValue().size() > x_wA.size())
     {
-        vOp(core::execparams::defaultInstance(), core::VecId::position(), core::VecId::restPosition());
+        vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::position, sofa::core::vec_id::read_access::restPosition);
     }
 
     // the given position and velocity vectors are empty
@@ -1097,9 +1097,9 @@ void MechanicalObject<DataTypes>::init()
     {
         // storing X0 from X
         if( restScale.getValue()!=1 )
-            vOp(core::execparams::defaultInstance(), core::VecId::restPosition(), core::ConstVecId::null(), core::VecId::position(), restScale.getValue());
+            vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::restPosition, core::ConstVecId::null(), sofa::core::vec_id::write_access::position, restScale.getValue());
         else
-            vOp(core::execparams::defaultInstance(), core::VecId::restPosition(), core::VecId::position());
+            vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::restPosition, sofa::core::vec_id::write_access::position);
     }
 
 
@@ -1134,10 +1134,10 @@ void MechanicalObject<DataTypes>::storeResetState()
     if( !isIndependent() ) return;
 
     // Save initial state for reset button
-    vOp(core::execparams::defaultInstance(), core::VecId::resetPosition(), core::VecId::position());
+    vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::restPosition, sofa::core::vec_id::read_access::position);
 
     // we only store a resetVelocity if the velocity is not zero
-    helper::ReadAccessor< Data<VecDeriv> > v = *this->read(core::vec_id::write_access::velocity);
+    helper::ReadAccessor< Data<VecDeriv> > v = *this->read(core::vec_id::read_access::velocity);
     bool zero = true;
     for (unsigned int i=0; i<v.size(); ++i)
     {
@@ -1147,7 +1147,7 @@ void MechanicalObject<DataTypes>::storeResetState()
         if (!zero) break;
     }
     if (!zero)
-        vOp(core::execparams::defaultInstance(), core::VecId::resetVelocity(), core::VecId::velocity());
+        vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::resetVelocity, sofa::core::vec_id::read_access::velocity);
 }
 
 
@@ -1155,24 +1155,24 @@ template <class DataTypes>
 void MechanicalObject<DataTypes>::reset()
 {
     // resetting force for every dofs, even mapped ones
-    vOp(core::execparams::defaultInstance(), core::VecId::force());
+    vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::force);
 
     if (!reset_position.isSet()) // mapped states are deduced from independent ones
         return;
 
-    vOp(core::execparams::defaultInstance(), core::VecId::position(), core::VecId::resetPosition());
+    vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::position, sofa::core::vec_id::read_access::resetPosition);
 
     if (!reset_velocity.isSet())
     {
-        vOp(core::execparams::defaultInstance(), core::VecId::velocity());
+        vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::velocity);
     }
     else
     {
-        vOp(core::execparams::defaultInstance(), core::VecId::velocity(), core::VecId::resetVelocity());
+        vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::velocity, sofa::core::vec_id::write_access::resetVelocity);
     }
 
-    if( xfree.isSet() ) vOp(core::execparams::defaultInstance(), core::VecId::freePosition(), core::VecId::position());
-    if( vfree.isSet() ) vOp(core::execparams::defaultInstance(), core::VecId::freeVelocity(), core::VecId::velocity());
+    if( xfree.isSet() ) vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::freePosition, sofa::core::vec_id::read_access::position);
+    if( vfree.isSet() ) vOp(core::execparams::defaultInstance(), sofa::core::vec_id::write_access::freeVelocity, sofa::core::vec_id::read_access::velocity);
 }
 
 
@@ -1285,9 +1285,9 @@ SReal MechanicalObject<DataTypes>::compareVec(core::ConstVecId v, std::istream &
 template <class DataTypes>
 void MechanicalObject<DataTypes>::writeState(std::ostream& out)
 {
-    writeVec(core::VecId::position(),out);
+    writeVec(sofa::core::vec_id::read_access::position,out);
     out << " ";
-    writeVec(core::VecId::velocity(),out);
+    writeVec(sofa::core::vec_id::read_access::velocity,out);
 }
 
 template <class DataTypes>
@@ -2445,11 +2445,11 @@ SReal MechanicalObject<DataTypes>::getConstraintJacobianTimesVecDeriv(unsigned i
     const VecDeriv *data = 0;
 
     // Maybe we should extend this to restvelocity
-    if (id == core::ConstVecId::velocity())
+    if (id == sofa::core::vec_id::read_access::velocity)
     {
         data = &v.getValue();
     }
-    else if (id == core::ConstVecId::dx())
+    else if (id == sofa::core::vec_id::read_access::dx)
     {
         data = &dx.getValue();
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Visitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Visitor.cpp
@@ -289,16 +289,16 @@ void Visitor::debug_write_state_before( core::objectmodel::BaseObject* obj )
     if( core::behavior::BaseMechanicalState* dof = obj->getContext()->getMechanicalState() )
     {
         tmp<<", state:\nx= ";
-        dof->writeVec(core::VecId::position(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::position, tmp);
 
         tmp<<"\nv= ";
-        dof->writeVec(core::VecId::velocity(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::velocity, tmp);
 
         tmp<<"\ndx= ";
-        dof->writeVec(core::VecId::dx(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::dx, tmp);
 
         tmp<<"\nf= ";
-        dof->writeVec(core::VecId::force(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::force, tmp);
     }
     dmsg_info("Visitor(debug)") << tmp.str() ;
 }
@@ -311,16 +311,16 @@ void Visitor::debug_write_state_after( core::objectmodel::BaseObject* obj )
     if( core::behavior::BaseMechanicalState* dof = obj->getContext()->getMechanicalState() )
     {
         tmp<<", state:\nx= ";
-        dof->writeVec(core::VecId::position(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::position, tmp);
 
         tmp<<"\nv= ";
-        dof->writeVec(core::VecId::velocity(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::velocity, tmp);
 
         tmp<<"\ndx= ";
-        dof->writeVec(core::VecId::dx(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::dx, tmp);
 
         tmp<<"\nf= ";
-        dof->writeVec(core::VecId::force(), tmp);
+        dof->writeVec(sofa::core::vec_id::read_access::force, tmp);
     }
     dmsg_info("Visitor(debug)") << tmp.str() ;
 }


### PR DESCRIPTION
Not done with Find/Replace dumbly because some functions were using the "write" access when they need a read access only.

- https://github.com/sofa-framework/sofa/pull/5082



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
