### PR TITLE
[Core] Update deprecation date

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseConstraint.h
@@ -23,9 +23,9 @@
 
 #include <sofa/core/behavior/BaseLagrangianConstraint.h>
 
-SOFA_HEADER_DEPRECATED("v25.06", "v26.06", "sofa/core/behavior/BaseLagrangianConstraint.h")
+SOFA_HEADER_DEPRECATED("v25.12", "v26.12", "sofa/core/behavior/BaseLagrangianConstraint.h")
 
 namespace sofa::core::behavior
 {
-using BaseConstraint SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v26.06", "BaseConstraint has been renamed to BaseLagrangianConstraint") = BaseLagrangianConstraint;
+using BaseConstraint SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v26.12", "BaseConstraint has been renamed to BaseLagrangianConstraint") = BaseLagrangianConstraint;
 }

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -131,5 +131,5 @@
 #define SOFA_ATTRIBUTE_DEPRECATED__TOBASECONSTRAINT()
 #else
 #define SOFA_ATTRIBUTE_DEPRECATED__TOBASECONSTRAINT() \
-    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v26.06", "Use toBaseLagrangianConstraint instead.")
+    SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v26.12", "Use toBaseLagrangianConstraint instead.")
 #endif


### PR DESCRIPTION
https://github.com/sofa-framework/sofa/pull/5423 is not included in the v25.06, so I update the deprecation versions for the next release



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
