### PR TITLE
[Core] SingleStateAccessor: add explicit instantiations

### DIFF
--- a/Sofa/framework/Core/CMakeLists.txt
+++ b/Sofa/framework/Core/CMakeLists.txt
@@ -108,6 +108,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/behavior/StateAccessor.h
     ${SRC_ROOT}/behavior/SingleMatrixAccessor.h
     ${SRC_ROOT}/behavior/SingleStateAccessor.h
+    ${SRC_ROOT}/behavior/SingleStateAccessor.inl
     ${SRC_ROOT}/behavior/fwd.h
     ${SRC_ROOT}/collision/BroadPhaseDetection.h
     ${SRC_ROOT}/collision/CollisionAlgorithm.h
@@ -264,6 +265,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/behavior/PairInteractionProjectiveConstraintSet.cpp
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.cpp
     ${SRC_ROOT}/behavior/SingleMatrixAccessor.cpp
+    ${SRC_ROOT}/behavior/SingleStateAccessor.cpp
     ${SRC_ROOT}/behavior/fwd.cpp
     ${SRC_ROOT}/collision/BroadPhaseDetection.cpp
     ${SRC_ROOT}/collision/Contact.cpp

--- a/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.cpp
@@ -19,45 +19,22 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
+#define SOFA_CORE_BEHAVIOR_SINGLESTATEACCESSOR_CPP
 
-#include <sofa/core/behavior/StateAccessor.h>
-#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/SingleStateAccessor.inl>
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/defaulttype/RigidTypes.h>
 
 namespace sofa::core::behavior
 {
 
-/**
- * Base class for components having access to one mechanical state with a specific template parameter, in order to read
- * and/or write state variables.
- */
-template<class DataTypes>
-class SingleStateAccessor : public virtual StateAccessor
-{
-public:
-    SOFA_ABSTRACT_CLASS(SOFA_TEMPLATE(SingleStateAccessor, DataTypes), StateAccessor);
+using namespace sofa::defaulttype;
 
-    void init() override;
-
-    MechanicalState<DataTypes>* getMState();
-    const MechanicalState<DataTypes>* getMState() const;
-
-protected:
-
-    explicit SingleStateAccessor(MechanicalState<DataTypes>* mm = nullptr);
-
-    ~SingleStateAccessor() override = default;
-
-    SingleLink<SingleStateAccessor<DataTypes>, MechanicalState<DataTypes>, BaseLink::FLAG_STRONGLINK> mstate;
-};
-
-#if !defined(SOFA_CORE_BEHAVIOR_SINGLESTATEACCESSOR_CPP)
-extern template class SOFA_CORE_API SingleStateAccessor<sofa::defaulttype::Vec1Types>;
-extern template class SOFA_CORE_API SingleStateAccessor<sofa::defaulttype::Vec2Types>;
-extern template class SOFA_CORE_API SingleStateAccessor<sofa::defaulttype::Vec3Types>;
-extern template class SOFA_CORE_API SingleStateAccessor<sofa::defaulttype::Vec6Types>;
-extern template class SOFA_CORE_API SingleStateAccessor<sofa::defaulttype::Rigid2Types>;
-extern template class SOFA_CORE_API SingleStateAccessor<sofa::defaulttype::Rigid3Types>;
-#endif
+template class SOFA_CORE_API SingleStateAccessor<Vec1Types>;
+template class SOFA_CORE_API SingleStateAccessor<Vec2Types>;
+template class SOFA_CORE_API SingleStateAccessor<Vec3Types>;
+template class SOFA_CORE_API SingleStateAccessor<Vec6Types>;
+template class SOFA_CORE_API SingleStateAccessor<Rigid2Types>;
+template class SOFA_CORE_API SingleStateAccessor<Rigid3Types>;
 
 }

--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -34,6 +34,7 @@ set(HEADER_FILES
     ### Mechanical
     ${SOFACUDA_SOURCE_DIR}/component/statecontainer/CudaMechanicalObject.h
     ${SOFACUDA_SOURCE_DIR}/component/statecontainer/CudaMechanicalObject.inl
+    sofa/gpu/cuda/CudaSingleStateAccessor.h
 
     ### Mappings
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaBarycentricMapping.h

--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -111,6 +111,7 @@ set(SOURCE_FILES
     ### Mechanical
     ${SOFACUDA_SOURCE_DIR}/component/statecontainer/CudaMechanicalObject.cpp
     sofa/gpu/cuda/CudaSetTopology.cpp
+    sofa/gpu/cuda/CudaSingleStateAccessor.cpp
 
     ### Mappings
     ${SOFACUDA_SOURCE_DIR}/component/mapping/linear/CudaBarycentricMapping-3f.cpp

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSingleStateAccessor.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSingleStateAccessor.cpp
@@ -1,0 +1,50 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/gpu/cuda/CudaTypes.h>
+
+#include <sofa/core/behavior/SingleStateAccessor.h>
+#include <sofa/core/behavior/SingleStateAccessor.inl>
+
+
+namespace sofa::core::behavior
+{
+
+using namespace sofa::gpu::cuda;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec1dTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec2dTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3dTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3d1Types>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec6dTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid2dTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid3dTypes>;
+#endif // SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec1fTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec2fTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3fTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3f1Types>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec6fTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid2fTypes>;
+template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid3fTypes>;
+
+} // namespace sofa::core::behavior

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSingleStateAccessor.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSingleStateAccessor.h
@@ -19,34 +19,34 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_GPU_CUDA_CUDASINGLESTATEACCESSOR_CPP
 #include <sofa/gpu/cuda/CudaTypes.h>
 
-#include <sofa/gpu/cuda/CudaSingleStateAccessor.h>
-
-#include <sofa/core/behavior/SingleStateAccessor.inl>
-
+#include <sofa/core/behavior/SingleStateAccessor.h>
 
 namespace sofa::core::behavior
 {
+#if !defined(SOFA_GPU_CUDA_CUDALINEMODEL_CPP)
 
 using namespace sofa::gpu::cuda;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec1dTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec2dTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3dTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3d1Types>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec6dTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid2dTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid3dTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec1dTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec2dTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3d1Types>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec6dTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid2dTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid3dTypes>;
 #endif // SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec1fTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec2fTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3fTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3f1Types>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec6fTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid2fTypes>;
-template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid3fTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec1fTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec2fTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec3f1Types>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaVec6fTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid2fTypes>;
+extern template class SOFA_GPU_CUDA_API SingleStateAccessor<CudaRigid3fTypes>;
+
+#endif
+
 
 } // namespace sofa::core::behavior


### PR DESCRIPTION
The first intention is to fix weird linking errors (symbols already  defined in Sofa.Core) with MSVC in a plugin which is  implementing 2+ components inheriting SingleStateAccessor. The errors do not occur on macOS though (and I guess linux too)

This PR fixes this, and anyway it is always good to use explicit instantiations anyway 😗



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
