### PR TITLE
[all] Replace find by contains

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/DirectSAPNarrowPhase.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/DirectSAPNarrowPhase.cpp
@@ -235,7 +235,7 @@ void DirectSAPNarrowPhase::cacheData()
         data.doesBoxSelfCollide = lastCollisionModel->getSelfCollision();
         data.isBoxSimulated = lastCollisionModel->isSimulated();
         data.collisionElementIterator = box.cube.getExternalChildren().first;
-        data.isInBroadPhase = (m_broadPhaseCollisionModels.find(firstCollisionModel) != m_broadPhaseCollisionModels.end() );
+        data.isInBroadPhase = m_broadPhaseCollisionModels.contains(firstCollisionModel);
     }
 }
 

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/IncrSAP.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/IncrSAP.cpp
@@ -184,7 +184,7 @@ void IncrSAP::reinit()
 
 inline bool IncrSAP::added(core::CollisionModel *cm) const
 {
-    return collisionModels.count(cm->getLast()) >= 1;
+    return collisionModels.contains(cm->getLast());
 }
 
 

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
@@ -64,7 +64,7 @@ sofa::helper::OptionsGroup CollisionResponse::initializeResponseOptions(sofa::co
     }
 
     sofa::helper::OptionsGroup responseOptions(listResponse);
-    if (listResponse.find("PenalityContactForceField") != listResponse.end())
+    if (listResponse.contains("PenalityContactForceField"))
         responseOptions.setSelectedItem("PenalityContactForceField");
 
     return responseOptions;
@@ -210,7 +210,7 @@ CollisionResponse::removeInactiveContacts(const core::collision::ContactManager:
         core::collision::Contact::SPtr contact = contactIt->second;
         dmsg_error_when(contact == nullptr) << "Checking if inactive on invalid contact";
 
-        if (outputsMap.find(contactIt->first) == outputsMap.end())
+        if (!outputsMap.contains(contactIt->first))
         {
             //contact is not found among the result of the collision detection during this time step
             //the contact comes from a previous time step

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/RuleBasedContactManager.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/RuleBasedContactManager.h
@@ -86,7 +86,7 @@ public:
             }
             else
             {
-                if ( model1->getGroups().count(group1)==0 )
+                if (!model1->getGroups().contains(group1) )
                     return false;
             }
             if (!name2.empty())
@@ -96,7 +96,7 @@ public:
             }
             else
             {
-                if ( model2->getGroups().count(group2)==0 )
+                if (!model2->getGroups().contains(group2) )
                     return false;
             }
             return true;

--- a/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
+++ b/Sofa/Component/Engine/Analyze/src/sofa/component/engine/analyze/Distances.inl
@@ -309,7 +309,7 @@ void Distances< DataTypes >::computeGeodesicalDistance ( const unsigned int& map
         const core::topology::BaseMeshTopology::HexaID& hexaID = hexaCoord.first;
         const double& distance = hexaCoord.second;
 
-        if ( hexasParsed.find ( hexaID ) != hexasParsed.end() ) continue;
+        if ( hexasParsed.contains ( hexaID )) continue;
         hexasParsed.insert ( hexaID ); // This hexa has been parsed
 
         // Continue if the distance max is reached

--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/ExtrudeSurface.inl
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/ExtrudeSurface.inl
@@ -120,7 +120,7 @@ void ExtrudeSurface<DataTypes>::doUpdate()
         //a table is also used to map old vertex indices with the new set of indices
         for (unsigned int i=0 ; i<3 ; i++)
         {
-            if (pointMatching.find(triangle[i]) == pointMatching.end())
+            if (!pointMatching.contains(triangle[i]))
             {
                 extrusionVertices->push_back(surfaceVertices[triangle[i]]);
                 extrusionVertices->push_back(surfaceVertices[triangle[i]] + normals[triangle[i]].first*heightFactor.getValue());
@@ -152,9 +152,9 @@ void ExtrudeSurface<DataTypes>::doUpdate()
 
         for (unsigned int i=0 ; i<3 ; i++)
         {
-            if ( edgesOnBorder.find(e[i])  == edgesOnBorder.end())
+            if (!edgesOnBorder.contains(e[i]))
             {
-                if ( edgesOnBorder.find(ei[i])  == edgesOnBorder.end())
+                if (!edgesOnBorder.contains(ei[i]))
                     edgesOnBorder[e[i]] = true;
                 else
                     edgesOnBorder[ei[i]] = false;

--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/GenerateCylinder.inl
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/GenerateCylinder.inl
@@ -357,11 +357,11 @@ void GenerateCylinder<DataTypes>::doUpdate()
                     // check if a triangle with an opposite orientation already exists
                     Triangle tr = Triangle(v[0], v[2], v[1]);
 
-                    if (triangleMap.find(tr) == triangleMap.end())
+                    if (!triangleMap.contains(tr))
                     {
                         // triangle not in triangleMap so create a new one
                         tr = Triangle(v[0], v[1], v[2]);
-                        if (triangleMap.find(tr) == triangleMap.end())
+                        if (!triangleMap.contains(tr))
                         {
                             triangleMap[tr] = triangleRank++;
                         }

--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/MeshTetraStuffing.cpp
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/MeshTetraStuffing.cpp
@@ -227,7 +227,7 @@ void MeshTetraStuffing::doUpdate()
                 std::set< int > tris;
                 for (unsigned int i=0; i<results.size(); ++i)
                 {
-                    if (tris.find(results[i].tid) != tris.end())
+                    if (tris.contains(results[i].tid))
                     {
                         if (i < results.size()-1)
                             results[i] = results[results.size()-1];

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SelectConnectedLabelsROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SelectConnectedLabelsROI.h
@@ -135,7 +135,7 @@ protected:
                     for(unsigned int l2=0; l2<nb && !connected;l2++)
                         if(l1!=l2)
                             for(size_t i2=0; i2<(*labels[l2])[i].size() && !connected;i2++)
-                                if(connectS.find(TPair((*labels[l1])[i][i1],(*labels[l2])[i][i2]))!=connectS.end())
+                                if(connectS.contains(TPair((*labels[l1])[i][i1],(*labels[l2])[i][i2])))
                                     connected=true;
             if(connected)
                 indices.push_back((sofa::Index)i);

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SelectLabelROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SelectLabelROI.h
@@ -91,7 +91,7 @@ protected:
         for(sofa::Index i=0; i<nb;i++)
         {
             for(size_t j=0; j<labels[i].size();j++)
-                if(selectLabelsSet.find(labels[i][j])!=selectLabelsSet.end())
+                if(selectLabelsSet.contains(labels[i][j]))
                 {
                     indices.push_back(i);
                     break;

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/GridMeshCreator.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/GridMeshCreator.cpp
@@ -61,7 +61,7 @@ void GridMeshCreator::doClearBuffers()
 
 void GridMeshCreator::insertUniqueEdge( unsigned a, unsigned b )
 {
-    if( uniqueEdges.find(Edge(b,a))==uniqueEdges.end() ) // symmetric not found
+    if(!uniqueEdges.contains(Edge(b,a)) ) // symmetric not found
         uniqueEdges.insert(Edge(a,b));                   // redundant elements are automatically pruned
 }
 

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshGmshLoader.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshGmshLoader.cpp
@@ -339,7 +339,7 @@ bool MeshGmshLoader::readGmsh(std::ifstream &file, const unsigned int gmshFormat
                         size_t v1 = std::max(nodes[edgesInQuadraticTriangle[j][0]],
                             nodes[edgesInQuadraticTriangle[j][1]]);
                         Edge e(v0, v1);
-                        if (edgeSet.find(e) == edgeSet.end()) {
+                        if (!edgeSet.contains(e)) {
                             edgeSet.insert(e);
                             addEdge(my_edges.wref(), v0, v1);
                             hoep[0] = nodes[j + 3];
@@ -362,7 +362,7 @@ bool MeshGmshLoader::readGmsh(std::ifstream &file, const unsigned int gmshFormat
                         size_t v1 = std::max(nodes[edgesInQuadraticTetrahedron[j][0]],
                             nodes[edgesInQuadraticTetrahedron[j][1]]);
                         Edge e(v0, v1);
-                        if (edgeSet.find(e) == edgeSet.end()) {
+                        if (!edgeSet.contains(e)) {
                             edgeSet.insert(e);
                             addEdge(my_edges.wref(), v0, v1);
                             hoep[0] = nodes[j + 4];
@@ -543,7 +543,7 @@ bool MeshGmshLoader::readGmsh(std::ifstream &file, const unsigned int gmshFormat
                             size_t v1 = std::max(nodes[edgesInQuadraticTriangle[j][0]],
                                 nodes[edgesInQuadraticTriangle[j][1]]);
                             Edge e(v0, v1);
-                            if (edgeSet.find(e) == edgeSet.end())
+                            if (!edgeSet.contains(e))
                             {
                                 edgeSet.insert(e);
                                 addEdge(my_edges.wref(), v0, v1);
@@ -568,7 +568,7 @@ bool MeshGmshLoader::readGmsh(std::ifstream &file, const unsigned int gmshFormat
                             size_t v1 = std::max(nodes[edgesInQuadraticTetrahedron[j][0]],
                                 nodes[edgesInQuadraticTetrahedron[j][1]]);
                             Edge e(v0, v1);
-                            if (edgeSet.find(e) == edgeSet.end())
+                            if (!edgeSet.contains(e))
                             {
                                 edgeSet.insert(e);
                                 addEdge(my_edges.wref(), v0, v1);

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshOBJLoader.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshOBJLoader.cpp
@@ -497,7 +497,7 @@ bool MeshOBJLoader::readOBJ (std::ifstream &file, const char* filename)
                 if (vsplit)
                 {
                     vertPosIdx[j] = i;
-                    if (normMap.count(n))
+                    if (normMap.contains(n))
                         vertNormIdx[j] = normMap[n];
                     else
                     {

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshVTKLoader.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshVTKLoader.cpp
@@ -433,7 +433,7 @@ bool MeshVTKLoader::setInputsMesh()
                     sofa::Index v1 = std::max( inFP[i + edgesInQuadraticTriangle[j][0]],
                             inFP[i + edgesInQuadraticTriangle[j][1]]);
                     Edge e(v0, v1);
-                    if (edgeSet.find(e) == edgeSet.end())
+                    if (!edgeSet.contains(e))
                     {
                         edgeSet.insert(e);
                         addEdge(my_edges.wref(), v0, v1);
@@ -457,7 +457,7 @@ bool MeshVTKLoader::setInputsMesh()
                     sofa::Index v1 = std::max( inFP[i + edgesInQuadraticTetrahedron[j][0]],
                             inFP[i + edgesInQuadraticTetrahedron[j][1]]);
                     Edge e(v0, v1);
-                    if (edgeSet.find(e) == edgeSet.end())
+                    if (!edgeSet.contains(e))
                     {
                         edgeSet.insert(e);
                         addEdge(my_edges.wref(), v0, v1);

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/VoxelGridLoader.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/VoxelGridLoader.cpp
@@ -162,7 +162,7 @@ void VoxelGridLoader::reinit()
                 {
                     // add only points that were used above
                     const unsigned int pidx = i + j * numPointsX + k * numPointsX * numPointsY;
-                    if ( keepPoint.find ( pidx ) != keepPoint.end() )
+                    if ( keepPoint.contains ( pidx ))
                     {
                         renumberingMap[pidx] = pointIdx;
                         auto& pnt = seqPoints[pointIdx];

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSolverFactory.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSolverFactory.h
@@ -189,7 +189,7 @@ public:
     template<class Scalar>
     bool hasObject(const std::string& orderingMethodName )
     {
-        return m_registeredTypes.find(join<Scalar>(orderingMethodName)) != m_registeredTypes.end();
+        return m_registeredTypes.contains(join<Scalar>(orderingMethodName));
     }
 
     [[nodiscard]]

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MappingGraph.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MappingGraph.cpp
@@ -169,7 +169,7 @@ bool MappingGraph::hasAnyMappingInput(core::behavior::BaseMechanicalState* mstat
     }
 
     //only main (non mapped) mechanical states are in this map
-    return m_positionInGlobalMatrix.find(mstate) == m_positionInGlobalMatrix.end();
+    return !m_positionInGlobalMatrix.contains(mstate);
 }
 
 bool MappingGraph::hasAnyMappingInput(core::behavior::BaseForceField* forceField) const

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/LineSetSkinningMapping.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/LineSetSkinningMapping.inl
@@ -162,7 +162,7 @@ void LineSetSkinningMapping<TIn, TOut>::init()
 
         while (linesInfluencedByVertice[verticeIndex].size() < numberInfluencedLines.getValue() && lineInfluencedIndex < lines.size())
         {
-            if (neighborhood[max].count(lines[lineInfluencedIndex].lineIndex) != 0)
+            if (neighborhood[max].contains(lines[lineInfluencedIndex].lineIndex))
             {
                 sumWeights += lines[lineInfluencedIndex].weight;
                 linesInfluencedByVertice[verticeIndex].push_back(lines[lineInfluencedIndex]);

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.cpp
@@ -64,7 +64,7 @@ void APIVersion::checkInputData()
 
     const auto & API_version = d_level.getValue();
     static const std::set<std::string> allowedAPIVersions { "17.06", "17.12", "18.06", "18.12", "19.06", "19.12", "20.06", "20.12", SOFA_VERSION_STR } ;
-    if( allowedAPIVersions.find(API_version) == std::cend(allowedAPIVersions) )
+    if(!allowedAPIVersions.contains(API_version))
     {
         const auto allowedVersionStr = std::accumulate(std::next(allowedAPIVersions.begin()), allowedAPIVersions.end(), *(allowedAPIVersions.begin()), [](const std::string & s, const std::string & v) {
             return s + ", " + v;

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/MeshSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/MeshSpringForceField.inl
@@ -80,12 +80,12 @@ void MeshSpringForceField<DataTypes>::addSpring(std::set<std::pair<sofa::Index, 
 
     if (m1<m2)
     {
-        if (sset.count(std::make_pair(m1,m2))>0) return;
+        if (sset.contains(std::make_pair(m1,m2))) return;
         sset.insert(std::make_pair(m1,m2));
     }
     else
     {
-        if (sset.count(std::make_pair(m2,m1))>0) return;
+        if (sset.contains(std::make_pair(m2,m1))) return;
         sset.insert(std::make_pair(m2,m1));
     }
     const Real l = ((mstate2->read(core::vec_id::read_access::restPosition)->getValue())[m2] - (mstate1->read(core::vec_id::read_access::restPosition)->getValue())[m1]).norm();

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadBendingSprings.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/QuadBendingSprings.inl
@@ -56,7 +56,7 @@ void QuadBendingSprings<DataTypes>::addSpring( unsigned a, unsigned b, std::set<
         if ((int)a > d_localRange.getValue()[1] && (int)b > d_localRange.getValue()[1]) return;
     }
     const IndexPair ab(a<b?a:b, a<b?b:a);
-    if (springSet.find(ab) != springSet.end()) return;
+    if (springSet.contains(ab)) return;
     springSet.insert(ab);
     const VecCoord& x =this->mstate1->read(core::vec_id::read_access::position)->getValue();
     Real s = (Real)this->d_ks.getValue()[0];
@@ -73,7 +73,7 @@ void QuadBendingSprings<DataTypes>::registerEdge( IndexPair ab, IndexPair cd, st
         ab = std::make_pair(ab.second,ab.first);
         cd = std::make_pair(cd.second,cd.first);
     }
-    if (edgeMap.find(ab) == edgeMap.end())
+    if (!edgeMap.contains(ab))
     {
         edgeMap[ab] = cd;
     }

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangleBendingSprings.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/TriangleBendingSprings.inl
@@ -59,7 +59,7 @@ void TriangleBendingSprings<DataTypes>::registerTriangle( unsigned a, unsigned b
     {
         const IndexPair edge(a<b ? a : b,a<b ? b : a);
         const unsigned opposite = c;
-        if( edgeMap.find( edge ) == edgeMap.end() )
+        if(!edgeMap.contains( edge ))
         {
             edgeMap[edge] = opposite;
         }
@@ -73,7 +73,7 @@ void TriangleBendingSprings<DataTypes>::registerTriangle( unsigned a, unsigned b
     {
         const IndexPair edge(b<c ? b : c,b<c ? c : b);
         const unsigned opposite = a;
-        if( edgeMap.find( edge ) == edgeMap.end() )
+        if(!edgeMap.contains( edge ))
         {
             edgeMap[edge] = opposite;
         }
@@ -87,7 +87,7 @@ void TriangleBendingSprings<DataTypes>::registerTriangle( unsigned a, unsigned b
     {
         const IndexPair edge(c<a ? c : a,c<a ? a : c);
         const unsigned  opposite = b;
-        if( edgeMap.find( edge ) == edgeMap.end() )
+        if(!edgeMap.contains( edge ))
         {
             edgeMap[edge] = opposite;
         }

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -2397,7 +2397,7 @@ std::list< core::behavior::BaseMechanicalState::ConstraintBlock > MechanicalObje
             for( ; chunk != chunkEnd ; chunk++)
             {
                 const unsigned int column = chunk.index();
-                if( blocks.find( column ) == blocks.end() )
+                if(!blocks.contains( column ))
                 {
                     // nope: let's create it
                     matrix_t* mat = new matrix_t(linearalgebra::BaseMatrix::Index(indices.size()), linearalgebra::BaseMatrix::Index(dimensionDeriv));

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
@@ -135,7 +135,7 @@ void HexahedronSetTopologyContainer::createEdgeSetArray()
             PointID v2 = t[edgesInHexahedronArray[j][1]];
             const Edge e((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
 
-            if(edgeMap.find(e)==edgeMap.end())
+            if(!edgeMap.contains(e))
             {
                 // edge not in edgeMap so create a new one
                 const size_t edgeIndex = edgeMap.size();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/MultilevelHexahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/MultilevelHexahedronSetTopologyContainer.cpp
@@ -279,7 +279,7 @@ MultilevelHexahedronSetTopologyContainer::getHexaChildren(const Index hexaId,
 
     for(Size i=0; i<_fineComponents.getValue().size(); ++i)
     {
-        if(compSet.find(_fineComponents.getValue()[i]) != compSet.end())
+        if(compSet.contains(_fineComponents.getValue()[i]))
             children.push_back(i);
     }
 
@@ -498,7 +498,7 @@ void MultilevelHexahedronSetTopologyContainer::Component::removeVoxels(const std
 
 bool MultilevelHexahedronSetTopologyContainer::Component::hasVoxel(const Vec3i& voxel) const
 {
-    return (this->_voxels.find(voxel) != this->_voxels.end());
+    return this->_voxels.contains(voxel);
 }
 
 bool MultilevelHexahedronSetTopologyContainer::Component::isEmpty() const

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
@@ -204,7 +204,7 @@ void QuadSetTopologyContainer::createEdgeSetArray()
             // sort vertices in lexicographic order
             const Edge e = ((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
 
-            if(edgeMap.find(e) == edgeMap.end())
+            if(!edgeMap.contains(e))
             {
                 // edge not in edgeMap so create a new one
                 const EdgeID edgeIndex = (EdgeID)edgeMap.size();

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
@@ -133,7 +133,7 @@ void TetrahedronSetTopologyContainer::createEdgeSetArray()
             // sort vertices in lexicographic order
             const Edge e((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
 
-            if (edgeMap.find(e)==edgeMap.end())
+            if (!edgeMap.contains(e))
             {
                 // edge not in edgeMap so create a new one
                 const size_t edgeIndex = edgeMap.size();
@@ -222,7 +222,7 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
                 // sort vertices in lexicographic order
                 const Edge e((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
 
-                if (edgeMap.find(e)==edgeMap.end())
+                if (!edgeMap.contains(e))
                 {
                     // edge not in edgeMap so create a new one
                     const size_t edgeIndex = edgeMap.size();
@@ -277,11 +277,11 @@ void TetrahedronSetTopologyContainer::createTriangleSetArray()
             // check if a triangle with an opposite orientation already exists
             Triangle tr = Triangle(v[0], v[2], v[1]);
 
-            if (triangleMap.find(tr) == triangleMap.end())
+            if (!triangleMap.contains(tr))
             {
                 // triangle not in triangleMap so create a new one
                 tr = Triangle(v[0], v[1], v[2]);
-                if (triangleMap.find(tr) == triangleMap.end())
+                if (!triangleMap.contains(tr))
                 {
                     triangleMap[tr] = (TriangleID)m_triangle.size();
                     m_triangle.push_back(tr);

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
@@ -4135,7 +4135,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::SnapAlongPath(sofa::type::vector<
         {
         case geometry::ElementType::POINT:
         {
-            if (map_point2snap.find(intersected_indices[i]) != map_point2snap.end())
+            if (map_point2snap.contains(intersected_indices[i]))
             {
                 map_point2snap[intersected_indices[i]].push_back((PointID)i);
 
@@ -4152,7 +4152,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::SnapAlongPath(sofa::type::vector<
             for (EdgeID indEdge = 0; indEdge < 2; indEdge++)
             {
                 PointID thePoint = theEdge[indEdge];
-                if (map_point2snap.find(thePoint) != map_point2snap.end())
+                if (map_point2snap.contains(thePoint))
                 {
                     PointFind = true;
                     map_point2snap[thePoint].push_back((PointID)i);
@@ -4179,7 +4179,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::SnapAlongPath(sofa::type::vector<
             {
                 PointID thePoint = theTriangle[indTri];
 
-                if ((map_point2snap.find(thePoint) != map_point2snap.end()) && (intersected_barycoefs[i][indTri] > (1 - epsilon)))
+                if ((map_point2snap.contains(thePoint)) && (intersected_barycoefs[i][indTri] > (1 - epsilon)))
                 {
                     PointFind = true;
                     map_point2snap[thePoint].push_back((PointID)i);

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
@@ -222,7 +222,7 @@ void TriangleSetTopologyContainer::createEdgeSetArray()
             // sort vertices in lexicographic order
             const Edge e = ((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
 
-            if(edgeMap.find(e) == edgeMap.end())
+            if(!edgeMap.contains(e))
             {
                 // edge not in edgeMap so create a new one
                 const size_t edgeIndex = edgeMap.size();
@@ -326,7 +326,7 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                 // sort vertices in lexicographic order
                 const Edge e = ((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
 
-                if(edgeMap.find(e) == edgeMap.end())
+                if(!edgeMap.contains(e))
                 {
                     // edge not in edgeMap so create a new one
                     const size_t edgeIndex = edgeMap.size();

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.cpp
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.cpp
@@ -123,7 +123,7 @@ void GridTopology::GridUpdate::updateEdges()
                 // sort vertices in lexicographic order
                 const Edge e = ((v1<v2) ? Edge(v1, v2) : Edge(v2, v1));
 
-                if (edgeMap.find(e) == edgeMap.end())
+                if (!edgeMap.contains(e))
                 {
                     // edge not in edgeMap so create a new one
                     const size_t edgeIndex = edgeMap.size();

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -435,7 +435,7 @@ void VisualModelImpl::setMesh(helper::io::Mesh &objLoader, bool tex)
             {
                 vertices2[j] = verticesImport[i];
                 vertPosIdx[j] = i;
-                if (normMap.count(n))
+                if (normMap.contains(n))
                     vertNormIdx[j] = normMap[n];
                 else
                 {

--- a/Sofa/GL/src/sofa/gl/BasicShapesGL.inl
+++ b/Sofa/GL/src/sofa/gl/BasicShapesGL.inl
@@ -176,7 +176,7 @@ void BasicShapesGL_Sphere<VertexType>::afterDraw(const GLBuffers &/* buffer */)
 template<class VertexType>
 void BasicShapesGL_Sphere<VertexType>::checkBuffers(const SphereDescription& desc)
 {
-    if (m_mapBuffers.find(desc) == m_mapBuffers.end())
+    if (!m_mapBuffers.contains(desc))
     {
         GLBuffers glbuffer;
         generateBuffer(desc, glbuffer);

--- a/Sofa/GL/src/sofa/gl/GLSLShader.cpp
+++ b/Sofa/GL/src/sofa/gl/GLSLShader.cpp
@@ -316,8 +316,8 @@ void GLSLShader::InitShaders()
     // Make sure the user passed in at least a vertex and fragment shader file
     if( !GetVertexShaderFileName().length() || !GetFragmentShaderFileName().length() )
     {
-        if(m_hShaderContents.find(GL_VERTEX_SHADER_ARB) == m_hShaderContents.end()
-            || m_hShaderContents.find(GL_FRAGMENT_SHADER_ARB) == m_hShaderContents.end())
+        if(!m_hShaderContents.contains(GL_VERTEX_SHADER_ARB)
+           || !m_hShaderContents.contains(GL_FRAGMENT_SHADER_ARB))
         {
             msg_error() << "GLSLShader requires setting a VertexShader and a FragmentShader";
             return;

--- a/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.cpp
@@ -146,7 +146,7 @@ void ArgumentParser::showArgs()
 std::vector<std::string> ArgumentParser::getInputFileList()
 {
     auto result = getMap();
-    if (result.count("input-file"))
+    if (result.contains("input-file"))
     {
         std::vector<std::string> tmp;
         cxxopts::values::parse_value(result["input-file"], tmp);

--- a/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/ArgumentParser.h
@@ -103,7 +103,7 @@ public:
         auto result = this->getMap();
         try
         {
-            if (result.count(key))
+            if (result.contains(key))
             {
                 cxxopts::values::parse_value(result[key], value);
                 ret = true;

--- a/Sofa/framework/Core/src/sofa/core/DataTracker.cpp
+++ b/Sofa/framework/Core/src/sofa/core/DataTracker.cpp
@@ -34,7 +34,7 @@ void DataTracker::trackData( const objectmodel::BaseData& data )
 
 bool DataTracker::hasChanged( const objectmodel::BaseData& data ) const
 {
-    if (m_dataTrackers.find(&data) != m_dataTrackers.end())
+    if (m_dataTrackers.contains(&data))
         return m_dataTrackers.at(&data) != data.getCounter();
     return false;
 }

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -37,7 +37,7 @@ ObjectFactory::~ObjectFactory()
 
 ObjectFactory::ClassEntry& ObjectFactory::getEntry(std::string classname)
 {
-    if (registry.find(classname) == registry.end())
+    if (!registry.contains(classname))
     {
         registry[classname] = std::make_shared<ClassEntry>();
         registry[classname]->className = classname;
@@ -201,7 +201,7 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
     {
         entry = it->second;
         // If no template has been given or if the template does not exist, first try with the default one
-        if(templatename.empty() || entry->creatorMap.find(templatename) == entry->creatorMap.end())
+        if(templatename.empty() || !entry->creatorMap.contains(templatename))
             templatename = entry->defaultTemplate;
 
 
@@ -686,7 +686,7 @@ ObjectRegistrationData& ObjectRegistrationData::addCreator(std::string classname
     {
         msg_error("ObjectFactory") << "Template already instantiated with a different classname: " << entry.className << " != " << classname;
     }
-    else if (entry.creatorMap.find(templatename) != entry.creatorMap.end())
+    else if (entry.creatorMap.contains(templatename))
     {
         msg_error("ObjectFactory") << "Component already registered: " << classname << "<" << templatename << ">";
     }
@@ -740,7 +740,7 @@ bool ObjectRegistrationData::commitTo(sofa::core::ObjectFactory* objectFactory) 
 
         for (const auto & alias : entry.aliases)
         {
-            if (reg.aliases.find(alias) == reg.aliases.end())
+            if (!reg.aliases.contains(alias))
             {
                 objectFactory->addAlias(alias,entry.className);
             }
@@ -773,7 +773,7 @@ bool ObjectFactory::registerObjectsFromPlugin(const std::string& pluginName)
     }
 
     // do not register if it was already done before
-    if(m_registeredPluginSet.count(pluginName) > 0)
+    if(m_registeredPluginSet.contains(pluginName))
     {
         // This warning should be generalized (i.e not only in dev mode) when runSofa will not auto-load modules/plugins by default anymore
         dmsg_warning("ObjectFactory") << pluginName << " has already registered its components.";

--- a/Sofa/framework/Core/src/sofa/core/behavior/DefaultMultiMatrixAccessor.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/DefaultMultiMatrixAccessor.cpp
@@ -346,7 +346,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
 
 
         //for toModel -----------------------------------------------------------
-        if(mappedMatrices.find(outstate) == mappedMatrices.end())
+        if(!mappedMatrices.contains(outstate))
         {
             if(m_doPrintInfo)
             {
@@ -354,7 +354,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
             }
         }
 
-        if(diagonalStiffnessBloc.find(outstate) != diagonalStiffnessBloc.end())
+        if(diagonalStiffnessBloc.contains(outstate))
         {
             //=================================
             //           K11 += Jt * K22 * J

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.cpp
@@ -112,7 +112,7 @@ void Base::addUpdateCallback(const std::string& name,
 
 void Base::addOutputsToCallback(const std::string& name, std::initializer_list<BaseData*> outputs)
 {
-    if (m_internalEngine.find(name) != m_internalEngine.end())
+    if (m_internalEngine.contains(name))
         m_internalEngine[name].addOutputs(outputs);
 }
 
@@ -263,7 +263,7 @@ const std::string Base::getLoggedMessagesAsString(const sofa::helper::logging::M
 {
     std::stringstream tmpstr ;
     for(Message& m : m_messageslog){
-        if( t.find(m.type()) !=  t.end() )
+        if( t.contains(m.type()))
         {
             tmpstr << m.type() << ":" <<  m.messageAsString() << std::endl;
         }
@@ -275,7 +275,7 @@ size_t Base::countLoggedMessages(const sofa::helper::logging::Message::TypeSet t
 {
     size_t tmp=0;
     for(Message& m : m_messageslog){
-        if( t.find(m.type()) !=  t.end() )
+        if( t.contains(m.type()))
         {
             tmp++;
         }
@@ -396,8 +396,8 @@ Base* Base::findLinkDestClass(const BaseClass* /*destType*/, const std::string& 
 
 bool Base::hasField( const std::string& attribute) const
 {
-    return m_aliasData.find(attribute) != m_aliasData.end()
-                                          || m_aliasLink.find(attribute) != m_aliasLink.end();
+    return m_aliasData.contains(attribute)
+           || m_aliasLink.contains(attribute);
 }
 
 /// Assign one field value (Data or Link)

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/ComponentState.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/ComponentState.cpp
@@ -51,7 +51,7 @@ std::istream& operator>>(std::istream& i, ComponentState& s)
                                                           {"Invalid", ComponentState::Invalid}};
     std::string tmp;
     i >> tmp;
-    if(str2s.find(tmp) == str2s.end())
+    if(!str2s.contains(tmp))
     {
         i.setstate(std::ios::failbit);
         return i;

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/TagSet.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/TagSet.cpp
@@ -32,7 +32,7 @@ TagSet::TagSet(const Tag& t)
 
 bool TagSet::includes(const Tag& t) const
 {
-    return m_set.count(t) > 0;
+    return m_set.contains(t);
 }
 
 bool TagSet::includes(const TagSet& t) const

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/TemplatesAliases.cpp
@@ -44,7 +44,7 @@ TemplateAliasesMap& getTemplateAliasesMap()
 bool TemplateAliases::addAlias(const std::string& name, const std::string& result, const bool doWarnUser)
 {
     TemplateAliasesMap& templateAliases = getTemplateAliasesMap();
-    if (templateAliases.find(name) != templateAliases.end())
+    if (templateAliases.contains(name))
     {
         msg_warning("ObjectFactory") << "cannot create template alias " << name <<
             " as it already exists";

--- a/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
@@ -595,7 +595,7 @@ void TimerData::process()
         {
             AdvancedTimer::IdStep id;
             if (r.type != Record::RBEGIN) id = AdvancedTimer::IdStep(r.id);
-            if (stepData.find(id) == stepData.end())
+            if (!stepData.contains(id))
                 steps.push_back(id);
             StepData& data = stepData[id];
             data.level = level;
@@ -631,7 +631,7 @@ void TimerData::process()
         case Record::RVAL_ADD:
         {
             AdvancedTimer::IdVal id = AdvancedTimer::IdVal(r.id);
-            if (valData.find(id) == valData.end())
+            if (!valData.contains(id))
                 vals.push_back(id);
             ValData& data = valData[id];
             if (r.type == Record::RVAL_SET || (data.lastIt != nbIter))

--- a/Sofa/framework/Helper/src/sofa/helper/Factory.h
+++ b/Sofa/framework/Helper/src/sofa/helper/Factory.h
@@ -72,7 +72,7 @@ protected:
 public:
     bool registerCreator(Key key, Creator* creator, bool multi=false)
     {
-        if(!multi && this->registry.find(key) != this->registry.end())
+        if(!multi && this->registry.contains(key))
             return false; // key used
         logFactoryRegister(gettypename(typeid(Object)), gettypename(creator->type()), key, multi);
         this->registry.insert(std::pair<Key, Creator*>(key, creator));

--- a/Sofa/framework/Helper/src/sofa/helper/Factory.inl
+++ b/Sofa/framework/Helper/src/sofa/helper/Factory.inl
@@ -105,7 +105,7 @@ void Factory<TKey, TObject, TArgument, TPtr>::uniqueKeys(OutIterator out)
 template <typename TKey, class TObject, typename TArgument, typename TPtr>
 bool Factory<TKey, TObject, TArgument, TPtr>::hasKey(Key key)
 {
-    return (this->registry.find(key) != this->registry.end());
+    return this->registry.contains(key);
 }
 
 template <typename TKey, class TObject, typename TArgument, typename TPtr>

--- a/Sofa/framework/Helper/src/sofa/helper/MarchingCubeUtility.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/MarchingCubeUtility.cpp
@@ -599,7 +599,7 @@ namespace sofa::helper
             cubeCoord = cubesToGenerate.top(); // Get the last cube on the stack.
             cubesToGenerate.pop();             // Remove it from the stack.
 
-            if ( generatedCubes.find ( cubeCoord ) != generatedCubes.end() ) continue;
+            if ( generatedCubes.contains ( cubeCoord )) continue;
 
             GridCell cell;
             initCell ( cell, cubeCoord, data, gridStep, dataGridStep );
@@ -800,7 +800,7 @@ namespace sofa::helper
                     if ( data[index] >= isoValue)
                     {
                         type::Vec3i currentCube ( i, j , k );
-                        if ( parsedVoxels.find ( index ) == parsedVoxels.end() )
+                        if (!parsedVoxels.contains ( index ))
                         {
                             seeds.push_back ( currentCube - type::Vec3 ( 1_sreal, 0_sreal, 0_sreal ) );
                             // propager sur les autres voxels et les incrire ds parsedVoxels.
@@ -890,7 +890,7 @@ namespace sofa::helper
 
             const int index = coord[0] + coord[1]*dataResolution[0] + coord[2]*dataResolution[0]*dataResolution[1];
 
-            if ( connectedVoxels.find ( index ) != connectedVoxels.end() ) continue;
+            if ( connectedVoxels.contains ( index )) continue;
 
             if ( data[index] < isoValue ) continue;
 

--- a/Sofa/framework/Helper/src/sofa/helper/io/MeshGmsh.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/io/MeshGmsh.cpp
@@ -287,7 +287,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                         auto v1 = std::max(nodes[edgesInQuadraticTriangle[j][0]],
                             nodes[edgesInQuadraticTriangle[j][1]]);
                         Edge e(v0, v1);
-                        if (edgeSet.find(e) == edgeSet.end()) {
+                        if (!edgeSet.contains(e)) {
                             edgeSet.insert(e);
                             m_edges.push_back(Edge(v0, v1));
                             hoep[0] = nodes[j + 3];
@@ -310,7 +310,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                         auto v1 = std::max(nodes[edgesInQuadraticTetrahedron[j][0]],
                             nodes[edgesInQuadraticTetrahedron[j][1]]);
                         Edge e(v0, v1);
-                        if (edgeSet.find(e) == edgeSet.end()) {
+                        if (!edgeSet.contains(e)) {
                             edgeSet.insert(e);
                             m_edges.push_back(Edge(v0, v1));
                             hoep[0] = nodes[j + 4];
@@ -498,7 +498,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                             auto v1 = std::max(nodes[edgesInQuadraticTriangle[j][0]],
                                 nodes[edgesInQuadraticTriangle[j][1]]);
                             Edge e(v0, v1);
-                            if (edgeSet.find(e) == edgeSet.end())
+                            if (!edgeSet.contains(e))
                             {
                                 edgeSet.insert(e);
                                 m_edges.push_back(Edge(v0, v1));
@@ -523,7 +523,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                             auto v1 = std::max(nodes[edgesInQuadraticTetrahedron[j][0]],
                                 nodes[edgesInQuadraticTetrahedron[j][1]]);
                             Edge e(v0, v1);
-                            if (edgeSet.find(e) == edgeSet.end())
+                            if (!edgeSet.contains(e))
                             {
                                 edgeSet.insert(e);
                                 m_edges.push_back(Edge(v0, v1));

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -399,7 +399,7 @@ const std::unordered_set<std::string>& PluginManager::unloadedPlugins() const
 
 bool PluginManager::isPluginUnloaded(const std::string& pluginName) const
 {
-    return m_unloadedPlugins.find(pluginName) != m_unloadedPlugins.end();
+    return m_unloadedPlugins.contains(pluginName);
 }
 
 Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /*suffix*/, bool /*ignoreCase*/)
@@ -410,7 +410,7 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /
         return getPluginByName(plugin);
     }
 
-    if (!pluginPath.empty() && m_pluginMap.find(pluginPath) != m_pluginMap.end())
+    if (!pluginPath.empty() && m_pluginMap.contains(pluginPath))
     {
         return &m_pluginMap[pluginPath];
     }
@@ -649,7 +649,7 @@ std::pair<std::string, bool> PluginManager::isPluginLoaded(const std::string& pl
 
     /// Check that the path (either provided by user or through the call to findPlugin()
     /// leads to a loaded plugin.
-    const bool isPluginPathInMap = m_pluginMap.find(pluginPath) != m_pluginMap.end();
+    const bool isPluginPathInMap = m_pluginMap.contains(pluginPath);
     return {pluginPath, isPluginPathInMap};
 }
 

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/AttributeElement.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/AttributeElement.cpp
@@ -50,7 +50,7 @@ bool AttributeElement::initNode()
 {
     const std::string name = getAttribute( "type", "");
 
-    if (this->replaceAttribute.find(name) != this->replaceAttribute.end())
+    if (this->replaceAttribute.contains(name))
     {
         value=replaceAttribute[name];
     }

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/BaseElement.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/BaseElement.cpp
@@ -84,7 +84,7 @@ void BaseElement::setSrcLine(const int l)
 
 bool BaseElement::presenceAttribute(const std::string& s)
 {
-    return (attributes.find(s) != attributes.end());
+    return attributes.contains(s);
 }
 /// Remove an attribute. Fails if this attribute is "name" or "type"
 bool BaseElement::removeAttribute(const std::string& attr)

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/ObjectElement.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/ObjectElement.cpp
@@ -60,7 +60,7 @@ bool ObjectElement::initNode()
 
     for (AttributeMap::iterator it = attributes.begin(), itend = attributes.end(); it != itend; ++it)
     {
-        if (replaceAttribute.find(it->first) != replaceAttribute.end())
+        if (replaceAttribute.contains(it->first))
         {
             setAttribute(it->first,replaceAttribute[it->first]);
         }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/ExportDotVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/ExportDotVisitor.cpp
@@ -211,7 +211,7 @@ std::string ExportDotVisitor::getParentName(core::objectmodel::BaseObject* obj)
 std::string ExportDotVisitor::getName(core::objectmodel::Base* o, std::string prefix)
 {
     if (!o) return "";
-    if (names.count(o)>0)
+    if (names.contains(o))
         return names[o];
     const std::string oname = o->getName();
     std::string name = prefix;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerRegistry.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerRegistry.cpp
@@ -56,7 +56,7 @@ TaskScheduler* TaskSchedulerRegistry::getTaskScheduler(const std::string& taskSc
 
 bool TaskSchedulerRegistry::hasScheduler(const std::string& taskSchedulerName) const
 {
-    return m_schedulers.find(taskSchedulerName) != m_schedulers.end();
+    return m_schedulers.contains(taskSchedulerName);
 }
 
 const std::optional<std::pair<std::string, TaskScheduler*>>& TaskSchedulerRegistry::getLastInserted() const

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalIdentityBlocksInJacobianVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalIdentityBlocksInJacobianVisitor.cpp
@@ -51,7 +51,7 @@ void MechanicalIdentityBlocksInJacobianVisitor::bwdMappedMechanicalState(simulat
     sofa::core::behavior::BaseMechanicalState* mm)
 {
     SOFA_UNUSED(node);
-    if (listParentMStates.find(mm) == listParentMStates.end())
+    if (!listParentMStates.contains(mm))
     {
         //this mechanical state does not have any children
 

--- a/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.cpp
+++ b/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.cpp
@@ -77,7 +77,7 @@ public:
     Result processNodeTopDown(simulation::Node* node) override
     {
         const DAGNode* dagnode = dynamic_cast<const DAGNode*>(node);
-        if( dagnode->_descendancy.find(_searchNode)!=dagnode->_descendancy.end() ) // searchNode is in the current node descendancy, so the current node is a parent of searchNode
+        if( dagnode->_descendancy.contains(_searchNode) ) // searchNode is in the current node descendancy, so the current node is a parent of searchNode
         {
             dagnode->getLocalObjects( _class_info, _container, _tags );
             return RESULT_CONTINUE;
@@ -653,7 +653,7 @@ void DAGNode::executeVisitorTopDown(simulation::Visitor* action, NodeList& execu
         for ( unsigned int i = 0; i < parents.size() ; i++ )
         {
             // if the visitor is run from a sub-graph containing a multinode linked with a node outside of the subgraph, do not consider the outside node by looking on the sub-graph descendancy
-            if ( visitorRoot->_descendancy.find(parents[i])!=visitorRoot->_descendancy.end() || parents[i]==visitorRoot )
+            if ( visitorRoot->_descendancy.contains(parents[i]) || parents[i]==visitorRoot )
             {
                 // all parents must have been visited before
                 if ( statusMap[parents[i]] == NOT_VISITED )
@@ -834,7 +834,7 @@ DAGNode* DAGNode::findCommonParent(DAGNode* node1, DAGNode* node2)
 {
     updateDescendancy();
 
-    if (_descendancy.find(node1) == _descendancy.end() || _descendancy.find(node2) == _descendancy.end())
+    if (!_descendancy.contains(node1) || !_descendancy.contains(node2))
         return nullptr; // this is NOT a parent
 
     // this is a parent

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
@@ -330,7 +330,7 @@ void addCollisionModels(Node::SPtr parent, const std::vector<std::string> &eleme
 
     for (auto& element : elements)
     {
-        if( alias.find(element) == alias.end() )
+        if(!alias.contains(element))
         {
             msg_error(parent.get()) << "Unable to create collision model from '"<< element << "'" ;
             continue;

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckAPIChange.cpp
@@ -94,7 +94,7 @@ void SceneCheckAPIChange::doCheckOn(sofa::simulation::Node* node)
     {
         Base* o = object.get();
 
-        if(m_selectedApiLevel != m_currentApiLevel && m_changesets.find(m_selectedApiLevel) != m_changesets.end())
+        if(m_selectedApiLevel != m_currentApiLevel && m_changesets.contains(m_selectedApiLevel))
         {
             for(auto& hook : m_changesets[m_selectedApiLevel])
             {

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
@@ -57,7 +57,7 @@ void SceneCheckDeprecatedComponents::doCheckOn(Node* node)
     {
         if (const sofa::core::Base* o = object.get())
         {
-            if( deprecatedComponents.find( o->getClassName() ) != deprecatedComponents.end() )
+            if( deprecatedComponents.contains( o->getClassName() ))
             {
                 msg_deprecated(o) << this->getName() << ": "
                     << deprecatedComponents.at(o->getClassName()).getMessage();

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
@@ -54,14 +54,14 @@ void SceneCheckDuplicatedName::doCheckOn(sofa::simulation::Node* node)
     std::map<std::string, int> duplicated;
     for (auto& object : node->object )
     {
-        if( duplicated.find(object->getName()) == duplicated.end() )
+        if(!duplicated.contains(object->getName()))
             duplicated[object->getName()] = 0;
         duplicated[object->getName()]++;
     }
 
     for (auto& child : node->child )
     {
-        if( duplicated.find(child->getName()) == duplicated.end() )
+        if(!duplicated.contains(child->getName()))
             duplicated[child->getName()] = 0;
         duplicated[child->getName()]++;
     }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
@@ -62,7 +62,7 @@ void SceneCheckMissingRequiredPlugin::doCheckOn(sofa::simulation::Node* node)
                 const std::string pluginName = it->second->getTarget();
                 const std::string path = PluginManager::getInstance().findPlugin(pluginName);
                 if( PluginManager::getInstance().pluginIsLoaded(path)
-                        && m_loadedPlugins.find(pluginName) == m_loadedPlugins.end() )
+                        && !m_loadedPlugins.contains(pluginName))
                 {
                     m_requiredPlugins[pluginName].push_back(object->getClassName());
                 }

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
     // Add resources dir to GuiDataRepository
     const std::string runSofaIniFilePath = Utils::getSofaPathTo("/etc/runSofa.ini");
     std::map<std::string, std::string> iniFileValues = Utils::readBasicIniFile(runSofaIniFilePath);
-    if (iniFileValues.find("RESOURCES_DIR") != iniFileValues.end())
+    if (iniFileValues.contains("RESOURCES_DIR"))
     {
         std::string dir = iniFileValues["RESOURCES_DIR"];
         dir = SetDirectory::GetRelativeFromProcess(dir.c_str());


### PR DESCRIPTION
Before C++20, checking if a collection contains a value was done by using `find` and comparing to a sentinel (e.g. `m_broadPhaseCollisionModels.find(firstCollisionModel) != m_broadPhaseCollisionModels.end()`).

This approach is error-prone:
- You must not forget to compare find to a iterator
- The iterator can be unrelated to the searched collection

In C++20, `.contains` can be used instead, eliminating the mentioned risks of error. In addition, the intention is clearer.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
