### PR TITLE
[Framework] Apply template method design pattern to BaseRotationFinder

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
@@ -145,7 +145,7 @@ public:
     const Transformation& getElementRotation(const sofa::Index elemidx);
 
     void getNodeRotation(Transformation& R, sofa::Index nodeIdx) ;
-    void getRotations(linearalgebra::BaseMatrix * rotations,int offset = 0) override ;
+    void doGetRotations(linearalgebra::BaseMatrix * rotations,int offset = 0) override ;
 
     using Inherit1::addKToMatrix;
     void addKToMatrix(sofa::linearalgebra::BaseMatrix * matrix, SReal kFact, unsigned int &offset) override;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.inl
@@ -973,7 +973,7 @@ void HexahedronFEMForceField<DataTypes>::getNodeRotation(Transformation& R, unsi
 }
 
 template<class DataTypes>
-void HexahedronFEMForceField<DataTypes>::getRotations(linearalgebra::BaseMatrix * rotations,int offset)
+void HexahedronFEMForceField<DataTypes>::doGetRotations(linearalgebra::BaseMatrix * rotations,int offset)
 {
     auto nbdof = this->mstate->getSize();
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -182,7 +182,7 @@ public:
     void getRotations(VecReal& vecR) ;
     
     // BaseRotationFinder API
-    void getRotations(linearalgebra::BaseMatrix * rotations,int offset = 0) override;
+    void doGetRotations(linearalgebra::BaseMatrix * rotations,int offset = 0) override;
     // RotationFinder<T> API
     type::vector< Mat33 > m_rotations;
     const type::vector<Mat33>& getRotations() override;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -2042,7 +2042,7 @@ void TetrahedronFEMForceField<DataTypes>::getRotations(VecReal& vecR)
 }
 
 template<class DataTypes>
-void TetrahedronFEMForceField<DataTypes>::getRotations(linearalgebra::BaseMatrix * rotations,int offset)
+void TetrahedronFEMForceField<DataTypes>::doGetRotations(linearalgebra::BaseMatrix * rotations,int offset)
 {
     const std::size_t nbdof = this->mstate->getSize();
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseRotationFinder.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseRotationFinder.h
@@ -43,7 +43,7 @@ public:
     virtual void getRotations(linearalgebra::BaseMatrix * m, int offset = 0) final
     {
         //TODO (SPRINT SED 2025): Component state mechamism
-        this->doGetRotations(m,offset);
+        doGetRotations(m,offset);
     }
 
 protected:

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseRotationFinder.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseRotationFinder.h
@@ -32,7 +32,22 @@ class BaseRotationFinder : public virtual sofa::core::objectmodel::BaseComponent
 public:
     SOFA_ABSTRACT_CLASS(BaseRotationFinder, sofa::core::objectmodel::BaseComponent);
 
-    virtual void getRotations(linearalgebra::BaseMatrix * m, int offset = 0) = 0;
+    /**
+     * !!! WARNING since v25.12 !!!
+     *
+     * The template method pattern has been applied to this part of the API.
+     * This method calls the newly introduced method "doGetRotations" internally,
+     * which is the method to override from now on.
+     *
+     **/
+    virtual void getRotations(linearalgebra::BaseMatrix * m, int offset = 0) final
+    {
+        //TODO (SPRINT SED 2025): Component state mechamism
+        this->doGetRotations(m,offset);
+    }
+
+protected:
+    virtual void doGetRotations(linearalgebra::BaseMatrix * m, int offset = 0) = 0;
 };
 
 } // namespace sofa::core::behavior

--- a/Sofa/framework/Core/src/sofa/core/behavior/RotationFinder.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/RotationFinder.h
@@ -42,7 +42,7 @@ public:
     typedef typename Coord::value_type Real;
     typedef type::Mat< 3, 3, Real > Mat3x3;
 
-    using BaseRotationFinder::getRotations;
+    using BaseRotationFinder::doGetRotations;
     virtual const type::vector< Mat3x3 >& getRotations() = 0;
 };
 

--- a/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.h
+++ b/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.h
@@ -353,7 +353,7 @@ public:
     template<> void HexahedronFEMForceField< T >::reinit(); \
     template<> void HexahedronFEMForceField< T >::addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v); \
     template<> void HexahedronFEMForceField< T >::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx); \
-    template<> void HexahedronFEMForceField< T >::getRotations(linearalgebra::BaseMatrix* rotations, int offset); \
+    template<> void HexahedronFEMForceField< T >::doGetRotations(linearalgebra::BaseMatrix* rotations, int offset); \
 
 CudaHexahedronFEMForceField_DeclMethods(gpu::cuda::CudaVec3fTypes);
 

--- a/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.inl
+++ b/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaHexahedronFEMForceField.inl
@@ -249,7 +249,7 @@ const HexahedronFEMForceField<gpu::cuda::CudaVec3fTypes>::Transformation& Hexahe
 }
 
 template<>
-void HexahedronFEMForceField<gpu::cuda::CudaVec3fTypes>::getRotations(linearalgebra::BaseMatrix * rotations,int offset)
+void HexahedronFEMForceField<gpu::cuda::CudaVec3fTypes>::doGetRotations(linearalgebra::BaseMatrix * rotations,int offset)
 {
     const auto nbdof = this->mstate->getSize();
 

--- a/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.h
+++ b/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.h
@@ -276,7 +276,7 @@ public:
     template<> void TetrahedronFEMForceField< T >::reinit(); \
     template<> void TetrahedronFEMForceField< T >::addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v); \
     template<> void TetrahedronFEMForceField< T >::getRotations(VecReal& vecR); \
-    template<> void TetrahedronFEMForceField< T >::getRotations(linearalgebra::BaseMatrix * vecR,int offset); \
+    template<> void TetrahedronFEMForceField< T >::doGetRotations(linearalgebra::BaseMatrix * vecR,int offset); \
     template<> void TetrahedronFEMForceField< T >::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx); \
     template<> void TetrahedronFEMForceField< T >::addKToMatrix(sofa::linearalgebra::BaseMatrix* mat, SReal kFactor, unsigned int& offset); \
 

--- a/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.inl
+++ b/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/solidmechanics/fem/elastic/CudaTetrahedronFEMForceField.inl
@@ -634,7 +634,7 @@ void TetrahedronFEMForceFieldInternalData< gpu::cuda::CudaVectorTypes<TCoord,TDe
 } \
     template<> inline void TetrahedronFEMForceField< T >::getRotations(VecReal & rotations) \
 { data.getRotations(this, rotations); } \
-    template<> inline void TetrahedronFEMForceField< T >::getRotations(linearalgebra::BaseMatrix * rotations,int offset) \
+    template<> inline void TetrahedronFEMForceField< T >::doGetRotations(linearalgebra::BaseMatrix * rotations,int offset) \
 { data.getRotations(this, rotations,offset); } \
     template<> inline void TetrahedronFEMForceField< T >::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) \
 { \


### PR DESCRIPTION


BaseRotationFinder::getRotations is now "template method pattern" ready.

RotationFinder, HexahedronFEMForceField, TetrahedronFEMForceField, and their cuda counterparts have been modified accordingly.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
