### PR TITLE
[github] Add workflow for performance testing launch

### DIFF
--- a/.github/workflows/launch-perf-test.yml
+++ b/.github/workflows/launch-perf-test.yml
@@ -1,0 +1,21 @@
+name: Launch performance testing
+on:
+  push:
+    branches:
+      - master
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'sofa-framework' }}
+
+    steps:
+      - name: Launch performance regression test
+        run: |
+          sudo apt install curl
+          
+          curl -L -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $GITHUB_TOKEN"  \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/sofa-framework/PerformanceRegression/dispatches \
+          -d '{"event_type":"Launch perf test from SOFA commit","client_payload":{"branch":"master","commit_hash":"${{ github.head_ref }}.${{ github.sha }}"}}'

--- a/.github/workflows/launch-perf-test.yml
+++ b/.github/workflows/launch-perf-test.yml
@@ -15,7 +15,7 @@ jobs:
           
           curl -L -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $GITHUB_TOKEN"  \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"  \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/sofa-framework/PerformanceRegression/dispatches \
-          -d '{"event_type":"Launch perf test from SOFA commit","client_payload":{"branch":"master","commit_hash":"${{ github.head_ref }}.${{ github.sha }}"}}'
+          -d '{"event_type":"Launch perf test from SOFA commit","client_payload":{"branch":"master","commit_hash":"${{ github.sha }}"}}'


### PR DESCRIPTION
Add workflow to launch the performance testing through repository dispatch.
This relies on the [PerformanceRegression](https://github.com/sofa-framework/PerformanceRegression) repository



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
