### PR TITLE
[Simulation] Trigger warning when Node already contains component

### DIFF
--- a/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
@@ -90,25 +90,22 @@ public:
         }
     }
 
-    void checkBasicBehavior(const std::string& filename, std::vector<std::string> pathes){
+    void checkBasicBehavior(const std::string& filename, std::vector<std::string> pathes)
+    {
         dataPath = pathes ;
 
         EXPECT_MSG_NOEMIT(Error, Warning) ;
-        std::stringstream scene1;
-        scene1 <<
-                "<?xml version='1.0'?> \n"
-                "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >       \n"
-                "   <DefaultAnimationLoop/>                                        \n"
-                "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
-                "   <MeshOBJLoader name='loader' filename='mesh/liver-smooth.obj'/> \n"
-                "   <VisualModel src='@loader'/>                                      \n"
-                "   <STLExporter name='exporter1' printLog='false' filename='"<< filename << "' exportAtBegin='true' /> \n"
-                "</Node>                                                           \n" ;
 
-        const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
+        const Node::SPtr root = sofa::simpleapi::createRootNode(sofa::simulation::getSimulation(), "root", {{"gravity", "0 0 0"}});
+        sofa::simpleapi::createObject(root, "DefaultAnimationLoop");
+        sofa::simpleapi::createObject(root, "MechanicalObject", {{"position", "0 1 2 3 4 5 6 7 8 9"}});
+        sofa::simpleapi::createObject(root, "MeshOBJLoader", {{"name", "loader"}, {"filename", "mesh/liver-smooth.obj"}});
+        const Node::SPtr visualNode = sofa::simpleapi::createChild(root, "Visual");
+        sofa::simpleapi::createObject(visualNode, "VisualModel", {{"src", "@../loader"}});
+        sofa::simpleapi::createObject(visualNode, "STLExporter", {{"name", "exporter1"}, {"filename", filename}, {"exportAtBegin", "true"}});
 
-        ASSERT_NE(root.get(), nullptr) << scene1.str() ;
-        root->init(sofa::core::execparams::defaultInstance()) ;
+        ASSERT_NE(root.get(), nullptr);
+        sofa::simulation::node::initRoot(root.get());
 
         // SimulationInitDoneEvent is used to trigger exportAtBegin
         SimulationInitDoneEvent endInit;
@@ -119,32 +116,27 @@ public:
 
         for(auto& pathToCheck : pathes)
         {
-            EXPECT_TRUE( FileSystem::exists(pathToCheck) ) << "Problem with '" << pathToCheck  << "'"<< std::endl
-                                                           << "================= scene dump ==========================="
-                                                           << scene1.str() ;
+            EXPECT_TRUE( FileSystem::exists(pathToCheck) );
         }
     }
 
 
-    void checkSimulationWriteEachNbStep(const std::string& filename, std::vector<std::string> pathes, unsigned int numstep){
+    void checkSimulationWriteEachNbStep(const std::string& filename, std::vector<std::string> pathes, unsigned int numstep)
+    {
         dataPath = pathes ;
 
         EXPECT_MSG_NOEMIT(Error, Warning) ;
-        std::stringstream scene1;
-        scene1 <<
-                "<?xml version='1.0'?> \n"
-                "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >       \n"
-                "   <DefaultAnimationLoop/>                                        \n"
-                "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
-                "   <MeshOBJLoader name='loader' filename='mesh/liver-smooth.obj'/> \n"
-                "   <VisualModel src='@loader'/>                                      \n"
-                "   <STLExporter name='exporterA' printLog='false' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
-                "</Node>                                                           \n" ;
 
-        const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene1.str().c_str());
+        const Node::SPtr root = sofa::simpleapi::createRootNode(sofa::simulation::getSimulation(), "root", {{"gravity", "0 0 0"}});
+        sofa::simpleapi::createObject(root, "DefaultAnimationLoop");
+        sofa::simpleapi::createObject(root, "MechanicalObject", {{"position", "0 1 2 3 4 5 6 7 8 9"}});
+        sofa::simpleapi::createObject(root, "MeshOBJLoader", {{"name", "loader"}, {"filename", "mesh/liver-smooth.obj"}});
+        const Node::SPtr visualNode = sofa::simpleapi::createChild(root, "Visual");
+        sofa::simpleapi::createObject(visualNode, "VisualModel", {{"src", "@../loader"}});
+        sofa::simpleapi::createObject(visualNode, "STLExporter", {{"name", "exporterA"}, {"filename", filename}, {"exportEveryNumberOfSteps", "5"}});
 
         ASSERT_NE(root.get(), nullptr) ;
-        root->init(sofa::core::execparams::defaultInstance()) ;
+        sofa::simulation::node::initRoot(root.get());
 
         for(unsigned int i=0;i<numstep;i++)
         {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -1024,8 +1024,25 @@ void Node::setSleeping(bool val)
     }
 }
 
+template<class LinkType, class Component>
+void checkAlreadyContains(Node& self, LinkType& link, Component* obj)
+{
+    if constexpr (!LinkType::IsMultiLink)
+    {
+        if (link != obj && link != nullptr)
+        {
+            static const auto componentClassName = Component::GetClass()->className;
+            msg_error(&self) << "Trying to add a " << componentClassName << " ('" << obj->getName() << "' " << obj << ")"
+                << " into the Node '" << self.getPathName()
+                << "', whereas it already contains one ('" << link->getName() << "' " << link.get() << ")."
+                << " Only one " << componentClassName << " is permitted in a Node. The previous "
+                << componentClassName << " is replaced and the behavior is undefined.";
+        }
+    }
+}
+
 #define NODE_DEFINE_SEQUENCE_ACCESSOR( CLASSNAME, FUNCTIONNAME, SEQUENCENAME ) \
-    void Node::add##FUNCTIONNAME( CLASSNAME* obj ) { SEQUENCENAME.add(obj); } \
+    void Node::add##FUNCTIONNAME( CLASSNAME* obj ) { checkAlreadyContains(*this, SEQUENCENAME, obj); SEQUENCENAME.add(obj); } \
     void Node::remove##FUNCTIONNAME( CLASSNAME* obj ) { SEQUENCENAME.remove(obj); }
 
 NODE_DEFINE_SEQUENCE_ACCESSOR( sofa::core::behavior::BaseAnimationLoop, AnimationLoop, animationManager )

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -1032,7 +1032,7 @@ void checkAlreadyContains(Node& self, LinkType& link, Component* obj)
         if (link != obj && link != nullptr)
         {
             static const auto componentClassName = Component::GetClass()->className;
-            msg_error(&self) << "Trying to add a " << componentClassName << " ('"
+            msg_warning(&self) << "Trying to add a " << componentClassName << " ('"
                 << obj->getName() << "' [" << obj->getClassName() << "] " << obj << ")"
                 << " into the Node '" << self.getPathName()
                 << "', whereas it already contains one ('" << link->getName() << "' [" << link->getClassName() << "] " << link.get() << ")."

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -1032,9 +1032,10 @@ void checkAlreadyContains(Node& self, LinkType& link, Component* obj)
         if (link != obj && link != nullptr)
         {
             static const auto componentClassName = Component::GetClass()->className;
-            msg_error(&self) << "Trying to add a " << componentClassName << " ('" << obj->getName() << "' " << obj << ")"
+            msg_error(&self) << "Trying to add a " << componentClassName << " ('"
+                << obj->getName() << "' [" << obj->getClassName() << "] " << obj << ")"
                 << " into the Node '" << self.getPathName()
-                << "', whereas it already contains one ('" << link->getName() << "' " << link.get() << ")."
+                << "', whereas it already contains one ('" << link->getName() << "' [" << link->getClassName() << "] " << link.get() << ")."
                 << " Only one " << componentClassName << " is permitted in a Node. The previous "
                 << componentClassName << " is replaced and the behavior is undefined.";
         }

--- a/Sofa/framework/Simulation/Graph/test/Node_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Node_test.cpp
@@ -219,7 +219,7 @@ TEST(Node_test, twoMechanicalStatesInTheSameNode)
     const auto plugins = testing::makeScopedPlugin({Sofa.Component.StateContainer});
     sofa::simpleapi::createObject(root, "MechanicalObject", {{"template", "Vec3"}, {"name", "A"}});
 
-    EXPECT_MSG_EMIT(Error);
+    EXPECT_MSG_EMIT(Warning);
     sofa::simpleapi::createObject(root, "MechanicalObject", {{"template", "Vec3"}, {"name", "B"}});
 
     //the last added state is the one in Node

--- a/Sofa/framework/Simulation/Graph/test/Node_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Node_test.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest ;
 
@@ -33,6 +35,9 @@ namespace sofa
 
 TEST( Node_test, getPathName)
 {
+    // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+
     /* create trivial DAG :
      *
      * A
@@ -90,6 +95,9 @@ TEST(Node_test, addObjectAtFront)
 
 TEST(Node_test, addObjectPreventingSharedContext)
 {
+    // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+
     const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
 
     const BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
@@ -175,6 +183,53 @@ TEST(Node_test, getObjectsStdUnorderedSet)
 
     EXPECT_NE(objects.find(A.get()), objects.end());
     EXPECT_NE(objects.find(B.get()), objects.end());
+}
+
+class CounterVisitor : public simulation::MechanicalVisitor
+{
+public:
+    using MechanicalVisitor::MechanicalVisitor;
+
+    Result fwdMechanicalState(simulation::Node* node, sofa::core::behavior::BaseMechanicalState* state) override
+    {
+        SOFA_UNUSED(node);
+        SOFA_UNUSED(state);
+        m_counter++;
+        return Result::RESULT_CONTINUE;
+    }
+
+    Result fwdMappedMechanicalState(simulation::Node* node, sofa::core::behavior::BaseMechanicalState* state) override
+    {
+        SOFA_UNUSED(node);
+        SOFA_UNUSED(state);
+        ++m_counter;
+        return Result::RESULT_CONTINUE;
+    }
+
+    std::size_t m_counter = 0;
+};
+
+TEST(Node_test, twoMechanicalStatesInTheSameNode)
+{
+    // required to be able to use EXPECT_MSG_NOEMIT and EXPECT_MSG_EMIT
+    sofa::helper::logging::MessageDispatcher::addHandler(sofa::testing::MainGtestMessageHandler::getInstance() ) ;
+
+    const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
+
+    const auto plugins = testing::makeScopedPlugin({Sofa.Component.StateContainer});
+    sofa::simpleapi::createObject(root, "MechanicalObject", {{"template", "Vec3"}, {"name", "A"}});
+
+    EXPECT_MSG_EMIT(Error);
+    sofa::simpleapi::createObject(root, "MechanicalObject", {{"template", "Vec3"}, {"name", "B"}});
+
+    //the last added state is the one in Node
+    EXPECT_EQ(root->mechanicalState->getName(), "B");
+
+    CounterVisitor visitor(core::MechanicalParams::defaultInstance());
+    root->executeVisitor(&visitor);
+
+    //only one of the two added states is visited
+    EXPECT_EQ(visitor.m_counter, 1);
 }
 
 }// namespace sofa

--- a/Sofa/framework/Simulation/Graph/test/Simulation_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Simulation_test.cpp
@@ -223,10 +223,9 @@ protected:
         root = simulation::getSimulation()->createNewGraph("root");
         root->addObject(core::objectmodel::New<InstrumentedObject<MechanicalObject3> >());
 
-        typename UniformMass3::SPtr uniformMass = core::objectmodel::New<UniformMass3>();
+        typename UniformMass3::SPtr uniformMass = core::objectmodel::New<InstrumentedObject<UniformMass3>>();
         uniformMass->d_totalMass.setValue(1.0);
         root->addObject(uniformMass);
-        root->addObject(core::objectmodel::New<InstrumentedObject<UniformMass3> >());
 
         const simulation::Node::SPtr child  = simulation::getSimulation()->createNewNode("child");
         root->addChild(child);


### PR DESCRIPTION
For some component types (see list below), visitors only consider the last added component in the Node. This is due to the fact that Node stores some links as `SingleLink`. The user has no idea of that, so this PR triggers an error when a second component of the same type is added into a Node.

The error message looks like:

```
[ERROR]   [Node(root)] Trying to add a BaseMechanicalState ('unnamed' [MechanicalObject] 000001634787E4E0) into the Node '/', whereas it already contains one ('A' [MechanicalObject] 00000163467EA9A0). Only one BaseMechanicalState is permitted in a Node. The previous BaseMechanicalState is replaced and the behavior is undefined.
```

Note that the name is 'unnamed' because its has not been parsed. I added the address of the object in case both objects have the same name.

A unit test is added on `BaseMechanicalState`.

List of concerned components:

```cpp
    NodeSingle<sofa::core::behavior::BaseAnimationLoop> animationManager;
    NodeSingle<sofa::core::visual::VisualLoop> visualLoop;
    NodeSingle<sofa::core::visual::BaseVisualStyle> visualStyle;
    NodeSingle<sofa::core::topology::Topology> topology;
    NodeSingle<sofa::core::topology::BaseMeshTopology> meshTopology;
    NodeSingle<sofa::core::BaseState> state;
    NodeSingle<sofa::core::behavior::BaseMechanicalState> mechanicalState;
    NodeSingle<sofa::core::BaseMapping> mechanicalMapping;
    NodeSingle<sofa::core::behavior::BaseMass> mass;
    NodeSingle<sofa::core::collision::Pipeline> collisionPipeline;
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
