### PR TITLE
[Core] Simplify constraint force computation

### DIFF
--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
@@ -87,16 +87,9 @@ public:
     typedef sofa::linearalgebra::SparseMatrix<Real> JMatrixType;
     typedef linearalgebra::BaseMatrix ResMatrixType;
 
-    void projectForceInConstraintSpace(linearalgebra::BaseVector* r,const linearalgebra::BaseVector* f) {
-        for (typename linearalgebra::SparseMatrix<Real>::LineConstIterator jit = J_local.begin(), jitend = J_local.end(); jit != jitend; ++jit) {
-            auto row = jit->first;
-            auto force = f->element(row);
-            for (typename linearalgebra::SparseMatrix<Real>::LElementConstIterator i2 = jit->second.begin(), i2end = jit->second.end(); i2 != i2end; ++i2) {
-                auto col = i2->first;
-                auto val = i2->second;
-                r->add(col,val * force);
-            }
-        }
+    void projectForceInConstraintSpace(linearalgebra::BaseVector* r,const linearalgebra::BaseVector* f)
+    {
+        J_local.addMulTranspose(r, f);
     }
 
     JMatrixType * getLocalJ() {

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.inl
@@ -157,9 +157,13 @@ void ConstraintCorrection< DataTypes >::addConstraintForceInMotionSpace(const co
     auto force = sofa::helper::getWriteAccessor(f);
 
     const size_t numDOFs = mstate->getSize();
+    const size_t fPrevSize = force.size();
+
     if (numDOFs > force.size())
     {
-        force.resize(numDOFs, Deriv());
+        force.resize(numDOFs);
+        for (size_t i = fPrevSize; i < numDOFs; ++i)
+            force[i] = Deriv();
     }
 
     const MatrixDeriv& c = j.getValue();

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.inl
@@ -159,7 +159,7 @@ void ConstraintCorrection< DataTypes >::addConstraintForceInMotionSpace(const co
     const size_t numDOFs = mstate->getSize();
     const size_t fPrevSize = force.size();
 
-    if (numDOFs > force.size())
+    if (numDOFs > fPrevSize)
     {
         force.resize(numDOFs);
         for (size_t i = fPrevSize; i < numDOFs; ++i)


### PR DESCRIPTION
The manual loops over the matrix are replaced by the call of a function doing the same computation.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
