### PR TITLE
[Lagrangian.Model] Remove extra endEdit

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/FixedLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/FixedLagrangianConstraint.inl
@@ -61,7 +61,6 @@ void FixedLagrangianConstraint<DataTypes>::buildConstraintMatrix(const core::Con
 
         doBuildConstraintLine(c,i);
     }
-    c_d.endEdit();
 }
 
 template<class DataTypes>


### PR DESCRIPTION
Removed because a RAII-based accessor is used.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
