### PR TITLE
[all] use std::views::keys/values

### DIFF
--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/RuleBasedContactManager.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/RuleBasedContactManager.cpp
@@ -24,6 +24,8 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
 
+#include <ranges>
+
 namespace sofa::component::collision::response::contact
 {
 
@@ -45,9 +47,9 @@ RuleBasedContactManager::RuleBasedContactManager()
 
 RuleBasedContactManager::~RuleBasedContactManager()
 {
-    for(const auto& d : variablesData)
+    for(const auto& d : variablesData | std::views::values)
     {
-        delete d.second;
+        delete d;
     }
 }
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.cpp
@@ -37,6 +37,8 @@ using sofa::simulation::mechanicalvisitor::MechanicalGetConstraintInfoVisitor;
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
 
+#include <ranges>
+
 using sofa::core::VecId;
 
 namespace sofa::component::constraint::lagrangian::solver
@@ -709,12 +711,12 @@ void LCPConstraintSolver::keepContactForcesValue()
     for (unsigned int c=0; c<_numConstraints; ++c)
         _previousForces[c] = (*_result)[c];
     // clear previous history
-    for (auto& previousConstraint : _previousConstraints)
+    for (auto& buf : _previousConstraints | std::views::values)
     {
-        ConstraintBlockBuf& buf = previousConstraint.second;
-        for (auto& it2 : buf.persistentToConstraintIdMap)
-            it2.second = -1;
+        for (auto& constraintId : buf.persistentToConstraintIdMap | std::views::values)
+            constraintId = -1;
     }
+    
     // fill info from current ids
     for (const ConstraintBlockInfo& info : constraintBlockInfo)
     {

--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSolverFactory.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/EigenSolverFactory.h
@@ -32,6 +32,8 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/type/vector.h>
 
+#include <ranges>
+
 
 namespace sofa::component::linearsolver::direct
 {
@@ -195,13 +197,8 @@ public:
     [[nodiscard]]
     sofa::type::vector<OrderingMethodName> registeredObjects() const
     {
-        sofa::type::vector<OrderingMethodName> list;
-        list.reserve(m_registeredTypes.size());
-        for(const auto& [key, _] : m_registeredTypes)
-        {
-            list.push_back(key);
-        }
-        return list;
+        auto list = m_registeredTypes | std::views::keys;
+        return {list.begin(), list.end()};
     }
 
 private:

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -42,6 +42,8 @@
 #include <cassert>
 #include <sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h>
 
+#include <ranges>
+
 
 namespace
 {
@@ -1003,8 +1005,8 @@ void MechanicalObject<DataTypes>::init()
 
         // Print a warning if one or more vector don't match the maximum size
         bool allSizeAreEqual = true;
-        for (const std::pair<const std::string, const Size>& vector_size : vector_sizes) {
-            const Size& size = vector_size.second;
+        for (const auto& size : vector_sizes | std::views::values)
+        {
             if (size > 1 && size != maxSize) {
                 allSizeAreEqual = false;
                 break;

--- a/Sofa/GL/src/sofa/gl/GLSLShader.cpp
+++ b/Sofa/GL/src/sofa/gl/GLSLShader.cpp
@@ -29,6 +29,8 @@
 
 #include <sofa/helper/logging/Messaging.h>
 
+#include <ranges>
+
 namespace sofa::gl
 {
 
@@ -140,10 +142,10 @@ void GLSLShader::SetShaderFileName(GLint target, const std::string& filename)
 
 void GLSLShader::forceReloadShaderFromFile(const std::string& filename)
 {
-    for(auto& fn : m_hShaderContents){
-        if(fn.second.filename == filename)
+    for(auto& shaderContent : m_hShaderContents | std::views::values){
+        if(shaderContent.filename == filename)
         {
-            fn.second.text = "" ;
+            shaderContent.text = "" ;
         }
     }
 }

--- a/Sofa/framework/Core/src/sofa/core/collision/NarrowPhaseDetection.cpp
+++ b/Sofa/framework/Core/src/sofa/core/collision/NarrowPhaseDetection.cpp
@@ -22,15 +22,15 @@
 #include <sofa/core/collision/NarrowPhaseDetection.h>
 #include <sofa/core/visual/VisualParams.h>
 
+#include <ranges>
+
 namespace sofa::core::collision
 {
 
 NarrowPhaseDetection::~NarrowPhaseDetection()
 {
-    for (const auto& it : m_outputsMap)
+    for (DetectionOutputVector* do_vec : m_outputsMap | std::views::values)
     {
-        DetectionOutputVector* do_vec = it.second;
-
         if (do_vec != nullptr)
         {
             do_vec->clear();

--- a/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PluginManager.cpp
@@ -27,8 +27,6 @@ using sofa::helper::system::FileSystem;
 #include <sofa/helper/StringUtils.h>
 #include <sofa/helper/logging/Messaging.h>
 
-#include <ranges>
-
 #if __has_include(<filesystem>)
   #include <filesystem>
   namespace fs = std::filesystem;
@@ -85,7 +83,7 @@ PluginManager::~PluginManager()
 
 void PluginManager::cleanup()
 {
-    for (const auto& callback : m_onPluginCleanupCallbacks | std::views::values)
+    for (const auto& [key, callback] : m_onPluginCleanupCallbacks)
     {
         if(callback)
         {
@@ -131,7 +129,7 @@ void PluginManager::readFromIniFile(const std::string& path, type::vector<std::s
 void PluginManager::writeToIniFile(const std::string& path)
 {
     std::ofstream outstream(path.c_str());
-    for(const auto& pluginPath : m_pluginMap | std::views::keys)
+    for( const auto& [pluginPath, _] : m_pluginMap)
     {
         if (const auto* plugin = getPlugin(pluginPath))
         {
@@ -238,7 +236,7 @@ PluginManager::PluginLoadStatus PluginManager::loadPluginByPath(const std::strin
 
     msg_info("PluginManager") << "Loaded plugin: " << pluginPath;
 
-    for (const auto& callback : m_onPluginLoadedCallbacks | std::views::values)
+    for (const auto& [key, callback] : m_onPluginLoadedCallbacks)
     {
         if(callback)
         {
@@ -387,12 +385,12 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /
         // check if a plugin with a same name but a different path is loaded
         // problematic case per se but at least we can warn the user
         const auto& pluginName = GetPluginNameFromPath(pluginPath);
-        for (auto& loadedPlugin : m_pluginMap | std::views::values)
+        for (auto& k : m_pluginMap)
         {
-            if (pluginName == loadedPlugin.getModuleName())
+            if (pluginName == k.second.getModuleName())
             {
                 msg_warning("PluginManager") << "Plugin " << pluginName << " is already loaded from a different path, check you configuration.";
-                return &loadedPlugin;
+                return &k.second;
             }
         }
 

--- a/Sofa/framework/Helper/test/system/PluginManager_test.cpp
+++ b/Sofa/framework/Helper/test/system/PluginManager_test.cpp
@@ -29,6 +29,7 @@
 #include <sofa/testing/BaseTest.h>
 using sofa::testing::BaseTest;
 
+#include <ranges>
 #include <fstream>
 
 using sofa::helper::system::PluginManager;
@@ -93,9 +94,9 @@ struct PluginManager_test: public BaseTest
         PluginManager&pm = PluginManager::getInstance();
         //empty loaded plugin(s)
         std::vector<std::string> toDelete;
-        for (const auto& it : pm.getPluginMap())
+        for (const auto& pluginName : pm.getPluginMap() | std::views::keys)
         {
-            toDelete.push_back(it.first);
+            toDelete.push_back(pluginName);
         }
 
         for(const std::string& p : toDelete)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerFactory.cpp
@@ -23,6 +23,8 @@
 #include <sofa/simulation/TaskScheduler.h>
 #include <sofa/helper/logging/Messaging.h>
 
+#include <ranges>
+
 namespace sofa::simulation
 {
 
@@ -54,7 +56,7 @@ TaskScheduler* TaskSchedulerFactory::instantiate(const std::string& name)
 std::set<std::string> TaskSchedulerFactory::getAvailableSchedulers()
 {
     std::set<std::string> schedulers;
-    for (const auto& [name, _] : m_schedulerCreationFunctions)
+    for (const auto& name : m_schedulerCreationFunctions | std::views::keys)
     {
         schedulers.insert(name);
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerRegistry.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TaskSchedulerRegistry.cpp
@@ -23,6 +23,8 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/simulation/TaskScheduler.h>
 
+#include <ranges>
+
 namespace sofa::simulation
 {
 
@@ -66,9 +68,9 @@ const std::optional<std::pair<std::string, TaskScheduler*>>& TaskSchedulerRegist
 
 void TaskSchedulerRegistry::clear()
 {
-    for (const auto& p : m_schedulers)
+    for (const auto& scheduler : m_schedulers | std::views::values)
     {
-        delete p.second;
+        delete scheduler;
     }
     m_schedulers.clear();
 }

--- a/Sofa/framework/Type/src/sofa/type/vector_T.h
+++ b/Sofa/framework/Type/src/sofa/type/vector_T.h
@@ -80,6 +80,11 @@ public:
     /// Move constructor
     vector(std::vector<T,Alloc>&& v): std::vector<T,Alloc>(std::move(v)) {}
 
+    /// Constructor from a range
+    template< std::input_iterator InputIt >
+    constexpr vector(InputIt first, InputIt last)
+    : std::vector<T,Alloc>(first, last) {}
+    
     /// Copy operator
     vector& operator=(const std::vector<T, Alloc>& x)
     {
@@ -154,13 +159,17 @@ public:
         std::fill(this->begin(), this->end(), value);
     }
 
-    /// this function is useful for vector_device because it resize the vector without device operation (if device is not valid).
-    /// Therefore the function is used in asynchronous code to safely resize a vector which is either cuda of type::vector
+    /// this function is useful for vector_device because it resizes the vector without device operation (if device is not valid).
+    /// Therefore, the function is used in asynchronous code to safely resize a vector which is either cuda of type::vector
     void fastResize(Size n)
     {
         this->resize(n);
     }
 
 };
+
+//template deduction guide
+template< std::input_iterator InputIt >
+vector(InputIt first, InputIt last) -> vector<typename std::iterator_traits<InputIt>::value_type>;
 
 } /// namespace sofa::type

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
@@ -29,6 +29,8 @@
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/SceneCheckMainRegistry.h>
 
+#include <ranges>
+
 namespace sofa::_scenechecking_
 {
 
@@ -71,11 +73,11 @@ void SceneCheckMissingRequiredPlugin::doCheckOn(sofa::simulation::Node* node)
     }
 
     //sort and remove duplicates
-    for (auto& plugins : m_requiredPlugins)
+    for (auto& objects : m_requiredPlugins | std::views::values)
     {
-        auto& v = plugins.second;
-        std::sort(v.begin(), v.end());
-        v.erase(std::unique(v.begin(), v.end()), v.end());
+        std::ranges::sort(objects);
+        const auto ret = std::ranges::unique(objects);
+        objects.erase(ret.begin(), ret.end());
     }
 }
 

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <ranges>
 #include <sstream>
 using std::ostringstream ;
 #include <fstream>
@@ -414,7 +415,7 @@ int main(int argc, char** argv)
 
     sofa::core::ObjectFactory* objectFactory = sofa::core::ObjectFactory::getInstance();
     // calling explicitly registerObjects from loadedPlugins
-    for (const auto& [pluginPath, plugin] : pluginManager.getPluginMap())
+    for (const auto& plugin : pluginManager.getPluginMap() | std::views::values)
     {
         const auto& pluginName = plugin.getModuleName();
         objectFactory->registerObjectsFromPlugin(pluginName);


### PR DESCRIPTION
As suggested by the linter, `std::views::keys` and `std::views::values` can be used in some loops on `std::map`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
