### PR TITLE
[Helper] Readability in ComponentChange

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -654,14 +654,6 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     { "TriangleLocalMinDistanceFilter", RemovedIn("v21.12").afterDeprecationIn("v21.12") },
 
     /***********************/
-    // REMOVED SINCE v21.06
-
-    {"LengthContainer", Removed("v21.06", "v21.06")},
-    {"PoissonContainer", Removed("v21.06", "v21.06")},
-    {"RadiusContainer", Removed("v21.06", "v21.06")},
-    {"StiffnessContainer", Removed("v21.06", "v21.06")},
-
-    /***********************/
     // REMOVED SINCE v20.12
 
     { "DynamicSparseGridTopologyAlgorithms", Removed("v20.12", "v20.12") },

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -612,8 +612,8 @@ const std::map<std::string, ComponentChange, std::less<> > movedComponents = {
     { "CompareTopology", Moved("v22.06", "SofaValidation", Sofa.Component.Playback) },
 
     // Removed in #4040, deprecated in #2777
-    { "MechanicalMatrixMapper", Removed("v23.06", "v23.12") },
-    { "MappingGeometricStiffnessForceField", Removed("v23.06", "v23.12") },
+    { "MechanicalMatrixMapper", RemovedIn("v23.12").afterDeprecationIn("v23.06") },
+    { "MappingGeometricStiffnessForceField", RemovedIn("v23.12").afterDeprecationIn("v23.06") },
 
     // Moved to CSparseSolvers
     { "SparseCholeskySolver", Moved("v23.12", Sofa.Component.LinearSolver.Direct, "CSparseSolvers") },
@@ -636,22 +636,22 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     /***********************/
     // REMOVED SINCE v23.06
 
-    { "OglGrid", Removed("v22.12", "v23.06")},
-    { "OglLineAxis", Removed("v22.12", "v23.06")},
+    { "OglGrid", RemovedIn("v23.06").afterDeprecationIn("v22.12")},
+    { "OglLineAxis", RemovedIn("v23.06").afterDeprecationIn("v22.12")},
 
     /***********************/
     // REMOVED SINCE v22.06
 
-    {"PointConstraint", Removed("v21.12", "v22.06")},
+    {"PointConstraint", RemovedIn("v22.06").afterDeprecationIn("v21.12")},
 
     /***********************/
     // REMOVED SINCE v21.12
 
-    { "LMDNewProximityIntersection", Removed("v21.12", "v21.12") },
-    { "LocalMinDistanceFilter", Removed("v21.12", "v21.12") },
-    { "LineLocalMinDistanceFilter", Removed("v21.12", "v21.12") },
-    { "PointLocalMinDistanceFilter", Removed("v21.12", "v21.12") },
-    { "TriangleLocalMinDistanceFilter", Removed("v21.12", "v21.12") },
+    { "LMDNewProximityIntersection", RemovedIn("v21.12").afterDeprecationIn("v21.12") },
+    { "LocalMinDistanceFilter", RemovedIn("v21.12").afterDeprecationIn("v21.12") },
+    { "LineLocalMinDistanceFilter", RemovedIn("v21.12").afterDeprecationIn("v21.12") },
+    { "PointLocalMinDistanceFilter", RemovedIn("v21.12").afterDeprecationIn("v21.12") },
+    { "TriangleLocalMinDistanceFilter", RemovedIn("v21.12").afterDeprecationIn("v21.12") },
 
     /***********************/
     // REMOVED SINCE v21.06
@@ -675,64 +675,64 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     /***********************/
     // REMOVED SINCE v20.06
 
-    {"Euler", Removed("v19.12", "v20.06")},
-    {"EulerExplicit", Removed("v19.12", "v20.06")},
-    {"ExplicitEuler", Removed("v19.12", "v20.06")},
-    {"EulerSolver", Removed("v19.12", "v20.06")},
-    {"ExplicitEulerSolver", Removed("v19.12", "v20.06")},
+    {"Euler", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"EulerExplicit", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"ExplicitEuler", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"EulerSolver", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"ExplicitEulerSolver", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Capsule", Removed("v19.12", "v20.06")},
-    {"CapsuleModel", Removed("v19.12", "v20.06")},
-    {"TCapsuleModel", Removed("v19.12", "v20.06")},
+    {"Capsule", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"CapsuleModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TCapsuleModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Cube", Removed("v19.12", "v20.06")},
-    {"CubeModel", Removed("v19.12", "v20.06")},
+    {"Cube", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"CubeModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"CudaPoint", Removed("v19.12", "v20.06")},
-    {"CudaPointModel", Removed("v19.12", "v20.06")},
+    {"CudaPoint", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"CudaPointModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Cylinder", Removed("v19.12", "v20.06")},
-    {"CylinderModel", Removed("v19.12", "v20.06")},
+    {"Cylinder", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"CylinderModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Line", Removed("v19.12", "v20.06")},
-    {"TLineModel", Removed("v19.12", "v20.06")},
-    {"LineMeshModel", Removed("v19.12", "v20.06")},
-    {"LineSetModel", Removed("v19.12", "v20.06")},
-    {"LineMesh", Removed("v19.12", "v20.06")},
-    {"LineSet", Removed("v19.12", "v20.06")},
-    {"LineModel", Removed("v19.12", "v20.06")},
+    {"Line", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TLineModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"LineMeshModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"LineSetModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"LineMesh", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"LineSet", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"LineModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"OBB", Removed("v19.12", "v20.06")},
-    {"OBBModel", Removed("v19.12", "v20.06")},
-    {"TOBBModel", Removed("v19.12", "v20.06")},
+    {"OBB", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"OBBModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TOBBModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Point", Removed("v19.12", "v20.06")},
-    {"TPointModel", Removed("v19.12", "v20.06")},
-    {"PointModel", Removed("v19.12", "v20.06")},
-    {"PointMesh", Removed("v19.12", "v20.06")},
-    {"PointSet", Removed("v19.12", "v20.06")},
+    {"Point", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TPointModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"PointModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"PointMesh", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"PointSet", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Ray", Removed("v19.12", "v20.06")},
-    {"RayModel", Removed("v19.12", "v20.06")},
+    {"Ray", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"RayModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"RigidCapsule", Removed("v19.12", "v20.06")},
-    {"RigidCapsuleModel", Removed("v19.12", "v20.06")},
-    {"RigidCapsuleCollisionModel", Removed("v19.12", "v20.06")},
+    {"RigidCapsule", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"RigidCapsuleModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"RigidCapsuleCollisionModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Sphere", Removed("v19.12", "v20.06")},
-    {"SphereModel", Removed("v19.12", "v20.06")},
-    {"TSphereModel", Removed("v19.12", "v20.06")},
+    {"Sphere", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"SphereModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TSphereModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Tetrahedron", Removed("v19.12", "v20.06")},
-    {"TetrahedronModel", Removed("v19.12", "v20.06")},
+    {"Tetrahedron", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TetrahedronModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
-    {"Triangle", Removed("v19.12", "v20.06")},
-    {"TriangleSet", Removed("v19.12", "v20.06")},
-    {"TriangleMesh", Removed("v19.12", "v20.06")},
-    {"TriangleSetModel", Removed("v19.12", "v20.06")},
-    {"TriangleMeshModel", Removed("v19.12", "v20.06")},
-    {"TriangleModel", Removed("v19.12", "v20.06")},
-    {"TTriangleModel", Removed("v19.12", "v20.06")},
+    {"Triangle", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TriangleSet", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TriangleMesh", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TriangleSetModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TriangleMeshModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TriangleModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
+    {"TTriangleModel", RemovedIn("v20.06").afterDeprecationIn("v19.12")},
 
 };
 

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -630,8 +630,8 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     /***********************/
     // REMOVED SINCE v25.06
 
-    { "MakeAliasComponent", Removed("v24.12", "v25.06")},
-    { "MakeDataAliasComponent", Removed("v24.12", "v25.06")},
+    { "MakeAliasComponent", RemovedIn("v25.06").afterDeprecationIn("v24.12")},
+    { "MakeDataAliasComponent", RemovedIn("v25.06").afterDeprecationIn("v24.12")},
 
     /***********************/
     // REMOVED SINCE v23.06

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -656,13 +656,13 @@ const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents
     /***********************/
     // REMOVED SINCE v20.12
 
-    { "DynamicSparseGridTopologyAlgorithms", Removed("v20.12", "v20.12") },
-    { "HexahedronSetTopologyAlgorithms", Removed("v20.12", "v20.12") },
-    { "TetrahedronSetTopologyAlgorithms", Removed("v20.12", "v20.12") },
-    { "QuadSetTopologyAlgorithms", Removed("v20.12", "v20.12") },
-    { "TriangleSetTopologyAlgorithms", Removed("v20.12", "v20.12") },
-    { "EdgeSetTopologyAlgorithms", Removed("v20.12", "v20.12") },
-    { "PointSetTopologyAlgorithms", Removed("v20.12", "v20.12") },
+    { "DynamicSparseGridTopologyAlgorithms", RemovedIn("v20.12").withoutAnyDeprecation() },
+    { "HexahedronSetTopologyAlgorithms", RemovedIn("v20.12").withoutAnyDeprecation() },
+    { "TetrahedronSetTopologyAlgorithms", RemovedIn("v20.12").withoutAnyDeprecation() },
+    { "QuadSetTopologyAlgorithms", RemovedIn("v20.12").withoutAnyDeprecation() },
+    { "TriangleSetTopologyAlgorithms", RemovedIn("v20.12").withoutAnyDeprecation() },
+    { "EdgeSetTopologyAlgorithms", RemovedIn("v20.12").withoutAnyDeprecation() },
+    { "PointSetTopologyAlgorithms", RemovedIn("v20.12").withoutAnyDeprecation() },
 
     /***********************/
     // REMOVED SINCE v20.06

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
@@ -83,7 +83,7 @@ public:
 
 struct SOFA_HELPER_API RemovedIn
 {
-    explicit RemovedIn(std::string removedVersion) : m_removalVersion(std::move(removedVersion)) {}
+    explicit RemovedIn(std::string removalVersion) : m_removalVersion(std::move(removalVersion)) {}
 
 private:
     struct SOFA_HELPER_API AfterDeprecationIn : public ComponentChange

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
@@ -81,22 +81,6 @@ public:
     }
 };
 
-class SOFA_HELPER_API Removed : public ComponentChange
-{
-public:
-    explicit Removed(const std::string&  sinceVersion, const std::string& atVersion)
-    {
-        std::stringstream output;
-        output << "This component has been REMOVED since SOFA " << atVersion << " "
-                  "(deprecated since " << sinceVersion << "). "
-                  "\nPlease consider updating your scene. "
-                  "If this component is crucial to you please report in a GitHub issue "
-                  "in order to reconsider this component for future re-integration.";
-        m_message = output.str();
-        m_changeVersion = atVersion;
-    }
-};
-
 struct SOFA_HELPER_API RemovedIn
 {
     explicit RemovedIn(std::string removedVersion) : m_removalVersion(std::move(removedVersion)) {}

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.h
@@ -97,6 +97,55 @@ public:
     }
 };
 
+struct SOFA_HELPER_API RemovedIn
+{
+    explicit RemovedIn(std::string removedVersion) : m_removalVersion(std::move(removedVersion)) {}
+
+private:
+    struct SOFA_HELPER_API AfterDeprecationIn : public ComponentChange
+    {
+        AfterDeprecationIn(const std::string& removalVersion, const std::string& deprecationVersion)
+        {
+            std::stringstream output;
+            output << "This component has been REMOVED since SOFA " << removalVersion << " "
+                      "(deprecated since " << deprecationVersion << "). "
+                      "\nPlease consider updating your scene. "
+                      "If this component is crucial to you please report in a GitHub issue "
+                      "in order to reconsider this component for future re-integration.";
+            m_message = output.str();
+            m_changeVersion = removalVersion;
+        }
+    };
+
+    struct SOFA_HELPER_API WithoutAnyDeprecation : public ComponentChange
+    {
+        explicit WithoutAnyDeprecation(const std::string& removalVersion)
+        {
+            std::stringstream output;
+            output << "This component has been REMOVED since SOFA " << removalVersion <<
+                      "\nPlease consider updating your scene. "
+                      "If this component is crucial to you please report in a GitHub issue "
+                      "in order to reconsider this component for future re-integration.";
+            m_message = output.str();
+            m_changeVersion = removalVersion;
+        }
+    };
+
+public:
+    [[nodiscard]] AfterDeprecationIn afterDeprecationIn(const std::string& deprecationVersion) const
+    {
+        return { m_removalVersion, deprecationVersion };
+    }
+
+    [[nodiscard]] WithoutAnyDeprecation withoutAnyDeprecation() const
+    {
+        return WithoutAnyDeprecation{ m_removalVersion };
+    }
+
+private:
+    std::string m_removalVersion;
+};
+
 class SOFA_HELPER_API Moved : public ComponentChange
 {
 public:


### PR DESCRIPTION
In https://github.com/sofa-framework/sofa/pull/5241, components are removed without deprecation phase. This is not supported by the `Removed` class (a deprecation version must be provided). That is why I introduce two different classes: 1) one with a deprecation version, 2) one without deprecation.

The syntax should be very easy to read:
```cpp
RemovedIn("v23.06").afterDeprecationIn("v22.12")
```
or
```cpp
RemovedIn("v20.12").withoutAnyDeprecation()
```

I removed the `Remove` class. Therefore, it is breaking.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
