### PR TITLE
[examples] Add an option to (not) build SimpleAPI examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,10 @@ add_subdirectory(applications/plugins)
 add_subdirectory(applications/projects)
 
 ## SimpleAPI examples
-add_subdirectory(examples/SimpleAPI)
+option(SOFA_BUILD_SIMPLEAPI_EXAMPLES "Build SOFA scenes based on SimpleAPI." OFF)
+if(SOFA_BUILD_SIMPLEAPI_EXAMPLES)
+    add_subdirectory(examples/SimpleAPI)
+endif()
 
 
 ## SOFA scenes

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,11 +98,15 @@
     {
       "name": "standard",
       "displayName": "Standard Config",
-      "description": "Adds the default GUI, the SofaPhysics API and the Python3 support",
+      "description": "Adds the default GUI, the SofaPhysics API, the examples based on SimpleAPI and the Python3 support",
       "hidden": false,
       "inherits": ["minimal","defaultGUI"],
       "cacheVariables": {
         "APPLICATION_SOFAPHYSICSAPI": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "SOFA_BUILD_SIMPLEAPI_EXAMPLES": {
           "type": "BOOL",
           "value": "ON"
         },

--- a/examples/SimpleAPI/CMakeLists.txt
+++ b/examples/SimpleAPI/CMakeLists.txt
@@ -4,7 +4,14 @@ project(SimpleAPIExamples)
 sofa_find_package(Sofa.Config REQUIRED)
 sofa_find_package(Sofa.Simulation REQUIRED)
 sofa_find_package(Sofa.SimpleApi REQUIRED)
-sofa_find_package(Sofa.GUI REQUIRED)
+sofa_find_package(Sofa.GUI QUIET)
 
-add_executable(fallingSOFA fallingSOFA.cpp)
-target_link_libraries(fallingSOFA Sofa.SimpleApi Sofa.Simulation Sofa.Config Sofa.GUI)
+if(NOT Sofa.GUI_FOUND)
+	message("Sofa.GUI is not built, disabling SimpleAPI examples using Sofa.GUI.")
+endif()
+
+if(Sofa.GUI_FOUND)
+	# Scenes with GUI
+	add_executable(fallingSOFA fallingSOFA.cpp)
+	target_link_libraries(fallingSOFA Sofa.SimpleApi Sofa.Simulation Sofa.Config Sofa.GUI)
+endif()


### PR DESCRIPTION
Based on 
- #5361 
---

Due to 
- #5339 

SimpleAPI examples are always built (whereas the tutorials which it was supposed to replace were not)

By default it is OFF, and it is enabled in all standard config in the Presets.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
