### PR TITLE
[SOFADistanceGrid] Replace pointer to the mstate with a link in the collision models of the plugin

### DIFF
--- a/applications/plugins/SofaDistanceGrid/examples/FFDDistanceGridCollisionModel_liver_DefaultAnimationLoop.scn
+++ b/applications/plugins/SofaDistanceGrid/examples/FFDDistanceGridCollisionModel_liver_DefaultAnimationLoop.scn
@@ -38,7 +38,7 @@
 
         <MechanicalObject />
         <UniformMass totalMass="1000.0" />
-        <SparseGridTopology n="8 6 6" filename="mesh/liver-smooth.obj" />
+        <SparseGridTopology name="grid" n="8 6 6" filename="mesh/liver-smooth.obj" />
         <BoxROI name="box1" box="-2.5 0 -2.5 7.5 3 2" />
         <FixedProjectiveConstraint indices="@box1.indices"/>
         <HexahedronFEMForceField poissonRatio="0" youngModulus="7000"/>
@@ -49,6 +49,7 @@
             proximity="0.1" 
             contactStiffness="500.0" 
             contactFriction="0.0" 
+            topology="@grid"
         />
         <Node name="Visu">
             <MeshOBJLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" translation="0 0 0" handleSeams="1" />

--- a/applications/plugins/SofaDistanceGrid/examples/FFDDistanceGridCollisionModel_liver_FreeMotionAnimationLoop.scn
+++ b/applications/plugins/SofaDistanceGrid/examples/FFDDistanceGridCollisionModel_liver_FreeMotionAnimationLoop.scn
@@ -20,6 +20,9 @@
     <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <RequiredPlugin name="SofaDistanceGrid"/> <!-- Needed to use components [FFDDistanceGridCollisionModel] -->
+    <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->  
+    <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [UncoupledConstraintCorrection] -->  
+    <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Solver"/> <!-- Needed to use components [LCPConstraintSolver] -->  
 
     <FreeMotionAnimationLoop/>
     <LCPConstraintSolver tolerance="1e-3" maxIt="1000"/>
@@ -39,7 +42,7 @@
 
         <MechanicalObject />
         <UniformMass totalMass="1000.0" />
-        <SparseGridTopology n="8 6 6" filename="mesh/liver-smooth.obj" />
+        <SparseGridTopology name="grid" n="8 6 6" filename="mesh/liver-smooth.obj" />
         <BoxROI name="box1" box="-2.5 0 -2.5 7.5 3 2" />
         <FixedProjectiveConstraint indices="@box1.indices"/>
         <HexahedronFEMForceField poissonRatio="0" youngModulus="7000"/>
@@ -48,8 +51,8 @@
             scale="1.0" 
             usePoints="0" 
             proximity="0.1" 
-            contactStiffness="500.0" 
             contactFriction="0.0" 
+            topology="@grid"
         />
         <Node name="Visu">
             <MeshOBJLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" translation="0 0 0" handleSeams="1" />

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
@@ -453,8 +453,6 @@ FFDDistanceGridCollisionModel::FFDDistanceGridCollisionModel()
     , l_ffd(initLink("ffdState", "link to a MechanicalObject of Vec3 type associated with this collision model"))
 {
     ffdMesh = NULL;
-    ffdRGrid = NULL;
-    ffdSGrid = NULL;
     addAlias(&fileFFDDistanceGrid,"fileFFDDistanceGrid");
     enum_type = FFDDISTANCE_GRIDE_TYPE;
 }
@@ -468,8 +466,8 @@ void FFDDistanceGridCollisionModel::init()
 {
     this->core::CollisionModel::init();
     ffdMesh = getContext()->getMeshTopology();
-    ffdRGrid = dynamic_cast< topology::container::grid::RegularGridTopology* > (ffdMesh);
-    ffdSGrid = dynamic_cast< topology::container::grid::SparseGridTopology* > (ffdMesh);
+    topology::container::grid::RegularGridTopology* ffdRGrid = dynamic_cast< topology::container::grid::RegularGridTopology* > (ffdMesh);
+    topology::container::grid::SparseGridTopology* ffdSGrid = dynamic_cast< topology::container::grid::SparseGridTopology* > (ffdMesh);
     if (!l_ffd || (!ffdRGrid && !ffdSGrid))
     {
         msg_error() << "Requires a Vec3-based deformable model with associated RegularGridTopology or SparseGridTopology";

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
@@ -442,7 +442,8 @@ protected:
     core::objectmodel::SingleLink<FFDDistanceGridCollisionModel,
                                   core::behavior::MechanicalState<defaulttype::Vec3Types>,
                                   BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_ffd;
-    core::topology::BaseMeshTopology* ffdMesh;
+    core::objectmodel::SingleLink<FFDDistanceGridCollisionModel, core::topology::BaseMeshTopology,
+                                  BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_ffdMesh;
 
     void updateGrid();
 public:
@@ -459,11 +460,11 @@ protected:
     ~FFDDistanceGridCollisionModel() override;
 public:
     core::behavior::MechanicalState<DataTypes>* getDeformModel() { return l_ffd; }
-    core::topology::BaseMeshTopology* getDeformGrid() { return ffdMesh; }
+    core::topology::BaseMeshTopology* getDeformGrid() { return l_ffdMesh; }
 
     /// alias used by ContactMapper
     core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return l_ffd; }
-    core::topology::BaseMeshTopology* getCollisionTopology() override { return ffdMesh; }
+    core::topology::BaseMeshTopology* getCollisionTopology() override { return l_ffdMesh; }
 
     void init() override;
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
@@ -34,6 +34,7 @@
 #include <sofa/component/topology/container/grid/SparseGridTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 
 #include "../../DistanceGrid.h"
 
@@ -86,9 +87,10 @@ public:
 };
 
 class SOFA_SOFADISTANCEGRID_API RigidDistanceGridCollisionModel : public core::CollisionModel
+    , public core::behavior::SingleStateAccessor<defaulttype::Rigid3Types>
 {
 public:
-    SOFA_CLASS(RigidDistanceGridCollisionModel,sofa::core::CollisionModel);
+    SOFA_CLASS2(RigidDistanceGridCollisionModel, sofa::core::CollisionModel, SOFA_TEMPLATE(SingleStateAccessor, defaulttype::Rigid3Types));
 
 protected:
 
@@ -114,10 +116,6 @@ protected:
 
     sofa::type::vector<ElementData> elems;
     bool modified;
-    core::objectmodel::SingleLink<RigidDistanceGridCollisionModel,
-                                  core::behavior::MechanicalState<defaulttype::RigidTypes>,
-                                  BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_rigid;
-
     void updateGrid();
 
 public:
@@ -148,8 +146,8 @@ protected:
 
     ~RigidDistanceGridCollisionModel() override;
 public:
-    core::behavior::MechanicalState<InDataTypes>* getRigidModel() { return l_rigid; }
-    core::behavior::MechanicalState<InDataTypes>* getMechanicalState() { return l_rigid; }
+    core::behavior::MechanicalState<InDataTypes>* getRigidModel() { return this->mstate ; }
+    core::behavior::MechanicalState<InDataTypes>* getMechanicalState() { return this->mstate ; }
 
     void init() override;
 
@@ -278,9 +276,10 @@ public:
 };
 
 class SOFA_SOFADISTANCEGRID_API FFDDistanceGridCollisionModel : public core::CollisionModel
+    , public core::behavior::SingleStateAccessor<defaulttype::Vec3Types>
 {
 public:
-    SOFA_CLASS(FFDDistanceGridCollisionModel,sofa::core::CollisionModel);
+    SOFA_CLASS2(FFDDistanceGridCollisionModel, sofa::core::CollisionModel, SOFA_TEMPLATE(SingleStateAccessor, defaulttype::Vec3Types));
 
     typedef SReal GSReal;
     typedef DistanceGrid::Coord GCoord;
@@ -439,11 +438,8 @@ protected:
     Data< int > nz; ///< number of values on Z axis
     sofa::core::objectmodel::DataFileName dumpfilename;
 
-    core::objectmodel::SingleLink<FFDDistanceGridCollisionModel,
-                                  core::behavior::MechanicalState<defaulttype::Vec3Types>,
-                                  BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_ffd;
     core::objectmodel::SingleLink<FFDDistanceGridCollisionModel, core::topology::BaseMeshTopology,
-                                  BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_ffdMesh;
+                                  BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_ffdMesh;
 
     void updateGrid();
 public:
@@ -459,11 +455,11 @@ protected:
 
     ~FFDDistanceGridCollisionModel() override;
 public:
-    core::behavior::MechanicalState<DataTypes>* getDeformModel() { return l_ffd; }
+    core::behavior::MechanicalState<DataTypes>* getDeformModel() { return this->mstate; }
     core::topology::BaseMeshTopology* getDeformGrid() { return l_ffdMesh; }
 
     /// alias used by ContactMapper
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return l_ffd; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate; }
     core::topology::BaseMeshTopology* getCollisionTopology() override { return l_ffdMesh; }
 
     void init() override;

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
@@ -443,8 +443,6 @@ protected:
                                   core::behavior::MechanicalState<defaulttype::Vec3Types>,
                                   BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_ffd;
     core::topology::BaseMeshTopology* ffdMesh;
-    topology::container::grid::RegularGridTopology* ffdRGrid;
-    topology::container::grid::SparseGridTopology* ffdSGrid;
 
     void updateGrid();
 public:

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
@@ -114,7 +114,9 @@ protected:
 
     sofa::type::vector<ElementData> elems;
     bool modified;
-    core::behavior::MechanicalState<defaulttype::RigidTypes>* rigid;
+    core::objectmodel::SingleLink<RigidDistanceGridCollisionModel,
+                                  core::behavior::MechanicalState<defaulttype::RigidTypes>,
+                                  BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_rigid;
 
     void updateGrid();
 
@@ -146,8 +148,8 @@ protected:
 
     ~RigidDistanceGridCollisionModel() override;
 public:
-    core::behavior::MechanicalState<InDataTypes>* getRigidModel() { return rigid; }
-    core::behavior::MechanicalState<InDataTypes>* getMechanicalState() { return rigid; }
+    core::behavior::MechanicalState<InDataTypes>* getRigidModel() { return l_rigid; }
+    core::behavior::MechanicalState<InDataTypes>* getMechanicalState() { return l_rigid; }
 
     void init() override;
 
@@ -437,9 +439,10 @@ protected:
     Data< int > nz; ///< number of values on Z axis
     sofa::core::objectmodel::DataFileName dumpfilename;
 
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* ffd;
+    core::objectmodel::SingleLink<FFDDistanceGridCollisionModel,
+                                  core::behavior::MechanicalState<defaulttype::Vec3Types>,
+                                  BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STOREPATH> l_ffd;
     core::topology::BaseMeshTopology* ffdMesh;
-    //topology::RegularGridTopology* ffdGrid;
     topology::container::grid::RegularGridTopology* ffdRGrid;
     topology::container::grid::SparseGridTopology* ffdSGrid;
 
@@ -457,11 +460,11 @@ protected:
 
     ~FFDDistanceGridCollisionModel() override;
 public:
-    core::behavior::MechanicalState<DataTypes>* getDeformModel() { return ffd; }
+    core::behavior::MechanicalState<DataTypes>* getDeformModel() { return l_ffd; }
     core::topology::BaseMeshTopology* getDeformGrid() { return ffdMesh; }
 
     /// alias used by ContactMapper
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return ffd; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return l_ffd; }
     core::topology::BaseMeshTopology* getCollisionTopology() override { return ffdMesh; }
 
     void init() override;


### PR DESCRIPTION
**This should be reviewed and merged after #5411 to include regression tests**

This PR replaces the MechanicalState pointer with a link in the RigidDistanceGridCollisionModel & FFDDistanceGridCollisionModel. Apart from this change:
- For the RigidDistanceGridCollisionModel, an error is sent to the output if the user omits to create the link or if the MechanicalObject is not templated as a Rigid type.
- A suggestion to use a link for the BaseMeshTopology pointer in the FFDDistanceGridCollisionModel

[ci-depends-on https://github.com/sofa-framework/Regression/pull/81]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
