### PR TITLE
[Type] Remove the namespace on sqrt

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Vec.h
+++ b/Sofa/framework/Type/src/sofa/type/Vec.h
@@ -474,7 +474,7 @@ public:
     /// Euclidean norm.
     ValueType norm() const noexcept
     {
-        return ValueType(std::sqrt(norm2()));
+        return ValueType(sqrt(norm2()));
     }
 
     /// l-norm of the vector


### PR DESCRIPTION
I remove the `std` namespace when calling the `sqrt` function because a custom type (`ValueType`) is not necessarily supported by `std::sqrt`



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
