### PR TITLE
[IO.Mesh.BlenderExporter] Inherit from BaseSimulationExporter

### DIFF
--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
@@ -109,10 +109,6 @@ public:
         }
         return BaseObject::canCreate(obj, context, arg);
     }
-
-protected:
-
-    unsigned frameCounter;
 };
 
 } // namespace _blenderexporter_

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
@@ -94,8 +94,6 @@ public:
 
     void reset() override;
 
-    void handleEvent(sofa::core::objectmodel::Event* event) override;
-
     /// Pre-construction check method called by ObjectFactory.
     /// Check that DataTypes matches the MechanicalState.
     template<class T2>

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
@@ -25,7 +25,7 @@
 #include <sofa/component/io/mesh/config.h>
 
 #include <sofa/core/State.h>
-#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/simulation/BaseSimulationExporter.h>
 #include <sofa/core/objectmodel/Event.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
@@ -54,10 +54,10 @@ namespace _blenderexporter_
 // TODO: currently the export only support soft body and hair simulations, clothes, smoke and fluid simulation could be added.
 
 template<class T>
-class SOFA_COMPONENT_IO_MESH_API BlenderExporter: public core::objectmodel::BaseObject
+class SOFA_COMPONENT_IO_MESH_API BlenderExporter: public sofa::simulation::BaseSimulationExporter
 {
 public:
-    typedef core::objectmodel::BaseObject Inherit;
+    typedef sofa::simulation::BaseSimulationExporter Inherit;
     typedef sofa::core::State<T> DataType;
     typedef typename DataType::VecCoord VecCoord;
     typedef typename DataType::VecDeriv VecDeriv;
@@ -68,7 +68,7 @@ public:
 
     typedef enum{SoftBody,Particle,Cloth,Hair}SimulationType;
 
-    SOFA_CLASS(SOFA_TEMPLATE(BlenderExporter,T),core::objectmodel::BaseObject);
+    SOFA_CLASS(SOFA_TEMPLATE(BlenderExporter,T),sofa::simulation::BaseSimulationExporter);
 
     Data < std::string > d_path; ///< output path
     Data < std::string > d_baseName; ///< Base name for the output files
@@ -88,7 +88,9 @@ public:
 
     static const char* Name(){return "Blender exporter";}
 
-    void init() override;
+    void doInit() override;
+    void doReInit() override;
+    bool write() override;
 
     void reset() override;
 

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
@@ -36,8 +36,7 @@ BlenderExporter<T>::BlenderExporter()
       d_baseName(initData(&d_baseName, "baseName", "Base name for the output files")),
       d_simulationType(initData(&d_simulationType, 0, "simulationType", "simulation type (0: soft body, 1: particles, 2:cloth, 3:hair)")),
       d_simulationStep(initData(&d_simulationStep, 2, "step", "save the  simulation result every step frames")),
-      d_nbPtsByHair(initData(&d_nbPtsByHair, 20, "nbPtsByHair", "number of element by hair strand")),
-      frameCounter(0)
+      d_nbPtsByHair(initData(&d_nbPtsByHair, 20, "nbPtsByHair", "number of element by hair strand"))
 {
     Inherit::f_listening.setValue(true);
 }
@@ -57,10 +56,7 @@ void BlenderExporter<T>::doReInit()
     // if hair type simulation, create an additional information frame
     if(d_simulationType.getValue() == Hair)
     {
-        ostringstream iss;
-        iss << helper::system::FileSystem::append(d_path.getValue(), d_baseName.getValue())
-            << "_000000_00.bphys";
-        string fileName = iss.str();
+        string fileName = getOrCreateTargetPath(d_filename.getValue(), d_exportEveryNbSteps.getValue());
         // create the file
         ofstream file(fileName.c_str(), ios::out|ios::binary);
         if(file)
@@ -75,164 +71,155 @@ void BlenderExporter<T>::doReInit()
             file.close();
         }
     }
+    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 template<class T>
 bool BlenderExporter<T>::write()
 {
+    if(!this->isComponentStateValid())
+        return false;
+
+    string fileName = getOrCreateTargetPath(d_filename.getValue(), d_exportEveryNbSteps.getValue());
+    fileName += "_00.bphys";
+
+    // create the file
+    ofstream file(fileName.c_str(), ios::out|ios::binary);
+    
+    if(file)
+    {
+        msg_info()<<"writing in "<<fileName;
+    
+        // ############# write header
+    
+        const string bphysics = "BPHYSICS";
+        file.write(bphysics.c_str(),8);
+    
+        // types
+        unsigned type;
+        if(d_simulationType.getValue() == Hair)
+            type = Cloth; // blender hair exception
+        else
+            type = d_simulationType.getValue();
+        file.write((char*)&type,4);
+    
+        // number of data
+        auto size = mmodel->getSize();
+        if(d_simulationType.getValue() == Hair)
+        {
+            unsigned sizeHair = size+size/(d_nbPtsByHair.getValue());
+            file.write((char*)&sizeHair,4);
+        }
+        else
+            file.write((char*)&size,4);
+    
+        // dataType
+        unsigned dataType;
+        switch (d_simulationType.getValue())
+        {
+        case SoftBody: dataType = 6;
+            break;
+        case Hair: dataType = 22;
+            break;
+        default:  dataType = 6;
+            break;
+        }
+        file.write((char*)&dataType,4);
+    
+        // ############# write data
+    
+        float pos[3]={0,0,0};
+        float vel[3]={0,0,0};
+        float rest[3]={0,0,0};
+        float pos0[3]={0,0,0};
+        float vel0[3]={0,0,0};
+    
+        ReadVecCoord posData = mmodel->readPositions();
+    
+        for(int i= (int)size-1; i>=0; i--)
+        {
+            //create an additional point for root tangent
+            if((d_simulationType.getValue() == Hair && (i % d_nbPtsByHair.getValue() == 0)))
+            {
+    
+               auto  x0 = T::getCPos(posData[i]);
+               auto  x1 = T::getCPos(posData[i+1]);
+    
+                x1 = x1-x0;
+                x1.normalize();
+    
+                x0 = x0+x1;
+    
+                pos0[0] = (float)x0[0];
+                pos0[1] = (float)x0[1];
+                pos0[2] = (float)x0[2];
+    
+                file.write((char*)pos0,12);
+                file.write((char*)vel0,12);
+                file.write((char*)pos0,12);
+            }
+    
+            //Coord x0=restData[i];
+            Coord x=posData[i];
+            pos[0] = (float)x[0];
+            pos[1] = (float)x[1];
+            pos[2] = (float)x[2];
+    
+            Deriv v;
+            if((mmodel->read(core::vec_id::read_access::velocity)) && ((int) mmodel->readVelocities().size()>i))
+            {
+                v =mmodel->readVelocities()[i];
+                vel[0] = (float)v[0];
+                vel[1] = (float)v[1];
+                vel[2] = (float)v[2];
+            }
+    
+            Coord x0;
+            if((mmodel->read(core::vec_id::read_access::restPosition)) && ( (int)mmodel->readRestPositions().size()>i))
+            {
+                x0 =mmodel->readRestPositions()[i];
+                rest[0] = (float)x0[0];
+                rest[1] = (float)x0[1];
+                rest[2] = (float)x0[2];
+            }
+    
+            switch (d_simulationType.getValue())
+            {
+            case SoftBody:
+                file.write((char*)pos,12);
+                file.write((char*)vel,12);
+                break;
+            case Hair:
+                file.write((char*)pos,12);
+                file.write((char*)vel,12);
+                file.write((char*)rest,12);
+                break;
+            default:
+                file.write((char*)pos,12);
+                file.write((char*)vel,12);
+                break;
+            }
+        }
+        file.close();
+    }
+    else
+    {
+        msg_error() << "Unable to create the following file: "<<fileName;
+        return false;
+    }
     return true;
 }
 
 template<class T>
 void BlenderExporter<T>::reset()
 {
-    frameCounter=0;
+    m_stepCounter=0;
 }
 
 template<class T>
 void BlenderExporter<T>::handleEvent(sofa::core::objectmodel::Event* event)
 {
-
-    if (simulation::AnimateBeginEvent::checkEventType(event))
-    {
-        if(!(frameCounter % d_simulationStep.getValue())) // save a new frame!
-        {
-            int frameNumber = frameCounter / d_simulationStep.getValue();
-            ostringstream iss;
-            iss << helper::system::FileSystem::append(d_path.getValue(), d_baseName.getValue()) << "_";
-            iss<<std::setfill('0') << std::setw(6) << frameNumber+1<<"_00.bphys";
-            string fileName = iss.str();
-
-            // create the file
-            ofstream file(fileName.c_str(), ios::out|ios::binary);
-
-            if(file)
-            {
-                msg_info()<<"writing in "<<fileName;
-
-                // ############# write header
-
-                const string bphysics = "BPHYSICS";
-                file.write(bphysics.c_str(),8);
-
-                // types
-                unsigned type;
-                if(d_simulationType.getValue() == Hair)
-                    type = Cloth; // blender hair exception
-                else
-                    type = d_simulationType.getValue();
-                file.write((char*)&type,4);
-
-                // number of data
-                auto size = mmodel->getSize();
-                if(d_simulationType.getValue() == Hair)
-                {
-                    unsigned sizeHair = size+size/(d_nbPtsByHair.getValue());
-                    file.write((char*)&sizeHair,4);
-                }
-                else
-                    file.write((char*)&size,4);
-
-                // dataType
-                unsigned dataType;
-                switch (d_simulationType.getValue())
-                {
-                case SoftBody: dataType = 6;
-                    break;
-                case Hair: dataType = 22;
-                    break;
-                default:  dataType = 6;
-                    break;
-                }
-                file.write((char*)&dataType,4);
-
-                // ############# write data
-
-                float pos[3]={0,0,0};
-                float vel[3]={0,0,0};
-                float rest[3]={0,0,0};
-                float pos0[3]={0,0,0};
-                float vel0[3]={0,0,0};
-
-
-                ReadVecCoord posData = mmodel->readPositions();
-
-
-                for(int i= (int)size-1; i>=0; i--)
-                {
-                    //create an additional point for root tangent
-                    if((d_simulationType.getValue() == Hair && (i % d_nbPtsByHair.getValue() == 0)))
-                    {
-
-                       auto  x0 = T::getCPos(posData[i]);
-                       auto  x1 = T::getCPos(posData[i+1]);
-
-                        x1 = x1-x0;
-                        x1.normalize();
-
-                        x0 = x0+x1;
-
-                        pos0[0] = (float)x0[0];
-                        pos0[1] = (float)x0[1];
-                        pos0[2] = (float)x0[2];
-
-                        file.write((char*)pos0,12);
-                        file.write((char*)vel0,12);
-                        file.write((char*)pos0,12);
-                    }
-
-                    //Coord x0=restData[i];
-                    Coord x=posData[i];
-                    pos[0] = (float)x[0];
-                    pos[1] = (float)x[1];
-                    pos[2] = (float)x[2];
-
-                    Deriv v;
-                    if((mmodel->read(core::vec_id::read_access::velocity)) && ((int) mmodel->readVelocities().size()>i))
-                    {
-                        v =mmodel->readVelocities()[i];
-                        vel[0] = (float)v[0];
-                        vel[1] = (float)v[1];
-                        vel[2] = (float)v[2];
-                    }
-
-                    Coord x0;
-                    if((mmodel->read(core::vec_id::read_access::restPosition)) && ( (int)mmodel->readRestPositions().size()>i))
-                    {
-                        x0 =mmodel->readRestPositions()[i];
-                        rest[0] = (float)x0[0];
-                        rest[1] = (float)x0[1];
-                        rest[2] = (float)x0[2];
-                    }
-
-
-
-                    switch (d_simulationType.getValue())
-                    {
-                    case SoftBody:
-                        file.write((char*)pos,12);
-                        file.write((char*)vel,12);
-                        break;
-                    case Hair:
-                        file.write((char*)pos,12);
-                        file.write((char*)vel,12);
-                        file.write((char*)rest,12);
-                        break;
-                    default:
-                        file.write((char*)pos,12);
-                        file.write((char*)vel,12);
-                        break;
-                    }
-                }
-                file.close();
-            }
-            else
-                msg_error() << "Unable to create the following file: "<<fileName;
-
-        }
-        frameCounter++;
-    }
-
+    BaseSimulationExporter::handleEvent(event);
 }
 
 

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
@@ -216,11 +216,5 @@ void BlenderExporter<T>::reset()
     m_stepCounter=0;
 }
 
-template<class T>
-void BlenderExporter<T>::handleEvent(sofa::core::objectmodel::Event* event)
-{
-    BaseSimulationExporter::handleEvent(event);
-}
-
 
 } // namespace sofa::component::_blenderexporter_

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
@@ -44,12 +44,6 @@ BlenderExporter<T>::BlenderExporter()
 template<class T>
 void BlenderExporter<T>::doInit()
 {
-    doReInit();
-}
-
-template<class T>
-void BlenderExporter<T>::doReInit()
-{
     mmodel = getContext()->template get<DataType>(sofa::core::objectmodel::BaseContext::SearchDirection::Local);
     if(mmodel == nullptr)
         msg_error()<<"Initialization failed!";
@@ -72,6 +66,12 @@ void BlenderExporter<T>::doReInit()
         }
     }
     d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
+}
+
+template<class T>
+void BlenderExporter<T>::doReInit()
+{
+    doInit();
 }
 
 template<class T>

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.inl
@@ -43,12 +43,17 @@ BlenderExporter<T>::BlenderExporter()
 }
 
 template<class T>
-void BlenderExporter<T>::init()
+void BlenderExporter<T>::doInit()
+{
+    doReInit();
+}
+
+template<class T>
+void BlenderExporter<T>::doReInit()
 {
     mmodel = getContext()->template get<DataType>(sofa::core::objectmodel::BaseContext::SearchDirection::Local);
     if(mmodel == nullptr)
         msg_error()<<"Initialization failed!";
-    Inherit::init();
     // if hair type simulation, create an additional information frame
     if(d_simulationType.getValue() == Hair)
     {
@@ -70,6 +75,12 @@ void BlenderExporter<T>::init()
             file.close();
         }
     }
+}
+
+template<class T>
+bool BlenderExporter<T>::write()
+{
+    return true;
 }
 
 template<class T>

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshExporter.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshExporter.cpp
@@ -872,11 +872,6 @@ bool MeshExporter::writeMeshObj()
     return true ;
 }
 
-void MeshExporter::handleEvent(sofa::core::objectmodel::Event *event)
-{
-    BaseSimulationExporter::handleEvent(event);
-}
-
 } // namespace sofa::component::_meshexporter_
 
 namespace sofa::component::io::mesh

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshExporter.h
@@ -78,7 +78,6 @@ public:
 
     void doInit() override ;
     void doReInit() override ;
-    void handleEvent(Event *) override ;
 
     bool write() override ;
 

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/VisualModelOBJExporter.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/VisualModelOBJExporter.cpp
@@ -82,12 +82,6 @@ bool VisualModelOBJExporter::writeOBJ()
     return true ;
 }
 
-
-void VisualModelOBJExporter::handleEvent(Event *event)
-{
-    BaseSimulationExporter::handleEvent(event) ;
-}
-
 } // namespace sofa::component::_visualmodelobjexporter_
 
 namespace sofa::component::io::mesh

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/VisualModelOBJExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/VisualModelOBJExporter.h
@@ -42,8 +42,6 @@ public:
     bool write() override;
     bool writeOBJ();
 
-    void handleEvent(Event *event) override;
-
 protected:
     ~VisualModelOBJExporter() override;
 };

--- a/examples/Component/IO/Mesh/BlenderExporter.scn
+++ b/examples/Component/IO/Mesh/BlenderExporter.scn
@@ -10,10 +10,11 @@
     <MechanicalObject src="@loader" template="Vec3" name="mecha" showObject="1" />
     <TetrahedronSetTopologyContainer src="@loader" name="topo" />
     <BlenderExporter 
-        path="./" 
-        baseName="example"
-        step="3"
+        filename="example"
         listening="true" 
         exportAtBegin="1" 
+        exportAtEnd="1" 
+        exportEveryNumberOfSteps="3"
+        printLog="1"
     />
 </Node>

--- a/examples/Component/IO/Mesh/BlenderExporter.scn
+++ b/examples/Component/IO/Mesh/BlenderExporter.scn
@@ -9,7 +9,7 @@
     <MeshOBJLoader name="loader" filename="mesh/dragon.obj" />
     <MechanicalObject src="@loader" template="Vec3" name="mecha" showObject="1" />
     <TetrahedronSetTopologyContainer src="@loader" name="topo" />
-    <BlenderExporter 
+    <BlenderExporter name="ExportToBlender"
         filename="example"
         listening="true" 
         exportAtBegin="1" 

--- a/examples/Component/IO/Mesh/BlenderExporter.scn
+++ b/examples/Component/IO/Mesh/BlenderExporter.scn
@@ -1,0 +1,19 @@
+<Node name="root" dt="0.01" gravity="0 -9.81 0">
+	<RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader VTKExporter] -->
+	<RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+	<RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+	<RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetTopologyContainer] -->
+	<DefaultAnimationLoop/>
+
+    <MeshTopology name="mesh" filename="mesh/dragon.obj" />
+    <MeshOBJLoader name="loader" filename="mesh/dragon.obj" />
+    <MechanicalObject src="@loader" template="Vec3" name="mecha" showObject="1" />
+    <TetrahedronSetTopologyContainer src="@loader" name="topo" />
+    <BlenderExporter 
+        path="./" 
+        baseName="example"
+        step="3"
+        listening="true" 
+        exportAtBegin="1" 
+    />
+</Node>


### PR DESCRIPTION
Continuation of PRs to fix: https://github.com/sofa-framework/sofa/issues/5283.

- First two commits change the inheritance of the BlednerExporter from BaseObject to BaseSimulationExporter.
- Last commit is a suggested refactor/clean of BlenderExporter.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
