### PR TITLE
[LinearSolver] Fix usage of a wrong pointer

### DIFF
--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.inl
@@ -164,9 +164,10 @@ void MatrixLinearSolver<Matrix, Vector, NoThreadManager>::doCheckLinearSystem()
             }
             else
             {
+                auto* firstCandidate = *notAlreadyAssociated.begin();
                 if (notAlreadyAssociated.size() == 1)
                 {
-                    msg_info() << "Linear system found: " << l_linearSystem->getPathName();
+                    msg_info() << "Linear system found: " << firstCandidate->getPathName();
                 }
                 else
                 {
@@ -174,7 +175,7 @@ void MatrixLinearSolver<Matrix, Vector, NoThreadManager>::doCheckLinearSystem()
                         << "to this linear solver. The first one in the list is selected. Set the link " << l_linearSystem.getLinkedPath()
                         << " properly to remove this warning.";
                 }
-                l_linearSystem.set(*notAlreadyAssociated.begin());
+                l_linearSystem.set(firstCandidate);
             }
         }
     }


### PR DESCRIPTION
`l_linearSystem` was not yet set when it is used in the `msg_info`



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
