### PR TITLE
[examples] Fix wrong topology Data arrays on the surface mesh in HexahedralFEMForceField.scn 

### DIFF
--- a/examples/Component/SolidMechanics/FEM/HexahedralFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/HexahedralFEMForceField.scn
@@ -28,17 +28,29 @@
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <MeshGmshLoader name="loader" filename="mesh/nine_hexa.msh" />
         <MechanicalObject src="@loader" name="Hexa" />
-        <include href="Objects/HexahedronSetTopology.xml" src="@loader" />
+        <HexahedronSetTopologyContainer name="Container" src="@loader"/>
+        <HexahedronSetTopologyModifier name="Modifier" />
+        <HexahedronSetGeometryAlgorithms name="GeomAlgo" />
         <HexahedralFEMForceField name="FEM" youngModulus="100" poissonRatio="0.3" method="large" />
         <DiagonalMass massDensity="0.2" />
         <FixedProjectiveConstraint indices="12 15 28 31" />
         <Node name="Q">
-            <include href="Objects/QuadSetTopology.xml" src="@../loader" />
+            <QuadSetTopologyContainer name="Container" />
+            <QuadSetTopologyModifier name="Modifier" />
+            <QuadSetGeometryAlgorithms name="GeomAlgo" />
             <Hexa2QuadTopologicalMapping input="@../Container" output="@Container" />
+
             <Node name="T">
-                <include href="Objects/TriangleSetTopology.xml" src="@../Container" />
+                <TriangleSetTopologyContainer name="Container" />
+                <TriangleSetTopologyModifier name="Modifier" />
+                <TriangleSetGeometryAlgorithms name="GeomAlgo" />
                 <Quad2TriangleTopologicalMapping input="@../Container" output="@Container" />
                 <TriangleCollisionModel />
+                
+                <Node name="Visu">
+                    <OglModel name="Visual" color="yellow" />
+                    <IdentityMapping input="@../../../Hexa" output="@Visual" />
+                </Node>
             </Node>
         </Node>
     </Node>

--- a/examples/Component/SolidMechanics/FEM/HexahedralFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/HexahedralFEMForceField.scn
@@ -17,7 +17,7 @@
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <DefaultAnimationLoop/>
-    <VisualStyle displayFlags="showBehaviorModels" />
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <CollisionPipeline verbose="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
@@ -35,10 +35,6 @@
         <Node name="Q">
             <include href="Objects/QuadSetTopology.xml" src="@../loader" />
             <Hexa2QuadTopologicalMapping input="@../Container" output="@Container" />
-            <Node name="Visu">
-                <OglModel name="Visual" color="yellow" />
-                <IdentityMapping input="@../../Hexa" output="@Visual" />
-            </Node>
             <Node name="T">
                 <include href="Objects/TriangleSetTopology.xml" src="@../Container" />
                 <Quad2TriangleTopologicalMapping input="@../Container" output="@Container" />


### PR DESCRIPTION
Removing the visual model, not supporting topological changes (logically)

Noted by @CherryJGit in https://github.com/sofa-framework/sofa/discussions/5366

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
