### PR TITLE
[SceneChecking] Check if a Node has an empty name

### DIFF
--- a/applications/projects/SceneChecking/CMakeLists.txt
+++ b/applications/projects/SceneChecking/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADER_FILES
     ${SCENECHECK_SRC_DIR}/SceneCheckCollisionResponse.h
     ${SCENECHECK_SRC_DIR}/SceneCheckDeprecatedComponents.h
     ${SCENECHECK_SRC_DIR}/SceneCheckDuplicatedName.h
+    ${SCENECHECK_SRC_DIR}/SceneCheckEmptyNodeName.h
     ${SCENECHECK_SRC_DIR}/SceneCheckMissingRequiredPlugin.h
     ${SCENECHECK_SRC_DIR}/SceneCheckUsingAlias.h
     ${SCENECHECK_SRC_DIR}/SceneCheckerListener.h
@@ -28,6 +29,7 @@ set(SOURCE_FILES
     ${SCENECHECK_SRC_DIR}/SceneCheckCollisionResponse.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckDeprecatedComponents.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckDuplicatedName.cpp
+    ${SCENECHECK_SRC_DIR}/SceneCheckEmptyNodeName.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckMissingRequiredPlugin.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckUsingAlias.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckerListener.cpp

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckEmptyNodeName.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckEmptyNodeName.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SceneChecking/SceneCheckEmptyNodeName.h>
+
+#include <sofa/simulation/Node.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
+
+namespace sofa::scenechecking
+{
+
+const bool SceneCheckEmptyNodeNameRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckEmptyNodeName::newSPtr());
+
+SceneCheckEmptyNodeName::~SceneCheckEmptyNodeName() {}
+const std::string SceneCheckEmptyNodeName::getName() { return "SceneCheckEmptyNodeName"; }
+const std::string SceneCheckEmptyNodeName::getDesc() { return "Check if a Node has an empty name."; }
+
+void SceneCheckEmptyNodeName::doInit(sofa::simulation::Node* node)
+{
+    m_nbNodesWithEmptyName = 0;
+}
+
+void SceneCheckEmptyNodeName::doCheckOn(sofa::simulation::Node* node)
+{
+    const auto& nodeName = node->getName();
+
+    if (nodeName.empty())
+    {
+        ++m_nbNodesWithEmptyName;
+    }
+}
+
+void SceneCheckEmptyNodeName::doPrintSummary()
+{
+    msg_warning_when(m_nbNodesWithEmptyName > 0, getName()) << "Nodes with empty name are found in"
+        " the scene. This can lead to undefined behaviors. It is recommended to give a name to all Nodes.";
+}
+
+}  // namespace sofa::scenechecking

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckEmptyNodeName.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckEmptyNodeName.h
@@ -1,0 +1,46 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SceneChecking/config.h>
+#include <sofa/simulation/SceneCheck.h>
+
+namespace sofa::scenechecking
+{
+
+class SOFA_SCENECHECKING_API SceneCheckEmptyNodeName : public sofa::simulation::SceneCheck
+{
+public:
+    ~SceneCheckEmptyNodeName() override;
+    typedef std::shared_ptr<SceneCheckEmptyNodeName> SPtr;
+    static SPtr newSPtr() { return std::make_shared<SceneCheckEmptyNodeName>(); }
+    const std::string getName() override;
+    const std::string getDesc() override;
+    void doInit(sofa::simulation::Node* node) override;
+    void doCheckOn(sofa::simulation::Node* node) override;
+    void doPrintSummary() override;
+
+private:
+    unsigned int m_nbNodesWithEmptyName = 0;
+};
+
+}


### PR DESCRIPTION
An empty Node name can lead to undefined behavior. For example, call of `getPathName` on an object having a Node with an empty name in its parent hierarchy leads to a crash.
This check does not prevent the user to create such Node, but at least there is a warning.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
