### PR TITLE
[GL] OglSceneFrame: fix background

### DIFF
--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
@@ -42,6 +42,7 @@ OglSceneFrame::OglSceneFrame()
     , d_style(initData(&d_style, defaultStyle, "style", ("Style of the frame\n" + Style::dataDescription()).c_str()))
     , d_alignment(initData(&d_alignment, defaultAlignment, "alignment", ("Alignment of the frame in the view\n" + Alignment::dataDescription()).c_str()))
     , d_viewportSize(initData(&d_viewportSize, 150, "viewportSize", "Size of the viewport where the frame is rendered"))
+    , d_solidBackground(initData(&d_solidBackground, false, "solidBackground", "If true, an opaque bkacground will be rendered; otherwise the frame is rendered on top on the normal viewport."))
 {}
 
 void OglSceneFrame::drawArrows(const core::visual::VisualParams* vparams)
@@ -129,12 +130,19 @@ void OglSceneFrame::doDrawVisual(const core::visual::VisualParams* vparams)
             glScissor(0,viewport[3]-viewportSize,viewportSize,viewportSize);
             break;
     }
-
-
+        
     glEnable(GL_SCISSOR_TEST);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
-    glClearColor (1.0f, 1.0f, 1.0f, 0.0f);
-
+    if(d_solidBackground.getValue())
+    {
+        // reset color and depth for the mini viewport (setting a background and making render on front)
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
+    }
+    else
+    {
+        // only reset depth to appear on front
+        glClear(GL_DEPTH_BUFFER_BIT );
+    }
+    
     glMatrixMode(GL_PROJECTION);
     vparams->drawTool()->pushMatrix();
     glLoadIdentity();

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.cpp
@@ -42,7 +42,6 @@ OglSceneFrame::OglSceneFrame()
     , d_style(initData(&d_style, defaultStyle, "style", ("Style of the frame\n" + Style::dataDescription()).c_str()))
     , d_alignment(initData(&d_alignment, defaultAlignment, "alignment", ("Alignment of the frame in the view\n" + Alignment::dataDescription()).c_str()))
     , d_viewportSize(initData(&d_viewportSize, 150, "viewportSize", "Size of the viewport where the frame is rendered"))
-    , d_solidBackground(initData(&d_solidBackground, false, "solidBackground", "If true, an opaque bkacground will be rendered; otherwise the frame is rendered on top on the normal viewport."))
 {}
 
 void OglSceneFrame::drawArrows(const core::visual::VisualParams* vparams)
@@ -132,16 +131,8 @@ void OglSceneFrame::doDrawVisual(const core::visual::VisualParams* vparams)
     }
         
     glEnable(GL_SCISSOR_TEST);
-    if(d_solidBackground.getValue())
-    {
-        // reset color and depth for the mini viewport (setting a background and making render on front)
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
-    }
-    else
-    {
-        // only reset depth to appear on front
-        glClear(GL_DEPTH_BUFFER_BIT );
-    }
+    // only reset depth to appear on front
+    glClear(GL_DEPTH_BUFFER_BIT );
     
     glMatrixMode(GL_PROJECTION);
     vparams->drawTool()->pushMatrix();

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
@@ -58,7 +58,6 @@ public:
 
     Data<Alignment> d_alignment; ///< Alignment of the frame in the view
     Data<int> d_viewportSize; ///< Size of the viewport where the frame is rendered
-    Data<bool> d_solidBackground;
 
     OglSceneFrame();
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglSceneFrame.h
@@ -58,6 +58,7 @@ public:
 
     Data<Alignment> d_alignment; ///< Alignment of the frame in the view
     Data<int> d_viewportSize; ///< Size of the viewport where the frame is rendered
+    Data<bool> d_solidBackground;
 
     OglSceneFrame();
 


### PR DESCRIPTION
Problem:

![Screenshot 2025-01-16 at 09 25 53](https://github.com/user-attachments/assets/563d2c85-cfe2-4239-8d3b-f06c4ccc7e24)

The (scissored) viewport of the oglsceneframe clears its backbuffer so if a texture has been set in the background (typically by the GUI) it does produce a solid background behind ; which was weird to me.

This PR fixes it by disabling the clearing of the backbuffer. 

 
![Screenshot 2025-01-16 at 09 48 45](https://github.com/user-attachments/assets/2dbe8d03-fa37-4184-a04a-e7c58d6d47c3)

But I dont know if it was intended at the creation of this component. So I add a Data<bool> if one wants the legacy behavior (but the legacy behavior is unset by default)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
