### PR TITLE
[LinearSystem] Fix mass access on macos

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.cpp
@@ -23,12 +23,8 @@
 
 #include <sofa/core/ObjectFactory.h>
 
-#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
-#include <sofa/linearalgebra/SparseMatrix.h>
-#include <sofa/linearalgebra/DiagonalMatrix.h>
-#include <sofa/linearalgebra/RotationMatrix.h>
-#include <sofa/linearalgebra/FullMatrix.h>
-#include <sofa/linearalgebra/BlockDiagonalMatrix.h>
+
+#define SOFA_COMPONENT_LINEARSYSTEM_MATRIXLINEARSYSTEM_CPP
 
 namespace sofa::component::linearsystem
 {

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
@@ -354,17 +354,17 @@ using sofa::linearalgebra::RotationMatrix;
 using sofa::linearalgebra::FullMatrix;
 using sofa::linearalgebra::FullVector;
 
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< FullMatrix<SReal>, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< SparseMatrix<SReal>, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<SReal>, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,SReal> >, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,SReal> >, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,SReal> >, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,SReal> >, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,SReal> >, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< DiagonalMatrix<SReal>, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< BlockDiagonalMatrix<3,SReal>, FullVector<SReal> >;
-template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< RotationMatrix<SReal>, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< FullMatrix<SReal>, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< SparseMatrix<SReal>, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<SReal>, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,SReal> >, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,SReal> >, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,SReal> >, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,SReal> >, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,SReal> >, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< DiagonalMatrix<SReal>, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< BlockDiagonalMatrix<3,SReal>, FullVector<SReal> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< RotationMatrix<SReal>, FullVector<SReal> >;
 #endif
 
 } //namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
@@ -34,6 +34,12 @@
 #include <sofa/component/linearsystem/BaseMatrixProjectionMethod.h>
 #include <sofa/component/linearsystem/MappedMassMatrixObserver.h>
 
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <sofa/linearalgebra/SparseMatrix.h>
+#include <sofa/linearalgebra/DiagonalMatrix.h>
+#include <sofa/linearalgebra/RotationMatrix.h>
+#include <sofa/linearalgebra/FullMatrix.h>
+#include <sofa/linearalgebra/BlockDiagonalMatrix.h>
 
 namespace sofa::component::linearsystem
 {
@@ -338,5 +344,27 @@ inline std::ostream& operator<<(std::ostream& os,
     }
     return os;
 }
+
+#if !defined(SOFA_COMPONENT_LINEARSYSTEM_MATRIXLINEARSYSTEM_CPP)
+using sofa::linearalgebra::CompressedRowSparseMatrix;
+using sofa::linearalgebra::SparseMatrix;
+using sofa::linearalgebra::DiagonalMatrix;
+using sofa::linearalgebra::BlockDiagonalMatrix;
+using sofa::linearalgebra::RotationMatrix;
+using sofa::linearalgebra::FullMatrix;
+using sofa::linearalgebra::FullVector;
+
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< FullMatrix<SReal>, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< SparseMatrix<SReal>, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<SReal>, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,SReal> >, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,SReal> >, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,SReal> >, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,SReal> >, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,SReal> >, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< DiagonalMatrix<SReal>, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< BlockDiagonalMatrix<3,SReal>, FullVector<SReal> >;
+template class SOFA_COMPONENT_LINEARSYSTEM_API MatrixLinearSystem< RotationMatrix<SReal>, FullVector<SReal> >;
+#endif
 
 } //namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.cpp
@@ -20,6 +20,9 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#define SOFA_COMPONENT_LINEARSYSTEM_TYPEDMATRIXLINEARSYSTEM_CPP
+
+
 #include <sofa/component/linearsystem/TypedMatrixLinearSystem.inl>
 
 #include <sofa/linearalgebra/FullMatrix.h>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.cpp
@@ -25,12 +25,6 @@
 
 #include <sofa/component/linearsystem/TypedMatrixLinearSystem.inl>
 
-#include <sofa/linearalgebra/FullMatrix.h>
-#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
-#include <sofa/linearalgebra/SparseMatrix.h>
-#include <sofa/linearalgebra/DiagonalMatrix.h>
-#include <sofa/linearalgebra/RotationMatrix.h>
-#include <sofa/linearalgebra/BlockDiagonalMatrix.h>
 
 namespace sofa::component::linearsystem
 {

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
@@ -144,4 +144,31 @@ protected:
     }
 };
 
+#if !defined(SOFA_COMPONENT_LINEARSYSTEM_TYPEDMATRIXLINEARSYSTEM_CPP)
+
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< FullMatrix<double>, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< FullMatrix<float>, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< SparseMatrix<double>, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< SparseMatrix<float>, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<double>, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<float>, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,double> >, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,float> >, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,double> >, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,float> >, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,double> >, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,float> >, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,double> >, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,float> >, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,double> >, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,float> >, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< DiagonalMatrix<double>, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< DiagonalMatrix<float>, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< BlockDiagonalMatrix<3,double>, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< BlockDiagonalMatrix<3,float>, FullVector<float> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< RotationMatrix<double>, FullVector<double> >;
+extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< RotationMatrix<float>, FullVector<float> >;
+#endif
+
+
 } //namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
@@ -31,6 +31,13 @@
 #include <sofa/core/behavior/BaseLocalForceFieldMatrix.h>
 #include <sofa/core/behavior/BaseLocalMassMatrix.h>
 
+#include <sofa/linearalgebra/FullMatrix.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <sofa/linearalgebra/SparseMatrix.h>
+#include <sofa/linearalgebra/DiagonalMatrix.h>
+#include <sofa/linearalgebra/RotationMatrix.h>
+#include <sofa/linearalgebra/BlockDiagonalMatrix.h>
+
 namespace sofa::component::linearsystem
 {
 
@@ -145,29 +152,30 @@ protected:
 };
 
 #if !defined(SOFA_COMPONENT_LINEARSYSTEM_TYPEDMATRIXLINEARSYSTEM_CPP)
+using namespace sofa::linearalgebra;
 
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< FullMatrix<double>, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< FullMatrix<float>, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< SparseMatrix<double>, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< SparseMatrix<float>, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<double>, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<float>, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,double> >, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,float> >, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,double> >, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,float> >, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,double> >, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,float> >, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,double> >, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,float> >, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,double> >, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,float> >, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< DiagonalMatrix<double>, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< DiagonalMatrix<float>, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< BlockDiagonalMatrix<3,double>, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< BlockDiagonalMatrix<3,float>, FullVector<float> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< RotationMatrix<double>, FullVector<double> >;
-extern template SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< RotationMatrix<float>, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< FullMatrix<double>, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< FullMatrix<float>, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< SparseMatrix<double>, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< SparseMatrix<float>, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<double>, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<float>, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,double> >, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<2,2,float> >, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,double> >, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<3,3,float> >, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,double> >, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<4,4,float> >, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,double> >, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<6,6,float> >, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,double> >, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< CompressedRowSparseMatrix<type::Mat<8,8,float> >, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< DiagonalMatrix<double>, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< DiagonalMatrix<float>, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< BlockDiagonalMatrix<3,double>, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< BlockDiagonalMatrix<3,float>, FullVector<float> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< RotationMatrix<double>, FullVector<double> >;
+extern template class SOFA_COMPONENT_LINEARSYSTEM_API TypedMatrixLinearSystem< RotationMatrix<float>, FullVector<float> >;
 #endif
 
 


### PR DESCRIPTION
Dynamic cast of MatrixLinearSystem into TypedMatrixLinearSystem was not working in the Python factory on MacOS due to the lack of extern explicit instantiation. This fixes it.   



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
