### PR TITLE
[SofaMatrix] Put Qt dependent code into an extension

### DIFF
--- a/applications/plugins/SofaMatrix/CMakeLists.txt
+++ b/applications/plugins/SofaMatrix/CMakeLists.txt
@@ -6,7 +6,6 @@ sofa_find_package(Sofa.Core REQUIRED)
 sofa_find_package(Sofa.Component.Constraint.Lagrangian.Solver REQUIRED)
 sofa_find_package(Sofa.Component.LinearSolver.Direct REQUIRED)
 sofa_find_package(Eigen3 REQUIRED)
-sofa_find_package(Sofa.GUI.Qt QUIET)
 
 find_package(metis 5.1.0 EXACT QUIET)
 if(NOT metis_FOUND AND SOFA_ALLOW_FETCH_DEPENDENCIES)
@@ -54,37 +53,6 @@ set(MOC_FILES
 set(MOC_HEADER_FILES
 )
 
-if (NOT Sofa.GUI.Qt_FOUND)
-    message(NOTICE "[SofaMatrix] Module Sofa.GUI.Qt not found: some components (GlobalSystemMatrixImage) will not be compiled")
-else()
-    list(APPEND HEADER_FILES
-        ${SOFAMATRIX_SRC_DIR}/ComplianceMatrixImage.h
-        ${SOFAMATRIX_SRC_DIR}/GlobalSystemMatrixImage.h
-        ${SOFAMATRIX_SRC_DIR}/BaseMatrixImageProxy.h
-    )
-    list(APPEND SOURCE_FILES
-        ${SOFAMATRIX_SRC_DIR}/ComplianceMatrixImage.cpp
-        ${SOFAMATRIX_SRC_DIR}/GlobalSystemMatrixImage.cpp
-        ${SOFAMATRIX_SRC_DIR}/BaseMatrixImageViewerWidget.cpp
-    )
-    list(APPEND MOC_HEADER_FILES
-        ${SOFAMATRIX_SRC_DIR}/BaseMatrixImageViewerWidget.h
-    )
-    list(APPEND SOFA_MODULES
-        Sofa.GUI.Qt
-    )
-
-    find_package(Qt6 COMPONENTS Core CoreTools QUIET)
-    if (NOT Qt6Core_FOUND)
-        find_package(Qt5 COMPONENTS Core QUIET)
-    endif()
-    if(Qt5Core_FOUND)
-        qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
-    elseif (Qt6Core_FOUND)
-        qt6_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
-    endif()
-endif()
-
 # Create the plugin library.
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES} ${MOC_HEADER_FILES} ${MOC_FILES})
 
@@ -100,6 +68,9 @@ sofa_create_package_with_targets(
     INCLUDE_INSTALL_DIR ${PROJECT_NAME}
     RELOCATABLE "plugins"
     )
+
+sofa_add_subdirectory(plugin extensions/Qt SofaMatrix.Qt)
+
 
 # Tests
 # If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled

--- a/applications/plugins/SofaMatrix/examples/ComplianceMatrixImage.scn
+++ b/applications/plugins/SofaMatrix/examples/ComplianceMatrixImage.scn
@@ -13,7 +13,7 @@
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
     <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [EdgeSetGeometryAlgorithms EdgeSetTopologyContainer] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
-    <RequiredPlugin name="SofaMatrix"/> <!-- Needed to use components [ComplianceMatrixImage] -->
+    <RequiredPlugin name="SofaMatrix.Qt"/> <!-- Needed to use components [ComplianceMatrixImage] -->
 
     <VisualStyle displayFlags="hideVisualModels showBehaviorModels showMappings showForceFields" />
     <FreeMotionAnimationLoop solveVelocityConstraintFirst="true" />

--- a/applications/plugins/SofaMatrix/examples/FillReducingOrdering.scn
+++ b/applications/plugins/SofaMatrix/examples/FillReducingOrdering.scn
@@ -18,7 +18,8 @@ The scene compares two simulations in which only the vertices order differs:
     <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms TetrahedronSetTopologyContainer] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering2D"/> <!-- Needed to use components [OglLabel] -->
-    <RequiredPlugin name="SofaMatrix.Qt"/> <!-- Needed to use components [FillReducingOrdering GlobalSystemMatrixImage] -->
+    <RequiredPlugin name="SofaMatrix"/> <!-- Needed to use components [FillReducingOrdering] -->
+     <RequiredPlugin name="SofaMatrix.Qt"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
 
     <VisualStyle displayFlags="showForceFields hideVisualModels showBehaviorModels" />
 

--- a/applications/plugins/SofaMatrix/examples/FillReducingOrdering.scn
+++ b/applications/plugins/SofaMatrix/examples/FillReducingOrdering.scn
@@ -18,7 +18,7 @@ The scene compares two simulations in which only the vertices order differs:
     <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms TetrahedronSetTopologyContainer] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering2D"/> <!-- Needed to use components [OglLabel] -->
-    <RequiredPlugin name="SofaMatrix"/> <!-- Needed to use components [FillReducingOrdering GlobalSystemMatrixImage] -->
+    <RequiredPlugin name="SofaMatrix.Qt"/> <!-- Needed to use components [FillReducingOrdering GlobalSystemMatrixImage] -->
 
     <VisualStyle displayFlags="showForceFields hideVisualModels showBehaviorModels" />
 

--- a/applications/plugins/SofaMatrix/examples/GlobalSystemMatrixImage.scn
+++ b/applications/plugins/SofaMatrix/examples/GlobalSystemMatrixImage.scn
@@ -7,7 +7,7 @@
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
     <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
-    <RequiredPlugin name="SofaMatrix"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
+    <RequiredPlugin name="SofaMatrix.Qt"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
 

--- a/applications/plugins/SofaMatrix/extensions/Qt/CMakeLists.txt
+++ b/applications/plugins/SofaMatrix/extensions/Qt/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.22)
+project(SofaMatrix.Qt VERSION 1.0 LANGUAGES CXX)
+
+sofa_find_package(Sofa.Core REQUIRED)
+sofa_find_package(Sofa.Component.Constraint.Lagrangian.Solver REQUIRED)
+sofa_find_package(Sofa.Component.LinearSolver.Direct REQUIRED)
+sofa_find_package(Eigen3 REQUIRED)
+sofa_find_package(Sofa.GUI.Qt REQUIRED)
+
+set(SOFA_MODULES
+    Sofa.Component.Constraint.Lagrangian.Solver
+    Sofa.Component.LinearSolver.Direct
+    Sofa.Core
+    Eigen3::Eigen
+    Sofa.GUI.Qt
+    SofaMatrix
+)
+
+set(SOFAMATRIX_SRC_DIR src/SofaMatrix/Qt)
+
+set(HEADER_FILES
+    ${SOFAMATRIX_SRC_DIR}/config.h.in
+    ${SOFAMATRIX_SRC_DIR}/ComplianceMatrixImage.h
+    ${SOFAMATRIX_SRC_DIR}/GlobalSystemMatrixImage.h
+    ${SOFAMATRIX_SRC_DIR}/BaseMatrixImageProxy.h
+)
+
+set(SOURCE_FILES
+    ${SOFAMATRIX_SRC_DIR}/ComplianceMatrixImage.cpp
+    ${SOFAMATRIX_SRC_DIR}/GlobalSystemMatrixImage.cpp
+    ${SOFAMATRIX_SRC_DIR}/BaseMatrixImageViewerWidget.cpp
+    ${SOFAMATRIX_SRC_DIR}/initSofaMatrixQt.cpp
+)
+
+set(MOC_FILES
+)
+
+set(MOC_HEADER_FILES
+    ${SOFAMATRIX_SRC_DIR}/BaseMatrixImageViewerWidget.h
+)
+
+find_package(Qt6 COMPONENTS Core CoreTools QUIET)
+if (NOT Qt6Core_FOUND)
+    find_package(Qt5 COMPONENTS Core QUIET)
+endif()
+if(Qt5Core_FOUND)
+    qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
+    set(SOFAMATRIX_HAVE_QT5 1)
+elseif (Qt6Core_FOUND)
+    qt6_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
+    set(SOFAMATRIX_HAVE_QT6 1)
+endif()
+
+# Create the plugin library.
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${MOC_HEADER_FILES} ${MOC_FILES})
+
+# Link the plugin library to its dependency(ies).
+target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFA_MODULES})
+
+sofa_create_package_with_targets(
+    PACKAGE_NAME ${PROJECT_NAME}
+    PACKAGE_VERSION ${PROJECT_VERSION}
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+    INCLUDE_SOURCE_DIR "src"
+    INCLUDE_INSTALL_DIR ${PROJECT_NAME}
+    RELOCATABLE "plugins"
+    )
+
+# Tests
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+# cmake_dependent_option(SOFAMATRIX_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+#if(SOFAMATRIX_BUILD_TESTS)
+#    enable_testing()
+#    add_subdirectory(SofaMatrix_test)
+# endif()

--- a/applications/plugins/SofaMatrix/extensions/Qt/SofaMatrix.QtConfig.cmake.in
+++ b/applications/plugins/SofaMatrix/extensions/Qt/SofaMatrix.QtConfig.cmake.in
@@ -4,10 +4,23 @@
 @PACKAGE_INIT@
 
 
+
+set(SOFAMATRIX_QT_HAVE_QT5 @SOFAMATRIX_HAVE_QT5@)
+set(SOFAMATRIX_QT_HAVE_QT6 @SOFAMATRIX_HAVE_QT6@)
+
 find_package(Sofa.Core QUIET REQUIRED)
 find_package(Sofa.Component.Constraint.Lagrangian.Solver QUIET REQUIRED)
 find_package(Sofa.Component.LinearSolver.Direct QUIET REQUIRED)
 find_package(Eigen3 QUIET REQUIRED)
+find_package(Sofa.GUI.Qt QUIET REQUIRED)
+find_package(SofaMatrix QUIET REQUIRED)
+
+if(SOFAMATRIX_QT_HAVE_QT5)
+    find_package(Qt5 COMPONENTS Core QUIET REQUIRED)
+endif()
+if(SOFAMATRIX_QT_HAVE_QT6)
+    find_package(Qt6 COMPONENTS Core CoreTools QUIET)
+endif()
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageProxy.h
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageProxy.h
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaMatrix/config.h>
+#include <SofaMatrix/Qt/config.h>
 #include <sofa/linearalgebra/BaseMatrix.h>
 
 namespace sofa::type

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.cpp
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaMatrix/BaseMatrixImageViewerWidget.h>
+#include <SofaMatrix/Qt/BaseMatrixImageViewerWidget.h>
 
 namespace sofa::gui::qt
 {

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.h
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.h
@@ -20,12 +20,12 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaMatrix/config.h>
+#include <SofaMatrix/Qt/config.h>
 
 #include <QGraphicsView>
 #include <sofa/gui/qt/SimpleDataWidget.h>
 
-#include <SofaMatrix/BaseMatrixImageProxy.h>
+#include <SofaMatrix/Qt/BaseMatrixImageProxy.h>
 
 namespace sofa::gui::qt
 {

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/ComplianceMatrixImage.cpp
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/ComplianceMatrixImage.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaMatrix/ComplianceMatrixImage.h>
+#include <SofaMatrix/Qt/ComplianceMatrixImage.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/ComplianceMatrixImage.h
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/ComplianceMatrixImage.h
@@ -1,4 +1,4 @@
-﻿/******************************************************************************
+/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -20,35 +20,36 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaMatrix/config.h>
+#include <SofaMatrix/Qt/config.h>
 
 #include <sofa/core/objectmodel/BaseObject.h>
-#include <SofaMatrix/BaseMatrixImageProxy.h>
+#include <SofaMatrix/Qt/BaseMatrixImageProxy.h>
+#include <sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h>
 
-#include <sofa/core/behavior/BaseMatrixLinearSystem.h>
-
-namespace sofa::component::linearsolver
+namespace sofa::component::constraintset
 {
 
 /**
- * Component to convert a BaseMatrix from the linear solver into an image that can be visualized in the GUI.
- * Use GlobalSystemMatrixExporter in order to save an image on the disk.
+ * Component to convert a BaseMatrix from the constraint solver into an image that can be visualized in the GUI.
+ * Use ComplianceMatrixExporter in order to save an image on the disk.
+ *
+ * Note that the compliance matrix is dense. It means all the entries will proably be non-zero
  */
-class SOFA_SOFAMATRIX_API GlobalSystemMatrixImage : public core::objectmodel::BaseObject
+class SOFA_SOFAMATRIX_QT_API ComplianceMatrixImage : public core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(GlobalSystemMatrixImage, core::objectmodel::BaseObject);
+    SOFA_CLASS(ComplianceMatrixImage, core::objectmodel::BaseObject);
 
 protected:
 
-    GlobalSystemMatrixImage();
-    ~GlobalSystemMatrixImage() override;
+    ComplianceMatrixImage();
+    ~ComplianceMatrixImage() override;
 
     void init() override;
     void handleEvent(core::objectmodel::Event *event) override;
 
     Data< type::BaseMatrixImageProxy > d_bitmap; ///< Visualization of the representation of the matrix as a binary image. White pixels are zeros, black pixels are non-zeros.
-    SingleLink<GlobalSystemMatrixImage, sofa::core::behavior::BaseMatrixLinearSystem, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_linearSystem;
+    SingleLink<ComplianceMatrixImage, sofa::component::constraint::lagrangian::solver::ConstraintSolverImpl, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_constraintSolver;
 };
 
-} //namespace sofa::component::linearsolver
+} //namespace sofa::component::constraintset

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/GlobalSystemMatrixImage.cpp
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/GlobalSystemMatrixImage.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaMatrix/GlobalSystemMatrixImage.h>
+#include <SofaMatrix/Qt/GlobalSystemMatrixImage.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/simulation/AnimateEndEvent.h>

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/GlobalSystemMatrixImage.h
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/GlobalSystemMatrixImage.h
@@ -1,0 +1,54 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <SofaMatrix/Qt/config.h>
+
+#include <sofa/core/objectmodel/BaseObject.h>
+#include <SofaMatrix/Qt/BaseMatrixImageProxy.h>
+
+#include <sofa/core/behavior/BaseMatrixLinearSystem.h>
+
+namespace sofa::component::linearsolver
+{
+
+/**
+ * Component to convert a BaseMatrix from the linear solver into an image that can be visualized in the GUI.
+ * Use GlobalSystemMatrixExporter in order to save an image on the disk.
+ */
+class SOFA_SOFAMATRIX_QT_API GlobalSystemMatrixImage : public core::objectmodel::BaseObject
+{
+public:
+    SOFA_CLASS(GlobalSystemMatrixImage, core::objectmodel::BaseObject);
+
+protected:
+
+    GlobalSystemMatrixImage();
+    ~GlobalSystemMatrixImage() override;
+
+    void init() override;
+    void handleEvent(core::objectmodel::Event *event) override;
+
+    Data< type::BaseMatrixImageProxy > d_bitmap; ///< Visualization of the representation of the matrix as a binary image. White pixels are zeros, black pixels are non-zeros.
+    SingleLink<GlobalSystemMatrixImage, sofa::core::behavior::BaseMatrixLinearSystem, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_linearSystem;
+};
+
+} //namespace sofa::component::linearsolver

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/config.h.in
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/config.h.in
@@ -1,0 +1,34 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/config.h>
+
+#define SOFAMATRIX_QT_VERSION @PROJECT_VERSION@
+
+#ifdef SOFA_BUILD_SOFAMATRIX_QT
+#  define SOFA_TARGET @PROJECT_NAME@
+#  define SOFA_SOFAMATRIX_QT_API SOFA_EXPORT_DYNAMIC_LIBRARY
+#else
+#  define SOFA_SOFAMATRIX_QT_API SOFA_IMPORT_DYNAMIC_LIBRARY
+#endif
+

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/initSofaMatrixQt.cpp
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/initSofaMatrixQt.cpp
@@ -19,37 +19,57 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
-#include <SofaMatrix/config.h>
+#include <SofaMatrix/Qt/config.h>
 
-#include <sofa/core/objectmodel/BaseObject.h>
-#include <SofaMatrix/BaseMatrixImageProxy.h>
-#include <sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h>
+#include <SofaMatrix/MatrixImageExporter.h>
 
-namespace sofa::component::constraintset
+#include <sofa/core/ObjectFactory.h>
+using sofa::core::ObjectFactory;
+
+extern "C" {
+    SOFA_SOFAMATRIX_API void initExternalModule();
+    SOFA_SOFAMATRIX_API const char* getModuleName();
+    SOFA_SOFAMATRIX_API const char* getModuleVersion();
+    SOFA_SOFAMATRIX_API const char* getModuleLicense();
+    SOFA_SOFAMATRIX_API const char* getModuleDescription();
+    SOFA_SOFAMATRIX_API const char* getModuleComponentList();
+}
+
+void initExternalModule()
 {
+    static bool first = true;
+    if (first)
+    {
+        first = false;
 
-/**
- * Component to convert a BaseMatrix from the constraint solver into an image that can be visualized in the GUI.
- * Use ComplianceMatrixExporter in order to save an image on the disk.
- *
- * Note that the compliance matrix is dense. It means all the entries will proably be non-zero
- */
-class SOFA_SOFAMATRIX_API ComplianceMatrixImage : public core::objectmodel::BaseObject
+        sofa::component::initializeMatrixExporterComponents();
+    }
+}
+
+const char* getModuleName()
 {
-public:
-    SOFA_CLASS(ComplianceMatrixImage, core::objectmodel::BaseObject);
+    return sofa_tostring(SOFA_TARGET);
+}
 
-protected:
+const char* getModuleVersion()
+{
+    return sofa_tostring(SOFAMATRIX_VERSION);
+}
 
-    ComplianceMatrixImage();
-    ~ComplianceMatrixImage() override;
+const char* getModuleLicense()
+{
+    return "LGPL";
+}
 
-    void init() override;
-    void handleEvent(core::objectmodel::Event *event) override;
+const char* getModuleDescription()
+{
+    return "Sofa plugin gathering components related to linear system matrices.";
+}
 
-    Data< type::BaseMatrixImageProxy > d_bitmap; ///< Visualization of the representation of the matrix as a binary image. White pixels are zeros, black pixels are non-zeros.
-    SingleLink<ComplianceMatrixImage, sofa::component::constraint::lagrangian::solver::ConstraintSolverImpl, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_constraintSolver;
-};
+const char* getModuleComponentList()
+{
+    /// string containing the names of the classes provided by the plugin
+    static std::string classes = ObjectFactory::getInstance()->listClassesFromTarget(sofa_tostring(SOFA_TARGET));
+    return classes.c_str();
+}
 
-} //namespace sofa::component::constraintset

--- a/examples/Component/LinearSystem/CompositeLinearSystem.scn
+++ b/examples/Component/LinearSystem/CompositeLinearSystem.scn
@@ -13,7 +13,7 @@
     <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
-    <RequiredPlugin name="SofaMatrix"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
+    <RequiredPlugin name="SofaMatrix.Qt"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
 
     <VisualStyle displayFlags="showBehaviorModels showWireframe" />
 

--- a/examples/Component/LinearSystem/MatrixLinearSystem.scn
+++ b/examples/Component/LinearSystem/MatrixLinearSystem.scn
@@ -17,7 +17,7 @@
         <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
         <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
         <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
-        <RequiredPlugin name="SofaMatrix"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
+        <RequiredPlugin name="SofaMatrix.Qt"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
 
     </Node>
 


### PR DESCRIPTION
I need this for the CI to be happy in this PR : https://github.com/sofa-framework/sofa/pull/5176 

This PR now complies with the conclusion on the architecture of a plugin, described [in the doc](https://www.sofa-framework.org/community/doc/programming-with-sofa/create-your-plugin/#plugin-architecture)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
