### PR TITLE
[Playback] Remove deprecated macro

### DIFF
--- a/Sofa/Component/Playback/src/sofa/component/playback/CompareState.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/CompareState.cpp
@@ -263,7 +263,7 @@ void CompareState::draw(const core::visual::VisualParams* vparams)
 CompareStateCreator::CompareStateCreator(const core::ExecParams* params)
     : Visitor(params)
     , sceneName("")
-#if SOFAGENERALLOADER_HAVE_ZLIB
+#if SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB
     , extension(".txt.gz")
 #else
     , extension(".txt")
@@ -277,7 +277,7 @@ CompareStateCreator::CompareStateCreator(const core::ExecParams* params)
 CompareStateCreator::CompareStateCreator(const std::string &n, const core::ExecParams* params, bool i, int c)
     : Visitor(params)
     , sceneName(n)
-#if SOFAGENERALLOADER_HAVE_ZLIB
+#if SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB
     , extension(".txt.gz")
 #else
     , extension(".txt")

--- a/Sofa/Component/Playback/src/sofa/component/playback/CompareTopology.cpp
+++ b/Sofa/Component/Playback/src/sofa/component/playback/CompareTopology.cpp
@@ -298,7 +298,7 @@ void CompareTopology::processCompareTopology()
 CompareTopologyCreator::CompareTopologyCreator(const core::ExecParams* params)
     :Visitor(params)
     , sceneName("")
-#if SOFAGENERALLOADER_HAVE_ZLIB
+#if SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB
     , extension(".txt.gz")
 #else
     , extension(".txt")
@@ -312,7 +312,7 @@ CompareTopologyCreator::CompareTopologyCreator(const core::ExecParams* params)
 CompareTopologyCreator::CompareTopologyCreator(const std::string &n, const core::ExecParams* params, bool i, int c)
     :Visitor(params)
     , sceneName(n)
-#if SOFAGENERALLOADER_HAVE_ZLIB
+#if SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB
     , extension(".txt.gz")
 #else
     , extension(".txt")

--- a/Sofa/Component/Playback/src/sofa/component/playback/config.h.in
+++ b/Sofa/Component/Playback/src/sofa/component/playback/config.h.in
@@ -39,15 +39,6 @@ namespace sofa::component::playback
 	constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
 } // namespace sofa::component::playback
 
-// Keep the previous macros
-// This backward compatibility will be removed at v23.06
-#ifndef SOFAGENERALLOADER_HAVE_ZLIB
-#define SOFAGENERALLOADER_HAVE_ZLIB SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB
-#endif
-#ifndef SOFAEXPORTER_HAVE_ZLIB
-#define SOFAEXPORTER_HAVE_ZLIB SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB
-#endif
-
 #ifdef SOFA_BUILD_SOFA_COMPONENT_PLAYBACK
 #define SOFA_ATTRIBUTE_DEPRECATED__RENAME_DATA_IN_PLAYBACK()
 #else


### PR DESCRIPTION
Note: the macro `SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB` is not necessary as Zlib is required in the CMakeLists.txt, making the variable `SOFA_COMPONENT_PLAYBACK_HAVE_ZLIB` always true -> issue https://github.com/sofa-framework/sofa/issues/5232


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
