### PR TITLE
[DistanceGrid.CUDA] Fix compilation

### DIFF
--- a/applications/plugins/SofaDistanceGrid/extensions/CUDA/src/SofaDistanceGrid/CUDA/CudaCollisionDistanceGrid.cpp
+++ b/applications/plugins/SofaDistanceGrid/extensions/CUDA/src/SofaDistanceGrid/CUDA/CudaCollisionDistanceGrid.cpp
@@ -33,7 +33,6 @@
 #include <sofa/component/collision/detection/intersection/NewProximityIntersection.inl>
 #include <sofa/component/collision/detection/intersection/MeshNewProximityIntersection.inl>
 #include <sofa/component/collision/detection/intersection/RayDiscreteIntersection.inl>
-#include <sofa/component/collision/detection/intersection/NewProximityIntersection.inl>
 #include <sofa/component/collision/detection/intersection/DiscreteIntersection.h>
 #include <sofa/component/collision/response/contact/RayContact.h>
 #include <sofa/component/collision/response/contact/BarycentricPenalityContact.inl>


### PR DESCRIPTION
Compilation fails in the rare case where SofaCUDA has been compiled w/o Sofa.Gui.Qt enabled.

These includes are not needed anyway...


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
