### PR TITLE
[ODESolver] Remove repeated class name in log messages

### DIFF
--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -125,7 +125,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         // compute the net forces at the beginning of the time step
         mop.computeForce(f);                                                               //f = Kx + Bv
 
-        msg_info() << "EulerImplicitSolver, initial f = " << f;
+        msg_info() << "initial f = " << f;
     }
 
     {
@@ -141,7 +141,7 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
             // force in the current configuration
             b.eq(f);  // b = f
 
-            msg_info() << "EulerImplicitSolver, f = " << f;
+            msg_info() << "f = " << f;
 
             // add the change of force due to stiffness + Rayleigh damping
             mop.addMBKv(b, core::MatricesFactors::M(-d_rayleighMass.getValue()),
@@ -152,11 +152,11 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
             b.teq(h);                                             // b = h(f + ( rm M + (h+rs) K ) v )
         }
 
-        msg_info() << "EulerImplicitSolver, b = " << b;
+        msg_info() << "b = " << b;
 
         mop.projectResponse(b);                                   // b is projected to the constrained space
 
-        msg_info() << "EulerImplicitSolver, projected b = " << b;
+        msg_info() << "projected b = " << b;
     }
 
     {
@@ -299,10 +299,10 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         mop.projectVelocity(newVel);
         mop.propagateX(newPos);
         mop.propagateV(newVel);
-        msg_info() << "EulerImplicitSolver, final x = " << newPos;
-        msg_info() << "EulerImplicitSolver, final v = " << newVel;
+        msg_info() << "final x = " << newPos;
+        msg_info() << "final v = " << newVel;
         mop.computeForce(f);
-        msg_info() << "EulerImplicitSolver, final f = " << f;
+        msg_info() << "final f = " << f;
     }
 }
 


### PR DESCRIPTION
The class name is already mentioned in the header of the log message. No need to repeat it again.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
