### PR TITLE
[Core] Warn when input/output of mapping is deduced automatically

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/Mapping.h
+++ b/Sofa/framework/Core/src/sofa/core/Mapping.h
@@ -165,8 +165,6 @@ public:
     /// Propagate positions and velocities to the output
     void init() override;
 
-    void parse(objectmodel::BaseObjectDescription* arg) override;
-
     ///<TO REMOVE>  FF:why would we remove this, is there any alternative function ?
     // Useful ?
     /// Get the source (upper) model.

--- a/Sofa/framework/Core/src/sofa/core/Mapping.h
+++ b/Sofa/framework/Core/src/sofa/core/Mapping.h
@@ -165,6 +165,8 @@ public:
     /// Propagate positions and velocities to the output
     void init() override;
 
+    void parse(objectmodel::BaseObjectDescription* arg) override;
+
     ///<TO REMOVE>  FF:why would we remove this, is there any alternative function ?
     // Useful ?
     /// Get the source (upper) model.
@@ -230,40 +232,6 @@ public:
         }
 
         return BaseMapping::canCreate(obj, context, arg);
-    }
-
-    /// Construction method called by ObjectFactory.
-    ///
-    /// This implementation read the input and output attributes to
-    /// find the input and output models of this mapping.
-    template<class T>
-    static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
-        if (context)
-            context->addObject(obj);
-
-        if (arg)
-        {
-            std::string inPath, outPath;
-            if (arg->getAttribute("input"))
-                inPath = arg->getAttribute("input");
-            else
-                inPath = "@../";
-
-            if (arg->getAttribute("output"))
-                outPath = arg->getAttribute("output");
-            else
-                outPath = "@./";
-
-            obj->fromModel.setPath( inPath );
-            obj->toModel.setPath( outPath );
-
-            obj->parse(arg);
-        }
-
-        return obj;
     }
 
     template<class T>

--- a/Sofa/framework/Core/src/sofa/core/Mapping.inl
+++ b/Sofa/framework/Core/src/sofa/core/Mapping.inl
@@ -111,6 +111,31 @@ void Mapping<In,Out>::init()
         apply(mechanicalparams::defaultInstance(), vec_id::write_access::restPosition, vec_id::read_access::restPosition);
 }
 
+template <class TIn, class TOut>
+void Mapping<TIn, TOut>::parse(objectmodel::BaseObjectDescription* arg)
+{
+    BaseMapping::parse(arg);
+
+    const auto setLink = [arg, this]<typename LinkType>(LinkType& link, const char* attributeName, const std::string& defaultPath)
+    {
+        if (!arg->getAttribute(attributeName))
+        {
+            typename LinkType::DestType* state = nullptr;
+            this->getContext()->findLinkDest(state, defaultPath, nullptr);
+
+            if (state)
+            {
+                const std::string linkPath = "@" + state->getPathName();
+                msg_warning() << "The attribute '" << attributeName << "' of this component has not been defined. It is automatically set to '" << linkPath << "'. It is recommended to define it to avoid any error.";
+                link.setPath( linkPath );
+            }
+        }
+    };
+
+    setLink(this->fromModel, "input", "@../");
+    setLink(this->toModel, "output", "@./");
+}
+
 template <class In, class Out>
 sofa::linearalgebra::BaseMatrix* Mapping<In,Out>::createMappedMatrix(const behavior::BaseMechanicalState* state1, const behavior::BaseMechanicalState* state2, func_createMappedMatrix m_createMappedMatrix)
 {

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
@@ -348,7 +348,6 @@ bool BaseLink::updateLinks()
         Base* ptr;
         std::string path = getLinkedPath(i);
         /// Search for path and if any returns the pointer to the proper object.
-        /// Search for path and if any returns the pointer to the proper object.
         if(!getLinkedBase() && !path.empty())
         {
             ptr = PathResolver::FindBaseFromClassAndPath(getOwner(), getDestClass(), path);

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
@@ -94,7 +94,9 @@ std::string BaseNode::internalGetPathName() const {
         // no smarter choice without breaking the "Node" heritage
         str = parents[0]->internalGetPathName();
         str += '/';
-        str += getName();
+        const auto& myName = getName();
+        assert(!myName.empty());
+        str += myName;
     }
     return str;
 }

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/NodeElement.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/NodeElement.cpp
@@ -33,6 +33,12 @@ using namespace sofa::defaulttype;
 NodeElement::NodeElement(const std::string& name, const std::string& type, BaseElement* parent)
     : Element<core::objectmodel::BaseNode>(name, type, parent)
 {
+    if (name.empty())
+    {
+        const std::string nodeName = "node";
+        msg_warning("XML") << "Node name cannot be empty. An arbitrary name '" << nodeName << "' has been provided";
+        attributes["name"] = nodeName;
+    }
 }
 
 NodeElement::~NodeElement()

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -73,7 +73,7 @@ namespace sofa::simulation
 using core::objectmodel::BaseNode;
 using core::objectmodel::BaseObject;
 
-Node::Node(const std::string& name)
+Node::Node()
     : core::objectmodel::BaseNode()
     , sofa::core::objectmodel::Context()
     , child(initLink("child", "Child nodes"))
@@ -113,14 +113,20 @@ Node::Node(const std::string& name)
     , initialized(false)
 {
     _context = this;
-    setName(name);
     f_printLog.setValue(DEBUG_LINK);
 }
 
-
-Node::~Node()
+Node::Node(std::string nodeName) : Node()
 {
+    if (nodeName.empty())
+    {
+        nodeName = "node";
+        msg_warning(GetClass()->className) << "Node name cannot be empty. An arbitrary name '" << nodeName << "' has been provided";
+    }
+    setName(nodeName);
 }
+
+Node::~Node() = default;
 
 void Node::parse( sofa::core::objectmodel::BaseObjectDescription* arg )
 {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -152,7 +152,8 @@ public:
 
     typedef sofa::core::visual::DisplayFlags DisplayFlags;
 protected:
-    Node(const std::string& name="");
+    Node();
+    explicit Node(std::string nodeName);
 
     virtual ~Node() override;
 public:


### PR DESCRIPTION
The search for "input" and "output" can be moved into the `init` method. It is called anyway by the object factory. If we do that, the function `create` is identical to `BaseObject::create`. It is then useless to define it again.

In case a mapping is defined without "input" or "output", the warning looks like:

```
[WARNING] [RigidMapping()] The attribute 'input' of this component has not been defined. It is automatically set to '@/Torus3/MechanicalObject1'. It is recommended to define it to avoid any error.
[WARNING] [RigidMapping()] The attribute 'output' of this component has not been defined. It is automatically set to '@/Torus3/Surf2/MechanicalObject1'. It is recommended to define it to avoid any error.
```

To better understand the implicit mechanism, the full link is set. It is much more readable than `"@../"` and `"@./"`

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
