### PR TITLE
[Framework] Apply template method design pattern to BaseMass

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.h
@@ -311,8 +311,8 @@ public:
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
     void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
-    SReal getElementMass(sofa::Index index) const override;
-    void getElementMass(sofa::Index, linearalgebra::BaseMatrix *m) const override;
+    SReal doGetElementMass(sofa::Index index) const override;
+    void doGetElementMass(sofa::Index, linearalgebra::BaseMatrix *m) const override;
 
     bool isDiagonal() const override {return true;}
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.h
@@ -307,7 +307,7 @@ public:
 
     /// Add Mass contribution to global Matrix assembling
     void addMToMatrix(sofa::linearalgebra::BaseMatrix * mat, SReal mFact, unsigned int &offset) override;
-    void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
+    void doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
     void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -627,7 +627,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::addMToMatrix(sofa::linearalgebra
 }
 
 template <class DataTypes, class GeometricalTypes>
-void DiagonalMass<DataTypes, GeometricalTypes>::buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
+void DiagonalMass<DataTypes, GeometricalTypes>::doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
 {
     const MassVector &masses= d_vertexMass.getValue();
     static constexpr auto N = Deriv::total_size;

--- a/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -641,7 +641,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::doBuildMassMatrix(sofa::core::be
 
 
 template <class DataTypes, class GeometricalTypes>
-SReal DiagonalMass<DataTypes, GeometricalTypes>::getElementMass(sofa::Index index) const
+SReal DiagonalMass<DataTypes, GeometricalTypes>::doGetElementMass(sofa::Index index) const
 {
     return SReal(d_vertexMass.getValue()[index]);
 }
@@ -649,7 +649,7 @@ SReal DiagonalMass<DataTypes, GeometricalTypes>::getElementMass(sofa::Index inde
 
 //TODO: special case for Rigid Mass
 template <class DataTypes, class GeometricalTypes>
-void DiagonalMass<DataTypes, GeometricalTypes>::getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const
+void DiagonalMass<DataTypes, GeometricalTypes>::doGetElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const
 {
     static const linearalgebra::BaseMatrix::Index dimension = linearalgebra::BaseMatrix::Index(defaulttype::DataTypeInfo<Deriv>::size());
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -225,8 +225,8 @@ public:
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
     void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
-    SReal getElementMass(Index index) const override;
-    void getElementMass(Index index, linearalgebra::BaseMatrix *m) const override;
+    SReal doGetElementMass(Index index) const override;
+    void doGetElementMass(Index index, linearalgebra::BaseMatrix *m) const override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -221,7 +221,7 @@ public:
     /// Add Mass contribution to global Matrix assembling
     using Inherited::addMToMatrix;
     void addMToMatrix(sofa::linearalgebra::BaseMatrix * mat, SReal mFact, unsigned int &offset) override;
-    void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
+    void doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
     void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -2258,7 +2258,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addMToMatrix(sofa::linearalgeb
 }
 
 template <class DataTypes, class GeometricalTypes>
-void MeshMatrixMass<DataTypes, GeometricalTypes>::buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
+void MeshMatrixMass<DataTypes, GeometricalTypes>::doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
 {
     const MassVector &vertexMass= d_vertexMass.getValue();
     const MassVector &edgeMass= d_edgeMass.getValue();

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -2299,7 +2299,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::doBuildMassMatrix(sofa::core::
 
 
 template <class DataTypes, class GeometricalTypes>
-SReal MeshMatrixMass<DataTypes, GeometricalTypes>::getElementMass(Index index) const
+SReal MeshMatrixMass<DataTypes, GeometricalTypes>::doGetElementMass(Index index) const
 {
     const auto &vertexMass= d_vertexMass.getValue();
     const SReal mass = vertexMass[index] * m_massLumpingCoeff;
@@ -2310,7 +2310,7 @@ SReal MeshMatrixMass<DataTypes, GeometricalTypes>::getElementMass(Index index) c
 
 //TODO: special case for Rigid Mass
 template <class DataTypes, class GeometricalTypes>
-void MeshMatrixMass<DataTypes, GeometricalTypes>::getElementMass(Index index, linearalgebra::BaseMatrix *m) const
+void MeshMatrixMass<DataTypes, GeometricalTypes>::doGetElementMass(Index index, linearalgebra::BaseMatrix *m) const
 {
     static const linearalgebra::BaseMatrix::Index dimension = linearalgebra::BaseMatrix::Index(defaulttype::DataTypeInfo<Deriv>::size());
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);

--- a/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.h
@@ -146,7 +146,7 @@ public:
 
     using Inherited::addMToMatrix;
     void addMToMatrix(sofa::linearalgebra::BaseMatrix * mat, SReal mFact, unsigned int &offset) override; /// Add Mass contribution to global Matrix assembling
-    void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
+    void doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
     void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.h
@@ -150,8 +150,8 @@ public:
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
     void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
-    SReal getElementMass(sofa::Index index) const override;
-    void getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const override;
+    SReal doGetElementMass(sofa::Index index) const override;
+    void doGetElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const override;
 
     bool isDiagonal() const override {return true;}
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
@@ -593,14 +593,14 @@ void UniformMass<DataTypes>::doBuildMassMatrix(sofa::core::behavior::MassMatrixA
 
 
 template <class DataTypes>
-SReal UniformMass<DataTypes>::getElementMass (sofa::Index ) const
+SReal UniformMass<DataTypes>::doGetElementMass (sofa::Index ) const
 {
     return (SReal ( d_vertexMass.getValue() ));
 }
 
 
 template <class DataTypes>
-void UniformMass<DataTypes>::getElementMass (sofa::Index  index, BaseMatrix *m ) const
+void UniformMass<DataTypes>::doGetElementMass (sofa::Index  index, BaseMatrix *m ) const
 {
     SOFA_UNUSED(index);
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
@@ -572,7 +572,7 @@ void UniformMass<DataTypes>::addMToMatrix (sofa::linearalgebra::BaseMatrix * mat
 }
 
 template <class DataTypes>
-void UniformMass<DataTypes>::buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
+void UniformMass<DataTypes>::doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
 {
     if (!this->isComponentStateValid())
     {

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedralFEMForceFieldAndMass.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedralFEMForceFieldAndMass.h
@@ -106,7 +106,7 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
-    SReal getElementMass(sofa::Index index) const override;
+    SReal doGetElementMass(sofa::Index index) const override;
 
     void setDensity(Real d) {d_density.setValue(d );}
     Real getDensity() {return d_density.getValue();}

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedralFEMForceFieldAndMass.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedralFEMForceFieldAndMass.inl
@@ -436,7 +436,7 @@ void HexahedralFEMForceFieldAndMass<DataTypes>::addDForce(const core::Mechanical
 
 
 template<class DataTypes>
-SReal HexahedralFEMForceFieldAndMass<DataTypes>::getElementMass(sofa::Index /*index*/) const
+SReal HexahedralFEMForceFieldAndMass<DataTypes>::doGetElementMass(sofa::Index /*index*/) const
 {
     msg_error() << "HexahedralFEMForceFieldAndMass<DataTypes>::getElementMass not yet implemented";
     return 0.0;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.h
@@ -85,7 +85,7 @@ public:
     }
 
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix*) override;
-    void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
+    void doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
 
      void accFromF(const core::MechanicalParams* mparams, DataVecDeriv& a, const DataVecDeriv& f) override;
 
@@ -103,7 +103,7 @@ public:
         return 0.0;
     }
 
-    SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/) const override
+    SReal doGetPotentialEnergy(const core::MechanicalParams* /*mparams*/) const override
     {
         msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.h
@@ -113,7 +113,7 @@ public:
 
     void addGravityToV(const core::MechanicalParams* mparams, DataVecDeriv& d_v) override;
 
-    SReal getElementMass(Index index) const override;
+    SReal doGetElementMass(Index index) const override;
     // visual model
 
     void draw(const core::visual::VisualParams* vparams) override;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.inl
@@ -262,7 +262,7 @@ void HexahedronFEMForceFieldAndMass<DataTypes>::buildStiffnessMatrix(core::behav
 }
 
 template<class DataTypes>
-void HexahedronFEMForceFieldAndMass<DataTypes>::buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
+void HexahedronFEMForceFieldAndMass<DataTypes>::doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
 {
     int e = 0;
     for(auto it = this->getIndexedElements()->begin(); it != this->getIndexedElements()->end() ; ++it, ++e)

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceFieldAndMass.inl
@@ -337,7 +337,7 @@ void HexahedronFEMForceFieldAndMass<DataTypes>::addDForce(const core::Mechanical
 
 
 template<class DataTypes>
-SReal HexahedronFEMForceFieldAndMass<DataTypes>::getElementMass(sofa::Index /*index*/) const
+SReal HexahedronFEMForceFieldAndMass<DataTypes>::doGetElementMass(sofa::Index /*index*/) const
 {
     msg_warning()<<"HexahedronFEMForceFieldAndMass<DataTypes>::getElementMass not yet implemented"<<msgendl; return 0.0;
 }

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.cpp
@@ -35,6 +35,78 @@ BaseMass::BaseMass()
 {
 }
 
+void BaseMass::addMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor)
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doAddMDx(mparams, fid, factor);
+}
+
+void BaseMass::accFromF(const MechanicalParams* mparams, MultiVecDerivId aid)
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doAccFromF(mparams, aid);
+}
+
+void BaseMass::addGravityToV(const MechanicalParams* mparams, MultiVecDerivId vid)
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doAddGravityToV(mparams, vid);
+}
+
+SReal BaseMass::getKineticEnergy(const MechanicalParams* mparams) const
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    return doGetKineticEnergy(mparams);
+}
+
+SReal BaseMass::getPotentialEnergy(const MechanicalParams* mparams) const
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    return doGetPotentialEnergy(mparams);
+}
+
+type::Vec6 BaseMass::getMomentum(const MechanicalParams* mparams) const
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    return doGetMomentum(mparams);
+}
+
+void BaseMass::addMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doAddMToMatrix(mparams, matrix);
+}
+
+void BaseMass::buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doBuildMassMatrix(matrices);
+}
+
+void BaseMass::initGnuplot(const std::string path)
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doInitGnuplot(path);
+}
+
+void BaseMass::exportGnuplot(const MechanicalParams* mparams, SReal time)
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doExportGnuplot(mparams, time);
+}
+
+SReal BaseMass::getElementMass(sofa::Index index) const
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    return doGetElementMass(index);
+}
+
+void BaseMass::getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const
+{
+    //TODO (SPRINT SED 2025): Component state mechanism
+    doGetElementMass(index, m);
+}
+
 bool BaseMass::insertInNode( objectmodel::BaseNode* node )
 {
     node->addMass(this);

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.cpp
@@ -49,7 +49,7 @@ bool BaseMass::removeInNode( objectmodel::BaseNode* node )
     return true;
 }
 
-void BaseMass::buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
+void BaseMass::doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices)
 {
     static std::set<BaseMass*> hasEmittedWarning;
     if (hasEmittedWarning.insert(this).second)

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.h
@@ -57,6 +57,10 @@ protected:
     virtual type::Vec6 doGetMomentum(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const = 0;
     virtual void doAddMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) = 0;
     virtual void doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices);
+    virtual void doInitGnuplot(const std::string path) = 0;
+    virtual void doExportGnuplot(const MechanicalParams* mparams, SReal time) = 0;
+    virtual SReal doGetElementMass(sofa::Index index) const = 0;
+    virtual void doGetElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const = 0;
 
 private:
     BaseMass(const BaseMass& n) = delete;
@@ -198,16 +202,66 @@ public:
 
     /// @}
 
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doInitGnuplot", internally,
+     * which is the method to override from now on.
+     * 
+     **/
+
     /// initialization to export kinetic and potential energy to gnuplot files format
-    virtual void initGnuplot(const std::string path)=0;
+    virtual void initGnuplot(const std::string path) final
+    {
+        doInitGnuplot(path);
+    }
+
+
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doExportGnuplot", internally,
+     * which is the method to override from now on.
+     * 
+     **/
 
     /// export kinetic and potential energy state at "time" to a gnuplot file
-    virtual void exportGnuplot(const MechanicalParams* mparams, SReal time)=0;
+    virtual void exportGnuplot(const MechanicalParams* mparams, SReal time) final
+    {
+        doExportGnuplot(mparams, time);
+    }
+
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doGetElementMass", internally,
+     * which is the method to override from now on.
+     * 
+     **/
 
     /// Get the mass relative to the DOF at \a index.
-    virtual SReal getElementMass(sofa::Index index) const =0;
+    virtual SReal getElementMass(sofa::Index index) const final
+    {
+        return doGetElementMass(index);
+    }
+
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doGetElementMass", internally,
+     * which is the method to override from now on.
+     * 
+     **/
+
     /// Get the matrix relative to the DOF at \a index.
-    virtual void getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const = 0;
+    virtual void getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const final
+    {
+        doGetElementMass(index, m);
+    }
 
     virtual bool isDiagonal() const = 0;
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.h
@@ -52,9 +52,9 @@ protected:
     virtual void doAddMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor) = 0;
     virtual void doAccFromF(const MechanicalParams* mparams, MultiVecDerivId aid) = 0;
     virtual void doAddGravityToV(const MechanicalParams* mparams, MultiVecDerivId vid) = 0;
-    virtual SReal doGetKineticEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const = 0;
-    virtual SReal doGetPotentialEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const = 0;
-    virtual type::Vec6 doGetMomentum(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const = 0;
+    virtual SReal doGetKineticEnergy(const MechanicalParams* mparams) const = 0;
+    virtual SReal doGetPotentialEnergy(const MechanicalParams* mparams) const = 0;
+    virtual type::Vec6 doGetMomentum(const MechanicalParams* mparams) const = 0;
     virtual void doAddMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) = 0;
     virtual void doBuildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices);
     virtual void doInitGnuplot(const std::string path) = 0;
@@ -80,10 +80,7 @@ public:
      **/
 
     /// f += factor M dx
-    virtual void addMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor) final
-    {
-        doAddMDx(mparams, fid, factor);
-    }
+    virtual void addMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor) final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -95,10 +92,7 @@ public:
      **/
 
     /// dx = M^-1 f
-    virtual void accFromF(const MechanicalParams* mparams, MultiVecDerivId aid) final
-    {
-        doAccFromF(mparams, aid);
-    }
+    virtual void accFromF(const MechanicalParams* mparams, MultiVecDerivId aid) final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -112,10 +106,7 @@ public:
     /// \brief Perform  v += dt*g operation. Used if mass wants to added G separately from the other forces to v.
     ///
     /// \param mparams \a sofa::core::mechanicalparams::dt(mparams) is the time step of for temporal discretization.
-    virtual void addGravityToV(const MechanicalParams* mparams, MultiVecDerivId vid) final
-    {
-        doAddGravityToV(mparams, vid);
-    }
+    virtual void addGravityToV(const MechanicalParams* mparams, MultiVecDerivId vid) final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -127,10 +118,7 @@ public:
      **/
 
     /// vMv/2
-    virtual SReal getKineticEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final
-    {
-        return doGetKineticEnergy(mparams);
-    }
+    virtual SReal getKineticEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -142,10 +130,7 @@ public:
      **/
 
     /// Mgx
-    virtual SReal getPotentialEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final
-    {
-        return doGetPotentialEnergy(mparams);
-    }
+    virtual SReal getPotentialEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -157,10 +142,7 @@ public:
      **/
 
     /// (Mv,xMv+Iw) (linear and angular momenta against world origin)
-    virtual type::Vec6 getMomentum(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final
-    {
-        return doGetMomentum(mparams);
-    }
+    virtual type::Vec6 getMomentum(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final;
 
     /// @}
 
@@ -181,10 +163,7 @@ public:
     /// This method must be implemented by the component.
     /// \param matrix matrix to add the result to
     /// \param mparams \a mparams->mFactor() is the coefficient for mass contributions (i.e. second-order derivatives term in the ODE)
-    virtual void addMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) final
-    {
-        doAddMToMatrix(mparams, matrix);
-    }
+    virtual void addMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -195,10 +174,7 @@ public:
      * 
      **/
 
-    virtual void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) final
-    {
-        doBuildMassMatrix(matrices);
-    }
+    virtual void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) final;
 
     /// @}
 
@@ -212,11 +188,7 @@ public:
      **/
 
     /// initialization to export kinetic and potential energy to gnuplot files format
-    virtual void initGnuplot(const std::string path) final
-    {
-        doInitGnuplot(path);
-    }
-
+    virtual void initGnuplot(const std::string path) final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -228,10 +200,7 @@ public:
      **/
 
     /// export kinetic and potential energy state at "time" to a gnuplot file
-    virtual void exportGnuplot(const MechanicalParams* mparams, SReal time) final
-    {
-        doExportGnuplot(mparams, time);
-    }
+    virtual void exportGnuplot(const MechanicalParams* mparams, SReal time) final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -243,10 +212,7 @@ public:
      **/
 
     /// Get the mass relative to the DOF at \a index.
-    virtual SReal getElementMass(sofa::Index index) const final
-    {
-        return doGetElementMass(index);
-    }
+    virtual SReal getElementMass(sofa::Index index) const final;
 
     /**
      * !!! WARNING since v25.12 !!! 
@@ -258,10 +224,7 @@ public:
      **/
 
     /// Get the matrix relative to the DOF at \a index.
-    virtual void getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const final
-    {
-        doGetElementMass(index, m);
-    }
+    virtual void getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const final;
 
     virtual bool isDiagonal() const = 0;
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMass.h
@@ -81,11 +81,29 @@ public:
         doAddMDx(mparams, fid, factor);
     }
 
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doAccFromF", internally,
+     * which is the method to override from now on.
+     * 
+     **/
+
     /// dx = M^-1 f
     virtual void accFromF(const MechanicalParams* mparams, MultiVecDerivId aid) final
     {
         doAccFromF(mparams, aid);
     }
+
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doAddGravityToV", internally,
+     * which is the method to override from now on.
+     * 
+     **/
 
     /// \brief Perform  v += dt*g operation. Used if mass wants to added G separately from the other forces to v.
     ///
@@ -95,17 +113,44 @@ public:
         doAddGravityToV(mparams, vid);
     }
 
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doGetKineticEnergy", internally,
+     * which is the method to override from now on.
+     * 
+     **/
+
     /// vMv/2
     virtual SReal getKineticEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final
     {
         return doGetKineticEnergy(mparams);
     }
 
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doGetPotentialEnergy", internally,
+     * which is the method to override from now on.
+     * 
+     **/
+
     /// Mgx
     virtual SReal getPotentialEnergy(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final
     {
         return doGetPotentialEnergy(mparams);
     }
+
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doGetMomentum", internally,
+     * which is the method to override from now on.
+     * 
+     **/
 
     /// (Mv,xMv+Iw) (linear and angular momenta against world origin)
     virtual type::Vec6 getMomentum(const MechanicalParams* mparams = mechanicalparams::defaultInstance()) const final
@@ -118,6 +163,15 @@ public:
     /// @name Matrix operations
     /// @{
 
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doAddMToMatrix", internally,
+     * which is the method to override from now on.
+     * 
+     **/
+
     /// \brief Add Mass contribution to global Matrix assembling.
     ///
     /// This method must be implemented by the component.
@@ -127,6 +181,15 @@ public:
     {
         doAddMToMatrix(mparams, matrix);
     }
+
+    /**
+     * !!! WARNING since v25.12 !!! 
+     * 
+     * The template method pattern has been applied to this part of the API. 
+     * This method calls the newly introduced method "doBuildMassMatrix", internally,
+     * which is the method to override from now on.
+     * 
+     **/
 
     virtual void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) final
     {

--- a/Sofa/framework/Core/src/sofa/core/behavior/Mass.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/Mass.h
@@ -58,6 +58,15 @@ protected:
 
 public:
 
+    // Avoid warning : hidden [-Woverloaded-virtual=]
+    using BaseMass::addMDx;
+    using BaseMass::accFromF;
+    using BaseMass::getKineticEnergy;
+    using BaseMass::getPotentialEnergy;
+    using BaseMass::getMomentum;
+    using BaseMass::addMToMatrix;
+    using BaseMass::addGravityToV;
+    
     /// @name Vector operations
     /// @{
     ///                         $ f += factor M dx $

--- a/Sofa/framework/Core/src/sofa/core/behavior/Mass.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/Mass.h
@@ -66,7 +66,7 @@ public:
     using BaseMass::getMomentum;
     using BaseMass::addMToMatrix;
     using BaseMass::addGravityToV;
-    
+
     /// @name Vector operations
     /// @{
     ///                         $ f += factor M dx $
@@ -149,10 +149,10 @@ public:
     /// @}
 
     /// initialization to export kinetic and potential energy to gnuplot files format
-    void initGnuplot(const std::string path) override;
+    void doInitGnuplot(const std::string path) override;
 
     /// export kinetic and potential energy state at "time" to a gnuplot file
-    void exportGnuplot(const MechanicalParams* mparams, SReal time) override;
+    void doExportGnuplot(const MechanicalParams* mparams, SReal time) override;
 
     /// perform  v += dt*g operation. Used if mass wants to added G separately from the other forces to v.
     void doAddGravityToV(const MechanicalParams* mparams, MultiVecDerivId /*vid*/) override;
@@ -160,8 +160,8 @@ public:
 
 
     /// recover the mass of an element
-    SReal getElementMass(sofa::Index) const override;
-    void getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const override;
+    SReal doGetElementMass(sofa::Index) const override;
+    void doGetElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const override;
 
 protected:
     /// stream to export Kinematic, Potential and Mechanical Energy to gnuplot files

--- a/Sofa/framework/Core/src/sofa/core/behavior/Mass.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/Mass.h
@@ -54,8 +54,8 @@ public:
 
 protected:
     Mass(MechanicalState<DataTypes> *mm = nullptr);
-
     ~Mass() override;
+
 public:
 
     /// @name Vector operations
@@ -64,7 +64,7 @@ public:
     ///
     /// This method retrieves the force and dx vector and call the internal
     /// addMDx(const MechanicalParams*, DataVecDeriv&, const DataVecDeriv&, SReal) method implemented by the component.
-    void addMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor) override;
+    void doAddMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor) override;
 
     virtual void addMDx(const MechanicalParams* mparams, DataVecDeriv& f, const DataVecDeriv& dx, SReal factor);
 
@@ -72,7 +72,7 @@ public:
     ///
     /// This method retrieves the force and dx vector and call the internal
     /// accFromF(VecDeriv&,const VecDeriv&) method implemented by the component.
-    void accFromF(const MechanicalParams* mparams, MultiVecDerivId aid) override;
+    void doAccFromF(const MechanicalParams* mparams, MultiVecDerivId aid) override;
 
     virtual void accFromF(const MechanicalParams* mparams, DataVecDeriv& a, const DataVecDeriv& f);
 
@@ -96,14 +96,14 @@ public:
     ///
     /// This method retrieves the velocity vector and call the internal
     /// getKineticEnergy(const MechanicalParams*, const DataVecDeriv&) method implemented by the component.
-    SReal getKineticEnergy( const MechanicalParams* mparams) const override;
+    SReal doGetKineticEnergy( const MechanicalParams* mparams) const override;
     virtual SReal getKineticEnergy( const MechanicalParams* mparams, const DataVecDeriv& v) const;
 
     ///                         $ e = M g x $
     ///
     /// This method retrieves the positions vector and call the internal
     /// getPotentialEnergy(const MechanicalParams*, const VecCoord&) method implemented by the component.
-    SReal getPotentialEnergy( const MechanicalParams* mparams) const override;
+    SReal doGetPotentialEnergy( const MechanicalParams* mparams) const override;
     SReal getPotentialEnergy( const MechanicalParams* mparams, const DataVecCoord& x  ) const override;
 
 
@@ -112,7 +112,7 @@ public:
     ///
     /// This method retrieves the positions and velocity vectors and call the internal
     /// getMomentum(const MechanicalParams*, const VecCoord&, const VecDeriv&) method implemented by the component.
-    type::Vec6 getMomentum( const MechanicalParams* mparams ) const override;
+    type::Vec6 doGetMomentum( const MechanicalParams* mparams ) const override;
     virtual type::Vec6 getMomentum( const MechanicalParams* , const DataVecCoord& , const DataVecDeriv&  ) const;
 
 
@@ -125,7 +125,7 @@ public:
     void addKToMatrix(sofa::linearalgebra::BaseMatrix * /*matrix*/, SReal /*kFact*/, unsigned int &/*offset*/) override {}
     void addBToMatrix(sofa::linearalgebra::BaseMatrix * /*matrix*/, SReal /*bFact*/, unsigned int &/*offset*/) override {}
 
-    void addMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void doAddMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     virtual void addMToMatrix(sofa::linearalgebra::BaseMatrix * matrix, SReal mFact, unsigned int &offset);
 
 
@@ -146,7 +146,7 @@ public:
     void exportGnuplot(const MechanicalParams* mparams, SReal time) override;
 
     /// perform  v += dt*g operation. Used if mass wants to added G separately from the other forces to v.
-    void addGravityToV(const MechanicalParams* mparams, MultiVecDerivId /*vid*/) override;
+    void doAddGravityToV(const MechanicalParams* mparams, MultiVecDerivId /*vid*/) override;
     virtual void addGravityToV(const MechanicalParams* /* mparams */, DataVecDeriv& /* d_v */);
 
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/Mass.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/Mass.inl
@@ -191,7 +191,7 @@ void Mass<DataTypes>::addGravityToV(const MechanicalParams* /* mparams */, DataV
 
 
 template<class DataTypes>
-void Mass<DataTypes>::initGnuplot(const std::string path)
+void Mass<DataTypes>::doInitGnuplot(const std::string path)
 {
     if (!this->getName().empty())
     {
@@ -203,7 +203,7 @@ void Mass<DataTypes>::initGnuplot(const std::string path)
 }
 
 template<class DataTypes>
-void Mass<DataTypes>::exportGnuplot(const MechanicalParams* mparams, SReal time)
+void Mass<DataTypes>::doExportGnuplot(const MechanicalParams* mparams, SReal time)
 {
     if (m_gnuplotFileEnergy!=nullptr)
     {
@@ -215,14 +215,14 @@ void Mass<DataTypes>::exportGnuplot(const MechanicalParams* mparams, SReal time)
 }
 
 template <class DataTypes>
-SReal Mass<DataTypes>::getElementMass(sofa::Index ) const
+SReal Mass<DataTypes>::doGetElementMass(sofa::Index ) const
 {
     msg_warning() << "Method getElementMass with Scalar not implemented";
     return 0.0;
 }
 
 template <class DataTypes>
-void Mass<DataTypes>::getElementMass(sofa::Index, linearalgebra::BaseMatrix *m) const
+void Mass<DataTypes>::doGetElementMass(sofa::Index, linearalgebra::BaseMatrix *m) const
 {
     static const linearalgebra::BaseMatrix::Index dimension = (linearalgebra::BaseMatrix::Index) defaulttype::DataTypeInfo<Coord>::size();
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);

--- a/Sofa/framework/Core/src/sofa/core/behavior/Mass.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/Mass.inl
@@ -45,7 +45,7 @@ Mass<DataTypes>::~Mass()
 }
 
 template<class DataTypes>
-void Mass<DataTypes>::addMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor)
+void Mass<DataTypes>::doAddMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor)
 {
     if (mparams)
     {
@@ -66,7 +66,7 @@ void Mass<DataTypes>::addMDx(const MechanicalParams* /*mparams*/, DataVecDeriv& 
 
 
 template<class DataTypes>
-void Mass<DataTypes>::accFromF(const MechanicalParams* mparams, MultiVecDerivId aid)
+void Mass<DataTypes>::doAccFromF(const MechanicalParams* mparams, MultiVecDerivId aid)
 {
     if(mparams)
     {
@@ -102,7 +102,7 @@ void Mass<DataTypes>::addMBKdx(const MechanicalParams* mparams, MultiVecDerivId 
 }
 
 template<class DataTypes>
-SReal Mass<DataTypes>::getKineticEnergy(const MechanicalParams* mparams) const
+SReal Mass<DataTypes>::doGetKineticEnergy(const MechanicalParams* mparams) const
 {
     if (this->mstate)
         return getKineticEnergy(mparams /* PARAMS FIRST */, *mparams->readV(this->mstate.get()));
@@ -118,7 +118,7 @@ SReal Mass<DataTypes>::getKineticEnergy(const MechanicalParams* /*mparams*/, con
 
 
 template<class DataTypes>
-SReal Mass<DataTypes>::getPotentialEnergy(const MechanicalParams* mparams) const
+SReal Mass<DataTypes>::doGetPotentialEnergy(const MechanicalParams* mparams) const
 {
     if (this->mstate)
         return getPotentialEnergy(mparams /* PARAMS FIRST */, *mparams->readX(this->mstate.get()));
@@ -134,7 +134,7 @@ SReal Mass<DataTypes>::getPotentialEnergy(const MechanicalParams* /*mparams*/, c
 
 
 template<class DataTypes>
-type::Vec6 Mass<DataTypes>::getMomentum( const MechanicalParams* mparams ) const
+type::Vec6 Mass<DataTypes>::doGetMomentum( const MechanicalParams* mparams ) const
 {
     auto state = this->mstate.get();
     if (state)
@@ -152,7 +152,7 @@ type::Vec6 Mass<DataTypes>::getMomentum( const MechanicalParams* /*mparams*/, co
 
 
 template<class DataTypes>
-void Mass<DataTypes>::addMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
+void Mass<DataTypes>::doAddMToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
     if (r)
@@ -162,11 +162,7 @@ void Mass<DataTypes>::addMToMatrix(const MechanicalParams* mparams, const sofa::
 template<class DataTypes>
 void Mass<DataTypes>::addMToMatrix(sofa::linearalgebra::BaseMatrix * /*mat*/, SReal /*mFact*/, unsigned int &/*offset*/)
 {
-    static int i=0;
-    if (i < 10) {
-        msg_warning() << "Method addMToMatrix with Scalar not implemented";
-        i++;
-    }
+    msg_warning() << "Method addMToMatrix with Scalar not implemented";
 }
 
 template<class DataTypes>
@@ -174,11 +170,11 @@ void Mass<DataTypes>::addMBKToMatrix(const MechanicalParams* mparams, const sofa
 {
     this->ForceField<DataTypes>::addMBKToMatrix(mparams, matrix);
     if (mparams->mFactorIncludingRayleighDamping(rayleighMass.getValue()) != 0.0)
-        addMToMatrix(mparams, matrix);
+        BaseMass::addMToMatrix(mparams, matrix);
 }
 
 template<class DataTypes>
-void Mass<DataTypes>::addGravityToV(const MechanicalParams* mparams, MultiVecDerivId vid)
+void Mass<DataTypes>::doAddGravityToV(const MechanicalParams* mparams, MultiVecDerivId vid)
 {
     if(this->mstate)
     {
@@ -190,11 +186,7 @@ void Mass<DataTypes>::addGravityToV(const MechanicalParams* mparams, MultiVecDer
 template<class DataTypes>
 void Mass<DataTypes>::addGravityToV(const MechanicalParams* /* mparams */, DataVecDeriv& /* d_v */)
 {
-    static int i=0;
-    if (i < 10) {
-        msg_warning() << "Method addGravityToV with Scalar not implemented";
-        i++;
-    }
+    msg_warning() << "Method addGravityToV with Scalar not implemented";
 }
 
 
@@ -215,10 +207,10 @@ void Mass<DataTypes>::exportGnuplot(const MechanicalParams* mparams, SReal time)
 {
     if (m_gnuplotFileEnergy!=nullptr)
     {
-        (*m_gnuplotFileEnergy) << time <<"\t"<< this->getKineticEnergy(mparams)
-                               <<"\t"<< this->getPotentialEnergy(mparams)
-                              <<"\t"<< this->getPotentialEnergy(mparams)
-                                +this->getKineticEnergy(mparams)<< std::endl;
+        (*m_gnuplotFileEnergy) << time <<"\t"<< BaseMass::getKineticEnergy(mparams)
+                               <<"\t"<< BaseMass::getPotentialEnergy(mparams)
+                              <<"\t"<< BaseMass::getPotentialEnergy(mparams)
+                                +BaseMass::getKineticEnergy(mparams)<< std::endl;
     }
 }
 

--- a/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/mass/CudaUniformMass.inl
+++ b/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/mass/CudaUniformMass.inl
@@ -205,7 +205,7 @@ SReal UniformMass<gpu::cuda::CudaRigid3fTypes>::getPotentialEnergy(const core::M
 }
 
 template <>
-SReal UniformMass<gpu::cuda::CudaRigid3fTypes>::getElementMass(sofa::Index) const
+SReal UniformMass<gpu::cuda::CudaRigid3fTypes>::doGetElementMass(sofa::Index) const
 {
     return (SReal)(d_vertexMass.getValue().mass);
 }

--- a/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/mass/CudaUniformMass.inl
+++ b/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/mass/CudaUniformMass.inl
@@ -374,7 +374,7 @@ SReal UniformMass<gpu::cuda::CudaRigid3dTypes>::getPotentialEnergy(const core::M
 }
 
 template <>
-SReal UniformMass<gpu::cuda::CudaRigid3dTypes>::getElementMass(sofa::Index) const
+SReal UniformMass<gpu::cuda::CudaRigid3dTypes>::doGetElementMass(sofa::Index) const
 {
     return (SReal)(d_vertexMass.getValue().mass);
 }


### PR DESCRIPTION
Apply template method design pattern to BaseMass and its API:
- addMDx
- addMToMatrix
- buildMassMatrix
- accFromF
- addGravityToV
- getKineticEnergy
- getPotentialEnergy
- getMomentum
- initGnuplot
- exportGnuplot
- getElementMass
- isDiagonal

I created this PR in two parts since I doubt we actually need these functions to be concerned by the refactoring:
- initGnuplot
- exportGnuplot
- getElementMass
- isDiagonal
    
[ci-depends-on https://github.com/sofa-framework/BeamAdapter/pull/188]
[with-all-tests]


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
