### PR TITLE
[CI] Nix: Fix CI

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
       ./examples
       ./extlibs
       ./LICENSE-LGPL.md
-      ./package.cmake
       ./README.md
       ./scripts
       ./share


### PR DESCRIPTION
i dont like  ❌ in the builds results 🧐

Nix build file was referencing a deleted file, since 
- https://github.com/sofa-framework/sofa/pull/5325



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
