### PR TITLE
[SceneChecking] Trigger error instead of warning

### DIFF
--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
@@ -124,7 +124,7 @@ void SceneCheckCollisionResponse::doPrintSummary()
 {
     if(m_checkDone && m_message.str()!= "")
     {
-        msg_warning(this->getName()) << m_message.str();
+        msg_error(this->getName()) << m_message.str();
     }
 }
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDeprecatedComponents.cpp
@@ -59,7 +59,7 @@ void SceneCheckDeprecatedComponents::doCheckOn(Node* node)
         {
             if( deprecatedComponents.contains( o->getClassName() ))
             {
-                msg_deprecated(o) << this->getName() << ": "
+                msg_error(o) << this->getName() << ": "
                     << deprecatedComponents.at(o->getClassName()).getMessage();
             }
         }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckDuplicatedName.cpp
@@ -86,7 +86,7 @@ void SceneCheckDuplicatedName::doPrintSummary()
 {
     if(m_hasDuplicates)
     {
-        msg_warning(this->getName()) << msgendl
+        msg_error(this->getName()) << msgendl
                                      << m_duplicatedMsg.str()
                                      << "Nodes with similar names at the same level in your scene can "
                                         "crash certain operations, please rename them";

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckEmptyNodeName.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckEmptyNodeName.cpp
@@ -50,7 +50,7 @@ void SceneCheckEmptyNodeName::doCheckOn(sofa::simulation::Node* node)
 
 void SceneCheckEmptyNodeName::doPrintSummary()
 {
-    msg_warning_when(m_nbNodesWithEmptyName > 0, getName()) << "Nodes with empty name are found in"
+    msg_error_when(m_nbNodesWithEmptyName > 0, getName()) << "Nodes with empty name are found in"
         " the scene. This can lead to undefined behaviors. It is recommended to give a name to all Nodes.";
 }
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMissingRequiredPlugin.cpp
@@ -95,7 +95,7 @@ void SceneCheckMissingRequiredPlugin::printSummary(simulation::SceneLoader* scen
         {
             tmp << "Note that XML syntax is assumed in the suggested lines to add.";
         }
-        msg_warning(this->getName())
+        msg_error(this->getName())
                 << "This scene is using component defined in plugins but is not importing the required plugins." << msgendl
                 << indent << "Your scene may not work on a sofa environment with different pre-loaded plugins." << msgendl
                 << indent << "To fix your scene and remove this warning you just need to cut & paste the following lines at the beginning of your scene: " << msgendl

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckUsingAlias.cpp
@@ -99,7 +99,7 @@ void SceneCheckUsingAlias::doPrintSummary()
 
         if(i.first != m_componentsCreatedUsingAlias.rbegin()->first) usingAliasesWarning << msgendl;
     }
-    msg_warning(this->getName()) << usingAliasesWarning.str();
+    msg_error(this->getName()) << usingAliasesWarning.str();
 
     m_componentsCreatedUsingAlias.clear();
 }


### PR DESCRIPTION
⚠️ Not meant to be merged.

This PR can be used to detect example scenes which don't pass the scene checking.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
