### PR TITLE
[Defaulttype, Helper] Return empty string instead of zero

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
@@ -103,7 +103,7 @@ public:
     /// Relevant only if this type can be casted to `double`.
     double      getScalarValue (const void*, Index) const override {return 0;}
     /// Get the value at \a index of \a data as a string.
-    std::string getTextValue   (const void*, Index) const override {return 0;}
+    std::string getTextValue   (const void*, Index) const override {return "";}
 
     /// Set the value at \a index of \a data from an integer value.
     void setIntegerValue(void*, Index, long long ) const override {return;}

--- a/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
@@ -1457,12 +1457,12 @@ std::string AdvancedTimer::getTimeAnalysis(IdTimer id, double time, double delta
     if (curTimer.empty())
     {
         msg_error("AdvancedTimer::end") << "timer[" << id << "] called while begin was not" ;
-        return nullptr;
+        return "";
     }
     if (id != curTimer.top())
     {
         msg_error("AdvancedTimer::end") << "timer[" << id << "] does not correspond to last call to begin(" << curTimer.top() << ")" ;
-        return nullptr;
+        return "";
     }
     type::vector<Record>* curRecords = getCurRecords();
     if (curRecords)


### PR DESCRIPTION
The cast `nullptr/0 to an empty(?) string` has been deleted in C++23 (and is deprecated in C++20)
So this PR allows to compile SOFA in C++23 🤡

and it looks more consistent/safer anyway

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
