### PR TITLE
[Collision.Response.Mapper] Remove special characters for generated components' name

### DIFF
--- a/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/BaseContactMapper.cpp
+++ b/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/BaseContactMapper.cpp
@@ -33,7 +33,7 @@ namespace sofa::component::collision::response::mapper
 using namespace defaulttype;
 
 std::string GenerateStringID::generate(){
-    static std::string alphanum = "0123456789!@#$%^&*ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    constexpr std::string_view alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     std::string result;
     result.resize(length);
     for (int i = 0; i < length; i++)


### PR DESCRIPTION
To avoid problems like https://github.com/sofa-framework/SofaGLFW/issues/104

Fix https://github.com/sofa-framework/SofaGLFW/issues/104


Note: it could be good to use a "predictable" random generator like the LinearCongruentialRandomGenerator in Sofa.Testing. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
