### PR TITLE
[examples] Propose a new default scene

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -450,7 +450,7 @@ int main(int argc, char** argv)
             mrulist.close();
         }
         else
-            fileName = "Demos/caduceus.scn";
+            fileName = "Demos/fallingSOFA.scn";
 
         fileName = DataRepository.getFile(fileName);
     }

--- a/examples/Demos/fallingSOFA.scn
+++ b/examples/Demos/fallingSOFA.scn
@@ -53,12 +53,12 @@
     detection is being performed. The contact distance increases the contact distance between object, enforcing a 'skinning' behavior -->
     <NewProximityIntersection name="Intersection" alarmDistance="0.02" contactDistance="0.002" />
 
-    <!-- Non simulated node used to create underlying deformable topology -->
+    <!-- Non-simulated node used to create underlying deformable topology -->
     <Node name="BEAMVOLUME">
-        <!-- Computes a Hexaedric topology based on a parametric grid -->
+        <!-- Computes a hexahedral topology based on a parametric grid -->
         <RegularGridTopology name="HexaTop" n="15 3 6" min="0 0.02 0" max="0.5 0.08 0.22"/>
 
-        <!-- Transform the Hexaedric topology into a Tetraedric topology
+        <!-- Transform the hexahedral topology into a tetrahedral topology
         For more information see : https://sofa-framework.github.io/doc/simulation-principles/multi-model-representation/mapping/#topological-mapping -->
         <TetrahedronSetTopologyContainer name="Container" position="@HexaTop.position"/>
         <TetrahedronSetTopologyModifier name="Modifier"/>
@@ -66,12 +66,12 @@
     </Node>
 
     <!-- Simulated node -->
-    <Node name="FEM">
+    <Node name="FE-MechanicalModel">
         <!-- Use implicit integration scheme -->
         <EulerImplicitSolver />
         <!-- Direct linear solver used for the computation of linear products using the system matrix $Ax=b$ -->
         <SparseLDLSolver name="ldl" template="CompressedRowSparseMatrixMat3x3" parallelInverseProduct="true" />
-        <!-- Topology contains all topological information : elements type, elements array-->
+        <!-- Topology contains all topological information: elements type, elements array-->
         <TetrahedronSetTopologyContainer name="Container" position="@../BEAMVOLUME/HexaTop.position" tetrahedra="@../BEAMVOLUME/Container.tetrahedra"/>
         <TetrahedronSetTopologyModifier name="Modifier"/>
 
@@ -93,7 +93,7 @@
             <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" flipNormals="false"/>
             <MechanicalObject name="dofs" rest_position="@../mstate.rest_position"/>
 
-            <!-- This uses triangles as colliding element. It uses the triangles elements that arte presents in the topology
+            <!-- This uses triangles as colliding element. These triangular primitives are the triangles present in the topology
             For more information on collision models see : https://sofa-framework.github.io/doc/components/collision/geometry/collisionmodels/ -->
             <TriangleCollisionModel name="Collision" proximity="0.001" color="0.94117647058824 0.93725490196078 0.89411764705882" />
 
@@ -104,7 +104,7 @@
             <IdentityMapping name="SurfaceMapping"/>
         </Node>
 
-        <!-- Visual model is constituted of all the parts of the logo, mapped using barycentric mapping -->
+        <!-- Visual model is made up of all the parts of the logo, mapped using barycentric mapping -->
         <Node name="VisuLogo">
             <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/LogoVisu.obj" scale3d="0.015 0.015 0.015" translation="0 0.05 0" rotation="180 0 0"/>
             <!-- This replaces MechanicalObject for nodes that are only there for visualization -->
@@ -137,7 +137,7 @@
         </Node>
 
         <!-- Solver needed to compute lagrangian-based constraints interaction
-        It uses the Linear solver to compute the Compliance matrix and the motion correction
+        It uses the LinearSolver to compute the Compliance matrix and the motion correction
         For more information see : https://sofa-framework.github.io/doc/simulation-principles/constraint/lagrange-constraint/#constraintcorrection -->
         <LinearSolverConstraintCorrection linearSolver="@ldl"/>
     </Node>

--- a/examples/Demos/fallingSOFA.scn
+++ b/examples/Demos/fallingSOFA.scn
@@ -54,7 +54,7 @@
     <NewProximityIntersection name="Intersection" alarmDistance="0.02" contactDistance="0.002" />
 
     <!-- Non-simulated node used to create underlying deformable topology -->
-    <Node name="BEAMVOLUME">
+    <Node name="BeamDomainFromGridTopology">
         <!-- Computes a hexahedral topology based on a parametric grid -->
         <RegularGridTopology name="HexaTop" n="15 3 6" min="0 0.02 0" max="0.5 0.08 0.22"/>
 
@@ -72,7 +72,7 @@
         <!-- Direct linear solver used for the computation of linear products using the system matrix $Ax=b$ -->
         <SparseLDLSolver name="ldl" template="CompressedRowSparseMatrixMat3x3" parallelInverseProduct="true" />
         <!-- Topology contains all topological information: elements type, elements array-->
-        <TetrahedronSetTopologyContainer name="Container" position="@../BEAMVOLUME/HexaTop.position" tetrahedra="@../BEAMVOLUME/Container.tetrahedra"/>
+        <TetrahedronSetTopologyContainer name="Container" position="@../BeamDomainFromGridTopology/HexaTop.position" tetrahedra="@../BeamDomainFromGridTopology/Container.tetrahedra"/>
         <TetrahedronSetTopologyModifier name="Modifier"/>
 
         <!-- MechanicalObject contains all mechanical quantity of the object (e.g. position, velocity, acceleration, forces, constraints forces, etc...)
@@ -156,7 +156,7 @@
                                                  3 7 6  3 6 2
                                                  4 5 6  4 6 7" />
         <MechanicalObject template="Vec3"/>
-        <!-- Because it in neither simulated nor moving, we can speed the solver and collision detection by setting parameters moving="0" simulated="0" -->
+        <!-- Because it is neither simulated nor moving, we can speed the solver and collision detection by setting parameters moving="0" simulated="0" -->
         <TriangleCollisionModel name="FloorCM" proximity="0.001" moving="0" simulated="0" />
     </Node>
 

--- a/examples/Demos/fallingSOFA.scn
+++ b/examples/Demos/fallingSOFA.scn
@@ -27,12 +27,12 @@
     <VisualStyle displayFlags="showVisual"/>
     <ConstraintAttachButtonSetting /> <!-- The presence of this component sets the mouse interaction to Lagrangian-based constraints at the GUI launch -->
     <FreeMotionAnimationLoop />
-    <GenericConstraintSolver maxIterations="200" tolerance="1.0e-8"/>
+    <GenericConstraintSolver maxIterations="50" tolerance="1.0e-6"/>
     <CollisionPipeline name="Pipeline" />
-    <BruteForceBroadPhase name="BroadPhase" />
-    <BVHNarrowPhase name="NarrowPhase" />
+    <ParallelBruteForceBroadPhase name="BroadPhase" />
+    <ParallelBVHNarrowPhase name="NarrowPhase" />
     <CollisionResponse name="ContactManager" response="FrictionContactConstraint" responseParams="mu=0.3" />
-    <NewProximityIntersection name="Intersection" alarmDistance="0.05" contactDistance="0.002" />
+    <NewProximityIntersection name="Intersection" alarmDistance="0.02" contactDistance="0.002" />
 
     <Node name="BEAMVOLUME">
         <RegularGridTopology name="HexaTop" n="15 3 6" min="0 0.02 0" max="0.5 0.08 0.22"/>
@@ -43,16 +43,13 @@
 
     <Node name="FEM">
         <EulerImplicitSolver />
-        <PCGLinearSolver preconditioner="@precond"/>
-        <SparseLDLSolver name="precond" template="CompressedRowSparseMatrixMat3x3" parallelInverseProduct="true" />
-
-        <TetrahedronSetTopologyContainer name="Container" position="@../BEAMVOLUME/HexaTop.position"
-                                         tetrahedra="@../BEAMVOLUME/Container.tetrahedra"/>
+        <SparseLDLSolver name="ldl" template="CompressedRowSparseMatrixMat3x3" parallelInverseProduct="true" />
+        <TetrahedronSetTopologyContainer name="Container" position="@../BEAMVOLUME/HexaTop.position" tetrahedra="@../BEAMVOLUME/Container.tetrahedra"/>
         <TetrahedronSetTopologyModifier name="Modifier"/>
 
         <MechanicalObject name="mstate" template="Vec3d" src="@Container"/>
-        <TetrahedronFEMForceField name="forceField" listening="true" youngModulus="2e4" poissonRatio="0.4" />
-        <UniformMass totalMass="1.2"/>
+        <TetrahedronFEMForceField name="forceField" listening="true" youngModulus="2e4" poissonRatio="0.45" />
+        <MeshMatrixMass totalMass="1.2"/>
 
         <Node name="Surface">
             <TriangleSetTopologyContainer name="Container"/>
@@ -94,10 +91,8 @@
             <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
         </Node>
 
-        <LinearSolverConstraintCorrection linearSolver="@precond"/>
-
+        <LinearSolverConstraintCorrection linearSolver="@ldl"/>
     </Node>
-
 
     <Node name="Floor" tags="NoBBox" >
         <VisualStyle displayFlags="showCollisionModels"/>

--- a/examples/Demos/fallingSOFA.scn
+++ b/examples/Demos/fallingSOFA.scn
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<Node name="root" dt="0.01" gravity="0 0 -9.81">
+<Node name="root" dt="0.005" gravity="0 0 -9.81">
     <Node name="plugins">
         <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
         <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->

--- a/examples/Demos/fallingSOFA.scn
+++ b/examples/Demos/fallingSOFA.scn
@@ -22,6 +22,8 @@
         <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
         <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
         <RequiredPlugin name="Sofa.GUI.Component"/> <!-- Needed to use components [ConstraintAttachButtonSetting] -->
+        <RequiredPlugin name="MultiThreading"/> <!-- Needed to use components [ParallelBVHNarrowPhase,ParallelBruteForceBroadPhase] -->
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
     </Node>
 
     <VisualStyle displayFlags="showVisual"/>

--- a/examples/Demos/fallingSOFA.scn
+++ b/examples/Demos/fallingSOFA.scn
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+
+<Node name="root" dt="0.01" gravity="0 0 -9.81">
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [NewProximityIntersection] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [LinearSolverConstraintCorrection] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Solver"/> <!-- Needed to use components [GenericConstraintSolver] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [PCGLinearSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedronFEMForceField] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetTopologyContainer TetrahedronSetTopologyModifier TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping Tetra2TriangleTopologicalMapping] -->
+        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+        <RequiredPlugin name="Sofa.GUI.Component"/> <!-- Needed to use components [ConstraintAttachButtonSetting] -->
+    </Node>
+
+    <VisualStyle displayFlags="showVisual"/>
+    <ConstraintAttachButtonSetting /> <!-- The presence of this component sets the mouse interaction to Lagrangian-based constraints at the GUI launch -->
+    <FreeMotionAnimationLoop />
+    <GenericConstraintSolver maxIterations="200" tolerance="1.0e-8"/>
+    <CollisionPipeline name="Pipeline" />
+    <BruteForceBroadPhase name="BroadPhase" />
+    <BVHNarrowPhase name="NarrowPhase" />
+    <CollisionResponse name="ContactManager" response="FrictionContactConstraint" responseParams="mu=0.3" />
+    <NewProximityIntersection name="Intersection" alarmDistance="0.05" contactDistance="0.002" />
+
+    <Node name="BEAMVOLUME">
+        <RegularGridTopology name="HexaTop" n="15 3 6" min="0 0.02 0" max="0.5 0.08 0.22"/>
+        <TetrahedronSetTopologyContainer name="Container" position="@HexaTop.position"/>
+        <TetrahedronSetTopologyModifier name="Modifier"/>
+        <Hexa2TetraTopologicalMapping input="@HexaTop" output="@Container" swapping="true"/>
+    </Node>
+
+    <Node name="FEM">
+        <EulerImplicitSolver />
+        <PCGLinearSolver preconditioner="@precond"/>
+        <SparseLDLSolver name="precond" template="CompressedRowSparseMatrixMat3x3" parallelInverseProduct="true" />
+
+        <TetrahedronSetTopologyContainer name="Container" position="@../BEAMVOLUME/HexaTop.position"
+                                         tetrahedra="@../BEAMVOLUME/Container.tetrahedra"/>
+        <TetrahedronSetTopologyModifier name="Modifier"/>
+
+        <MechanicalObject name="mstate" template="Vec3d" src="@Container"/>
+        <TetrahedronFEMForceField name="forceField" listening="true" youngModulus="2e4" poissonRatio="0.4" />
+        <UniformMass totalMass="1.2"/>
+
+        <Node name="Surface">
+            <TriangleSetTopologyContainer name="Container"/>
+            <TriangleSetTopologyModifier name="Modifier"/>
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" flipNormals="false"/>
+            <MechanicalObject name="dofs" rest_position="@../mstate.rest_position"/>
+            <TriangleCollisionModel name="Collision" proximity="0.001" color="0.94117647058824 0.93725490196078 0.89411764705882" />
+            <IdentityMapping name="SurfaceMapping"/>
+        </Node>
+
+        <Node name="VisuLogo">
+            <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/LogoVisu.obj" scale3d="0.015 0.015 0.015" translation="0 0.05 0" rotation="180 0 0"/>
+            <OglModel name="VisualModel" color="0.7 .35 0 1.0" position="@SurfaceLoader.position" triangles="@SurfaceLoader.triangles" />
+            <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
+        </Node>
+
+
+        <Node name="VisuS">
+            <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/SVisu.obj" scale3d="0.015 0.015 0.015" translation="0 0.05 0" rotation="180 0 0"/>
+            <OglModel name="VisualModel" color="0.7 0.7 0.7 1" position="@SurfaceLoader.position" triangles="@SurfaceLoader.triangles" />
+            <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
+        </Node>
+
+        <Node name="VisuO">
+            <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/O.obj" scale3d="0.015 0.015 0.015"  translation="0 0.05 0" rotation="180 0 0"/>
+            <OglModel name="VisualModel" color="0.7 0.7 0.7 1" position="@SurfaceLoader.position" triangles="@SurfaceLoader.triangles" />
+            <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
+        </Node>
+
+        <Node name="VisuF">
+            <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/FVisu.obj" scale3d="0.015 0.015 0.015" translation="0 0.05 0" rotation="180 0 0"/>
+            <OglModel name="VisualModel" color="0.7 0.7 0.7 1" position="@SurfaceLoader.position" triangles="@SurfaceLoader.triangles" />
+            <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
+        </Node>
+
+        <Node name="VisuA">
+            <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/AVisu.obj" scale3d="0.015 0.015 0.015" translation="0 0.05 0" rotation="180 0 0"/>
+            <OglModel name="VisualModel" color="0.7 0.7 0.7 1" position="@SurfaceLoader.position" triangles="@SurfaceLoader.triangles" />
+            <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
+        </Node>
+
+        <LinearSolverConstraintCorrection linearSolver="@precond"/>
+
+    </Node>
+
+
+    <Node name="Floor" tags="NoBBox" >
+        <VisualStyle displayFlags="showCollisionModels"/>
+        <TriangleSetTopologyContainer name="FloorTopo"
+                                      position="0.2 0 -0.5   0.2 0.1 -0.5  0.3 0.1 -0.5   0.3 0 -0.5
+                                                0.2 0 -0.6   0.2 0.1 -0.6  0.3 0.1 -0.6   0.3 0 -0.6"
+                                      triangles="0 2 1  0 3 2
+                                                 0 1 5  0 5 4
+                                                 0 4 7  0 7 3
+                                                 1 2 6  1 6 5
+                                                 3 7 6  3 6 2
+                                                 4 5 6  4 6 7" />
+        <MechanicalObject template="Vec3"/>
+        <TriangleCollisionModel name="FloorCM" proximity="0.001" moving="0" simulated="0" />
+    </Node>
+
+</Node>
+
+

--- a/examples/Demos/fallingSOFA.scn
+++ b/examples/Demos/fallingSOFA.scn
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 
 <Node name="root" dt="0.005" gravity="0 0 -9.81">
+    <!-- List of plugins needed to load all components used by this scene -->
     <Node name="plugins">
         <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->
         <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
@@ -26,48 +27,90 @@
         <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
     </Node>
 
+
+    <!-- Rendering settings -->
     <VisualStyle displayFlags="showVisual"/>
-    <ConstraintAttachButtonSetting /> <!-- The presence of this component sets the mouse interaction to Lagrangian-based constraints at the GUI launch -->
+
+    <!-- Define Mouse left click as a Bilateral Lagrangian constraint -->
+    <ConstraintAttachButtonSetting />
+
+    <!-- Header of the simulation -->
+    <!-- This animation loop will add steps in the time intyegration to enable Lagrangian-based constraint solving
+     For more information see : https://sofa-framework.github.io/doc/components/animationloop/freemotionanimationloop/ -->
     <FreeMotionAnimationLoop />
+    <!-- This solver will perform the different constraint solving stages a.k.a. the constraint system building, the constraint solving and the motion correction
+     For more information see : https://sofa-framework.github.io/doc/simulation-principles/constraint/lagrange-constraint/ -->
     <GenericConstraintSolver maxIterations="50" tolerance="1.0e-6"/>
+
+    <!-- Definition of the collision pipeline -->
     <CollisionPipeline name="Pipeline" />
     <ParallelBruteForceBroadPhase name="BroadPhase" />
     <ParallelBVHNarrowPhase name="NarrowPhase" />
+    <!-- This set the model used for contact behavior as Colomb's friction contact law using Lagrangian-based constraints -->
     <CollisionResponse name="ContactManager" response="FrictionContactConstraint" responseParams="mu=0.3" />
+    <!-- This object is responsible for defining pairs of points used for contact simulation.
+    Alarm distance and contact distance are key parameters: alarm distance is the distance at which the collision
+    detection is being performed. The contact distance increases the contact distance between object, enforcing a 'skinning' behavior -->
     <NewProximityIntersection name="Intersection" alarmDistance="0.02" contactDistance="0.002" />
 
+    <!-- Non simulated node used to create underlying deformable topology -->
     <Node name="BEAMVOLUME">
+        <!-- Computes a Hexaedric topology based on a parametric grid -->
         <RegularGridTopology name="HexaTop" n="15 3 6" min="0 0.02 0" max="0.5 0.08 0.22"/>
+
+        <!-- Transform the Hexaedric topology into a Tetraedric topology
+        For more information see : https://sofa-framework.github.io/doc/simulation-principles/multi-model-representation/mapping/#topological-mapping -->
         <TetrahedronSetTopologyContainer name="Container" position="@HexaTop.position"/>
         <TetrahedronSetTopologyModifier name="Modifier"/>
         <Hexa2TetraTopologicalMapping input="@HexaTop" output="@Container" swapping="true"/>
     </Node>
 
+    <!-- Simulated node -->
     <Node name="FEM">
+        <!-- Use implicit integration scheme -->
         <EulerImplicitSolver />
+        <!-- Direct linear solver used for the computation of linear products using the system matrix $Ax=b$ -->
         <SparseLDLSolver name="ldl" template="CompressedRowSparseMatrixMat3x3" parallelInverseProduct="true" />
+        <!-- Topology contains all topological information : elements type, elements array-->
         <TetrahedronSetTopologyContainer name="Container" position="@../BEAMVOLUME/HexaTop.position" tetrahedra="@../BEAMVOLUME/Container.tetrahedra"/>
         <TetrahedronSetTopologyModifier name="Modifier"/>
 
+        <!-- MechanicalObject contains all mechanical quantity of the object (e.g. position, velocity, acceleration, forces, constraints forces, etc...)
+        For more information see : https://sofa-framework.github.io/doc/simulation-principles/mechanicalobject/ -->
         <MechanicalObject name="mstate" template="Vec3d" src="@Container"/>
-        <TetrahedronFEMForceField name="forceField" listening="true" youngModulus="2e4" poissonRatio="0.45" />
+
+        <!-- Use corotationnal linear elasticity for speed and stability -->
+        <TetrahedronFEMForceField name="forceField" listening="true" youngModulus="2e4" poissonRatio="0.45" method="large"/>
+        <!-- This is the more precise way to define mass for a meshed object, it is a full implementation of the FE method -->
         <MeshMatrixMass totalMass="1.2"/>
 
+        <!-- Collision surface node -->
         <Node name="Surface">
             <TriangleSetTopologyContainer name="Container"/>
             <TriangleSetTopologyModifier name="Modifier"/>
+
+            <!-- Extract surface of the simulated topology to account for contacts -->
             <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" flipNormals="false"/>
             <MechanicalObject name="dofs" rest_position="@../mstate.rest_position"/>
+
+            <!-- This uses triangles as colliding element. It uses the triangles elements that arte presents in the topology
+            For more information on collision models see : https://sofa-framework.github.io/doc/components/collision/geometry/collisionmodels/ -->
             <TriangleCollisionModel name="Collision" proximity="0.001" color="0.94117647058824 0.93725490196078 0.89411764705882" />
+
+            <!-- This is a mapping: it relates the position of this node to the one of the simulated node.
+            The position of this node (the output of the mapping) is totally defined by the position of the input node
+            (the simulated one) and forces from applied to this node will be transferred to the mechanical node.
+            For more info see : https://sofa-framework.github.io/doc/simulation-principles/multi-model-representation/mapping/ -->
             <IdentityMapping name="SurfaceMapping"/>
         </Node>
 
+        <!-- Visual model is constituted of all the parts of the logo, mapped using barycentric mapping -->
         <Node name="VisuLogo">
             <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/LogoVisu.obj" scale3d="0.015 0.015 0.015" translation="0 0.05 0" rotation="180 0 0"/>
+            <!-- This replaces MechanicalObject for nodes that are only there for visualization -->
             <OglModel name="VisualModel" color="0.7 .35 0 1.0" position="@SurfaceLoader.position" triangles="@SurfaceLoader.triangles" />
             <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
         </Node>
-
 
         <Node name="VisuS">
             <MeshOBJLoader name="SurfaceLoader" filename="mesh/SofaScene/SVisu.obj" scale3d="0.015 0.015 0.015" translation="0 0.05 0" rotation="180 0 0"/>
@@ -93,11 +136,16 @@
             <BarycentricMapping name="MappingVisu" input="@../mstate" output="@VisualModel" isMechanical="false" />
         </Node>
 
+        <!-- Solver needed to compute lagrangian-based constraints interaction
+        It uses the Linear solver to compute the Compliance matrix and the motion correction
+        For more information see : https://sofa-framework.github.io/doc/simulation-principles/constraint/lagrange-constraint/#constraintcorrection -->
         <LinearSolverConstraintCorrection linearSolver="@ldl"/>
     </Node>
 
+    <!-- Non-simulated obstacle -->
     <Node name="Floor" tags="NoBBox" >
         <VisualStyle displayFlags="showCollisionModels"/>
+        <!-- Surface triangles are defined by hand -->
         <TriangleSetTopologyContainer name="FloorTopo"
                                       position="0.2 0 -0.5   0.2 0.1 -0.5  0.3 0.1 -0.5   0.3 0 -0.5
                                                 0.2 0 -0.6   0.2 0.1 -0.6  0.3 0.1 -0.6   0.3 0 -0.6"
@@ -108,6 +156,7 @@
                                                  3 7 6  3 6 2
                                                  4 5 6  4 6 7" />
         <MechanicalObject template="Vec3"/>
+        <!-- Because it in neither simulated nor moving, we can speed the solver and collision detection by setting parameters moving="0" simulated="0" -->
         <TriangleCollisionModel name="FloorCM" proximity="0.001" moving="0" simulated="0" />
     </Node>
 

--- a/examples/Demos/fallingSOFA.scn.view
+++ b/examples/Demos/fallingSOFA.scn.view
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Camera version="1.0">
+    <!--Vector of 3 reals (x, y, z)-->
+    <position value="0.25 -1.1 -0.20"/>
+    <!--Quaternion (x, y, z, w)-->
+    <orientation value="0.707 0 0 0.707"/>
+    <!--Real-->
+    <fieldOfView value="45"/>
+    <!--Real-->
+    <distance value="0"/>
+    <!--Real-->
+    <zNear value="0.0349612"/>
+    <!--Real-->
+    <zFar value="2.64066"/>
+    <!--Int (0 -> Perspective, 1 -> Orthographic)-->
+    <projectionType value="Perspective"/>
+</Camera>

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -20,6 +20,7 @@ Demos/collisionMultiple.scn 100 1e-4 1 1
 Demos/liver.scn 100 1e-4 1 1
 Demos/simpleBoundaryConditions.scn 100 1e-4 1 1
 Demos/fallingBeamLagrangianCollision.scn 46 1e-7 1 1
+Demos/fallingSOFA.scn 200 1e-7 1 1
 Demos/SofaScene.scn 120 1e-5 1 1
 
 


### PR DESCRIPTION
This is my last attempt at getting rid of the old Caduceus. After that, we're doomed. 

Last time I tried the general comments where "this scene is too heavy, too complex, we need to propose something simpler or nothing at all"

Nothing at all is not an option in my mind, and keeping the old caduceus with a lot of old code, wrong behavior and bad implementation (for some part) in not an option either. 

Now this is as simple as it gets if you want to show something moving + deforming. Here is a gif : 
![new_sofa_scene](https://github.com/user-attachments/assets/8d2b273e-3988-494e-a61e-d451e947a8e6)

It take the backbone of `fallingBeamLagrangianCollision.scn`, adds the logo as visual model and makes it way faster and more interesting (we got a bounce !) 


[ci-depends-on https://github.com/sofa-framework/Regression/pull/77]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
