### PR TITLE
[Lagrangian] Add loading capability for bilateral constraints

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralConstraintResolution.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralConstraintResolution.h
@@ -68,9 +68,10 @@ class BilateralConstraintResolution3Dof : public ConstraintResolution
 {
 public:
 
-    BilateralConstraintResolution3Dof(sofa::type::Vec3* vec = nullptr)
+    BilateralConstraintResolution3Dof(sofa::type::Vec3* vec = nullptr, SReal load = 1.0_sreal)
         : ConstraintResolution(3)
         , _f(vec)
+        , m_load(load)
     {
     }
     void init(int line, SReal** w, SReal *force) override
@@ -115,7 +116,7 @@ public:
         for(int i=0; i<3; i++)
         {
             for(int j=0; j<3; j++)
-                force[line+i] -= d[line+j] * invW[i][j];
+                force[line+i] -= d[line+j] * invW[i][j] * m_load;
         }
     }
 
@@ -131,6 +132,7 @@ public:
 protected:
     sofa::type::Mat<3,3,SReal> invW;
     sofa::type::Vec3* _f;
+    SReal m_load;
 };
 
 class BilateralConstraintResolutionNDof : public ConstraintResolution

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
@@ -118,6 +118,7 @@ protected:
 
     Data<bool> d_activate; ///< control constraint activation (true by default)
     Data<bool> d_keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
+    Data<SReal> d_load; ///< Apply this factor to the constraint force to enable incremental loading
 
 
     SingleLink<BilateralLagrangianConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology1; ///< Link to be set to the first topology container in order to support topological changes

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.h
@@ -36,6 +36,7 @@
 #include <sofa/component/constraint/lagrangian/model/BilateralConstraintResolution.h>
 
 #include <sofa/core/objectmodel/lifecycle/RenamedData.h>
+#include <sofa/core/objectmodel/DataCallback.h>
 
 namespace sofa::component::constraint::lagrangian::model
 {
@@ -118,7 +119,9 @@ protected:
 
     Data<bool> d_activate; ///< control constraint activation (true by default)
     Data<bool> d_keepOrientDiff; ///< keep the initial difference in orientation (only for rigids)
-    Data<SReal> d_load; ///< Apply this factor to the constraint force to enable incremental loading
+    Data<SReal> d_load; ///< Apply this factor to the constraint force to enable incremental loading. This value should be in the interval [0.0, 1.0].
+    core::objectmodel::DataCallback c_loadCallback;
+
 
 
     SingleLink<BilateralLagrangianConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology1; ///< Link to be set to the first topology container in order to support topological changes

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
@@ -46,10 +46,27 @@ BilateralLagrangianConstraint<DataTypes>::BilateralLagrangianConstraint(Mechanic
     , d_restVector(initData(&d_restVector, "rest_vector","Relative position to maintain between attached points (optional)"))
     , d_activate( initData(&d_activate, true, "activate", "control constraint activation (true by default)"))
     , d_keepOrientDiff(initData(&d_keepOrientDiff, false, "keepOrientationDifference", "keep the initial difference in orientation (only for rigids)"))
-    , d_load(initData(&d_load, 1.0_sreal, "load", "Apply this factor to the constraint force to enable incremental loading"))
+    , d_load(initData(&d_load, 1.0_sreal, "load", "Apply this factor to the constraint force to enable incremental loading. This value should be in the interval [0.0, 1.0]."))
     , l_topology1(initLink("topology1", "link to the first topology container"))
     , l_topology2(initLink("topology2", "link to the second topology container"))
 {
+
+    c_loadCallback.addInput(&d_load);
+    c_loadCallback.addCallback([this]()
+    {
+        if (d_load.getValue()<0.0_sreal)
+        {
+            msg_warning()<<"The load cannot be negative. Setting it back to 0.0";
+            *d_load.beginWriteOnly() = 0.0_sreal;
+        }
+        else if (d_load.getValue()>1.0_sreal)
+        {
+            msg_warning()<<"The load cannot be greater than 1.0. Setting it back to 1.0";
+            *d_load.beginWriteOnly() = 1.0_sreal;
+        }
+
+    });
+
     this->f_listening.setValue(true);
 
     m1.setOriginalData(&d_m1);

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
@@ -56,13 +56,13 @@ BilateralLagrangianConstraint<DataTypes>::BilateralLagrangianConstraint(Mechanic
     {
         if (d_load.getValue()<0.0_sreal)
         {
-            msg_warning()<<"The load cannot be negative. Setting it back to 0.0";
-            *d_load.beginWriteOnly() = 0.0_sreal;
+            msg_warning()<<"The load cannot be negative. Setting it back to 0.0. Input value is "<<d_load.getValue();
+            d_load.setValue(0.0_sreal);
         }
         else if (d_load.getValue()>1.0_sreal)
         {
-            msg_warning()<<"The load cannot be greater than 1.0. Setting it back to 1.0";
-            *d_load.beginWriteOnly() = 1.0_sreal;
+            msg_warning()<<"The load cannot be greater than 1.0. Setting it back to 1.0. Input value is "<<d_load.getValue();
+            d_load.setValue(1.0_sreal);
         }
 
     });

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
@@ -46,6 +46,7 @@ BilateralLagrangianConstraint<DataTypes>::BilateralLagrangianConstraint(Mechanic
     , d_restVector(initData(&d_restVector, "rest_vector","Relative position to maintain between attached points (optional)"))
     , d_activate( initData(&d_activate, true, "activate", "control constraint activation (true by default)"))
     , d_keepOrientDiff(initData(&d_keepOrientDiff, false, "keepOrientationDifference", "keep the initial difference in orientation (only for rigids)"))
+    , d_load(initData(&d_load, 1.0_sreal, "load", "Apply this factor to the constraint force to enable incremental loading"))
     , l_topology1(initLink("topology1", "link to the first topology container"))
     , l_topology2(initLink("topology2", "link to the second topology container"))
 {
@@ -268,9 +269,10 @@ void BilateralLagrangianConstraint<DataTypes>::getConstraintResolution(const Con
     const unsigned minp=std::min(d_m1.getValue().size(), d_m2.getValue().size());
 
     prevForces.resize(minp);
+    const SReal load = d_load.getValue();
     for (unsigned pid=0; pid<minp; pid++)
     {
-        resTab[offset] = new BilateralConstraintResolution3Dof(&prevForces[pid]);
+        resTab[offset] = new BilateralConstraintResolution3Dof(&prevForces[pid], load);
         offset += 3;
     }
 }


### PR DESCRIPTION
This pr adds a data in `BileateralLagrangianConstraints`. It is a factor applied to the computed force. This helps to simulate incremental loading. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
