### PR TITLE
[Helper] WriteAccessorVector: add resize method with default filler value

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessorVector.h
+++ b/Sofa/framework/Helper/src/sofa/helper/accessor/WriteAccessorVector.h
@@ -72,6 +72,7 @@ public:
     ////// Modifiers //////    
     void clear() { vref->clear(); }
     void resize(Size s) { vref->resize(s); }
+    void resize(Size s, const value_type& value) { vref->resize(s, value); }
     
     iterator insert(const_iterator pos, const T& value) { return vref->insert(pos, value); }
     iterator erase(iterator pos) { return vref->erase(pos); }


### PR DESCRIPTION
to mimic the std::vector resize(m,v) method



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
