### PR TITLE
[GUI.Common] Change inheritance of ConstraintAttachOperation

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h
@@ -119,7 +119,7 @@ protected:
 };
 
 
-class SOFA_GUI_COMMON_API ConstraintAttachOperation : public sofa::gui::common::AttachOperation
+class SOFA_GUI_COMMON_API ConstraintAttachOperation : public Operation
 {
 public:
     static std::string getDescription() { return "Attach an object to the mouse using a bilateral interaction constraint"; }


### PR DESCRIPTION
I don't believe `ConstraintAttachOperation` should inherit from `AttachOperation`. It implies that:
- bilateral constraints can have a stiffness, and be represented by an arrow.
- `ConstraintAttachOperation` is related to `AttachBodyButtonSetting` (it's a class data member). But there is no direct inheritance relationship between `AttachBodyButtonSetting` and `ConstraintAttachButtonSetting`. This is source of a crash because of [this down cast](https://github.com/sofa-framework/sofa/blob/a7c6694212bd10fa6a37da101f57981a07293906/Sofa/GUI/Common/src/sofa/gui/common/MouseOperations.h#L114)






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
