### PR TITLE
[Engine] Remove docstring for GenerateCylinder

### DIFF
--- a/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/GenerateCylinder.h
+++ b/Sofa/Component/Engine/Generate/src/sofa/component/engine/generate/GenerateCylinder.h
@@ -33,10 +33,6 @@
 namespace sofa::component::engine::generate
 {
 
-/**
- * This class dilates the positions of one DataFields into new positions after applying a dilateation
-This dilateation can be either translation, rotation, scale
- */
 template <class DataTypes>
 class GenerateCylinder : public core::DataEngine
 {


### PR DESCRIPTION
The string does not seem to correspond to the behavior of `GenerateCylinder`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
