### PR TITLE
[CMake] Add possibility to remove auto installing of resource files

### DIFF
--- a/Sofa/framework/Config/cmake/SofaMacrosInstall.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosInstall.cmake
@@ -31,7 +31,7 @@ include(CMakeParseLibraryList)
 macro(sofa_create_package_with_targets)
     set(oneValueArgs PACKAGE_NAME PACKAGE_VERSION INCLUDE_ROOT_DIR INCLUDE_INSTALL_DIR INCLUDE_SOURCE_DIR EXAMPLE_INSTALL_DIR RELOCATABLE)
     set(multiValueArgs TARGETS)
-    set(optionalArgs AUTO_SET_TARGET_PROPERTIES)
+    set(optionalArgs AUTO_SET_TARGET_PROPERTIES NO_AUTO_RESOURCES_INSTALL)
     cmake_parse_arguments("ARG" "${optionalArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     # Required arguments
     foreach(arg ARG_PACKAGE_NAME ARG_PACKAGE_VERSION ARG_TARGETS)
@@ -226,7 +226,7 @@ endmacro()
 macro(sofa_add_targets_to_package)
     set(oneValueArgs PACKAGE_NAME PACKAGE_VERSION INCLUDE_ROOT_DIR INCLUDE_INSTALL_DIR INCLUDE_SOURCE_DIR EXAMPLE_INSTALL_DIR RELOCATABLE OPTIMIZE_BUILD_DIR)
     set(multiValueArgs TARGETS)
-    set(optionalArgs AUTO_SET_TARGET_PROPERTIES)
+    set(optionalArgs AUTO_SET_TARGET_PROPERTIES NO_AUTO_RESOURCES_INSTALL)
     cmake_parse_arguments("ARG" "${optionalArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     # Required arguments
     foreach(arg ARG_PACKAGE_NAME ARG_TARGETS)
@@ -600,7 +600,7 @@ endmacro()
 macro(sofa_install_targets_in_package)
     set(oneValueArgs PACKAGE_NAME PACKAGE_VERSION INCLUDE_ROOT_DIR INCLUDE_INSTALL_DIR INCLUDE_SOURCE_DIR EXAMPLE_INSTALL_DIR RELOCATABLE OPTIMIZE_BUILD_DIR)
     set(multiValueArgs TARGETS)
-    set(optionalArgs AUTO_SET_TARGET_PROPERTIES)
+    set(optionalArgs AUTO_SET_TARGET_PROPERTIES NO_AUTO_RESOURCES_INSTALL)
     cmake_parse_arguments("ARG" "${optionalArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     # Required arguments
     foreach(arg ARG_PACKAGE_NAME ARG_TARGETS ARG_INCLUDE_INSTALL_DIR)
@@ -700,16 +700,18 @@ macro(sofa_install_targets_in_package)
         endforeach()
     endforeach()
 
-    # Install examples and scenes
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples")
-        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/examples/"
-                DESTINATION "${example_install_dir}"
-                COMPONENT resources)
-    endif()
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scenes")
-        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/scenes/"
-                DESTINATION "${example_install_dir}"
-                COMPONENT resources)
+    if(NOT ARG_NO_AUTO_RESOURCES_INSTALL)
+        # Install examples and scenes
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples")
+            install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/examples/"
+                    DESTINATION "${example_install_dir}"
+                    COMPONENT resources)
+        endif()
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scenes")
+            install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/scenes/"
+                    DESTINATION "${example_install_dir}"
+                    COMPONENT resources)
+        endif()
     endif()
 
     # Install info files (README, license, etc.)


### PR DESCRIPTION
The goal of this PR is to be able to use the macro `sofa_create_package_with_targets` while still managing the resources ourself. Currently the macro is autodetecting folders examples and scenes and automatically installing them. But if we want to filter those files for instance, it is not possible. Now it is. 
--> the previous behavior is still the default one, the resources will not be automatically installed if the option `NO_AUTO_RESOURCES_INSTALL`  is passed. 

This is needed for the PR in ModelOrderReduction on which this PR depends.

-> might be great to link it to `SOFA_INSTALL_RESOURCES_FILES` to force `NO_AUTO_RESOURCES_INSTALL`  when we don't want to install ressource files at the level of the project

[ci-depends-on https://github.com/SofaDefrost/ModelOrderReduction/pull/152]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
