### PR TITLE
[IO.Mesh] Fix missing `iomanip` header in tests

### DIFF
--- a/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <iomanip>
+
 #include <vector>
 using std::vector;
 


### PR DESCRIPTION
Missing header for `setw` and `setfill`


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
