### PR TITLE
[tests] Prevent test leaks when loading plugins

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
@@ -76,8 +76,12 @@ public:
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Collision);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Collision.Detection.Algorithm,
+            Sofa.Component.Collision.Detection.Intersection,
+            Sofa.Component.Collision.Response.Contact
+        });
     }
 
     void doTearDown() override

--- a/Sofa/Component/Collision/Detection/Intersection/tests/LocalMinDistance_test.cpp
+++ b/Sofa/Component/Collision/Detection/Intersection/tests/LocalMinDistance_test.cpp
@@ -56,11 +56,7 @@ namespace
 struct TestLocalMinDistance : public BaseSimulationTest {
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Collision.Detection.Intersection);
-    }
-    void doTearDown() override
-    {
+        loadPlugins({Sofa.Component.StateContainer, Sofa.Component.Collision.Detection.Intersection});
     }
 
     void checkAttributes();

--- a/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
+++ b/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
@@ -72,15 +72,11 @@ struct TestSphere : public BaseSimulationTest
 {
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Collision.Geometry);
+        loadPlugins({Sofa.Component.StateContainer, Sofa.Component.Collision.Geometry});
 
         m_proxIntersection = sofa::core::objectmodel::New<MinProximityIntersection>();
         m_proxIntersection->setAlarmDistance(1.0);
         m_proxIntersection->setContactDistance(1.0);
-    }
-    void doTearDown() override
-    {
     }
 
     bool rigidRigid1();

--- a/Sofa/Component/Engine/Select/tests/MeshROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/MeshROI_test.cpp
@@ -63,9 +63,11 @@ struct MeshROI_test : public BaseSimulationTest,
 
     void doSetUp() override
     {
-        simpleapi::importPlugin(Sofa.Component.Engine.Select);
-        simpleapi::importPlugin(Sofa.Component.Topology.Container.Constant);
-        simpleapi::importPlugin(Sofa.Component.IO.Mesh);
+        loadPlugins({
+            Sofa.Component.Engine.Select,
+            Sofa.Component.Topology.Container.Constant,
+            Sofa.Component.IO.Mesh
+        });
 
         // SetUp3
         const string scene2 =

--- a/Sofa/Component/Engine/Select/tests/MeshSubsetEngine_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/MeshSubsetEngine_test.cpp
@@ -33,7 +33,7 @@ struct MeshSubsetEngine_test : public testing::BaseSimulationTest
 
     void doSetUp() override
     {
-        simpleapi::importPlugin(Sofa.Component.Engine.Select);
+        loadPlugins({Sofa.Component.Engine.Select});
 
         m_root = simulation::getSimulation()->createNewNode("root");
         ASSERT_NE(nullptr, m_root);

--- a/Sofa/Component/Engine/Select/tests/PlaneROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/PlaneROI_test.cpp
@@ -71,6 +71,8 @@ struct PlaneROI_test : public BaseSimulationTest,
         m_node1 = m_simu->createNewGraph("root");
         m_node1->addObject(m_thisObject);
 
+        this->loadPlugins({Sofa.Component.Engine.Select});
+
 
         // SetUp2
         const string scene1 =

--- a/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
@@ -79,8 +79,10 @@ public:
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Grid);
+        loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Grid
+        });
     }
 
     void doTearDown() override

--- a/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
@@ -67,9 +67,11 @@ public:
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Visual);
-        sofa::simpleapi::importPlugin(Sofa.Component.IO.Mesh);
+        loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Visual,
+            Sofa.Component.IO.Mesh
+        });
     }
 
     void doTearDown() override

--- a/Sofa/Component/LinearSystem/tests/MappingGraph_test.cpp
+++ b/Sofa/Component/LinearSystem/tests/MappingGraph_test.cpp
@@ -176,7 +176,7 @@ TEST(MappingGraph, diamondMapping)
     sofa::simulation::Node::SPtr root = simulation->createNewGraph("root");
     EXPECT_EQ(root->getName(), "root");
 
-    sofa::simpleapi::importPlugin(Sofa.Component.Mapping.Linear);
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.Mapping.Linear});
 
     const auto top = sofa::core::objectmodel::New<sofa::component::statecontainer::MechanicalObject<sofa::defaulttype::Vec3Types> >();
     root->addObject(top);

--- a/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
+++ b/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
@@ -98,10 +98,12 @@ public:
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Grid);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
+        this->loadPlugins({
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.Topology.Container.Grid,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass
+        });
 
         simulation = simulation::getSimulation();
         root = simulation::getSimulation()->createNewGraph("root");

--- a/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
+++ b/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
@@ -101,10 +101,12 @@ public:
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Grid);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
+        this->loadPlugins({
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.Topology.Container.Grid,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass
+        });
 
         simulation = simulation::getSimulation();
         root = simulation::getSimulation()->createNewGraph("root");

--- a/Sofa/Component/Mass/tests/UniformMass_test.cpp
+++ b/Sofa/Component/Mass/tests/UniformMass_test.cpp
@@ -79,8 +79,10 @@ struct UniformMassTest :  public BaseTest
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass
+        });
 
         todo = true ;
         m_simu = sofa::simulation::getSimulation();

--- a/Sofa/Component/MechanicalLoad/tests/ConstantForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/ConstantForceField_test.cpp
@@ -74,11 +74,13 @@ struct ConstantForceField_test : public BaseSimulationTest, NumericTest<typename
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.MechanicalLoad);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
+        this->loadPlugins({
+            Sofa.Component.ODESolver,
+            Sofa.Component.StateContainer,
+            Sofa.Component.MechanicalLoad,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.Mass,
+        });
     }
 
     void doTearDown() override {}

--- a/Sofa/Component/MechanicalLoad/tests/PlaneForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/PlaneForceField_test.cpp
@@ -118,8 +118,10 @@ struct PlaneForceField_test : public BaseSimulationTest
     */
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.MechanicalLoad);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.MechanicalLoad
+        });
     }
 
     void doTearDown() override {}

--- a/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
@@ -103,7 +103,7 @@ struct EulerImplicit_test_2_particles_to_equilibrium : public BaseSimulationTest
         const simulation::Node::SPtr root = simpleapi::createRootNode(simu, "root");
         //*******
         // begin create scene under the root node
-        makeScopedPlugin({
+        this->loadPlugins({
             Sofa.Component.ODESolver.Backward,
             Sofa.Component.LinearSolver.Iterative,
             Sofa.Component.StateContainer,
@@ -203,7 +203,7 @@ struct EulerImplicit_test_2_particles_in_different_nodes_to_equilibrium  : publi
         // create scene
         root->setGravity(Vec3(0,0,0));
 
-        makeScopedPlugin({
+        loadPlugins({
             Sofa.Component.ODESolver.Backward,
             Sofa.Component.LinearSolver.Iterative,
             Sofa.Component.StateContainer,

--- a/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
@@ -103,12 +103,14 @@ struct EulerImplicit_test_2_particles_to_equilibrium : public BaseSimulationTest
         const simulation::Node::SPtr root = simpleapi::createRootNode(simu, "root");
         //*******
         // begin create scene under the root node
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Projective);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.Spring);
+        makeScopedPlugin({
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass,
+            Sofa.Component.Constraint.Projective,
+            Sofa.Component.SolidMechanics.Spring
+        });
 
         // remove warnings
         simpleapi::createObject(root, "DefaultAnimationLoop", {});
@@ -201,12 +203,15 @@ struct EulerImplicit_test_2_particles_in_different_nodes_to_equilibrium  : publi
         // create scene
         root->setGravity(Vec3(0,0,0));
 
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Projective);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.Spring);
+        makeScopedPlugin({
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass,
+            Sofa.Component.Constraint.Projective,
+            Sofa.Component.SolidMechanics.Spring
+        });
+
         // remove warnings
         simpleapi::createObject(root, "DefaultAnimationLoop", {});
         simpleapi::createObject(root, "DefaultVisualManagerLoop", {});

--- a/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
@@ -57,11 +57,13 @@ struct EulerImplicit_with_damping_forcefield : public BaseSimulationTest, Numeri
 
         //*******
         // load appropriate modules
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver.Backward);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
-        sofa::simpleapi::importPlugin(Sofa.Component.MechanicalLoad);
+        makeScopedPlugin({
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass,
+            Sofa.Component.MechanicalLoad
+        });
 
         // avoid warnings
         simpleapi::createObject(root, "DefaultAnimationLoop", {});

--- a/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/EulerImplicitSolver_withDamping_test.cpp
@@ -57,7 +57,7 @@ struct EulerImplicit_with_damping_forcefield : public BaseSimulationTest, Numeri
 
         //*******
         // load appropriate modules
-        makeScopedPlugin({
+        loadPlugins({
             Sofa.Component.ODESolver.Backward,
             Sofa.Component.LinearSolver.Iterative,
             Sofa.Component.StateContainer,

--- a/Sofa/Component/ODESolver/Backward/tests/StaticSolver_test.cpp
+++ b/Sofa/Component/ODESolver/Backward/tests/StaticSolver_test.cpp
@@ -55,7 +55,19 @@ public:
 
         root = getSimulation()->createNewNode("root");
 
-        createObject(root, "RequiredPlugin", {{"pluginName", Sofa.Component}});
+        this->loadPlugins({
+            Sofa.Component.Topology.Container.Grid,
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Direct,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.Topology.Mapping,
+            Sofa.Component.SolidMechanics.FEM.HyperElastic,
+            Sofa.Component.Engine.Select,
+            Sofa.Component.Constraint.Projective,
+            Sofa.Component.MechanicalLoad
+        });
+
         createObject(root, "DefaultAnimationLoop");
         createObject(root, "RegularGridTopology", {{"name", "grid"}, {"min", "-7.5 -7.5 0"}, {"max", "7.5 7.5 80"}, {"n", "3 3 9"}});
         const auto s = createObject(root, "StaticSolver", {{"newton_iterations", "10"}});

--- a/Sofa/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/ODESolverSpringTest.h
+++ b/Sofa/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/ODESolverSpringTest.h
@@ -39,17 +39,22 @@ struct ODESolverSpringTest : public BaseSimulationTest
 {
     SceneInstance m_si{};
 
+    void doSetUp() override
+    {
+        this->loadPlugins({
+            Sofa.Component.ODESolver,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass,
+            Sofa.Component.Constraint.Projective,
+            Sofa.Component.SolidMechanics.Spring
+        });
+    }
+
     inline void prepareScene(double K, double m, double l0)
     {
         // Create the scene
         m_si.root->setGravity({ 0, -10, 0 });
-
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Projective);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.Spring);
 
         // remove warnings
         simpleapi::createObject(m_si.root, "DefaultAnimationLoop", {});

--- a/Sofa/Component/SceneUtility/tests/AddResourceRepository_test.cpp
+++ b/Sofa/Component/SceneUtility/tests/AddResourceRepository_test.cpp
@@ -46,7 +46,7 @@ struct AddResourceRepository_test : public BaseSimulationTest
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.SceneUtility);
+        this->loadPlugins({Sofa.Component.SceneUtility});
 
         m_testRepoDir = std::string(SOFA_COMPONENT_SCENEUTILITY_TEST_RESOURCES_DIR) + std::string("/repo");
     }

--- a/Sofa/Component/SceneUtility/tests/MessageHandlerComponent_test.cpp
+++ b/Sofa/Component/SceneUtility/tests/MessageHandlerComponent_test.cpp
@@ -45,8 +45,6 @@ using sofa::helper::logging::MessageDispatcher ;
 
 bool perTestInit()
 {
-    sofa::simpleapi::importPlugin(Sofa.Component.SceneUtility);
-
     /// THE TESTS HERE ARE NOT INHERITING FROM SOFA TEST SO WE NEED TO MANUALLY INSTALL THE HANDLER
     /// DO NO REMOVE
     MessageDispatcher::addHandler( sofa::testing::MainGtestMessageHandler::getInstance() );
@@ -58,6 +56,7 @@ bool inited = perTestInit() ;
 
 TEST(MessageHandlerComponent, simpleInit)
 {
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.SceneUtility});
     const string scene =
         "<?xml version='1.0'?>                                               "
         "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >         "
@@ -78,6 +77,7 @@ TEST(MessageHandlerComponent, simpleInit)
 
 TEST(MessageHandlerComponent, missingHandler)
 {
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.SceneUtility});
     const string scene =
         "<?xml version='1.0'?>                                               "
         "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >         "
@@ -94,6 +94,7 @@ TEST(MessageHandlerComponent, missingHandler)
 
 TEST(MessageHandlerComponent, invalidHandler)
 {
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.SceneUtility});
     const string scene =
         "<?xml version='1.0'?>                                               "
         "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >         "
@@ -110,6 +111,7 @@ TEST(MessageHandlerComponent, invalidHandler)
 
 TEST(MessageHandlerComponent, clangHandler)
 {
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.SceneUtility});
     const string scene =
         "<?xml version='1.0'?>                                               "
         "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >         "

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BaseTetrahedronFEMForceField_test.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BaseTetrahedronFEMForceField_test.h
@@ -93,10 +93,12 @@ public:
         simpleapi::createObject(m_root, "DefaultAnimationLoop");
         simpleapi::createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic,
+            Sofa.Component.Mass
+        });
 
         simpleapi::createObject(m_root, "MechanicalObject", { {"template", dataTypeName}, {"position", "0 0 0  1 0 0  0 1 0  0 0 1"} });
         simpleapi::createObject(m_root, "TetrahedronSetTopologyContainer", { {"tetrahedra","2 3 1 0"} });
@@ -121,17 +123,18 @@ public:
         simpleapi::createObject(m_root, "DefaultAnimationLoop");
         simpleapi::createObject(m_root, "DefaultVisualManagerLoop");
 
-
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Direct);
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver.Backward);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Lagrangian);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Mapping);
-        sofa::simpleapi::importPlugin(Sofa.Component.Engine.Select);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Projective);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic,
+            Sofa.Component.Mass,
+            Sofa.Component.LinearSolver.Direct,
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.Constraint.Lagrangian,
+            Sofa.Component.Topology.Mapping,
+            Sofa.Component.Engine.Select,
+            Sofa.Component.Constraint.Projective
+        });
 
         simpleapi::createObject(m_root, "GenericConstraintSolver", { {"tolerance", "1e-3"}, {"maxIt", "1000"} });
 
@@ -195,7 +198,7 @@ public:
         simpleapi::createObject(m_root, "DefaultAnimationLoop");
         simpleapi::createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
+        this->loadPlugins({Sofa.Component.StateContainer});
 
         simpleapi::createObject(m_root, "MechanicalObject", { {"template","Vec3"}, {"position", "0 0 0  1 0 0  0 1 0  0 0 1"} });
         addTetraFEMForceField(m_root, 100, 0.3, "large");
@@ -214,8 +217,10 @@ public:
         simpleapi::createObject(m_root, "DefaultAnimationLoop");
         simpleapi::createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic
+        });
 
         simpleapi::createObject(m_root, "MechanicalObject", { {"template","Vec3"} });
         simpleapi::createObject(m_root, "TetrahedronSetTopologyContainer");
@@ -234,9 +239,11 @@ public:
         simpleapi::createObject(m_root, "DefaultAnimationLoop");
         simpleapi::createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic
+        });
 
         simpleapi::createObject(m_root, "MechanicalObject", { {"template", dataTypeName}, {"position", "0 0 0  1 0 0  0 1 0  0 0 1"} });
         simpleapi::createObject(m_root, "TetrahedronSetTopologyContainer", { {"tetrahedra","2 3 1 0"} });

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BaseTetrahedronFEMForceField_test.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BaseTetrahedronFEMForceField_test.h
@@ -126,9 +126,10 @@ public:
         this->loadPlugins({
             Sofa.Component.StateContainer,
             Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.Topology.Container.Grid,
             Sofa.Component.SolidMechanics.FEM.Elastic,
             Sofa.Component.Mass,
-            Sofa.Component.LinearSolver.Direct,
+            Sofa.Component.LinearSolver.Iterative,
             Sofa.Component.ODESolver.Backward,
             Sofa.Component.Constraint.Lagrangian,
             Sofa.Component.Topology.Mapping,
@@ -222,7 +223,8 @@ public:
 
         this->loadPlugins({
             Sofa.Component.StateContainer,
-            Sofa.Component.Topology.Container.Dynamic
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic
         });
 
         simpleapi::createObject(m_root, "MechanicalObject", { {"template","Vec3"} });

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BaseTetrahedronFEMForceField_test.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BaseTetrahedronFEMForceField_test.h
@@ -198,7 +198,10 @@ public:
         simpleapi::createObject(m_root, "DefaultAnimationLoop");
         simpleapi::createObject(m_root, "DefaultVisualManagerLoop");
 
-        this->loadPlugins({Sofa.Component.StateContainer});
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.SolidMechanics.FEM.Elastic
+        });
 
         simpleapi::createObject(m_root, "MechanicalObject", { {"template","Vec3"}, {"position", "0 0 0  1 0 0  0 1 0  0 0 1"} });
         addTetraFEMForceField(m_root, 100, 0.3, "large");

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
@@ -68,7 +68,6 @@ public:
 
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component);
         m_simulation = sofa::simulation::getSimulation();
     }
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
@@ -86,6 +86,16 @@ public:
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");
 
+        this->loadPlugins({
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic,
+            Sofa.Component.Mass,
+            Sofa.Component.Constraint.Projective
+        });
+
         createObject(m_root, "EulerImplicitSolver");
         createObject(m_root, "CGLinearSolver", { { "iterations", "20" }, { "threshold", "1e-8" }, {"tolerance", "1e-5"} });
         createObject(m_root, "MechanicalObject", {{"template", rigidTypeName}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
@@ -131,15 +141,22 @@ public:
 
     void checkNoTopology()
     {
-        EXPECT_MSG_EMIT(Error);
-
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        this->loadPlugins({
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.StateContainer,
+            Sofa.Component.SolidMechanics.FEM.Elastic
+        });
+
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "EulerImplicitSolver");
         createObject(m_root, "CGLinearSolver", { { "iterations", "20" }, { "threshold", "1e-8" }, {"tolerance", "1e-5"} });
         createObject(m_root, "MechanicalObject", { {"template", rigidTypeName}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
         createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", rigidTypeName} });
 
+        EXPECT_MSG_EMIT(Error);
         sofa::simulation::node::initRoot(m_root.get());
 
         sofa::simulation::node::animate(m_root.get(), 0.01_sreal);
@@ -149,6 +166,13 @@ public:
     void checkEmptyTopology()
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic
+        });
+
         createObject(m_root, "MechanicalObject", { {"template",rigidTypeName}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
         createObject(m_root, "EdgeSetTopologyContainer");
         createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", rigidTypeName} });
@@ -163,6 +187,12 @@ public:
     void checkDefaultAttributes()
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic
+        });
 
         createObject(m_root, "MechanicalObject", { {"template",rigidTypeName}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
         createObject(m_root, "EdgeSetTopologyContainer", { {"edges","0 1  1 2  2 3"} });

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TriangleFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TriangleFEMForceField_test.cpp
@@ -97,10 +97,12 @@ public:
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic,
+            Sofa.Component.Mass
+        });
 
         createObject(m_root, "MechanicalObject", {{"template",dataTypeName}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
         createObject(m_root, "TriangleSetTopologyContainer", { {"triangles","0 1 2  1 3 2"} });
@@ -138,7 +140,7 @@ public:
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Grid);
+        loadPlugins({Sofa.Component.Topology.Container.Grid});
 
         createObject(m_root, "RegularGridTopology", { {"name", "grid"}, 
             {"n", str(type::Vec3(nbrGrid, nbrGrid, 1))}, {"min", "0 0 0"}, {"max", "10 10 0"} });
@@ -175,12 +177,14 @@ public:
     {
         const Node::SPtr FEMNode = sofa::simpleapi::createChild(m_root, nodeName);
 
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver.Backward);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Projective);
+        this->loadPlugins({
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.Mass,
+            Sofa.Component.Constraint.Projective
+        });
 
         createObject(FEMNode, "EulerImplicitSolver");
         createObject(FEMNode, "CGLinearSolver", {{ "iterations", "20" }, { "tolerance", "1e-5" }, {"threshold", "1e-6"}});
@@ -259,8 +263,7 @@ public:
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
+        this->loadPlugins({Sofa.Component.StateContainer, Sofa.Component.SolidMechanics.FEM.Elastic});
 
         createObject(m_root, "MechanicalObject", { {"template",dataTypeName}, {"position", "0 0 0  1 0 0  0 1 0"} });
         if (FEMType == 0) // TriangleModel
@@ -291,9 +294,11 @@ public:
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic
+        });
 
         createObject(m_root, "MechanicalObject", { {"template",dataTypeName} });
         createObject(m_root, "TriangleSetTopologyContainer");
@@ -326,9 +331,11 @@ public:
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");
 
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.FEM.Elastic
+        });
 
         createObject(m_root, "MechanicalObject", { {"template",dataTypeName}, {"position", "0 0 0  1 0 0  0 1 0"} });
         createObject(m_root, "TriangleSetTopologyContainer", { {"triangles","0 1 2"} });

--- a/Sofa/Component/SolidMechanics/Spring/tests/PolynomialRestShapeSpringsForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/PolynomialRestShapeSpringsForceField_test.cpp
@@ -42,9 +42,11 @@ public:
         root->setGravity(Vec3(0.0,0.0,0.0));
         root->setDt(dt);
 
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver.Forward);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.Spring);
+        this->loadPlugins({
+            Sofa.Component.ODESolver.Forward,
+            Sofa.Component.StateContainer,
+            Sofa.Component.SolidMechanics.Spring
+        });
 
         const Node::SPtr childNode = sofa::simpleapi::createChild(root, "Particle");
         sofa::simpleapi::createObject(childNode, "EulerExplicitSolver");

--- a/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
@@ -58,10 +58,13 @@ sofa::simulation::Node::SPtr RestSpringsForceField_test::createScene(const std::
 {
     const auto theSimulation = createSimulation();
     auto theRoot = createRootNode(theSimulation, "root");
-    sofa::simpleapi::importPlugin(Sofa.Component.ODESolver.Backward);
-    sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-    sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-    sofa::simpleapi::importPlugin(Sofa.Component.Mass);
+
+    this->loadPlugins({
+        Sofa.Component.ODESolver.Backward,
+        Sofa.Component.LinearSolver.Iterative,
+        Sofa.Component.StateContainer,
+        Sofa.Component.Mass
+    });
     
     createObject(theRoot, "DefaultAnimationLoop");
     createObject(theRoot, "EulerImplicitSolver");

--- a/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/RestShapeSpringsForceField_test.cpp
@@ -63,7 +63,8 @@ sofa::simulation::Node::SPtr RestSpringsForceField_test::createScene(const std::
         Sofa.Component.ODESolver.Backward,
         Sofa.Component.LinearSolver.Iterative,
         Sofa.Component.StateContainer,
-        Sofa.Component.Mass
+        Sofa.Component.Mass,
+        Sofa.Component.SolidMechanics.Spring
     });
     
     createObject(theRoot, "DefaultAnimationLoop");

--- a/Sofa/Component/SolidMechanics/Spring/tests/TriangularBendingSprings_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/TriangularBendingSprings_test.cpp
@@ -70,8 +70,10 @@ public:
     void doSetUp() override
     {
         m_simulation = sofa::simulation::getSimulation();
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Grid);
+        this->loadPlugins({
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.Topology.Container.Grid
+        });
     }
 
     void doTearDown() override

--- a/Sofa/Component/SolidMechanics/Spring/tests/TriangularBendingSprings_test.cpp
+++ b/Sofa/Component/SolidMechanics/Spring/tests/TriangularBendingSprings_test.cpp
@@ -86,6 +86,12 @@ public:
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
 
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.Spring
+        });
+
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");        
         createObject(m_root, "MechanicalObject", {{"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
@@ -105,6 +111,15 @@ public:
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
         m_root->setGravity(type::Vec3(0.0, -1.0, 0.0));
         m_root->setDt(0.01);
+
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Grid,
+            Sofa.Component.SolidMechanics.Spring,
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.Mass
+        });
 
         createObject(m_root, "DefaultAnimationLoop");
         createObject(m_root, "DefaultVisualManagerLoop");
@@ -151,6 +166,12 @@ public:
     void checkNoTopology()
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.SolidMechanics.Spring
+        });
+
         createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
         createObject(m_root, "TriangularBendingSprings");
 
@@ -164,6 +185,13 @@ public:
     void checkEmptyTopology()
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.Spring
+        });
+
         createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
         createObject(m_root, "TriangleSetTopologyContainer");
         createObject(m_root, "TriangularBendingSprings");
@@ -178,6 +206,12 @@ public:
     void checkDefaultAttributes()
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.SolidMechanics.Spring
+        });
 
         createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
         createObject(m_root, "TriangleSetTopologyContainer", { {"triangles","0 1 2  1 3 2"} });

--- a/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
+++ b/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
@@ -55,7 +55,9 @@ class OglLabelTest : public BaseTest
 public:
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.GL.Component.Rendering2D);
+        this->loadPlugins({
+            Sofa.GL.Component.Rendering2D
+        });
     }
 
     void checkExcludingAttributes()

--- a/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
+++ b/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
@@ -62,8 +62,10 @@ class TestClipPlane : public BaseTest {
 public:
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.GL.Component.Rendering3D);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
+        this->loadPlugins({
+            Sofa.GL.Component.Rendering3D,
+            Sofa.Component.StateContainer
+        });
     }
 
     void checkClipPlaneValidAttributes();

--- a/Sofa/GL/Component/Rendering3D/tests/OglModel_test.cpp
+++ b/Sofa/GL/Component/Rendering3D/tests/OglModel_test.cpp
@@ -19,11 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/gl/component/rendering3d/OglModel.h>
 #include <gtest/gtest.h>
+#include <sofa/Modules.h>
+#include <sofa/gl/component/rendering3d/OglModel.h>
+#include <sofa/simpleapi/SimpleApi.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/graph/DAGSimulation.h>
-#include <sofa/simpleapi/SimpleApi.h>
+#include <sofa/testing/ScopedPlugin.h>
 #include <sofa/testing/TestMessageHandler.h>
 
 namespace sofa
@@ -43,6 +45,8 @@ TEST(OglModel, templateName)
 
     simulation::Simulation* simulation = sofa::simulation::getSimulation();
     const simulation::Node::SPtr root = simulation->createNewGraph("root");
+
+    const auto plugins = testing::makeScopedPlugin({Sofa.GL.Component.Rendering3D});
 
     {
         EXPECT_MSG_NOEMIT(Error);

--- a/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
@@ -55,8 +55,10 @@ struct TestLightManager : public BaseTest
 {
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.GL.Component.Shader);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
+        this->loadPlugins({
+            Sofa.GL.Component.Shader,
+            Sofa.Component.StateContainer
+        });
     }
 };
 
@@ -94,7 +96,9 @@ void checkAttributes()
 
 TEST_F(TestLightManager, checkAttributes)
 {
-    sofa::simpleapi::importPlugin(Sofa.GL.Component.Shader);
+    this->loadPlugins({
+        Sofa.GL.Component.Shader
+    });
     checkAttributes();
 }
 

--- a/Sofa/GL/Component/Shader/tests/Light_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/Light_test.cpp
@@ -49,9 +49,11 @@ class TestLight : public BaseTest {
 public:
 
     void doSetUp() override
- {
-         sofa::simpleapi::importPlugin(Sofa.GL.Component.Shader);
-         sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
+    {
+        this->loadPlugins({
+            Sofa.GL.Component.Shader,
+            Sofa.Component.StateContainer
+        });
     }
 
     void checkSpotLightValidAttributes();

--- a/Sofa/framework/Simulation/Core/simutest/NodeContext_test.cpp
+++ b/Sofa/framework/Simulation/Core/simutest/NodeContext_test.cpp
@@ -39,10 +39,12 @@ class NodeContext_test: public BaseSimulationTest
 public:
 
 
-    NodeContext_test()
+    void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.SceneUtility);
+        this->loadPlugins({
+            Sofa.Component.StateContainer,
+            Sofa.Component.SceneUtility
+        });
     }
 
     void testGetNodeObjects()

--- a/Sofa/framework/Simulation/simutest/parallel_scenes_test.cpp
+++ b/Sofa/framework/Simulation/simutest/parallel_scenes_test.cpp
@@ -47,28 +47,30 @@ public:
     void doSetUp() override
     {
         EXPECT_MSG_NOEMIT(Error, Warning);
-        
-        sofa::simpleapi::importPlugin(Sofa.Component.AnimationLoop);
-        sofa::simpleapi::importPlugin(Sofa.Component.Collision.Detection.Algorithm);
-        sofa::simpleapi::importPlugin(Sofa.Component.Collision.Detection.Intersection);
-        sofa::simpleapi::importPlugin(Sofa.Component.Collision.Geometry);
-        sofa::simpleapi::importPlugin(Sofa.Component.Collision.Response.Contact);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Lagrangian.Correction);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Lagrangian.Solver);
-        sofa::simpleapi::importPlugin(Sofa.Component.Constraint.Projective);
-        sofa::simpleapi::importPlugin(Sofa.Component.IO.Mesh);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mapping.Linear);
-        sofa::simpleapi::importPlugin(Sofa.Component.Mass);
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver.Backward);
-        sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
-        sofa::simpleapi::importPlugin(Sofa.Component.StateContainer);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Constant);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Dynamic);
-        sofa::simpleapi::importPlugin(Sofa.Component.Topology.Container.Grid);
-        sofa::simpleapi::importPlugin(Sofa.Component.Visual);
-        sofa::simpleapi::importPlugin(Sofa.GL.Component.Rendering3D);
-        sofa::simpleapi::importPlugin(Sofa.Component.LinearSystem);
+
+        this->loadPlugins({
+            Sofa.Component.AnimationLoop,
+            Sofa.Component.Collision.Detection.Algorithm,
+            Sofa.Component.Collision.Detection.Intersection,
+            Sofa.Component.Collision.Geometry,
+            Sofa.Component.Collision.Response.Contact,
+            Sofa.Component.Constraint.Lagrangian.Correction,
+            Sofa.Component.Constraint.Lagrangian.Solver,
+            Sofa.Component.Constraint.Projective,
+            Sofa.Component.IO.Mesh,
+            Sofa.Component.LinearSolver.Iterative,
+            Sofa.Component.Mapping.Linear,
+            Sofa.Component.Mass,
+            Sofa.Component.ODESolver.Backward,
+            Sofa.Component.SolidMechanics.FEM.Elastic,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Topology.Container.Constant,
+            Sofa.Component.Topology.Container.Dynamic,
+            Sofa.Component.Topology.Container.Grid,
+            Sofa.Component.Visual,
+            Sofa.GL.Component.Rendering3D,
+            Sofa.Component.LinearSystem
+        });
     }
     
     void executeInParallel(const char* sceneStr, const std::size_t nbScenes, const std::size_t nbSteps)

--- a/Sofa/framework/Testing/src/sofa/testing/BaseSimulationTest.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/BaseSimulationTest.cpp
@@ -42,7 +42,8 @@ namespace sofa::testing
 
 bool BaseSimulationTest::importPlugin(const std::string& name)
 {
-    return sofa::simpleapi::importPlugin(name);
+    this->loadPlugins({name});
+    return true;
 }
 
 BaseSimulationTest::SceneInstance::SceneInstance(const std::string& type, const std::string& desc)

--- a/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
+++ b/applications/plugins/MultiThreading/test/ParallelImplementationsRegistry_test.cpp
@@ -19,13 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <gtest/gtest.h>
-#include <MultiThreading/initMultiThreading.h>
 #include <MultiThreading/ParallelImplementationsRegistry.h>
-#include <sofa/core/ObjectFactory.h>
+#include <MultiThreading/initMultiThreading.h>
+#include <gtest/gtest.h>
 #include <sofa/Modules.h>
-
+#include <sofa/core/ObjectFactory.h>
 #include <sofa/simpleapi/SimpleApi.h>
+#include <sofa/testing/ScopedPlugin.h>
 
 namespace multithreading
 {
@@ -33,11 +33,13 @@ namespace multithreading
 TEST(ParallelImplementationsRegistry, existInObjectFactory)
 {
     // sequential versions will be added to the ObjectFactory
-    sofa::simpleapi::importPlugin(Sofa.Component.LinearSolver.Iterative);
-    sofa::simpleapi::importPlugin(Sofa.Component.Collision.Detection.Algorithm);
-    sofa::simpleapi::importPlugin(Sofa.Component.SolidMechanics.FEM.Elastic);
-    sofa::simpleapi::importPlugin(Sofa.Component.Mapping.Linear);
-    sofa::simpleapi::importPlugin("MultiThreading");
+    const auto plugins = sofa::testing::makeScopedPlugin({
+        Sofa.Component.LinearSolver.Iterative,
+        Sofa.Component.Collision.Detection.Algorithm,
+        Sofa.Component.SolidMechanics.FEM.Elastic,
+        Sofa.Component.Mapping.Linear,
+        "MultiThreading"
+    });
 
     const auto implementations = ParallelImplementationsRegistry::getImplementations();
 

--- a/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
+++ b/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
@@ -60,8 +60,18 @@ class SceneCreator_test : public BaseSimulationTest
 public:
     void doSetUp() override
     {
-        sofa::simpleapi::importPlugin(Sofa.Component);
-        sofa::simpleapi::importPlugin(Sofa.GL.Component.Rendering3D);
+        this->loadPlugins({
+            Sofa.Component.Collision.Detection.Algorithm,
+            Sofa.Component.Collision.Detection.Intersection,
+            Sofa.Component.Collision.Response.Contact,
+            Sofa.Component.StateContainer,
+            Sofa.Component.Mass,
+            Sofa.Component.SolidMechanics.FEM.Elastic,
+            Sofa.Component.Topology.Container,
+            Sofa.Component.Collision.Geometry,
+            Sofa.Component.Mapping.Linear,
+            Sofa.GL.Component.Rendering3D
+        });
     }
 
     bool createCubeFailed();

--- a/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
+++ b/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
@@ -76,14 +76,9 @@ int ComponentDeprecatedClassId = sofa::core::RegisterObject("")
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 struct SceneChecker_test : public BaseSimulationTest
 {
-    void doSetUp() override
-    {
-    }
-
     void checkRequiredPlugin(bool missing)
     {
-        sofa::simpleapi::importPlugin(Sofa.Component.ODESolver.Forward);
-
+        this->loadPlugins({Sofa.Component.ODESolver.Forward});
         const std::string missStr = missing ? "" : "<RequiredPlugin name='Sofa.Component.ODESolver.Forward'/> \n";
         std::stringstream scene;
         scene << "<?xml version='1.0'?>                                             \n"
@@ -173,8 +168,8 @@ struct SceneChecker_test : public BaseSimulationTest
         EXPECT_MSG_NOEMIT(Warning);
 
         const std::string lvl = (shouldWarn)?"17.06":"17.12";
-        
-        sofa::simpleapi::importPlugin("Sofa.Component.SceneUtility");
+
+        this->loadPlugins({Sofa.Component.SceneUtility});
         
         std::stringstream scene;
         scene << "<?xml version='1.0'?>                                           \n"


### PR DESCRIPTION
Make sure the plugins loaded by the tests are unloaded when the test finishes.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
