### PR TITLE
[Geometry] Fix edge-edge intersection method avoiding decimal precision error

### DIFF
--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -292,8 +292,18 @@ struct Edge
                 return false;
             }
 
-            const T alpha = alphaNom / alphaDenom;
-            const T beta = (dCACD + alpha * dABCD) / dCDCD;
+            T alpha = alphaNom / alphaDenom;
+            T beta = (dCACD + alpha * dABCD) / dCDCD;
+
+            if (abs(alpha) < EQUALITY_THRESHOLD)
+                alpha = 0;
+            else if (alpha > (1 - EQUALITY_THRESHOLD) && alpha < (1+ EQUALITY_THRESHOLD))
+                alpha = 1;
+
+            if (abs(beta) < EQUALITY_THRESHOLD)
+                beta = 0;
+            else if (beta > (1 - EQUALITY_THRESHOLD) && beta < (1 + EQUALITY_THRESHOLD))
+                beta = 1;
 
             const Node pX = pA + alpha * AB;
             const Node pY = pC + beta * CD;

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -297,6 +297,8 @@ struct Edge
 
             const Node pX = pA + alpha * AB;
             const Node pY = pC + beta * CD;
+            std::cout << "alpha: " << alpha << " beta: " << beta << std::endl;
+            std::cout << "pX: " << pX << " pY: " << pY << std::endl;
 
             if (alpha < 0 || beta < 0 // if alpha or beta < 0 means on the exact same line but no overlap.
                 || alpha > 1 || beta > 1 // if alpha > 1 means intersection but after outside from [AB]

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -307,8 +307,6 @@ struct Edge
 
             const Node pX = pA + alpha * AB;
             const Node pY = pC + beta * CD;
-            std::cout << "alpha: " << alpha << " beta: " << beta << std::endl;
-            std::cout << "pX: " << pX << " pY: " << pY << std::endl;
 
             if (alpha < 0 || beta < 0 // if alpha or beta < 0 means on the exact same line but no overlap.
                 || alpha > 1 || beta > 1 // if alpha > 1 means intersection but after outside from [AB]

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -294,8 +294,6 @@ struct Edge
 
             T alpha = alphaNom / alphaDenom;
             T beta = (dCACD + alpha * dABCD) / dCDCD;
-            std::cout << "alpha before: " << alpha << std::endl;
-            std::cout << "beta before: " << alpha << std::endl;
 
             if (fabs(alpha) < EQUALITY_THRESHOLD)
                 alpha = 0;
@@ -306,10 +304,6 @@ struct Edge
                 beta = 0;
             else if (fabs(1-beta) < EQUALITY_THRESHOLD)
                 beta = 1;
-
-            std::cout << "alpha after: " << alpha << std::endl;
-            std::cout << "beta after: " << alpha << std::endl;
-            std::cout << "EQUALITY_THRESHOLD: " << EQUALITY_THRESHOLD << std::endl;
 
             const Node pX = pA + alpha * AB;
             const Node pY = pC + beta * CD;

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -297,7 +297,7 @@ struct Edge
 
             if (abs(alpha) < EQUALITY_THRESHOLD)
                 alpha = 0;
-            else if (alpha > (1 - EQUALITY_THRESHOLD) && alpha < (1+ EQUALITY_THRESHOLD))
+            else if (abs(1-alpha) < EQUALITY_THRESHOLD)
                 alpha = 1;
 
             if (abs(beta) < EQUALITY_THRESHOLD)

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -294,6 +294,8 @@ struct Edge
 
             T alpha = alphaNom / alphaDenom;
             T beta = (dCACD + alpha * dABCD) / dCDCD;
+            std::cout << "alpha before: " << alpha << std::endl;
+            std::cout << "beta before: " << alpha << std::endl;
 
             if (abs(alpha) < EQUALITY_THRESHOLD)
                 alpha = 0;
@@ -304,6 +306,10 @@ struct Edge
                 beta = 0;
             else if (abs(1-beta) < EQUALITY_THRESHOLD)
                 beta = 1;
+
+            std::cout << "alpha after: " << alpha << std::endl;
+            std::cout << "beta after: " << alpha << std::endl;
+            std::cout << "EQUALITY_THRESHOLD: " << EQUALITY_THRESHOLD << std::endl;
 
             const Node pX = pA + alpha * AB;
             const Node pY = pC + beta * CD;

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -297,14 +297,14 @@ struct Edge
             std::cout << "alpha before: " << alpha << std::endl;
             std::cout << "beta before: " << alpha << std::endl;
 
-            if (abs(alpha) < EQUALITY_THRESHOLD)
+            if (fabs(alpha) < EQUALITY_THRESHOLD)
                 alpha = 0;
-            else if (abs(1-alpha) < EQUALITY_THRESHOLD)
+            else if (fabs(1-alpha) < EQUALITY_THRESHOLD)
                 alpha = 1;
 
-            if (abs(beta) < EQUALITY_THRESHOLD)
+            if (fabs(beta) < EQUALITY_THRESHOLD)
                 beta = 0;
-            else if (abs(1-beta) < EQUALITY_THRESHOLD)
+            else if (fabs(1-beta) < EQUALITY_THRESHOLD)
                 beta = 1;
 
             std::cout << "alpha after: " << alpha << std::endl;

--- a/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Edge.h
@@ -302,7 +302,7 @@ struct Edge
 
             if (abs(beta) < EQUALITY_THRESHOLD)
                 beta = 0;
-            else if (beta > (1 - EQUALITY_THRESHOLD) && beta < (1 + EQUALITY_THRESHOLD))
+            else if (abs(1-beta) < EQUALITY_THRESHOLD)
                 beta = 1;
 
             const Node pX = pA + alpha * AB;

--- a/Sofa/framework/Geometry/test/Edge_test.cpp
+++ b/Sofa/framework/Geometry/test/Edge_test.cpp
@@ -328,7 +328,7 @@ TEST(GeometryEdge_test, intersectionWithEdge2f)
     // intersection in the middle
     auto res = sofa::geometry::Edge::intersectionWithEdge(e01, e02, e11, e12, baryCoords);
     inter = e01 * baryCoords[0] + e02 * baryCoords[1];
-    //EXPECT_TRUE(res);
+    EXPECT_TRUE(res);
     EXPECT_FLOAT_EQ(inter[0], 1.0f);
     EXPECT_FLOAT_EQ(inter[1], 1.0f);
 

--- a/Sofa/framework/Geometry/test/Edge_test.cpp
+++ b/Sofa/framework/Geometry/test/Edge_test.cpp
@@ -328,7 +328,7 @@ TEST(GeometryEdge_test, intersectionWithEdge2f)
     // intersection in the middle
     auto res = sofa::geometry::Edge::intersectionWithEdge(e01, e02, e11, e12, baryCoords);
     inter = e01 * baryCoords[0] + e02 * baryCoords[1];
-    EXPECT_TRUE(res);
+    //EXPECT_TRUE(res);
     EXPECT_FLOAT_EQ(inter[0], 1.0f);
     EXPECT_FLOAT_EQ(inter[1], 1.0f);
 


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
