### PR TITLE
[Type] Fix cmake warning for boost

### DIFF
--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -76,7 +76,7 @@ sofa_find_package(Sofa.Config REQUIRED)
 ## Boost (1.54.0 or higher) is now mandatory.
 set(BOOST_MIN_VERSION "1.54.0")
 set(Boost_NO_BOOST_CMAKE TRUE)
-sofa_find_package(Boost ${BOOST_MIN_VERSION} QUIET)
+sofa_find_package(Boost ${BOOST_MIN_VERSION} QUIET NO_MODULE)
 if(NOT Boost_FOUND)
     if(WIN32)
         message(FATAL_ERROR "Boost (${BOOST_MIN_VERSION} or higher) is mandatory.\n"
@@ -88,7 +88,7 @@ if(NOT Boost_FOUND)
         message(FATAL_ERROR "Boost (${BOOST_MIN_VERSION} or higher) is mandatory.")
     endif()
 endif()
-sofa_find_package(Boost QUIET REQUIRED)
+sofa_find_package(Boost QUIET REQUIRED NO_MODULE)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 

--- a/Sofa/framework/Type/Sofa.TypeConfig.cmake.in
+++ b/Sofa/framework/Type/Sofa.TypeConfig.cmake.in
@@ -5,7 +5,7 @@
 
 set(SOFA_TYPE_HAVE_SOFA_COMPAT "@SOFA_TYPE_HAVE_SOFA_COMPAT@")
 
-find_package(Boost QUIET REQUIRED)
+find_package(Boost QUIET REQUIRED NO_MODULE)
 find_package(Sofa.Config QUIET REQUIRED)
 
 if(SOFA_TYPE_HAVE_SOFA_COMPAT)


### PR DESCRIPTION
Using find_package without NO_MODULES threw a lot of warning because the findBoost module is deprecated. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
