### PR TITLE
[SlidingLagrangianConstraint] Fix SlidingLagrangianConstraint and make it compatible with Rigids

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.cpp
@@ -34,7 +34,8 @@ using namespace sofa::defaulttype;
 void registerSlidingLagrangianConstraint(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(core::ObjectRegistrationData("Lagrangian-based partial fixation of DOFs of the model, along an axis.")
-        .add< SlidingLagrangianConstraint<Vec3Types> >());
+        .add< SlidingLagrangianConstraint<Vec3Types> >()
+        .add< SlidingLagrangianConstraint<Rigid3Types> >());
 }
 
 template class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_MODEL_API SlidingLagrangianConstraint<Vec3Types>;

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.h
@@ -58,10 +58,6 @@ protected:
     Data<int> d_m2b; ///< index of the other end of the sliding axis
     Data<Deriv> d_force; ///< force (impulse) used to solve the constraint
 
-    Real m_dist;	// constraint violation
-    Real m_thirdConstraint; // 0 if A<proj<B, -1 if proj<A, 1 if B<proj
-
-
     SlidingLagrangianConstraint();
     SlidingLagrangianConstraint(MechanicalState* object);
     SlidingLagrangianConstraint(MechanicalState* object1, MechanicalState* object2);
@@ -98,7 +94,8 @@ public:
 
 private:
     // storage of force
-    Deriv  m_dirAxe, m_dirProj, m_dirOrtho;
+    std::vector<Deriv>  m_constraintDirections;
+    Real m_bary;
 
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.h
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.h
@@ -95,7 +95,7 @@ public:
 private:
     // storage of force
     std::vector<Deriv>  m_constraintDirections;
-    Real m_bary;
+    Real m_projectionBarycentricCoordinate;
 
 
 

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.inl
@@ -124,7 +124,6 @@ void SlidingLagrangianConstraint<DataTypes>::buildConstraintMatrix(const core::C
                 xVec[1] = 1;
 
             DataTypes::setDPos(dirProj, cross(xVec, DataTypes::getDPos(dirAxe)));
-
         }
         DataTypes::setDPos(dirProj,DataTypes::getDPos(dirProj).normalized()); // direction of the constraint
 
@@ -137,7 +136,9 @@ void SlidingLagrangianConstraint<DataTypes>::buildConstraintMatrix(const core::C
 
         m_constraintDirections.push_back(dirProj);
         if constexpr ( Deriv_t<DataTypes>::spatial_dimensions > 2 )
+        {
             m_constraintDirections.push_back(dirOrtho);
+        }
         m_constraintDirections.push_back(dirAxe);
         m_constraintDirections.push_back(-dirAxe);
     }
@@ -279,7 +280,7 @@ void SlidingLagrangianConstraint<DataTypes>::draw(const core::visual::VisualPara
 
     sofa::type::RGBAColor color;
 
-    if(m_constraintDirections.size()==Deriv_t<DataTypes>::spatial_dimensions)
+    if(m_constraintDirections.size() == Deriv_t<DataTypes>::spatial_dimensions)
         color = sofa::type::RGBAColor::yellow();
     else
         color = sofa::type::RGBAColor::green();

--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/SlidingLagrangianConstraint.inl
@@ -57,7 +57,6 @@ void SlidingLagrangianConstraint<DataTypes>::init()
     assert(this->mstate1);
     assert(this->mstate2);
 
-    m_thirdConstraint = 0;
 }
 
 
@@ -65,101 +64,166 @@ template<class DataTypes>
 void SlidingLagrangianConstraint<DataTypes>::buildConstraintMatrix(const core::ConstraintParams*, DataMatrixDeriv &c1_d, DataMatrixDeriv &c2_d, unsigned int &cIndex
         , const DataVecCoord &x1, const DataVecCoord &x2)
 {
-    int tm1 = d_m1.getValue();
+
+    int tm1 =  d_m1.getValue();
     int tm2a = d_m2a.getValue();
     int tm2b = d_m2b.getValue();
 
     auto c1 = sofa::helper::getWriteAccessor(c1_d);
     auto c2 = sofa::helper::getWriteAccessor(c2_d);
 
-    const Coord P = x1.getValue()[tm1];
-    const Coord A = x2.getValue()[tm2a];
-    const Coord B = x2.getValue()[tm2b];
+    const Coord_t<DataTypes> P = x1.getValue()[tm1];
+    const Coord_t<DataTypes> A = x2.getValue()[tm2a];
+    const Coord_t<DataTypes> B = x2.getValue()[tm2b];
 
     // the axis
-    m_dirAxe = B - A;
-    const Real ab = m_dirAxe.norm();
-    m_dirAxe.normalize();
+    Deriv_t<DataTypes> dirAxe;
+    DataTypes::setDPos(dirAxe, DataTypes::getCPos(B) - DataTypes::getCPos(A));
+    const Real ab = dirAxe.norm();
 
-    // projection of the point on the axis
-    Real r = (P-A) * m_dirAxe;
-    Real r2 = r / ab;
-    const Deriv proj = A + m_dirAxe * r;
+    m_constraintDirections.clear();
 
-    // We move the constraint point onto the projection
-    m_dirProj = P - proj;
-    m_dist = m_dirProj.norm(); // constraint violation
-    m_dirProj.normalize(); // direction of the constraint
+    Real m_bary=0; //Coef to point B -> proj = bary*B + (1-bary)*A
 
-    m_dirOrtho = cross(m_dirProj, m_dirAxe);
-    m_dirOrtho.normalize();
-
+    if ( ab < std::numeric_limits<Real>::epsilon() ) // If A and B are at the same position, then a full dof constraint must be applied totally linking position of P and A
     {
-        auto c1_it = c1->writeLine(cIndex);
-        c1_it.addCol(tm1, m_dirProj);
+        for (unsigned i=0; i<Deriv_t<DataTypes>::spatial_dimensions; ++i)
+        {
+            Deriv_t<DataTypes> temp;
+            temp[i] = 1;
+            m_constraintDirections.push_back(temp);
+        }
+    }
+    else
+    {
+        // Normalize direction
+        DataTypes::setDPos(dirAxe,DataTypes::getDPos(dirAxe).normalized());
 
-        auto c2_it = c2->writeLine(cIndex);
-        c2_it.addCol(tm2a, -m_dirProj * (1-r2));
-        c2_it.addCol(tm2b, -m_dirProj * r2);
+        // Distance to point A on sliding direction
+        Real r = dot(DataTypes::getCPos(P) - DataTypes::getCPos(A) , DataTypes::getDPos(dirAxe));
+        // Normalized distance to point A on sliding direction, if equal to 1 then it is the same distance to A as B
+        Real r2 = r / ab;
 
-        ++cIndex;
+        // Compute bary coef of normalized distance (if proj is outside of edge, it is forced to be applied on one side, either A (bary==0) or B (bary==1)
+        m_bary = r2 < 0 ?  0 : r2;
+        m_bary = m_bary > 1.0 ?  1.0 : m_bary;
+
+        // This is the coordinates of the projected point
+        Coord_t<DataTypes> proj;
+        DataTypes::setCPos(proj, DataTypes::getCPos(A) + DataTypes::getDPos(dirAxe) * r);
+
+        // Compute projection direction
+        Deriv_t<DataTypes> dirProj;
+        DataTypes::setDPos(dirProj, DataTypes::getCPos(P) -  DataTypes::getCPos(proj));
+        // If the projection is too close to the real point, create a proj dir that is randomly chosen around the edge
+        if (DataTypes::getDPos(dirProj).norm() < std::numeric_limits<Real>::epsilon())
+        {
+            typename DataTypes::DPos xVec;
+            xVec[0] = 1;
+            if ( cross(xVec, DataTypes::getDPos(dirAxe)).norm() < std::numeric_limits<Real>::epsilon())
+                xVec[1] = 1;
+
+            DataTypes::setDPos(dirProj, cross(xVec, DataTypes::getDPos(dirAxe)));
+
+        }
+        DataTypes::setDPos(dirProj,DataTypes::getDPos(dirProj).normalized()); // direction of the constraint
+
+        // Compute second normal that complete the set of constraint required to pull the point on the edge (only when dimension is supérior to 2)
+        Deriv_t<DataTypes> dirOrtho;
+        if ( Deriv_t<DataTypes>::spatial_dimensions > 2 )
+        {
+            DataTypes::setDPos(dirOrtho, cross(DataTypes::getDPos(dirProj), DataTypes::getDPos(dirAxe)).normalized());
+        }
+
+        m_constraintDirections.push_back(dirProj);
+        if ( Deriv_t<DataTypes>::spatial_dimensions > 2 )
+            m_constraintDirections.push_back(dirOrtho);
+        m_constraintDirections.push_back(dirAxe);
+        m_constraintDirections.push_back(-dirAxe);
     }
 
+    //Now add vectors to the constraint matrix
+    if(m_constraintDirections.size()==Deriv_t<DataTypes>::spatial_dimensions)
     {
-        auto c1_it = c1->writeLine(cIndex);
-        c1_it.setCol(tm1, m_dirOrtho);
+        //When A=B we don't care what point ton constraint, we just ocnstraint A
+        for(const auto & dirVec : m_constraintDirections)
+        {
+            auto c1_it = c1->writeLine(cIndex);
+            c1_it.setCol(tm1, dirVec);
 
-        auto c2_it = c2->writeLine(cIndex);
-        c2_it.addCol(tm2a, -m_dirOrtho * (1-r2));
-        c2_it.addCol(tm2b, -m_dirOrtho * r2);
+            auto c2_it = c2->writeLine(cIndex);
+            c2_it.addCol(tm2a, -dirVec);
 
-        ++cIndex;
+            ++cIndex;
+        }
     }
-
-    m_thirdConstraint = 0;
-
-    if (r < 0)
+    else
     {
-        m_thirdConstraint = r;
+        //When A!=B we want to allow motion between A and B, we must be careful on the constraint
+        //direction of the constraint applied to A and B so the Unilateral constraints allow motion
+        //inbetween the two points  A--------------B
+        //               (forbidden)|->  (free)   <-|(forbidden)
 
-        auto c1_it = c1->writeLine(cIndex);
-        c1_it.setCol(tm1, m_dirAxe);
+        for(unsigned i=0; i<m_constraintDirections.size()  - 2 ; ++i)
+        {
+            auto c1_it = c1->writeLine(cIndex);
+            c1_it.addCol(tm1, m_constraintDirections[i]);
 
-        auto c2_it = c2->writeLine(cIndex);
-        c2_it.addCol(tm2a, -m_dirAxe);
+            auto c2_it = c2->writeLine(cIndex);
+            c2_it.addCol(tm2a, -m_constraintDirections[i] * (1-m_bary));
+            c2_it.addCol(tm2b, -m_constraintDirections[i] * m_bary);
 
-        ++cIndex;
-    }
-    else if (r > ab)
-    {
-        m_thirdConstraint = r - ab;
+            ++cIndex;
+        }
 
-        auto c1_it = c1->writeLine(cIndex);
-        c1_it.setCol(tm1, -m_dirAxe);
+        auto c1_it_a = c1->writeLine(cIndex);
+        c1_it_a.setCol(tm1, m_constraintDirections[ m_constraintDirections.size() -2 ]);
+        auto c1_it_b = c1->writeLine(cIndex + 1);
+        c1_it_b.setCol(tm1, m_constraintDirections[ m_constraintDirections.size() -1 ]);
 
-        auto c2_it = c2->writeLine(cIndex);
-        c2_it.addCol(tm2b, m_dirAxe);
 
-        ++cIndex;
+        auto c2_it_a = c2->writeLine(cIndex);
+        c2_it_a.addCol(tm2a, -m_constraintDirections[ m_constraintDirections.size() -2 ]);
+        auto c2_it_b = c2->writeLine(cIndex + 1);
+        c2_it_b.addCol(tm2b, -m_constraintDirections[ m_constraintDirections.size() -1 ]);
+
+        cIndex += 2;
     }
 }
 
 
 template<class DataTypes>
-void SlidingLagrangianConstraint<DataTypes>::getConstraintViolation(const core::ConstraintParams *, linearalgebra::BaseVector *v, const DataVecCoord &, const DataVecCoord &
+void SlidingLagrangianConstraint<DataTypes>::getConstraintViolation(const core::ConstraintParams *, linearalgebra::BaseVector *v, const DataVecCoord & x1, const DataVecCoord & x2
         , const DataVecDeriv &, const DataVecDeriv &)
 {
+    const Coord_t<DataTypes> P = x1.getValue()[d_m1.getValue()];
+    const Coord_t<DataTypes> A = x2.getValue()[d_m2a.getValue()];
+    const Coord_t<DataTypes> B = x2.getValue()[d_m2b.getValue()];
+
     const auto constraintIndex = this->d_constraintIndex.getValue();
 
-    v->set(constraintIndex, m_dist);
-    v->set(constraintIndex+1, 0.0);
-
-    if(m_thirdConstraint)
+    if(m_constraintDirections.size()==Deriv_t<DataTypes>::spatial_dimensions) // A and B are on the same point
     {
-        if(m_thirdConstraint>0)
-            v->set(constraintIndex+2, -m_thirdConstraint);
-        else
-            v->set(constraintIndex+2, m_thirdConstraint);
+        //If A=B, we have bilateral constraint that fixed all dofs, they are thus aligned with the world system of coordinates and the violation is easily computed
+        typename DataTypes::CPos temp = DataTypes::getCPos(P)-DataTypes::getCPos(A);
+        for(unsigned i=0; i<m_constraintDirections.size() ; ++i)
+        {
+            v->set(constraintIndex + i, temp[i] );
+        }
+    }
+    else
+    {
+        typename DataTypes::CPos newProj = DataTypes::getCPos(B)*m_bary + DataTypes::getCPos(A)*(1-m_bary);
+        typename DataTypes::DPos PtoProj = DataTypes::getCPos(P) - newProj;
+        typename DataTypes::DPos PtoA = DataTypes::getCPos(P) - DataTypes::getCPos(A);
+        typename DataTypes::DPos PtoB = DataTypes::getCPos(P) - DataTypes::getCPos(B);
+
+        for(unsigned i=0; i<m_constraintDirections.size()  - 2 ; ++i)
+        {
+            v->set(constraintIndex + i, dot(PtoProj, DataTypes::getDPos(m_constraintDirections[i])) );
+        }
+        v->set(constraintIndex + 2, dot(PtoA ,  DataTypes::getDPos(m_constraintDirections[2])) );
+        v->set(constraintIndex + 3, dot(PtoB ,  DataTypes::getDPos(m_constraintDirections[3])) );
     }
 }
 
@@ -169,33 +233,38 @@ void SlidingLagrangianConstraint<DataTypes>::getConstraintResolution(const Const
                                                            std::vector<core::behavior::ConstraintResolution*>& resTab,
                                                            unsigned int& offset)
 {
-    resTab[offset++] = new BilateralConstraintResolution();
-    resTab[offset++] = new BilateralConstraintResolution();
-
-    if(m_thirdConstraint)
+    if(m_constraintDirections.size()==Deriv_t<DataTypes>::spatial_dimensions)
+    {
+        //If A=B only bilateral constraints
+        for(unsigned i=0; i<m_constraintDirections.size() ; ++i)
+        {
+            resTab[offset++] = new BilateralConstraintResolution();
+        }
+    }
+    else
+    {
+        // If A!=B, constraints applied to A and B (along sliding direction) must be unilateral
+        for(unsigned i=0; i<m_constraintDirections.size()  - 2 ; ++i)
+        {
+            resTab[offset++] = new BilateralConstraintResolution();
+        }
         resTab[offset++] = new UnilateralConstraintResolution();
+        resTab[offset++] = new UnilateralConstraintResolution();
+    }
+
 }
 
 
 template<class DataTypes>
 void SlidingLagrangianConstraint<DataTypes>::storeLambda(const ConstraintParams* /*cParams*/, sofa::core::MultiVecDerivId /*res*/, const sofa::linearalgebra::BaseVector* lambda)
 {
-    Real lamb1,lamb2, lamb3;
-
+    Deriv_t<DataTypes> force;
     const auto constraintIndex = this->d_constraintIndex.getValue();
-
-    lamb1 = lambda->element(constraintIndex);
-    lamb2 = lambda->element(constraintIndex+1);
-
-    if(m_thirdConstraint)
+    for (unsigned i=0; i< m_constraintDirections.size(); ++i )
     {
-        lamb3 = lambda->element(constraintIndex+2);
-        d_force.setValue( m_dirProj* lamb1 + m_dirOrtho * lamb2 + m_dirAxe * lamb3);
+        force += m_constraintDirections[i]*lambda->element(constraintIndex+i);
     }
-    else
-    {
-        d_force.setValue( m_dirProj* lamb1 + m_dirOrtho * lamb2 );
-    }
+    d_force.setValue(force);
 }
 
 template<class DataTypes>
@@ -210,14 +279,13 @@ void SlidingLagrangianConstraint<DataTypes>::draw(const core::visual::VisualPara
 
     sofa::type::RGBAColor color;
 
-    if(m_thirdConstraint<0)
+    if(m_constraintDirections.size()==Deriv_t<DataTypes>::spatial_dimensions)
         color = sofa::type::RGBAColor::yellow();
-    else if(m_thirdConstraint>0)
-        color = sofa::type::RGBAColor::green();
     else
-        color = sofa::type::RGBAColor::magenta();
+        color = sofa::type::RGBAColor::green();
 
-    std::vector<sofa::type::Vec3> vertices;
+
+    std::vector<typename DataTypes::CPos> vertices;
     vertices.push_back(DataTypes::getCPos((this->mstate1->read(core::vec_id::read_access::position)->getValue())[d_m1.getValue()]));
 
     vparams->drawTool()->drawPoints(vertices, 10, color);


### PR DESCRIPTION
The component was broken since https://github.com/sofa-framework/sofa/pull/5506

I didn't try to understand why, I just reworked the whole component which was messy and added checks for null size vectors before normalization. 

By trying to make it agnostic to the DataType I added support for Rigid3 because why not ? 

It has to be noted that I've slightly changed the behavior. Before, when the object projection was inside the edge, no unilateral constraint was added to avoid it going out of the edge, only when the projection was outside the edge. This is OK when the object is far from the vertices, but when close, this might lead to the object going out of the edge during one timestep. This is OK with small timestep, but with larger ones, especially because no friction is considered, this might lead to big errors.  
Now, two constraints keeping the object inside the egde along the edge are added every time. This is quasi harmless in term of computation time because they are never active. It will just take a little bit more time during the building of the compliance matrix and the motion correction.  



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
