### PR TITLE
[CMake] Update auto generated name for fetching

### DIFF
--- a/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
@@ -209,7 +209,8 @@ function(sofa_add_generic_external directory name type)
     endif()
 
     # Create option
-    string(TOUPPER ${PROJECT_NAME}_FETCH_${name} fetch_enabled)
+    string(REPLACE "\." "_"  fixed_name ${name})
+    string(TOUPPER ${PROJECT_NAME}_FETCH_${fixed_name} fetch_enabled)
     if(NOT "${ARG_WHEN_TO_SHOW}" STREQUAL "" AND NOT "${ARG_VALUE_IF_HIDDEN}" STREQUAL "")
         cmake_dependent_option(${fetch_enabled} "Fetch/update ${name} repository." ${active} "${ARG_WHEN_TO_SHOW}" ${ARG_VALUE_IF_HIDDEN})
     else()


### PR DESCRIPTION
Update macro to mirror behavior of cmake option for plugin activation for fetching plugin. 
Until now, to fetch and activate Sofa.Qt you needed to  add the two following cmake options : 
```
-DSOFA_FETCH_SOFA.QT=ON 
-DPLUGIN_SOFA_QT=ON
```
With this pr you'll need to add 
```
-DSOFA_FETCH_SOFA_QT=ON
-DPLUGIN_SOFA_QT=ON
```

WARNING: might cause issue with the presets (https://github.com/sofa-framework/sofa/pull/5272) 
                    --> if this is merged before, the PR5272 will need to be updated, otherwise, we need to update presets in this PR. 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
