### PR TITLE
[Type] Add tests on Vec default constructor

### DIFF
--- a/Sofa/framework/Type/test/VecTypes_test.cpp
+++ b/Sofa/framework/Type/test/VecTypes_test.cpp
@@ -23,6 +23,40 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <gtest/gtest.h>
 
+template < sofa::Size N, typename ValueType>
+void defaultConstructor()
+{
+    const sofa::type::Vec<N, ValueType> vec;
+    for (const auto& value : vec)
+    {
+        EXPECT_EQ(value, ValueType());
+    }
+}
+
+
+TEST(VecTest, DefaultConstructor)
+{
+    defaultConstructor<1, unsigned int>();
+    defaultConstructor<2, unsigned int>();
+    defaultConstructor<3, unsigned int>();
+    defaultConstructor<6, unsigned int>();
+
+    defaultConstructor<1, int>();
+    defaultConstructor<2, int>();
+    defaultConstructor<3, int>();
+    defaultConstructor<6, int>();
+
+    defaultConstructor<1, float>();
+    defaultConstructor<2, float>();
+    defaultConstructor<3, float>();
+    defaultConstructor<6, float>();
+
+    defaultConstructor<1, double>();
+    defaultConstructor<2, double>();
+    defaultConstructor<3, double>();
+    defaultConstructor<6, double>();
+}
+
 TEST(VecTest, StructuredBindings)
 {
     constexpr sofa::type::Vec3 vec { 1.0, 2.0, 3.0 };


### PR DESCRIPTION
To make sure all values are initialized to zero
See https://godbolt.org/z/f3YjK3ohE when a `std::array` is not initialized.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
