### PR TITLE
[StateContainer] Allow coord difference in vOp for rigids

### DIFF
--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.inl
@@ -2096,6 +2096,19 @@ void MechanicalObject<DataTypes>::vOp(const core::ExecParams* params, core::VecI
                     APPLY_PREDICATE_THREEPARAMS(vOp_vab, v, a, b)
                     msg_error_when(!canApplyPredicate) << "Cannot apply vector operation v = a+b (" << v << ',' << a << ',' << b << ',' << f << ")";
                 }
+                else if (f == -1._sreal &&
+                    (v.type == core::V_DERIV && a.type == core::V_COORD && b.type == core::V_COORD))
+                {
+                    // v = a-b
+                    auto vv = this->getWriteOnlyAccessor<core::V_DERIV>(v);
+                    auto va = this->getReadAccessor<core::V_COORD>(a);
+                    auto vb = this->getReadAccessor<core::V_COORD>(b);
+                    vv.resize(vb.size());
+                    for (unsigned int i = 0; i < vv.size(); ++i)
+                    {
+                        vv[i] = DataTypes::coordDifference(va[i], vb[i]);
+                    }
+                }
                 else
                 {
                     // v = a+b*f

--- a/Sofa/Component/StateContainer/tests/MechanicalObjectVOp_test.cpp
+++ b/Sofa/Component/StateContainer/tests/MechanicalObjectVOp_test.cpp
@@ -731,6 +731,31 @@ struct MechanicalObjectVOpTest : public testing::BaseTest
         checkVecValues<sofa::core::vec_id::read_access::velocity>(isRigid ? velocityCoefficient : forceCoefficient + positionCoefficient * 12);
     }
 
+    void equalCoordDifference() const
+    {
+        // v = a-b
+        m_mechanicalObject->vOp(nullptr, core::vec_id::write_access::velocity, core::vec_id::read_access::restPosition, core::vec_id::read_access::position, -1_sreal);
+
+        unsigned int index {};
+        auto vv = sofa::helper::getReadAccessor(*m_mechanicalObject->read(core::vec_id::read_access::velocity));
+        auto va = sofa::helper::getReadAccessor(*m_mechanicalObject->read(core::vec_id::read_access::restPosition));
+        auto vb = sofa::helper::getReadAccessor(*m_mechanicalObject->read(core::vec_id::read_access::position));
+
+        ASSERT_EQ(vv.size(), 10);
+        for (std::size_t i = 0; i < vv.size(); ++i)
+        {
+            const auto& v = vv[i];
+            const auto diff = DataTypes::coordDifference(va[i], vb[i]);
+            for (std::size_t j = 0; j < v.size(); ++j)
+            {
+                EXPECT_FLOATINGPOINT_EQ(v[j], diff[j])
+            }
+            ++index;
+        }
+
+        checkVecValues<core::vec_id::read_access::position>(positionCoefficient);
+    }
+
     typename MO::SPtr m_mechanicalObject;
 };
 
@@ -947,6 +972,11 @@ TYPED_TEST(MechanicalObjectVOpTest, equalSumWithScalarVelocityMix1)
 TYPED_TEST(MechanicalObjectVOpTest, equalSumWithScalarVelocityMix2)
 {
     this->equalSumWithScalarVelocityMix2();
+}
+
+TYPED_TEST(MechanicalObjectVOpTest, equalCoordDifference)
+{
+    this->equalCoordDifference();
 }
 
 }


### PR DESCRIPTION
Currently, the addition of 2 coords resulting in a deriv is not possible using vOp. But, it's a common case. For example, `v=(x_(n+1) - x_n)/dt`. This PR uses the function `coordDifference` to achieve that.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
