### PR TITLE
[GUI.Common] Clean and fix MouseOperation

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.cpp
@@ -47,7 +47,25 @@ helper::Creator<InteractionPerformer::InteractionPerformerFactory, SuturePointPe
 namespace sofa::gui::common
 {
 
-//*******************************************************************************************
+Operation::Operation(sofa::component::setting::MouseButtonSetting::SPtr s)
+    : pickHandle(nullptr), mbsetting(s), performer(nullptr), button(NONE)
+{
+}
+
+Operation::~Operation() = default;
+
+void Operation::configure(PickHandler* picker, const MOUSE_BUTTON b)
+{
+    pickHandle = picker;
+    button = b;
+}
+
+void Operation::configure(PickHandler* picker, sofa::component::setting::MouseButtonSetting* s)
+{
+    setSetting(s);
+    configure(picker, GetMouseId(s->d_button.getValue().getSelectedId()));
+}
+
 void Operation::start()
 {
     if (!performer)
@@ -114,7 +132,22 @@ void Operation::end()
     if (performer)
     {
         pickHandle->getInteraction()->mouseInteractor->removeInteractionPerformer(performer);
-        delete performer; performer=nullptr;
+        delete performer;
+        performer = nullptr;
+    }
+}
+MOUSE_BUTTON Operation::GetMouseId(unsigned int i)
+{
+    switch (i)
+    {
+        case LEFT:
+            return LEFT;
+        case MIDDLE:
+            return MIDDLE;
+        case RIGHT:
+            return RIGHT;
+        default:
+            return NONE;
     }
 }
 

--- a/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
@@ -57,29 +57,21 @@ class SOFA_GUI_COMMON_API Operation
 {
     friend class OperationFactory;
 public:
-    Operation(sofa::component::setting::MouseButtonSetting::SPtr s = nullptr): pickHandle(nullptr),mbsetting(s),performer(nullptr),button(NONE) {}
-    virtual ~Operation() {}
-    virtual void configure(PickHandler*picker, MOUSE_BUTTON b) { pickHandle=picker; button=b; }
-    virtual void configure(PickHandler* picker, sofa::component::setting::MouseButtonSetting* s)
-    { setSetting(s); configure(picker,GetMouseId(s->d_button.getValue().getSelectedId())); }
+    explicit Operation(sofa::component::setting::MouseButtonSetting::SPtr s = nullptr);
+    virtual ~Operation();
+    virtual void configure(PickHandler* picker, MOUSE_BUTTON b);
+    virtual void configure(PickHandler* picker, sofa::component::setting::MouseButtonSetting* s);
     virtual void start();                      /// This function is called each time the mouse is clicked.
     virtual void execution() {}
     virtual void end();                        /// This function is called after each mouse click.
     virtual void endOperation() { this->end(); }  /// This function is called when shift key is released.
     virtual void wait() {}
-    static MOUSE_BUTTON GetMouseId(unsigned int i)
-    {
-        switch (i)
-        {
-        case LEFT:   return LEFT;
-        case MIDDLE: return MIDDLE;
-        case RIGHT:  return RIGHT;
-        default:     return NONE;
-        }
-    }
+    static MOUSE_BUTTON GetMouseId(unsigned int i);
+
 protected:
     PickHandler *pickHandle;
     sofa::component::setting::MouseButtonSetting::SPtr mbsetting;
+
 public:
     virtual void setSetting(sofa::component::setting::MouseButtonSetting* s) { mbsetting = s; }
     sofa::gui::component::performer::InteractionPerformer *performer;
@@ -88,8 +80,10 @@ public:
     virtual void configurePerformer(sofa::gui::component::performer::InteractionPerformer* p);
     MOUSE_BUTTON getMouseButton() const { return button; }
     std::string getId() { return id; }
+
 protected:
     MOUSE_BUTTON button;
+
 private:
     std::string id;
 };
@@ -97,7 +91,8 @@ private:
 class SOFA_GUI_COMMON_API AttachOperation : public Operation
 {
 public:
-    AttachOperation(sofa::gui::component::AttachBodyButtonSetting::SPtr s = sofa::core::objectmodel::New<sofa::gui::component::AttachBodyButtonSetting>()) : Operation(s), setting(s)
+    explicit AttachOperation(sofa::gui::component::AttachBodyButtonSetting::SPtr s = sofa::core::objectmodel::New<sofa::gui::component::AttachBodyButtonSetting>())
+        : Operation(s), setting(s)
     {}
     ~AttachOperation() override {}
 
@@ -158,31 +153,40 @@ protected:
 class SOFA_GUI_COMMON_API AddRecordedCameraOperation : public Operation
 {
 public:
-	AddRecordedCameraOperation() : setting(sofa::core::objectmodel::New<sofa::gui::component::AddRecordedCameraButtonSetting>())
-	{}
-	static std::string getDescription() {return "Save camera's view points for navigation ";}
+    AddRecordedCameraOperation() : setting(sofa::core::objectmodel::New<sofa::gui::component::AddRecordedCameraButtonSetting>())
+    {}
+    static std::string getDescription() {return "Save camera's view points for navigation ";}
 protected:
     virtual std::string defaultPerformerType() override;
-	void configurePerformer(sofa::gui::component::performer::InteractionPerformer* p) override;
-	sofa::gui::component::AddRecordedCameraButtonSetting::SPtr setting;
+    void configurePerformer(sofa::gui::component::performer::InteractionPerformer* p) override;
+    sofa::gui::component::AddRecordedCameraButtonSetting::SPtr setting;
 };
 
 class SOFA_GUI_COMMON_API StartNavigationOperation : public Operation
 {
 public:
-	StartNavigationOperation() : setting(sofa::core::objectmodel::New<sofa::gui::component::StartNavigationButtonSetting>())
-	{}
-	static std::string getDescription() {return "Start navigation if camera's view points have been saved";}
+    StartNavigationOperation() : setting(sofa::core::objectmodel::New<sofa::gui::component::StartNavigationButtonSetting>())
+    {}
+    static std::string getDescription() {return "Start navigation if camera's view points have been saved";}
 protected:
     virtual std::string defaultPerformerType() override;
-	void configurePerformer(sofa::gui::component::performer::InteractionPerformer* p) override;
-	sofa::gui::component::StartNavigationButtonSetting::SPtr setting;
+    void configurePerformer(sofa::gui::component::performer::InteractionPerformer* p) override;
+    sofa::gui::component::StartNavigationButtonSetting::SPtr setting;
 };
 
 class SOFA_GUI_COMMON_API InciseOperation : public Operation
 {
 public:
-    InciseOperation():startPerformer(nullptr), cpt (0) {}
+    InciseOperation()
+     : startPerformer(nullptr),
+       method(0),
+       snapingBorderValue(0),
+       snapingValue(0),
+       cpt(0),
+       finishIncision(false),
+       keepPoint(false)
+    {}
+
     ~InciseOperation() override;
     void start() override ;
     void execution() override ;
@@ -216,7 +220,9 @@ protected:
 class SOFA_GUI_COMMON_API TopologyOperation : public Operation
 {
 public:
-    TopologyOperation():scale (0.0), volumicMesh (false), firstClick(true) {}
+    TopologyOperation() :
+        topologicalOperation(0), scale(0.0), volumicMesh(false), firstClick(true)
+    {}
 
     ~TopologyOperation() override {}
     void start() override;

--- a/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
@@ -234,7 +234,7 @@ public:
     void setScale (double s) {scale = s;}
     void setVolumicMesh (bool v) {volumicMesh = v;}
 
-    virtual int getTopologicalOperation() const { return volumicMesh;}
+    virtual int getTopologicalOperation() const { return topologicalOperation;}
     virtual double getScale() const {return scale;}
     virtual bool getVolumicMesh() const {return volumicMesh;}
 

--- a/Sofa/GUI/Common/src/sofa/gui/common/OperationFactory.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/OperationFactory.h
@@ -69,7 +69,7 @@ public:
 
     }
 
-    static SOFA_ATTRIBUTE_DEPRECATED__TYPO() Operation* Instanciate(const std::string &name)
+    SOFA_ATTRIBUTE_DEPRECATED__TYPO() static Operation* Instanciate(const std::string &name)
     {
         return Instantiate(name);
     }

--- a/Sofa/GUI/Common/src/sofa/gui/common/OperationFactory.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/OperationFactory.h
@@ -69,7 +69,12 @@ public:
 
     }
 
-    static Operation* Instanciate(const std::string &name)
+    static SOFA_ATTRIBUTE_DEPRECATED__TYPO() Operation* Instanciate(const std::string &name)
+    {
+        return Instantiate(name);
+    }
+
+    static Operation* Instantiate(const std::string &name)
     {
         const RegisterStorage &reg = getInstance()->registry;
         const RegisterStorage::const_iterator it = reg.find(name);
@@ -89,7 +94,7 @@ class SOFA_GUI_COMMON_API RegisterOperation
 {
 public:
     std::string name;
-    OperationCreator *creator;
+    OperationCreator *creator { nullptr };
 
     RegisterOperation(const std::string &n)
     {

--- a/Sofa/GUI/Common/src/sofa/gui/common/PickHandler.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/PickHandler.cpp
@@ -170,7 +170,7 @@ Operation *PickHandler::changeOperation(sofa::component::setting::MouseButtonSet
         delete operations[setting->d_button.getValue().getSelectedId()];
         operations[setting->d_button.getValue().getSelectedId()] = nullptr;
     }
-    Operation *mouseOp=OperationFactory::Instanciate(setting->getOperationType());
+    Operation *mouseOp=OperationFactory::Instantiate(setting->getOperationType());
     if (mouseOp)
     {
         mouseOp->configure(this,setting);
@@ -187,7 +187,7 @@ Operation *PickHandler::changeOperation(MOUSE_BUTTON button, const std::string &
         delete operations[button];
         operations[button] = nullptr;
     }
-    Operation *mouseOp=OperationFactory::Instanciate(op);
+    Operation *mouseOp=OperationFactory::Instantiate(op);
     mouseOp->configure(this,button);
     operations[button]=mouseOp;
     return mouseOp;

--- a/Sofa/GUI/Common/src/sofa/gui/common/config.h.in
+++ b/Sofa/GUI/Common/src/sofa/gui/common/config.h.in
@@ -33,3 +33,10 @@
 #else
 #  define SOFA_GUI_COMMON_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
+
+#ifdef SOFA_BUILD_SOFA_CORE
+#define SOFA_ATTRIBUTE_DEPRECATED__TYPO()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__TYPO() \
+    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v25.12", "Use function Instantiate instead.")
+#endif


### PR DESCRIPTION
2 important fixes:
1) Variables were not initialized
2) `getTopologicalOperation` returned the wrong variable

Typo: from `Instanciate` to `Instantiate`

The rest is cleaning.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
