### PR TITLE
[Core] Remove some static functions create

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/Multi2Mapping.h
+++ b/Sofa/framework/Core/src/sofa/core/Multi2Mapping.h
@@ -229,23 +229,6 @@ public:
 
         return !error && BaseMapping::canCreate(obj, context, arg);
     }
-    /// Construction method called by ObjectFactory.
-    ///
-    /// This implementation read the input and output attributes to
-    /// find the input and output models of this mapping.
-    template<class T>
-    static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
-        if (context)
-            context->addObject(obj);
-
-        if (arg)
-            obj->parse(arg);
-
-        return obj;
-    }
 
 protected:
     void getVecIn1Coord     (const MultiVecCoordId id,         type::vector<      DataVecCoord_t<In1>*> &v) const

--- a/Sofa/framework/Core/src/sofa/core/MultiMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/MultiMapping.h
@@ -231,26 +231,6 @@ public:
         return BaseMapping::canCreate(obj, context, arg);
     }
 
-    /// Construction method called by ObjectFactory.
-    ///
-    /// This implementation read the input and output attributes to
-    /// find the input and output models of this mapping.
-    template<class T>
-    static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
-        if (context)
-            context->addObject(obj);
-
-        if (arg)
-        {
-            obj->parse(arg);
-        }
-
-        return obj;
-    }
-
 protected:
 
     void getVecInCoord     (const MultiVecCoordId id,         type::vector<      InDataVecCoord* > &v) const

--- a/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionConstraint.h
@@ -113,21 +113,6 @@ public:
     /// This is the method that should be implemented by the component
     virtual void buildConstraintMatrix(const ConstraintParams* cParams, DataMatrixDeriv1 &c1, DataMatrixDeriv2 &c2, unsigned int &cIndex
             , const DataVecCoord1 &x1, const DataVecCoord2 &x2) = 0;
-
-
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T* p0, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
-    {
-        typename T::SPtr obj = core::behavior::BaseInteractionConstraint::create(p0, context, arg);
-
-        if (arg)
-        {
-            obj->parse(arg);
-        }
-
-        return obj;
-    }
 };
 
 #if !defined(SOFA_CORE_BEHAVIOR_MIXEDINTERACTIONCONSTRAINT_CPP)

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/animationloop/AnimationLoopParallelScheduler.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/animationloop/AnimationLoopParallelScheduler.h
@@ -76,17 +76,6 @@ public:
 
     void step(const sofa::core::ExecParams* params, SReal dt) override;
 
-    /// Construction method called by ObjectFactory.
-    template<class T>
-    static typename T::SPtr create(T*, sofa::core::objectmodel::BaseContext* context, sofa::core::objectmodel::BaseObjectDescription* arg)
-    {
-        sofa::simulation::Node* gnode = dynamic_cast<sofa::simulation::Node*>(context);
-        typename T::SPtr obj = sofa::core::objectmodel::New<T>(gnode);
-        if (context) context->addObject(obj);
-        if (arg) obj->parse(arg);
-        return obj;
-    }
-
 private :
 
     sofa::simulation::Node* gnode;


### PR DESCRIPTION
Some functions `create` are very similar to `BaseObject::create`. They don't add anything, so they can be removed.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
