### PR TITLE
[CMake] Remove references to deleted projects/option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,9 +188,9 @@ add_subdirectory(extlibs)
 add_subdirectory(Sofa)
 
 # SceneCreator plugin
-# Library used by SOFA_BUILD_TESTS and SOFA_BUILD_TUTORIALS
+# Library used by SOFA_BUILD_TESTS
 sofa_add_subdirectory(plugin applications/plugins/SceneCreator SceneCreator OFF
-    WHEN_TO_SHOW "NOT SOFA_BUILD_SCENECREATOR AND NOT SOFA_BUILD_TESTS AND NOT SOFA_BUILD_TUTORIALS AND NOT SOFA_BUILD_RELEASE_PACKAGE"
+    WHEN_TO_SHOW "NOT SOFA_BUILD_SCENECREATOR AND NOT SOFA_BUILD_TESTS AND NOT SOFA_BUILD_RELEASE_PACKAGE"
     VALUE_IF_HIDDEN "ON")
 
 ## Plugins

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,15 +98,11 @@
     {
       "name": "standard",
       "displayName": "Standard Config",
-      "description": "Adds the default GUI, the SofaPhysics API, the tutorials and the Python3 support",
+      "description": "Adds the default GUI, the SofaPhysics API and the Python3 support",
       "hidden": false,
       "inherits": ["minimal","defaultGUI"],
       "cacheVariables": {
         "APPLICATION_SOFAPHYSICSAPI": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "SOFA_BUILD_TUTORIALS": {
           "type": "BOOL",
           "value": "ON"
         },

--- a/applications/projects/CMakeLists.txt
+++ b/applications/projects/CMakeLists.txt
@@ -3,18 +3,11 @@ cmake_minimum_required(VERSION 3.22)
 sofa_add_subdirectory(application SceneChecking SceneChecking ON)
 sofa_add_subdirectory(application Modeler Modeler OFF)
 
-sofa_add_subdirectory(application getDeprecatedComponents getDeprecatedComponents OFF)
-
-sofa_add_subdirectory(application GenerateRigid GenerateRigid)
-
 sofa_add_subdirectory(application SofaPhysicsAPI SofaPhysicsAPI)
-sofa_add_subdirectory(application SofaGuiGlut SofaGuiGlut OFF)
 
 sofa_add_subdirectory(directory SofaGLFW SofaGLFW EXTERNAL GIT_REF master)
 sofa_add_subdirectory(plugin Sofa.Qt Sofa.Qt EXTERNAL GIT_REF master OFF)
 sofa_add_subdirectory(application runSofa runSofa ON)
-sofa_add_subdirectory(application sofaOPENCL sofaOPENCL OFF)
 
 sofa_add_subdirectory(directory Regression Regression EXTERNAL GIT_REF master)
 sofa_add_subdirectory(application sofaProjectExample sofaProjectExample)
-sofa_add_subdirectory(application sofaInfo sofaInfo)


### PR DESCRIPTION
Due to:
- #5339 

-> removed the SOFA_BUILD_TUTORIALS but there are references of it here and there (presets)

- #5340

-> removed references to deleted projects (and remove warnings in the cmake configuration...)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
