### PR TITLE
[Topology.Container.Dynamic] Missing call to super init

### DIFF
--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.cpp
@@ -54,6 +54,8 @@ EdgeSetTopologyContainer::EdgeSetTopologyContainer()
 
 void EdgeSetTopologyContainer::init()
 {
+    core::topology::TopologyContainer::init();
+
     const helper::ReadAccessor< Data< sofa::type::vector<Edge> > > m_edge = d_edge;
     
     if (d_initPoints.isSet())
@@ -71,8 +73,6 @@ void EdgeSetTopologyContainer::init()
             }
         }
     }
-
-    PointSetTopologyContainer::init();
 
     // only init if edges are present at init.
     if (!m_edge.empty())

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/HexahedronSetTopologyContainer.cpp
@@ -63,6 +63,8 @@ void HexahedronSetTopologyContainer::addHexa(Index a, Index b, Index c, Index d,
 
 void HexahedronSetTopologyContainer::init()
 {
+    core::topology::TopologyContainer::init();
+
     const helper::ReadAccessor< Data< sofa::type::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
 
     if (d_initPoints.isSet())

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/QuadSetTopologyContainer.cpp
@@ -53,6 +53,8 @@ void QuadSetTopologyContainer::addQuad(Index a, Index b, Index c, Index d )
 
 void QuadSetTopologyContainer::init()
 {
+    core::topology::TopologyContainer::init();
+
     const helper::ReadAccessor< Data< sofa::type::vector<Quad> > > m_quads = d_quad;
     if (d_initPoints.isSet())
     {

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.cpp
@@ -59,6 +59,8 @@ void TetrahedronSetTopologyContainer::addTetra(Index a, Index b, Index c, Index 
 
 void TetrahedronSetTopologyContainer::init()
 {
+    core::topology::TopologyContainer::init();
+
     const helper::ReadAccessor< Data< sofa::type::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
 
     if (d_initPoints.isSet())

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetTopologyContainer.cpp
@@ -52,6 +52,8 @@ void TriangleSetTopologyContainer::addTriangle(Index a, Index b, Index c )
 
 void TriangleSetTopologyContainer::init()
 {
+    core::topology::TopologyContainer::init();
+
     const helper::ReadAccessor< Data< sofa::type::vector<Triangle> > > m_triangle = d_triangle;
 
     if (d_initPoints.isSet())

--- a/examples/Demos/sofa_1000PR.scn
+++ b/examples/Demos/sofa_1000PR.scn
@@ -48,7 +48,9 @@
         <GenericConstraintCorrection name="Torus1_ConstraintCorrection" printLog="0" />
 
         <Node name="Surf">
-            <include href="Objects/HexahedronSetTopology.xml" src="@../grid" drawHexa="1" />
+            <HexahedronSetTopologyContainer  name="Container" position="@../grid.position" hexahedra="@../grid.hexahedra"/>
+            <HexahedronSetTopologyModifier   name="Modifier" />
+            <HexahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3"/>
             <Node name="Q">
                 <QuadSetTopologyContainer  name="Container" />
                 <QuadSetTopologyModifier   name="Modifier" />
@@ -78,7 +80,9 @@
         <GenericConstraintCorrection name="Torus1_ConstraintCorrection" printLog="0" />
 
         <Node name="Surf">
-            <include href="Objects/HexahedronSetTopology.xml" src="@../grid" drawHexa="1" />
+            <HexahedronSetTopologyContainer  name="Container" position="@../grid.position" hexahedra="@../grid.hexahedra" />
+            <HexahedronSetTopologyModifier   name="Modifier" />
+            <HexahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
             <Node name="Q">
                 <QuadSetTopologyContainer  name="Container" />
                 <QuadSetTopologyModifier   name="Modifier" />
@@ -107,7 +111,9 @@
         <HexahedronFEMForceField name="FEM" youngModulus="200" poissonRatio="0.3" method="large" />
         <GenericConstraintCorrection name="Torus1_ConstraintCorrection" printLog="0" />
         <Node name="Surf">
-            <include href="Objects/HexahedronSetTopology.xml" src="@../grid" drawHexa="1" />
+            <HexahedronSetTopologyContainer  name="Container" position="@../grid.position" hexahedra="@../grid.hexahedra" />
+            <HexahedronSetTopologyModifier   name="Modifier" />
+            <HexahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
             <Node name="Q">
                 <QuadSetTopologyContainer  name="Container" />
                 <QuadSetTopologyModifier   name="Modifier" />
@@ -136,7 +142,9 @@
         <HexahedronFEMForceField name="FEM" youngModulus="200" poissonRatio="0.3" method="large" />
         <GenericConstraintCorrection name="Torus1_ConstraintCorrection" printLog="0" />
         <Node name="Surf">
-            <include href="Objects/HexahedronSetTopology.xml" src="@../grid" drawHexa="1" />
+            <HexahedronSetTopologyContainer  name="Container" position="@../grid.position" hexahedra="@../grid.hexahedra" />
+            <HexahedronSetTopologyModifier   name="Modifier" />
+            <HexahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
             <Node name="Q">
                 <QuadSetTopologyContainer  name="Container" />
                 <QuadSetTopologyModifier   name="Modifier" />


### PR DESCRIPTION
The missing calls to super init prevent the loading of `BaseMeshTopology::fileTopology` in `BaseMeshTopology::init()` in derived classes.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
