### PR TITLE
[CMake] Remove cmake ignore path install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/etc/sofa/python.d)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Sofa/framework/Config/cmake")
-list(APPEND CMAKE_IGNORE_PATH "${CMAKE_INSTALL_PREFIX}") # ignore install directory for findXXX commands
 include(SofaMacros)
 
 install(FILES


### PR DESCRIPTION
It looks quite common to want to install SOFA where other packages (and 3rd party software) are installed, under which case we frequently have `CMAKE_INSTALL_PREFIX` equals to `CMAKE_PREFIX_PATH` .
So thanks to this line, `CMAKE_PREFIX_PATH` is ignored for all cmake `find_*` commands, and no cmake config files of 3rd party software installed there can be found.
This is for example typically the case with Conda environments, and so Pixi as well.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
