### PR TITLE
[CMake] Add BeamAdapter.CUDA to the presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -151,6 +151,10 @@
           "type": "BOOL",
           "value": "ON"
         },
+        "PLUGIN_BEAMADAPTER_CUDA": {
+          "type": "BOOL",
+          "value": "ON"
+        },
         "PLUGIN_SOFAMATRIX": {
           "type": "BOOL",
           "value": "ON"


### PR DESCRIPTION
[ci-depends-on https://github.com/sofa-framework/BeamAdapter/pull/196]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
