### PR TITLE
[Core] ObjectFactory: remove message when a plugin has already registered its components

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -775,6 +775,9 @@ bool ObjectFactory::registerObjectsFromPlugin(const std::string& pluginName)
     // do not register if it was already done before
     if(m_registeredPluginSet.contains(pluginName))
     {
+        // This warning should be generalized (i.e not only in dev mode) when runSofa will not auto-load modules/plugins by default anymore
+        // Commented warning since it is triggered even for SOFA meta-modules (e.g. Sofa.Components)
+        // dmsg_warning("ObjectFactory") << pluginName << " has already registered its components.";
         return false;
     }
 

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -775,8 +775,6 @@ bool ObjectFactory::registerObjectsFromPlugin(const std::string& pluginName)
     // do not register if it was already done before
     if(m_registeredPluginSet.contains(pluginName))
     {
-        // This warning should be generalized (i.e not only in dev mode) when runSofa will not auto-load modules/plugins by default anymore
-        dmsg_warning("ObjectFactory") << pluginName << " has already registered its components.";
         return false;
     }
 


### PR DESCRIPTION
Because it will appear quite often due to :
 - the auto-loading mechanism
 - the "meta-module" feature



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
