### PR TITLE
[SofaDistanceGrid] Substitute pointer-sharing and ref-counting mechanism of the DistanceGrid class with std smart pointers

### DIFF
--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.cpp
@@ -81,7 +81,6 @@ int validateDim(int n)
 
 DistanceGrid::DistanceGrid(int nx, int ny, int nz, Coord pmin, Coord pmax)
     : meshPts()
-    , m_nbRef(1)
     , m_nx(validateDim(nx)), m_ny(validateDim(ny)), m_nz(validateDim(nz))
     , m_nxny(m_nx*m_ny), m_nxnynz(m_nx*m_ny*m_nz)
     , m_dists(m_nx*m_ny*m_nz)
@@ -93,32 +92,10 @@ DistanceGrid::DistanceGrid(int nx, int ny, int nz, Coord pmin, Coord pmax)
 }
 
 DistanceGrid::~DistanceGrid()
-{
-    std::map<DistanceGridParams, DistanceGrid*>& shared = getShared();
-    std::map<DistanceGridParams, DistanceGrid*>::iterator it = shared.begin();
-    while (it != shared.end() && it->second != this) ++it;
-    if (it != shared.end())
-        shared.erase(it); // remove this grid from the list of already loaded grids
-}
-
-/// Add one reference to this grid. Note that loadShared already does this.
-DistanceGrid* DistanceGrid::addRef()
-{
-    ++m_nbRef;
-    return this;
-}
-
-/// Release one reference, deleting this grid if this is the last
-bool DistanceGrid::release()
-{
-    if (--m_nbRef != 0)
-        return false;
-    delete this;
-    return true;
-}
+{}
 
 //todo(dmarchal) we should make a loader for that...
-DistanceGrid* DistanceGrid::load(const std::string& filename,
+std::unique_ptr<DistanceGrid> DistanceGrid::load(const std::string& filename,
                                  double scale, double sampling,
                                  int nx, int ny, int nz, Coord pmin, Coord pmax)
 {
@@ -144,7 +121,7 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
                 if (bbmax[c] > pmax[c]) pmax[c] = bbmax[c];
             }
         }
-        DistanceGrid* grid = new DistanceGrid(nx, ny, nz, pmin, pmax);
+        std::unique_ptr<DistanceGrid> grid = std::make_unique<DistanceGrid>(nx, ny, nz, pmin, pmax);
         grid->calcCubeDistance(dim, np);
         if (sampling)
             grid->sampleSurface(sampling);
@@ -152,7 +129,7 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
     }
     else if (filename.length()>4 && filename.substr(filename.length()-4) == ".raw")
     {
-        DistanceGrid* grid = new DistanceGrid(nx, ny, nz, pmin, pmax);
+        std::unique_ptr<DistanceGrid> grid = std::make_unique<DistanceGrid>(nx, ny, nz, pmin, pmax);
         std::ifstream in(filename.c_str(), std::ios::in | std::ios::binary);
         in.read((char*)&(grid->m_dists[0]), grid->m_nxnynz*sizeof(SReal));
         if (scale != 1.0)
@@ -191,7 +168,7 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
         ftl::Vec3f fpmax = ftl::transform(mesh.distmap->mat,ftl::Vec3f((float)(nx-1),(float)(ny-1),(float)(nz-1)))*(float)absscale;
         pmin = Coord(fpmin.ptr());
         pmax = Coord(fpmax.ptr());
-        DistanceGrid* grid = new DistanceGrid(nx, ny, nz, pmin, pmax);
+        std::unique_ptr<DistanceGrid> grid = std::make_unique<DistanceGrid>(nx, ny, nz, pmin, pmax);
         for (int i=0; i< grid->m_nxnynz; i++)
             grid->m_dists[i] = mesh.distmap->data[i]*scale;
         if (sampling)
@@ -269,7 +246,7 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
                 if (bbmax[c] > pmax[c]) pmax[c] = bbmax[c];
             }
         }
-        DistanceGrid* grid = new DistanceGrid(nx, ny, nz, pmin, pmax);
+        std::unique_ptr<DistanceGrid> grid = std::make_unique<DistanceGrid>(nx, ny, nz, pmin, pmax);
         grid->calcDistance(mesh, scale);
         if (sampling)
             grid->sampleSurface(sampling);
@@ -286,7 +263,7 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
     else
     {
          msg_error("DistanceGrid")<< "Unknown extension: "<<filename;
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -345,7 +322,7 @@ template<class T> bool readData(std::istream& in, int dataSize, bool binary, Dis
     }
 }
 
-DistanceGrid* DistanceGrid::loadVTKFile(const std::string& filename, double scale, double sampling)
+std::unique_ptr<DistanceGrid> DistanceGrid::loadVTKFile(const std::string& filename, double scale, double sampling)
 {
     // Format doc: http://www.vtk.org/pdf/file-formats.pdf
     // http://www.cacr.caltech.edu/~slombey/asci/vtk/vtk_formats.simple.html
@@ -353,13 +330,13 @@ DistanceGrid* DistanceGrid::loadVTKFile(const std::string& filename, double scal
     std::ifstream inVTKFile(filename.c_str(), std::ifstream::in & std::ifstream::binary);
     if( !inVTKFile.is_open() )
     {
-        return NULL;
+        return nullptr;
     }
     std::string line;
 
     // Part 1
     std::getline(inVTKFile, line);
-    if (std::string(line,0,23) != "# vtk DataFile Version ") return NULL;
+    if (std::string(line,0,23) != "# vtk DataFile Version ") return nullptr;
     std::string version(line,23);
 
     // Part 2
@@ -372,13 +349,13 @@ DistanceGrid* DistanceGrid::loadVTKFile(const std::string& filename, double scal
     bool binary;
     if (line == "BINARY") binary = true;
     else if (line == "ASCII") binary = false;
-    else return NULL;
+    else return nullptr;
 
     // Part 4
     std::getline(inVTKFile, line);
     if (line != "DATASET STRUCTURED_POINTS")
     {
-        return NULL;
+        return nullptr;
     }
 
     msg_info("DistanceGrid")<< (binary ? "Binary" : "Text") << " VTK File " << filename << " (version " << version << "): " << header;
@@ -422,7 +399,8 @@ DistanceGrid* DistanceGrid::loadVTKFile(const std::string& filename, double scal
             msg_info("DistanceGrid")<< "Found " << typestr << " data: " << name;
             std::getline(inVTKFile, line); // lookup_table, ignore
             msg_info("DistanceGrid")<< "Loading " << nx<<"x"<<ny<<"x"<<nz << " volume...";
-            DistanceGrid* grid = new DistanceGrid(nx, ny, nz, origin, origin + Coord(spacing[0] * nx, spacing[1] * ny, spacing[2]*nz));
+            std::unique_ptr<DistanceGrid> grid = std::make_unique<DistanceGrid>(nx, ny, nz, origin,
+                                 origin + Coord(spacing[0] * nx, spacing[1] * ny, spacing[2] * nz));
             bool ok = true;
             if (typestr == "char") ok = readData<char>(inVTKFile, dataSize, binary, grid->m_dists, scale);
             else if (typestr == "unsigned_char") ok = readData<unsigned char>(inVTKFile, dataSize, binary, grid->m_dists, scale);
@@ -441,8 +419,7 @@ DistanceGrid* DistanceGrid::loadVTKFile(const std::string& filename, double scal
             }
             if (!ok)
             {
-                delete grid;
-                return NULL;
+                return nullptr;
             }
             msg_info("DistanceGrid")<< "Volume data loading OK.";
             grid->computeBBox();
@@ -451,7 +428,7 @@ DistanceGrid* DistanceGrid::loadVTKFile(const std::string& filename, double scal
             return grid; // we read one scalar field, stop here.
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 template<class T>
@@ -464,7 +441,7 @@ void * readData(std::istream& in, int dataSize, bool binary)
         if (in.eof() || in.bad())
         {
             delete[] buffer;
-            return NULL;
+            return nullptr;
         }
     }
     else
@@ -481,7 +458,7 @@ void * readData(std::istream& in, int dataSize, bool binary)
         if (i < dataSize)
         {
             delete[] buffer;
-            return NULL;
+            return nullptr;
         }
     }
     return buffer;
@@ -528,8 +505,6 @@ int DistanceGrid::index(const Coord& p, Coord& coefs) const
     coefs[2] -= z;
     return x+m_nx*(y+m_ny*(z));
 }
-
-
 
 void DistanceGrid::computeBBox()
 {
@@ -1235,7 +1210,7 @@ void DistanceGrid::sampleSurface(double sampling)
 }
 
 
-DistanceGrid* DistanceGrid::loadShared(const std::string& filename,
+std::shared_ptr<DistanceGrid> DistanceGrid::loadShared(const std::string& filename,
                                        double scale, double sampling, int nx, int ny, int nz, Coord pmin, Coord pmax)
 {
     DistanceGridParams params;
@@ -1247,10 +1222,12 @@ DistanceGrid* DistanceGrid::loadShared(const std::string& filename,
     params.nz = nz;
     params.pmin = pmin;
     params.pmax = pmax;
-    std::map<DistanceGridParams, DistanceGrid*>& shared = getShared();
-    std::map<DistanceGridParams, DistanceGrid*>::iterator it = shared.find(params);
+    std::map<DistanceGridParams, std::shared_ptr<DistanceGrid> >& shared = getShared();
+    std::map<DistanceGridParams, std::shared_ptr<DistanceGrid> >::iterator it = shared.find(params);
     if (it != shared.end())
-        return it->second->addRef();
+    {
+        return it->second;
+    }
     else
     {
         return shared[params] = load(filename, scale, sampling, nx, ny, nz, pmin, pmax);
@@ -1450,9 +1427,9 @@ bool DistanceGrid::DistanceGridParams::operator>(const DistanceGridParams& v) co
     return false;
 }
 
-std::map<DistanceGrid::DistanceGridParams, DistanceGrid*>& DistanceGrid::getShared()
+std::map<DistanceGrid::DistanceGridParams, std::shared_ptr<DistanceGrid> >& DistanceGrid::getShared()
 {
-    static std::map<DistanceGridParams, DistanceGrid*> instance;
+    static std::map<DistanceGridParams, std::shared_ptr<DistanceGrid> > instance;
     return instance;
 }
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.h
@@ -66,25 +66,19 @@ public:
 
 public:
     /// Load a distance grid
-    static DistanceGrid* load(const std::string& filename,
+    static std::unique_ptr<DistanceGrid> load(const std::string& filename,
                               double scale=1.0, double sampling=0.0,
                               int m_nx=64, int m_ny=64, int m_nz=64,
                               Coord m_pmin = Coord(), Coord m_pmax = Coord());
 
-    static DistanceGrid* loadVTKFile(const std::string& filename,
+    static std::unique_ptr<DistanceGrid> loadVTKFile(const std::string& filename,
                                      double scale=1.0, double sampling=0.0);
 
     /// Load or reuse a distance grid
-    static DistanceGrid* loadShared(const std::string& filename,
+    static std::shared_ptr<DistanceGrid> loadShared(const std::string& filename,
                                     double scale=1.0, double sampling=0.0,
                                     int m_nx=64, int m_ny=64, int m_nz=64,
                                     Coord m_pmin = Coord(), Coord m_pmax = Coord());
-
-    /// Add one reference to this grid. Note that loadShared already does this.
-    DistanceGrid* addRef();
-
-    /// Release one reference, deleting this grid if this is the last
-    bool release();
 
     /// Save current grid
     bool save(const std::string& filename);
@@ -222,7 +216,6 @@ public:
     VecCoord meshPts;
 
 protected:
-    int m_nbRef;
     const int m_nx,m_ny,m_nz;
     const int m_nxny, m_nxnynz;
     VecSReal m_dists;
@@ -255,7 +248,7 @@ protected:
         bool operator>(const DistanceGridParams& v) const ;
     };
 
-    static std::map<DistanceGridParams, DistanceGrid*>& getShared();
+    static std::map<DistanceGridParams, std::shared_ptr<DistanceGrid> >& getShared();
 };
 
 } // namespace _distancegrid

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.h
@@ -248,7 +248,7 @@ protected:
         bool operator>(const DistanceGridParams& v) const ;
     };
 
-    static std::map<DistanceGridParams, std::shared_ptr<DistanceGrid> >& getShared();
+    static std::map<DistanceGridParams, std::weak_ptr<DistanceGrid> > instances;
 };
 
 } // namespace _distancegrid

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
@@ -91,13 +91,7 @@ RigidDistanceGridCollisionModel::RigidDistanceGridCollisionModel()
 }
 
 RigidDistanceGridCollisionModel::~RigidDistanceGridCollisionModel()
-{
-    for (unsigned int i=0; i<elems.size(); i++)
-    {
-        if (elems[i].grid!=NULL) elems[i].grid->release();
-        if (elems[i].prevGrid!=NULL) elems[i].prevGrid->release();
-    }
-}
+{}
 
 void RigidDistanceGridCollisionModel::init()
 {
@@ -111,10 +105,10 @@ void RigidDistanceGridCollisionModel::init()
         return;
     }
 
-    DistanceGrid* grid = NULL;
+    std::shared_ptr<DistanceGrid> grid;
     if (fileRigidDistanceGrid.getValue().empty())
     {
-        if (elems.size() == 0 || elems[0].grid == NULL)
+        if (elems.size() == 0 || elems[0].grid == nullptr)
             msg_error() << "An input filename is required.";
         // else the grid has already been set
         return;
@@ -149,19 +143,8 @@ void RigidDistanceGridCollisionModel::resize(sofa::Size s)
     elems.resize(s);
 }
 
-void RigidDistanceGridCollisionModel::setGrid(DistanceGrid* surf, sofa::Index index)
+void RigidDistanceGridCollisionModel::setNewState(sofa::Index index, double dt, const std::shared_ptr<DistanceGrid> grid, const Matrix3& rotation, const Vec3& translation)
 {
-    if (elems[index].grid == surf) return;
-    if (elems[index].grid!=NULL) elems[index].grid->release();
-    elems[index].grid = surf->addRef();
-    modified = true;
-}
-
-void RigidDistanceGridCollisionModel::setNewState(sofa::Index index, double dt, DistanceGrid* grid, const Matrix3& rotation, const Vec3& translation)
-{
-    grid->addRef();
-    if (elems[index].prevGrid!=NULL)
-        elems[index].prevGrid->release();
     elems[index].prevGrid = elems[index].grid;
     elems[index].grid = grid;
     elems[index].prevRotation = elems[index].rotation;
@@ -282,7 +265,7 @@ void RigidDistanceGridCollisionModel::draw(const core::visual::VisualParams* vpa
         if (vparams->displayFlags().getShowWireFrame())
             glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     }
-    if (getPrevious()!=NULL)
+    if (getPrevious()!=nullptr)
         getPrevious()->draw(vparams);
 #endif // SOFADISTANCEGRID_HAVE_SOFA_GL == 1
 }
@@ -304,7 +287,7 @@ void RigidDistanceGridCollisionModel::draw(const core::visual::VisualParams* ,so
         sofa::gl::glMultMatrix(m.ptr());
     }
 
-    DistanceGrid* grid = getGrid(index);
+    const std::shared_ptr<DistanceGrid> grid = getGrid(index);
     DistanceGrid::Coord corners[8];
     for(unsigned int i=0; i<8; i++)
         corners[i] = grid->getCorner(i);
@@ -457,9 +440,7 @@ FFDDistanceGridCollisionModel::FFDDistanceGridCollisionModel()
 }
 
 FFDDistanceGridCollisionModel::~FFDDistanceGridCollisionModel()
-{
-    if (elems.size()>0 && elems[0].grid!=NULL) elems[0].grid->release();
-}
+{}
 
 void FFDDistanceGridCollisionModel::init()
 {
@@ -478,7 +459,7 @@ void FFDDistanceGridCollisionModel::init()
         return;
     }
 
-    DistanceGrid* grid = NULL;
+    std::shared_ptr<DistanceGrid> grid;
     if (fileFFDDistanceGrid.getValue().empty())
     {
         msg_error() << "Requires an input filename";
@@ -588,11 +569,6 @@ bool FFDDistanceGridCollisionModel::canCollideWithElement(sofa::Index index, Col
     if (index >= index2) return false;
     if (elems[index].neighbors.count(index2)) return false;
     return true;
-}
-
-void FFDDistanceGridCollisionModel::setGrid(DistanceGrid* surf, sofa::Index index)
-{
-    elems[index].grid = surf;
 }
 
 /// Create or update the bounding volume hierarchy.
@@ -726,7 +702,7 @@ void FFDDistanceGridCollisionModel::draw(const core::visual::VisualParams* vpara
         if (vparams->displayFlags().getShowWireFrame())
             glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     }
-    if (getPrevious()!=NULL)
+    if (getPrevious()!=nullptr)
         getPrevious()->draw(vparams);
 #endif // SOFADISTANCEGRID_HAVE_SOFA_GL == 1
 }

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
@@ -64,26 +64,24 @@ public:
 
     explicit RigidDistanceGridCollisionElement(const core::CollisionElementIterator& i);
 
-    DistanceGrid* getGrid();
+    std::shared_ptr<DistanceGrid> getGrid();
 
     bool isTransformed();
     const type::Matrix3& getRotation();
     const type::Vec3& getTranslation();
     bool isFlipped();
 
-    void setGrid(DistanceGrid* surf);
-
     /// @name Previous state data
     /// Used to estimate velocity in case the distance grid itself is dynamic
     /// @{
-    DistanceGrid* getPrevGrid();
+    std::shared_ptr<DistanceGrid> getPrevGrid();
     const type::Matrix3& getPrevRotation();
     const type::Vec3& getPrevTranslation();
     double getPrevDt();
     /// @}
 
     /// Set new grid and transform, keeping the old state to estimate velocity
-    void setNewState(double dt, DistanceGrid* grid, const type::Matrix3& rotation, const type::Vec3& translation);
+    void setNewState(double dt, const std::shared_ptr<DistanceGrid> grid, const type::Matrix3& rotation, const type::Vec3& translation);
 };
 
 class SOFA_SOFADISTANCEGRID_API RigidDistanceGridCollisionModel : public core::CollisionModel
@@ -99,19 +97,19 @@ protected:
     public:
         type::Matrix3 rotation;
         type::Vec3 translation;
-        DistanceGrid* grid;
+        std::shared_ptr<DistanceGrid> grid;
 
         /// @name Previous state data
         /// Used to estimate velocity in case the distance grid itself is dynamic
         /// @{
-        DistanceGrid* prevGrid; ///< Previous grid
+        std::shared_ptr<DistanceGrid> prevGrid; ///< Previous grid
         type::Matrix3 prevRotation; ///< Previous rotation
         type::Vec3 prevTranslation; ///< Previous translation
         double prevDt; ///< Time difference between previous and current state
         /// @}
 
         bool isTransformed; ///< True if translation/rotation was set
-        ElementData() : grid(NULL), prevGrid(NULL), prevDt(0.0), isTransformed(false) { rotation.identity(); prevRotation.identity(); }
+        ElementData() : grid(nullptr), prevGrid(nullptr), prevDt(0.0), isTransformed(false) { rotation.identity(); prevRotation.identity(); }
     };
 
     sofa::type::vector<ElementData> elems;
@@ -151,7 +149,7 @@ public:
 
     void init() override;
 
-    DistanceGrid* getGrid(sofa::Index index=0)
+    std::shared_ptr<DistanceGrid> getGrid(sofa::Index index=0)
     {
         return elems[index].grid;
     }
@@ -191,9 +189,7 @@ public:
         return flipNormals.getValue();
     }
 
-    void setGrid(DistanceGrid* surf, sofa::Index index=0);
-
-    DistanceGrid* getPrevGrid(sofa::Index index=0)
+    std::shared_ptr<DistanceGrid> getPrevGrid(sofa::Index index=0)
     {
         return elems[index].prevGrid;
     }
@@ -211,7 +207,7 @@ public:
     }
 
     /// Set new grid and transform, keeping the old state to estimate velocity
-    void setNewState(sofa::Index index, double dt, DistanceGrid* grid, const type::Matrix3& rotation, const type::Vec3& translation);
+    void setNewState(sofa::Index index, double dt, const std::shared_ptr<DistanceGrid> grid, const type::Matrix3& rotation, const type::Vec3& translation);
 
     /// @}
 
@@ -238,20 +234,19 @@ inline RigidDistanceGridCollisionElement::RigidDistanceGridCollisionElement(cons
 {
 }
 
-inline DistanceGrid* RigidDistanceGridCollisionElement::getGrid() { return model->getGrid(index); }
-inline void RigidDistanceGridCollisionElement::setGrid(DistanceGrid* surf) { return model->setGrid(surf, index); }
+inline std::shared_ptr<DistanceGrid> RigidDistanceGridCollisionElement::getGrid() { return model->getGrid(index); }
 
 inline bool RigidDistanceGridCollisionElement::isTransformed() { return model->isTransformed(index); }
 inline const type::Matrix3& RigidDistanceGridCollisionElement::getRotation() { return model->getRotation(index); }
 inline const type::Vec3& RigidDistanceGridCollisionElement::getTranslation() { return model->getTranslation(index); }
 inline bool RigidDistanceGridCollisionElement::isFlipped() { return model->isFlipped(); }
 
-inline DistanceGrid* RigidDistanceGridCollisionElement::getPrevGrid() { return model->getPrevGrid(index); }
+inline std::shared_ptr<DistanceGrid> RigidDistanceGridCollisionElement::getPrevGrid() { return model->getPrevGrid(index); }
 inline const type::Matrix3& RigidDistanceGridCollisionElement::getPrevRotation() { return model->getPrevRotation(index); }
 inline const type::Vec3& RigidDistanceGridCollisionElement::getPrevTranslation() { return model->getPrevTranslation(index); }
 inline double RigidDistanceGridCollisionElement::getPrevDt() { return model->getPrevDt(index); }
 
-inline void RigidDistanceGridCollisionElement::setNewState(double dt, DistanceGrid* grid, const type::Matrix3& rotation, const type::Vec3& translation)
+inline void RigidDistanceGridCollisionElement::setNewState(double dt, const std::shared_ptr<DistanceGrid> grid, const type::Matrix3& rotation, const type::Vec3& translation)
 {
     return model->setNewState(this->getIndex(), dt, grid, rotation, translation);
 }
@@ -270,9 +265,7 @@ public:
 
     explicit FFDDistanceGridCollisionElement(const core::CollisionElementIterator& i);
 
-    DistanceGrid* getGrid();
-
-    void setGrid(DistanceGrid* surf);
+    std::shared_ptr<DistanceGrid> getGrid();
 };
 
 class SOFA_SOFADISTANCEGRID_API FFDDistanceGridCollisionModel : public core::CollisionModel
@@ -286,8 +279,8 @@ public:
     class SOFA_SOFADISTANCEGRID_API DeformedCube
     {
     public:
-        DistanceGrid* grid;
-        DeformedCube() : grid(NULL) {}
+        std::shared_ptr<DistanceGrid> grid;
+        DeformedCube() : grid(nullptr) {}
         int elem; ///< Index of the corresponding element in the topology
         std::set<int> neighbors; ///< Index of the neighbors (used for self-collisions)
         struct Point
@@ -464,7 +457,7 @@ public:
 
     void init() override;
 
-    DistanceGrid* getGrid(sofa::Index index=0)
+    std::shared_ptr<DistanceGrid> getGrid(sofa::Index index=0)
     {
         return elems[index].grid;
     }
@@ -473,8 +466,6 @@ public:
     {
         return elems[index];
     }
-
-    void setGrid(DistanceGrid* surf, sofa::Index index=0);
 
     /// CollisionModel interface
     void resize(sofa::Size size) override;
@@ -498,8 +489,7 @@ inline FFDDistanceGridCollisionElement::FFDDistanceGridCollisionElement(const co
 {
 }
 
-inline DistanceGrid* FFDDistanceGridCollisionElement::getGrid() { return model->getGrid(index); }
-inline void FFDDistanceGridCollisionElement::setGrid(DistanceGrid* surf) { return model->setGrid(surf, index); }
+inline std::shared_ptr<DistanceGrid> FFDDistanceGridCollisionElement::getGrid() { return model->getGrid(index); }
 
 /// Mapper for FFDDistanceGridCollisionModel
 template <class DataTypes>
@@ -540,7 +530,7 @@ public:
         using sofa::component::mapping::linear::IdentityMapping;
 
         MMechanicalState* outmodel = Inherit::createMapping(name);
-        if (this->child!=NULL && this->mapping==NULL)
+        if (this->child!=nullptr && this->mapping==nullptr)
         {
             //TODO(dmarchal):2017-05-26 This comment may become a conditional code.
             // add velocity visualization
@@ -587,9 +577,9 @@ public:
                 {
                     v = (x - (model->getPrevTranslation(index) + model->    getPrevRotation(index) * P)) * (1.0/gdt);
                 }
-                DistanceGrid* prevGrid = model->getPrevGrid(index);
+                std::shared_ptr<DistanceGrid> prevGrid = model->getPrevGrid(index);
                 //DistanceGrid* grid = model->getGrid(index);
-                //if (prevGrid != NULL && prevGrid != grid && prevGrid->inGrid(P))
+                //if (prevGrid != nullptr && prevGrid != grid && prevGrid->inGrid(P))
                 {
                     DistanceGrid::Coord coefs;
                     int ii = prevGrid->index(P, coefs);

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
@@ -62,8 +62,8 @@ bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollis
 int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, RigidDistanceGridCollisionElement& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     int nc = 0;
-    DistanceGrid* grid1 = e1.getGrid();
-    DistanceGrid* grid2 = e2.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid2 = e2.getGrid();
     FFDDistanceGridCollisionModel::DeformedCube& c1 = e1.getCollisionModel()->getDeformCube(e1.getIndex());
     bool useXForm = e2.isTransformed();
     //const type::Vec3& t1 = e1.getTranslation();
@@ -238,8 +238,8 @@ bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollis
 int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, FFDDistanceGridCollisionElement& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     int nc = 0;
-    DistanceGrid* grid1 = e1.getGrid();
-    DistanceGrid* grid2 = e2.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid2 = e2.getGrid();
     FFDDistanceGridCollisionModel::DeformedCube& c1 = e1.getCollisionModel()->getDeformCube(e1.getIndex());
     FFDDistanceGridCollisionModel::DeformedCube& c2 = e2.getCollisionModel()->getDeformCube(e2.getIndex());
     const bool usePoints1 = e1.getCollisionModel()->usePoints.getValue();
@@ -435,7 +435,7 @@ bool FFDDistanceGridDiscreteIntersection::testIntersection(FFDDistanceGridCollis
 int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, Point& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
 
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     FFDDistanceGridCollisionModel::DeformedCube& c1 = e1.getCollisionModel()->getDeformCube(e1.getIndex());
 
     const double d0 = e1.getProximity() + e2.getProximity() + intersection->getContactDistance();
@@ -526,7 +526,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
     const int f2 = e2.flags();
     if (!(f2&TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS)) return 0; // no points associated with this triangle
 
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     FFDDistanceGridCollisionModel::DeformedCube& c1 = e1.getCollisionModel()->getDeformCube(e1.getIndex());
 
     const double d0 = e1.getProximity() + e2.getProximity() + intersection->getContactDistance();
@@ -621,7 +621,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(Ray& e2, FFDDistanc
     type::Vec3 rayDirection(e2.direction());
     const double rayLength = e2.l();
 
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     FFDDistanceGridCollisionModel::DeformedCube& c1 = e1.getCollisionModel()->getDeformCube(e1.getIndex());
 
     // Center of the sphere

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.inl
@@ -51,7 +51,7 @@ template<class T>
 int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridCollisionElement& e1, geometry::TSphere<T>& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
 
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     FFDDistanceGridCollisionModel::DeformedCube& c1 = e1.getCollisionModel()->getDeformCube(e1.getIndex());
 
     const double d0 = e1.getProximity() + e2.getProximity() + intersection->getContactDistance() + e2.r();

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
@@ -65,8 +65,8 @@ bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCo
 int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, RigidDistanceGridCollisionElement& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
     int nc = 0;
-    DistanceGrid* grid1 = e1.getGrid();
-    DistanceGrid* grid2 = e2.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid2 = e2.getGrid();
     bool useXForm = e1.isTransformed() || e2.isTransformed();
     const type::Vec3& t1 = e1.getTranslation();
     const Matrix3& r1 = e1.getRotation();
@@ -556,7 +556,7 @@ bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCo
 
 int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, Point& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     bool useXForm = e1.isTransformed();
     const type::Vec3& t1 = e1.getTranslation();
     const Matrix3& r1 = e1.getRotation();
@@ -621,7 +621,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
 {
     const int f2 = e2.flags();
     if (!(f2&(TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS|TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_BEDGES))) return 0; // no points associated with this triangle
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     const bool useXForm = e1.isTransformed();
     const type::Vec3& t1 = e1.getTranslation();
     const Matrix3& r1 = e1.getRotation();
@@ -730,7 +730,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
 {
     const int f2 = e2.flags();
     if (!(f2&LineCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS)) return 0; // no points associated with this line
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     const bool useXForm = e1.isTransformed();
     const type::Vec3& t1 = e1.getTranslation();
     const Matrix3& r1 = e1.getRotation();
@@ -797,7 +797,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(Ray& e2, RigidDis
     const double rayLength = e2.l();
 
     int nc = 0;
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     bool useXForm = e1.isTransformed();
 
     if (useXForm)

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
@@ -48,7 +48,7 @@ bool RigidDistanceGridDiscreteIntersection::testIntersection(RigidDistanceGridCo
 template<class T>
 int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGridCollisionElement& e1, geometry::TSphere<T>& e2, OutputVector* contacts, const core::collision::Intersection* intersection)
 {
-    DistanceGrid* grid1 = e1.getGrid();
+    const std::shared_ptr<DistanceGrid> grid1 = e1.getGrid();
     bool useXForm = e1.isTransformed();
     const type::Vec3& t1 = e1.getTranslation();
     const sofa::type::Matrix3& r1 = e1.getRotation();

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
@@ -62,7 +62,7 @@ public:
     typedef container::DistanceGrid DistanceGrid;
 
 protected:
-    DistanceGrid* grid;
+    std::shared_ptr<DistanceGrid> grid;
 
     class Contact
     {
@@ -170,7 +170,7 @@ public:
     Data< type::Vec<2,int> > localRange;
 protected:
     DistanceGridForceField()
-        : grid(NULL)
+        : grid(nullptr)
         , fileDistanceGrid( initData( &fileDistanceGrid, "filename", "load distance grid from specified file"))
         , scale( initData( &scale, 1.0, "scale", "scaling factor for input file"))
         , box( initData( &box, "box", "Field bounding box defined by xmin,ymin,zmin, xmax,ymax,zmax") )

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -50,7 +50,7 @@ void DistanceGridForceField<DataTypes>::init()
 
     if (fileDistanceGrid.getValue().empty())
     {
-        if (grid==NULL)
+        if (grid == nullptr)
             msg_error() << "DistanceGridForceField requires an input filename." ;
         /// the grid has already been set
         return;


### PR DESCRIPTION
**Should be reviewed and merged after https://github.com/sofa-framework/sofa/pull/5411 to include regression tests**

The DistanceGrid class is responsible for computing/loading a distance grid and sharing it with the other components of the plugin. Since more than one component may use the same grid, a static map is used to load each separate instance once and store it globally to share it whenever required:
https://github.com/sofa-framework/sofa/blob/f8fb655aebc38238fcf68c110c58b2ddc114a8ed/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.cpp#L1453-L1457
It keeps count of the pointers it has shared and deletes itself when all of them are freed.
https://github.com/sofa-framework/sofa/blob/f8fb655aebc38238fcf68c110c58b2ddc114a8ed/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.cpp#L112-L118

This PR reproduces the functionality with smart pointers. Less manual memory management.
[ci-depends-on https://github.com/sofa-framework/Regression/pull/81]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
