### PR TITLE
[All] Fix compilation with FLOATING_POINT_TYPE=float

### DIFF
--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/AugmentedLagrangianResponse.inl
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/AugmentedLagrangianResponse.inl
@@ -42,8 +42,8 @@ AugmentedLagrangianResponse<TCollisionModel1,TCollisionModel2,ResponseDataTypes>
 template < class TCollisionModel1, class TCollisionModel2, class ResponseDataTypes  >
 AugmentedLagrangianResponse<TCollisionModel1,TCollisionModel2,ResponseDataTypes>::AugmentedLagrangianResponse(CollisionModel1* model1, CollisionModel2* model2, Intersection* intersectionMethod)
     : BaseUnilateralContactResponse<TCollisionModel1, TCollisionModel2, constraint::lagrangian::model::AugmentedLagrangianContactParameters, ResponseDataTypes>(model1,model2,intersectionMethod)
-    , d_mu (initData(&d_mu, 0.0, "mu", "Friction coefficient (0 for frictionless contacts)"))
-    , d_epsilon (initData(&d_epsilon, 0.0, "epsilon", "Penalty parameter. It can be think of as a proportional controller, the Lagrange multiplier is augmented by the violation multiplied by this factor at each solving iteration."))
+    , d_mu (initData(&d_mu, 0.0_sreal, "mu", "Friction coefficient (0 for frictionless contacts)"))
+    , d_epsilon (initData(&d_epsilon, 0.0_sreal, "epsilon", "Penalty parameter. It can be thought of as a proportional controller, the Lagrange multiplier is augmented by the violation multiplied by this factor at each solving iteration."))
 {
 
 }

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralConstraintResolution.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralConstraintResolution.h
@@ -68,7 +68,7 @@ class BilateralConstraintResolution3Dof : public ConstraintResolution
 {
 public:
 
-    BilateralConstraintResolution3Dof(sofa::type::Vec3d* vec = nullptr)
+    BilateralConstraintResolution3Dof(sofa::type::Vec3* vec = nullptr)
         : ConstraintResolution(3)
         , _f(vec)
     {
@@ -130,7 +130,7 @@ public:
 
 protected:
     sofa::type::Mat<3,3,SReal> invW;
-    sofa::type::Vec3d* _f;
+    sofa::type::Vec3* _f;
 };
 
 class BilateralConstraintResolutionNDof : public ConstraintResolution

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
@@ -49,7 +49,7 @@ using sofa::core::ConstraintParams ;
 using sofa::core::ConstVecCoordId;
 
 using sofa::linearalgebra::BaseVector ;
-using sofa::type::Vec3d;
+using sofa::type::Vec3;
 using sofa::type::Quat ;
 
 using sofa::defaulttype::Rigid3Types ;
@@ -123,7 +123,7 @@ protected:
     SingleLink<BilateralLagrangianConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology1; ///< Link to be set to the first topology container in order to support topological changes
     SingleLink<BilateralLagrangianConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology2; ///< Link to be set to the second topology container in order to support topological changes
 
-    std::vector<Vec3d> prevForces;
+    std::vector<Vec3> prevForces;
 
     BilateralLagrangianConstraint(MechanicalState* object1, MechanicalState* object2) ;
     BilateralLagrangianConstraint(MechanicalState* object) ;

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/StableNeoHookean.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/StableNeoHookean.h
@@ -1,4 +1,4 @@
-﻿/******************************************************************************
+/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -125,7 +125,7 @@ public:
         MatrixSym Firstmatrix;
         MatrixSym::Mat2Sym(inverse_C * (inputTensor * inverse_C), Firstmatrix);
 
-        outputTensor = 0.5 * (lambda + mu) * (Firstmatrix * (-2 * J * (J - alpha))
+        outputTensor = 0.5_sreal * (lambda + mu) * (Firstmatrix * (-2 * J * (J - alpha))
             + inverse_C * (J * (2 * J - alpha) * trHC));
     }
 


### PR DESCRIPTION
Title.

This only fixes the compilation by the way, and the CI only uses double so it should not change anything.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
