### PR TITLE
[ODESolver] Add option to compute residual at the end of the solving

### DIFF
--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.cpp
@@ -28,6 +28,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
 
+#include <iomanip>
 
 namespace sofa::component::odesolver::backward
 {
@@ -44,6 +45,8 @@ EulerImplicitSolver::EulerImplicitSolver()
     , d_trapezoidalScheme( initData(&d_trapezoidalScheme,false,"trapezoidalScheme","Boolean to use the trapezoidal scheme instead of the implicit Euler scheme and get second order accuracy in time (false by default)") )
     , d_solveConstraint(initData(&d_solveConstraint, false, "solveConstraint", "Apply ConstraintSolver (requires a ConstraintSolver in the same node as this solver, disabled by by default for now)") )
     , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_computeResidual(initData(&d_computeResidual, false, "computeResidual", "If true, the residual is computed at the end of the solving"))
+    , d_residual(initData(&d_residual, std::numeric_limits<SReal>::max(), "residual", "Residual norm at the end of the solving"))
 {
     f_rayleighStiffness.setOriginalData(&d_rayleighStiffness);
     f_rayleighMass.setOriginalData(&d_rayleighMass);
@@ -55,9 +58,12 @@ EulerImplicitSolver::EulerImplicitSolver()
 
 void EulerImplicitSolver::init()
 {
+    sofa::core::behavior::OdeSolver::init();
+    sofa::core::behavior::LinearSolverAccessor::init();
+
     if (!this->getTags().empty())
     {
-        msg_info() << "EulerImplicitSolver: responsible for the following objects with tags " << this->getTags() << " :";
+        msg_info() << "Responsible for the following objects with tags " << this->getTags() << " :";
         type::vector<core::objectmodel::BaseObject*> objs;
         this->getContext()->get<core::objectmodel::BaseObject>(&objs,this->getTags(),sofa::core::objectmodel::BaseContext::SearchDown);
         for (const auto* obj : objs)
@@ -65,15 +71,19 @@ void EulerImplicitSolver::init()
             msg_info() << "  " << obj->getClassName() << ' ' << obj->getName();
         }
     }
-    sofa::core::behavior::OdeSolver::init();
-    sofa::core::behavior::LinearSolverAccessor::init();
+
+    simulation::common::VectorOperations vop(sofa::core::execparams::defaultInstance(), this->getContext());
+    reallocSolutionVector(&vop);
+    reallocRightHandSideVector(&vop);
 }
 
 void EulerImplicitSolver::cleanup()
 {
-    // free the locally created vector x (including eventual external mechanical states linked by an InteractionForceField)
+    // free the locally created vectors (including eventual external mechanical states linked by an InteractionForceField)
     sofa::simulation::common::VectorOperations vop( core::execparams::defaultInstance(), this->getContext() );
     vop.v_free(x.id(), !d_threadSafeVisitor.getValue(), true);
+    vop.v_free(b.id(), !d_threadSafeVisitor.getValue(), true);
+    vop.v_free(m_residual.id(), !d_threadSafeVisitor.getValue(), true);
 }
 
 void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult)
@@ -86,7 +96,6 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
     MultiVecCoord pos(&vop, core::vec_id::write_access::position );
     MultiVecDeriv vel(&vop, core::vec_id::write_access::velocity );
     MultiVecDeriv f(&vop, core::vec_id::write_access::force );
-    MultiVecDeriv b(&vop, true, core::VecIdProperties{"RHS", GetClass()->className});
     MultiVecCoord newPos(&vop, xResult );
     MultiVecDeriv newVel(&vop, vResult );
 
@@ -98,8 +107,8 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
     MultiVecDeriv dx(&vop, core::vec_id::write_access::dx);
     dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
 
-    x.realloc(&vop, !d_threadSafeVisitor.getValue(), true, core::VecIdProperties{"solution", GetClass()->className});
-
+    reallocSolutionVector(&vop);
+    reallocRightHandSideVector(&vop);
 
 #ifdef SOFA_DUMP_VISITOR_INFO
     sofa::simulation::Visitor::printCloseNode("SolverVectorAllocation");
@@ -304,6 +313,34 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         mop.computeForce(f);
         msg_info() << "final f = " << f;
     }
+
+    if (d_computeResidual.getValue())
+    {
+        reallocResidualVector(&vop);
+
+        // r = 0
+        vop.v_clear(m_residual);
+
+        // r += M (v - v_n)
+        {
+            core::behavior::MultiVecDeriv tmp(&vop);
+
+            vop.v_eq(tmp, newVel);
+            vop.v_peq(tmp, vel, -1);
+            mop.addMdx(m_residual, tmp);
+        }
+
+        // r += - dt * F
+        mop.computeForce(f);
+        vop.v_peq(m_residual, f, -dt);
+
+        mop.projectResponse(m_residual);
+
+        vop.v_dot(m_residual, m_residual);
+        d_residual.setValue(vop.finish());
+
+        msg_info() << "Residual norm: " << std::setw(6) << vop.finish();
+    }
 }
 
 
@@ -338,11 +375,27 @@ SReal EulerImplicitSolver::getSolutionIntegrationFactor(int outputDerivative) co
 
 SReal EulerImplicitSolver::getSolutionIntegrationFactor(int outputDerivative, SReal dt) const
 {
-    const SReal vect[3] = { dt, 1, 1/dt};
+    const SReal vect[3] = {dt, 1, 1 / dt};
     if (outputDerivative >= 3)
         return 0;
     else
         return vect[outputDerivative];
+}
+
+void EulerImplicitSolver::reallocSolutionVector(sofa::simulation::common::VectorOperations* vop)
+{
+    x.realloc(vop, !d_threadSafeVisitor.getValue(), true,
+        core::VecIdProperties{.label = "solution", .group = GetClass()->className});
+}
+void EulerImplicitSolver::reallocRightHandSideVector(sofa::simulation::common::VectorOperations* vop)
+{
+    b.realloc(vop, !d_threadSafeVisitor.getValue(), true,
+        core::VecIdProperties{.label = "RHS", .group = GetClass()->className});
+}
+void EulerImplicitSolver::reallocResidualVector(sofa::simulation::common::VectorOperations* vop)
+{
+    m_residual.realloc(vop, !d_threadSafeVisitor.getValue(), true,
+       core::VecIdProperties{.label = "residual", .group = GetClass()->className});
 }
 
 void registerEulerImplicitSolver(sofa::core::ObjectFactory* factory)

--- a/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.h
+++ b/Sofa/Component/ODESolver/Backward/src/sofa/component/odesolver/backward/EulerImplicitSolver.h
@@ -27,6 +27,11 @@
 
 #include <sofa/core/objectmodel/lifecycle/RenamedData.h>
 
+namespace sofa::simulation::common
+{
+class VectorOperations;
+}
+
 namespace sofa::component::odesolver::backward
 {
 
@@ -129,6 +134,9 @@ public:
     Data<bool> d_solveConstraint; ///< Apply ConstraintSolver (requires a ConstraintSolver in the same node as this solver, disabled by by default for now)
     Data<bool> d_threadSafeVisitor; ///< If true, do not use realloc and free visitors in fwdInteractionForceField.
 
+    Data<bool> d_computeResidual;
+    Data<SReal> d_residual;
+    
 protected:
     EulerImplicitSolver();
 public:
@@ -182,6 +190,15 @@ protected:
     /// the solution vector is stored for warm-start
     core::behavior::MultiVecDeriv x;
 
+    /// Right-hand side vector
+    core::behavior::MultiVecDeriv b;
+
+    /// Residual vector (optionally computed)
+    core::behavior::MultiVecDeriv m_residual;
+
+    void reallocSolutionVector(sofa::simulation::common::VectorOperations* vop);
+    void reallocRightHandSideVector(sofa::simulation::common::VectorOperations* vop);
+    void reallocResidualVector(sofa::simulation::common::VectorOperations* vop);
 };
 
 } // namespace sofa::component::odesolver::backward

--- a/examples/Component/ODESolver/Backward/EulerImplicitSolver.scn
+++ b/examples/Component/ODESolver/Backward/EulerImplicitSolver.scn
@@ -13,7 +13,7 @@
 
     <Node name="DeformableObject">
 
-        <EulerImplicitSolver name="odeImplicitSolver" />
+        <EulerImplicitSolver name="odeImplicitSolver" computeResidual="true"/>
         <CGLinearSolver iterations="1000" tolerance="1e-9" threshold="1e-9"/>
 
         <MeshGmshLoader name="loader" filename="mesh/truthcylinder1.msh" />


### PR DESCRIPTION
Clean up the usage of VecIds. Now there is a new one to compute the residual if a Data is activated.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
