### PR TITLE
[Framework] Apply template method design pattern to BaseOrderingMethod

### DIFF
--- a/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/BaseEigenOrderingMethod.h
+++ b/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/BaseEigenOrderingMethod.h
@@ -39,15 +39,17 @@ public:
 
     using core::behavior::BaseOrderingMethod::SparseMatrixPattern;
 
-    void computePermutation(
+protected:
+    void doComputePermutation(
         const SparseMatrixPattern& inPattern,
         int* outPermutation,
         int* outInversePermutation) override;
 };
 
 template <class EigenOrderingMethodType>
-void BaseEigenOrderingMethod<EigenOrderingMethodType>::computePermutation(
-    const SparseMatrixPattern& inPattern, int* outPermutation,
+void BaseEigenOrderingMethod<EigenOrderingMethodType>::doComputePermutation(
+    const SparseMatrixPattern& inPattern, 
+    int* outPermutation,
     int* outInversePermutation)
 {
     EigenOrderingMethodType ordering;

--- a/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/NaturalOrderingMethod.cpp
+++ b/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/NaturalOrderingMethod.cpp
@@ -31,7 +31,7 @@ std::string NaturalOrderingMethod::methodName() const
     return "Natural";
 }
 
-void NaturalOrderingMethod::computePermutation(
+void NaturalOrderingMethod::doComputePermutation(
     const SparseMatrixPattern& inPattern, int* outPermutation,
     int* outInversePermutation)
 {

--- a/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/NaturalOrderingMethod.h
+++ b/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/NaturalOrderingMethod.h
@@ -36,7 +36,8 @@ public:
 
     std::string methodName() const override;
 
-    void computePermutation(
+protected:
+    void doComputePermutation(
         const SparseMatrixPattern& inPattern,
         int* outPermutation,
         int* outInversePermutation) override;

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseOrderingMethod.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseOrderingMethod.h
@@ -47,8 +47,19 @@ public:
         int* colsIndex;
     };
 
+    /**
+     * Returns an identifier for the method name. This can be used as a key
+     * in a factory of solvers. See @EigenDirectSparseSolver
+     */
+    virtual std::string methodName() const = 0;
 
     /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doComputePermutation" internally,
+     * which is the method to override from now on.
+     * 
      * Computes a permutation so that a permutation matrix can be applied on
      * sparse matrices before a factorization. It helps to reduce the number of
      * elements in the decomposition, hence improving the computation time
@@ -59,18 +70,16 @@ public:
      * \param outInversePermutation The inverse of the computed permutation. A
      * memory space of the size of the matrix is expected.
      */
-    virtual void computePermutation(
-        const SparseMatrixPattern& inPattern,
-        int* outPermutation,
-        int* outInversePermutation) = 0;
+    virtual void computePermutation(const SparseMatrixPattern& inPattern, int* outPermutation, int* outInversePermutation) final {
+        //TODO (SPRINT SED 2025): Component state mechamism
+        this->doComputePermutation(inPattern, outPermutation, outInversePermutation);
+    }
 
-    /**
-     * Returns an identifier for the method name. This can be used as a key
-     * in a factory of solvers. See @EigenDirectSparseSolver
-     */
-    virtual std::string methodName() const = 0;
+    static void computeInverseFromPermutation(int matrixSize, const int* inPermutation, int* outInversePermutation) ;
 
-    static void computeInverseFromPermutation(int matrixSize, const int* inPermutation, int* outInversePermutation);
+protected:
+    virtual void doComputePermutation(const SparseMatrixPattern& inPattern, int* outPermutation, int* outInversePermutation) = 0;
+
 };
 
 }

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseOrderingMethod.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseOrderingMethod.h
@@ -70,7 +70,8 @@ public:
      * \param outInversePermutation The inverse of the computed permutation. A
      * memory space of the size of the matrix is expected.
      */
-    virtual void computePermutation(const SparseMatrixPattern& inPattern, int* outPermutation, int* outInversePermutation) final {
+    virtual void computePermutation(const SparseMatrixPattern& inPattern, int* outPermutation, int* outInversePermutation) final
+    {
         //TODO (SPRINT SED 2025): Component state mechamism
         this->doComputePermutation(inPattern, outPermutation, outInversePermutation);
     }


### PR DESCRIPTION
**SED Sprint 2025**

Base class `BaseOrderingMethod`, function modified:   
- `computePermutation (const SparseMatrixPattern& inPattern, int* outPermutation, int* outInversePermutation)`

Child classes modified:
- Sofa: components
  - `BaseEigenOrderingMethod`
  - `NaturalOrderingMethod`

+ child class `MetisOrderingMethod` modified in Sofa.Metis plugin (see below)

[ci-depends-on https://github.com/sofa-framework/Sofa.Metis/pull/10]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
