### PR TITLE
[Simulation] Introduce function to visit mappings according to the mapping graph

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -680,7 +680,8 @@ void ConstraintAnimationLoop::step ( const core::ExecParams* params, SReal dt )
     {
         SCOPED_TIMER_VARNAME(updateMappingTimer, "UpdateMapping");
 
-        node->execute<UpdateMappingVisitor>(params);
+        simulation::common::MechanicalOperations mop(params, getContext());
+        mop.propagateXAndV(core::vec_id::write_access::position, core::vec_id::write_access::velocity, false);
         sofa::helper::AdvancedTimer::step("UpdateMappingEndEvent");
         {
             UpdateMappingEndEvent ev ( dt );

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -304,7 +304,7 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
     {
         SCOPED_TIMER("UpdateMapping");
         //Visual Information update: Ray Pick add a MechanicalMapping used as VisualMapping
-        node->execute<UpdateMappingVisitor>(params);
+        mop.propagateXAndV(core::vec_id::write_access::position, core::vec_id::write_access::velocity, false);
         {
             UpdateMappingEndEvent ev ( dt );
             PropagateEventVisitor act ( params , &ev );

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
@@ -20,21 +20,20 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/component/animationloop/MultiStepAnimationLoop.h>
-
-#include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/simulation/MechanicalVisitor.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
-#include <sofa/simulation/UpdateMappingEndEvent.h>
-#include <sofa/simulation/UpdateBoundingBoxVisitor.h>
-#include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/BehaviorUpdatePositionVisitor.h>
-#include <sofa/simulation/UpdateInternalDataVisitor.h>
+#include <sofa/simulation/MechanicalOperations.h>
+#include <sofa/simulation/MechanicalVisitor.h>
+#include <sofa/simulation/PropagateEventVisitor.h>
+#include <sofa/simulation/UpdateBoundingBoxVisitor.h>
 #include <sofa/simulation/UpdateContextVisitor.h>
+#include <sofa/simulation/UpdateInternalDataVisitor.h>
+#include <sofa/simulation/UpdateMappingEndEvent.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
-#include <sofa/helper/ScopedAdvancedTimer.h>
-
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
 
@@ -124,7 +123,8 @@ void MultiStepAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt
     //Visual Information update: Ray Pick add a MechanicalMapping used as VisualMapping
     {
         SCOPED_TIMER_VARNAME(updateMappingTimer, "UpdateMapping");
-        node->execute<UpdateMappingVisitor>(params);
+        simulation::common::MechanicalOperations mop(params, getContext());
+        mop.propagateXAndV(core::vec_id::write_access::position, core::vec_id::write_access::velocity, false);
     }
     {
         UpdateMappingEndEvent ev ( dt );

--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
@@ -20,21 +20,20 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/component/animationloop/MultiTagAnimationLoop.h>
-
-#include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/simulation/MechanicalVisitor.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
-#include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/BehaviorUpdatePositionVisitor.h>
-#include <sofa/simulation/UpdateInternalDataVisitor.h>
-#include <sofa/simulation/UpdateContextVisitor.h>
-#include <sofa/simulation/UpdateMappingVisitor.h>
-#include <sofa/simulation/UpdateMappingEndEvent.h>
+#include <sofa/simulation/MechanicalOperations.h>
+#include <sofa/simulation/MechanicalVisitor.h>
+#include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/UpdateBoundingBoxVisitor.h>
-#include <sofa/helper/ScopedAdvancedTimer.h>
-
+#include <sofa/simulation/UpdateContextVisitor.h>
+#include <sofa/simulation/UpdateInternalDataVisitor.h>
+#include <sofa/simulation/UpdateMappingEndEvent.h>
+#include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
 
@@ -126,7 +125,8 @@ void MultiTagAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt)
     //Visual Information update: Ray Pick add a MechanicalMapping used as VisualMapping
     {
         SCOPED_TIMER_VARNAME(updateMappingTimer, "UpdateMapping");
-        node->execute<UpdateMappingVisitor>(params);
+        simulation::common::MechanicalOperations mop(params, getContext());
+        mop.propagateXAndV(core::vec_id::write_access::position, core::vec_id::write_access::velocity, false);
     }
     {
         UpdateMappingEndEvent ev ( dt );

--- a/Sofa/framework/Core/src/sofa/core/BaseMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/BaseMapping.h
@@ -48,7 +48,7 @@ protected:
 
     /// Destructor
     ~BaseMapping() override;
-	
+
 private:
     BaseMapping(const BaseMapping& n) = delete;
     BaseMapping& operator=(const BaseMapping& n) = delete;

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/InitVisitor.h
     ${SRC_ROOT}/IntegrateBeginEvent.h
     ${SRC_ROOT}/IntegrateEndEvent.h
+    ${SRC_ROOT}/MappingGraph.h
     ${SRC_ROOT}/MechanicalOperations.h
     ${SRC_ROOT}/MechanicalVPrintVisitor.h
     ${SRC_ROOT}/MechanicalVisitor.h
@@ -167,6 +168,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/IntegrateEndEvent.cpp
     ${SRC_ROOT}/MainTaskSchedulerRegistry.cpp
     ${SRC_ROOT}/MainTaskSchedulerFactory.cpp
+    ${SRC_ROOT}/MappingGraph.cpp
     ${SRC_ROOT}/MechanicalOperations.cpp
     ${SRC_ROOT}/MechanicalVPrintVisitor.cpp
     ${SRC_ROOT}/MechanicalVisitor.cpp

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -60,7 +60,7 @@
 #include <sofa/simulation/mechanicalvisitor/MechanicalProjectPositionAndVelocityVisitor.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalPropagateOnlyPositionAndVelocityVisitor.h>
 
-#include "MechanicalOperations.h"
+#include <sofa/simulation/MechanicalOperations.h>
 
 namespace sofa::simulation
 {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -41,17 +41,26 @@
 #include <sofa/simulation/CollisionBeginEvent.h>
 #include <sofa/simulation/CollisionEndEvent.h>
 #include <sofa/simulation/CollisionVisitor.h>
+#include <sofa/simulation/DefaultAnimationLoop.h>
 #include <sofa/simulation/IntegrateBeginEvent.h>
 #include <sofa/simulation/IntegrateEndEvent.h>
 #include <sofa/simulation/MainTaskSchedulerFactory.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/SolveVisitor.h>
 #include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/UpdateBoundingBoxVisitor.h>
+#include <sofa/simulation/UpdateContextVisitor.h>
+#include <sofa/simulation/UpdateInternalDataVisitor.h>
+#include <sofa/simulation/UpdateMappingEndEvent.h>
+#include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalAccumulateMatrixDeriv.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalBeginIntegrationVisitor.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalEndIntegrationVisitor.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalProjectPositionAndVelocityVisitor.h>
 #include <sofa/simulation/mechanicalvisitor/MechanicalPropagateOnlyPositionAndVelocityVisitor.h>
 
+#include "MechanicalOperations.h"
 
 namespace sofa::simulation
 {
@@ -149,7 +158,8 @@ void DefaultAnimationLoop::updateMapping(const core::ExecParams* params, const S
 {
     SCOPED_TIMER("UpdateMapping");
     //Visual Information update: Ray Pick add a MechanicalMapping used as VisualMapping
-    m_node->execute<UpdateMappingVisitor>(params);
+    simulation::common::MechanicalOperations mop(params, m_node);
+    mop.propagateXAndV(core::vec_id::write_access::position, core::vec_id::write_access::velocity, false);
     {
         UpdateMappingEndEvent ev(dt);
         PropagateEventVisitor propagateEventVisitor(params, &ev);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/simulation/MappingGraph.h>
+
+namespace sofa::simulation
+{
+
+namespace
+{
+template <class T>
+bool haveCommonElement(const std::vector<T>& a, const std::vector<T>& b)
+{
+    if (&a == &b) return true;
+
+    const std::vector<T>& smaller = (a.size() < b.size()) ? a : b;
+    const std::vector<T>& larger = (a.size() < b.size()) ? b : a;
+
+    std::unordered_set<T> elements(smaller.begin(), smaller.end());
+
+    return std::any_of(larger.begin(), larger.end(),
+                       [&elements](const T& val) { return elements.count(val); });
+}
+}
+
+void findNextMappingsToProcess(
+    const std::vector<core::BaseMapping*>& mappingList,
+    std::queue<core::BaseMapping*>& mappings,
+    MappingGraphDirection direction)
+{
+    for (auto* mapping1 : mappingList)
+    {
+        auto inputs1 = mapping1->getFrom();
+        auto outputs1 = mapping1->getTo();
+        bool isNext = true;
+        for (auto* mapping2 : mappingList)
+        {
+            if (mapping1 != mapping2)
+            {
+                auto inputs2 = mapping2->getFrom();
+                auto outputs2 = mapping2->getTo();
+                const bool commonElement =
+                    (direction == MappingGraphDirection::TOP_DOWN) ?
+                        haveCommonElement(inputs1, outputs2) :
+                        haveCommonElement(outputs1, inputs2);
+                if (commonElement)
+                {
+                    isNext = false;
+                    break;
+                }
+                if (haveCommonElement(outputs1, outputs2))
+                {
+                    msg_warning("MappingGraph")
+                        << "Mapping " << mapping1->getName() << " has common output with "
+                        << mapping2->getName();
+                }
+            }
+        }
+
+        if (isNext)
+        {
+            mappings.push(mapping1);
+        }
+    }
+}
+
+}  // namespace sofa::simulation

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
@@ -41,17 +41,17 @@ bool haveCommonElement(const std::vector<T>& a, const std::vector<T>& b)
 }
 }
 
-void findNextMappingsToProcess(
-    const std::vector<core::BaseMapping*>& mappingList,
-    std::queue<core::BaseMapping*>& mappings,
+void findIndependentMappings(
+    const std::vector<core::BaseMapping*>& allMappings,
+    std::queue<core::BaseMapping*>& independentMappings,
     MappingGraphDirection direction)
 {
-    for (auto* mapping1 : mappingList)
+    for (auto* mapping1 : allMappings)
     {
-        auto inputs1 = mapping1->getFrom();
-        auto outputs1 = mapping1->getTo();
-        bool isNext = true;
-        for (auto* mapping2 : mappingList)
+        type::vector<core::BaseState*> inputs1 = mapping1->getFrom();
+        type::vector<core::BaseState*> outputs1 = mapping1->getTo();
+        bool isIndependent = true;
+        for (auto* mapping2 : allMappings)
         {
             if (mapping1 != mapping2)
             {
@@ -63,7 +63,8 @@ void findNextMappingsToProcess(
                         haveCommonElement(outputs1, inputs2);
                 if (commonElement)
                 {
-                    isNext = false;
+                    // mapping1 is not an independent mapping because it shares common elements with mapping2
+                    isIndependent = false;
                     break;
                 }
                 if (haveCommonElement(outputs1, outputs2))
@@ -75,9 +76,9 @@ void findNextMappingsToProcess(
             }
         }
 
-        if (isNext)
+        if (isIndependent)
         {
-            mappings.push(mapping1);
+            independentMappings.push(mapping1);
         }
     }
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
@@ -58,7 +58,7 @@ void findNextMappingsToProcess(
                 auto inputs2 = mapping2->getFrom();
                 auto outputs2 = mapping2->getTo();
                 const bool commonElement =
-                    (direction == MappingGraphDirection::TOP_DOWN) ?
+                    (direction == MappingGraphDirection::FORWARD) ?
                         haveCommonElement(inputs1, outputs2) :
                         haveCommonElement(outputs1, inputs2);
                 if (commonElement)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
@@ -31,23 +31,23 @@
 namespace sofa::simulation
 {
 
-enum class SOFA_SIMULATION_CORE_API MappingGraphDirection : std::uint8_t
+enum class SOFA_SIMULATION_CORE_API MappingGraphDirection : bool
 {
-    TOP_DOWN,
-    BOTTOM_UP
+    FORWARD,
+    BACKWARD
 };
 
 SOFA_SIMULATION_CORE_API
 void findNextMappingsToProcess(const std::vector<sofa::core::BaseMapping*>& mappingList,
                                std::queue<sofa::core::BaseMapping*>& mappings,
-                               MappingGraphDirection direction = MappingGraphDirection::TOP_DOWN);
+                               MappingGraphDirection direction = MappingGraphDirection::FORWARD);
 
 template <class Callable>
 void mappingGraphBreadthFirstTraversal(
     sofa::core::objectmodel::BaseContext* context,
     Callable f,
     bool filterNonMechanicalMappings = true,
-    MappingGraphDirection direction = MappingGraphDirection::TOP_DOWN)
+    MappingGraphDirection direction = MappingGraphDirection::FORWARD)
 {
     auto mappingList =
     context->getObjects<sofa::core::BaseMapping>(sofa::core::objectmodel::BaseContext::SearchDirection::SearchDown);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
@@ -31,7 +31,7 @@
 namespace sofa::simulation
 {
 
-enum class SOFA_SIMULATION_CORE_API MappingGraphDirection
+enum class SOFA_SIMULATION_CORE_API MappingGraphDirection : std::uint8_t
 {
     TOP_DOWN,
     BOTTOM_UP
@@ -65,7 +65,7 @@ void mappingGraphBreadthFirstTraversal(
 
         if (mappingsToProcess.empty())
         {
-            msg_warning("MappingGraph") << "Cannot find next mappings to process. Abort.";
+            msg_error("MappingGraph") << "Cannot find next mappings to process. Abort.";
             break;
         }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
@@ -1,0 +1,85 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/simulation/config.h>
+#include <sofa/core/BaseMapping.h>
+#include <sofa/core/objectmodel/BaseContext.h>
+
+#include <queue>
+#include <unordered_set>
+
+namespace sofa::simulation
+{
+
+enum class SOFA_SIMULATION_CORE_API MappingGraphDirection
+{
+    TOP_DOWN,
+    BOTTOM_UP
+};
+
+SOFA_SIMULATION_CORE_API
+void findNextMappingsToProcess(const std::vector<sofa::core::BaseMapping*>& mappingList,
+                               std::queue<sofa::core::BaseMapping*>& mappings,
+                               MappingGraphDirection direction = MappingGraphDirection::TOP_DOWN);
+
+template <class Callable>
+void mappingGraphBreadthFirstTraversal(
+    sofa::core::objectmodel::BaseContext* context,
+    Callable f,
+    bool filterNonMechanicalMappings = true,
+    MappingGraphDirection direction = MappingGraphDirection::TOP_DOWN)
+{
+    auto mappingList =
+    context->getObjects<sofa::core::BaseMapping>(sofa::core::objectmodel::BaseContext::SearchDirection::SearchDown);
+
+    if (filterNonMechanicalMappings)
+    {
+        std::erase_if(mappingList, [](const sofa::core::BaseMapping* mapping){return !mapping->isMechanical();});
+    }
+
+    std::queue<sofa::core::BaseMapping*> mappingsToProcess;
+
+    while (!mappingList.empty())
+    {
+        findNextMappingsToProcess(mappingList, mappingsToProcess, direction);
+
+        if (mappingsToProcess.empty())
+        {
+            msg_warning("MappingGraph") << "Cannot find next mappings to process. Abort.";
+            break;
+        }
+
+        while (!mappingsToProcess.empty())
+        {
+            auto* mapping = mappingsToProcess.front();
+            mappingsToProcess.pop();
+
+            f(mapping);
+
+            std::erase(mappingList, mapping);
+        }
+
+    }
+}
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
@@ -55,6 +55,7 @@
 #include <sofa/core/behavior/ConstraintSolver.h>
 
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/simulation/MappingGraph.h>
 
 #include <numeric>
 
@@ -256,7 +257,15 @@ void MechanicalOperations::computeForce(core::MultiVecDerivId result, bool clear
         executeVisitor( MechanicalResetForceVisitor(&mparams, result, false) );
         //finish();
     }
-    executeVisitor( MechanicalComputeForceVisitor(&mparams, result, accumulate) );
+    executeVisitor( MechanicalComputeForceVisitor(&mparams, result, false) );
+
+    if (accumulate)
+    {
+        mappingGraphBreadthFirstTraversal(ctx, [&mparams = mparams, &result](BaseMapping* mapping)
+        {
+            mapping->applyJT(&mparams, result, result);
+        }, true, MappingGraphDirection::BOTTOM_UP);
+    }
 }
 
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
@@ -141,7 +141,7 @@ void MechanicalOperations::apply(core::MultiVecCoordId out, core::ConstMultiVecC
         [params = &mparams, &out, &in](BaseMapping* mapping)
         {
             mapping->apply(params, out, in);
-        }, filterNonMechanical, MappingGraphDirection::TOP_DOWN);
+        }, filterNonMechanical, MappingGraphDirection::FORWARD);
 }
 
 void MechanicalOperations::applyJ(core::MultiVecDerivId out, core::ConstMultiVecDerivId in, bool filterNonMechanical)
@@ -151,7 +151,7 @@ void MechanicalOperations::applyJ(core::MultiVecDerivId out, core::ConstMultiVec
         {
             mapping->applyJ(params, out, in);
         },
-        filterNonMechanical, MappingGraphDirection::TOP_DOWN);
+        filterNonMechanical, MappingGraphDirection::FORWARD);
 }
 
 void MechanicalOperations::applyJT(core::MultiVecDerivId in, core::ConstMultiVecDerivId out, bool filterNonMechanical)
@@ -160,7 +160,7 @@ void MechanicalOperations::applyJT(core::MultiVecDerivId in, core::ConstMultiVec
         [params = &mparams, &out, &in](core::BaseMapping* mapping)
         {
             mapping->applyJT(params, in, out);
-        }, filterNonMechanical, MappingGraphDirection::BOTTOM_UP);
+        }, filterNonMechanical, MappingGraphDirection::BACKWARD);
 }
 
 /// Propagate the given displacement through all mappings
@@ -174,7 +174,7 @@ void MechanicalOperations::propagateDx(core::MultiVecDerivId dx, bool ignore_fla
         {
             mapping->applyJ(&params, dx, dx);
         }
-    }, true, MappingGraphDirection::TOP_DOWN);
+    }, true, MappingGraphDirection::FORWARD);
 }
 
 /// Propagate the given displacement through all mappings and reset the current force delta
@@ -315,7 +315,7 @@ void MechanicalOperations::computeDf(core::MultiVecDerivId df, bool clear, bool 
             mapping->applyJT(&mparams, df, df); // apply material stiffness: variation of force below the mapping
             if( mparams.kFactor() )
                 mapping->applyDJT(&mparams, df, df); // apply geometric stiffness: variation due to a change of mapping, with a constant force below the mapping
-        }, true, MappingGraphDirection::BOTTOM_UP);
+        }, true, MappingGraphDirection::BACKWARD);
     }
 }
 
@@ -339,7 +339,7 @@ void MechanicalOperations::computeDfV(core::MultiVecDerivId df, bool clear, bool
             mapping->applyJT(&mparams, df, df); // apply material stiffness: variation of force below the mapping
             if( mparams.kFactor() != 0_sreal)
                 mapping->applyDJT(&mparams, df, df); // apply geometric stiffness: variation due to a change of mapping, with a constant force below the mapping
-        }, true, MappingGraphDirection::BOTTOM_UP);
+        }, true, MappingGraphDirection::BACKWARD);
     }
 
     mparams.setDx(dx);
@@ -370,7 +370,7 @@ void MechanicalOperations::addMBKdx(core::MultiVecDerivId df,
             mapping->applyJT(&mparams, df, df);
             if( mparams.kFactor() != 0_sreal)
                 mapping->applyDJT(&mparams, df, df);
-        }, true, MappingGraphDirection::BOTTOM_UP);
+        }, true, MappingGraphDirection::BACKWARD);
     }
 }
 
@@ -402,7 +402,7 @@ void MechanicalOperations::addMBKv(core::MultiVecDerivId df,
             mapping->applyJT(&mparams, df, df);
             if( mparams.kFactor() != 0_sreal)
                 mapping->applyDJT(&mparams, df, df);
-        }, true, MappingGraphDirection::BOTTOM_UP);
+        }, true, MappingGraphDirection::BACKWARD);
     }
 
     mparams.setDx(dx);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.cpp
@@ -205,8 +205,15 @@ void MechanicalOperations::propagateV(core::MultiVecDerivId v, bool filterNonMec
 /// Propagate the given position and velocity through all mappings
 void MechanicalOperations::propagateXAndV(core::MultiVecCoordId x, core::MultiVecDerivId v, bool filterNonMechanical)
 {
-    propagateX(x, filterNonMechanical);
-    propagateV(v, filterNonMechanical);
+    setX(x);
+    setV(v);
+
+    mappingGraphBreadthFirstTraversal(ctx,
+    [params = &mparams, &x, &v](BaseMapping* mapping)
+    {
+        mapping->apply(params, x, x);
+        mapping->applyJ(params, v, v);
+    }, filterNonMechanical, MappingGraphDirection::FORWARD);
 }
 
 /// Propagate the given position through all mappings and reset the current force delta

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
@@ -51,6 +51,10 @@ public:
     /// @name Mechanical Vector operations
 /// @{
 
+    void apply(core::MultiVecCoordId out, core::ConstMultiVecCoordId in);
+    void applyJ(core::MultiVecDerivId out, core::ConstMultiVecDerivId in);
+    void applyJT(core::MultiVecDerivId in, core::ConstMultiVecDerivId out);
+
     /// Propagate the given displacement through all mappings
     void propagateDx(core::MultiVecDerivId dx, bool ignore_flag = false);
     /// Propagate the given displacement through all mappings and reset the current force delta

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
@@ -28,6 +28,7 @@
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/simulation/VisitorExecuteFunc.h>
 #include <sofa/core/ConstraintParams.h>
+#include <sofa/core/MechanicalParams.h>
 #include <sofa/core/MatricesFactors.h>
 
 
@@ -37,69 +38,69 @@ namespace sofa::simulation::common
 class SOFA_SIMULATION_CORE_API MechanicalOperations
 {
 public:
-    core::MechanicalParams mparams;
-    core::ConstraintParams cparams;
-    core::objectmodel::BaseContext* ctx;
+    sofa::core::MechanicalParams mparams;
+    sofa::core::ConstraintParams cparams;
+    sofa::core::objectmodel::BaseContext* ctx;
 
-    MechanicalOperations(const core::MechanicalParams* mparams, core::objectmodel::BaseContext* ctx, bool precomputedTraversalOrder=false);
+    MechanicalOperations(const sofa::core::MechanicalParams* mparams, sofa::core::objectmodel::BaseContext* ctx, bool precomputedTraversalOrder=false);
 
-    MechanicalOperations(const core::ExecParams* params, core::objectmodel::BaseContext* ctx, bool precomputedTraversalOrder=false);
+    MechanicalOperations(const sofa::core::ExecParams* params, sofa::core::objectmodel::BaseContext* ctx, bool precomputedTraversalOrder=false);
 
-    core::MechanicalParams* operator->() { return &mparams; }
-    operator const core::MechanicalParams*() { return &mparams; }
+    sofa::core::MechanicalParams* operator->() { return &mparams; }
+    operator const sofa::core::MechanicalParams*() { return &mparams; }
 
     /// @name Mechanical Vector operations
 /// @{
 
-    void apply(core::MultiVecCoordId out, core::ConstMultiVecCoordId in);
-    void applyJ(core::MultiVecDerivId out, core::ConstMultiVecDerivId in);
-    void applyJT(core::MultiVecDerivId in, core::ConstMultiVecDerivId out);
+    void apply(sofa::core::MultiVecCoordId out, sofa::core::ConstMultiVecCoordId in, bool filterNonMechanical = true);
+    void applyJ(sofa::core::MultiVecDerivId out, sofa::core::ConstMultiVecDerivId in, bool filterNonMechanical = true);
+    void applyJT(sofa::core::MultiVecDerivId in, sofa::core::ConstMultiVecDerivId out, bool filterNonMechanical = true);
 
     /// Propagate the given displacement through all mappings
-    void propagateDx(core::MultiVecDerivId dx, bool ignore_flag = false);
+    void propagateDx(sofa::core::MultiVecDerivId dx, bool ignore_flag = false, bool filterNonMechanical = true);
     /// Propagate the given displacement through all mappings and reset the current force delta
-    void propagateDxAndResetDf(core::MultiVecDerivId dx, core::MultiVecDerivId df);
+    void propagateDxAndResetDf(sofa::core::MultiVecDerivId dx, sofa::core::MultiVecDerivId df, bool filterNonMechanical = true);
     /// Propagate the given position through all mappings
-    void propagateX(core::MultiVecCoordId x);
+    void propagateX(sofa::core::MultiVecCoordId x, bool filterNonMechanical = true);
     /// Propagate the given velocity through all mappings
-    void propagateV(core::MultiVecDerivId v);
+    void propagateV(sofa::core::MultiVecDerivId v, bool filterNonMechanical = true);
     /// Propagate the given position and velocity through all mappings
-    void propagateXAndV(core::MultiVecCoordId x, core::MultiVecDerivId v);
+    void propagateXAndV(sofa::core::MultiVecCoordId x, sofa::core::MultiVecDerivId v, bool filterNonMechanical = true);
     /// Propagate the given position through all mappings and reset the current force delta
-    void propagateXAndResetF(core::MultiVecCoordId x, core::MultiVecDerivId f);
+    void propagateXAndResetF(sofa::core::MultiVecCoordId x, sofa::core::MultiVecDerivId f);
     /// Apply projective constraints to the given position vector
-    void projectPosition(core::MultiVecCoordId x, SReal time = 0.0);
+    void projectPosition(sofa::core::MultiVecCoordId x, SReal time = 0.0);
     /// Apply projective constraints to the given velocity vector
-    void projectVelocity(core::MultiVecDerivId v, SReal time = 0.0);
+    void projectVelocity(sofa::core::MultiVecDerivId v, SReal time = 0.0);
     /// Apply projective constraints to the given vector
-    void projectResponse(core::MultiVecDerivId dx, double **W=nullptr);
+    void projectResponse(sofa::core::MultiVecDerivId dx, double **W=nullptr);
     /// Apply projective constraints to the given position and velocity vectors
-    void projectPositionAndVelocity(core::MultiVecCoordId x, core::MultiVecDerivId v, double time = 0.0);
-    void addMdx(core::MultiVecDerivId res, core::MultiVecDerivId dx, SReal factor = 1.0); ///< res += factor M.dx
-    void integrateVelocity(core::MultiVecDerivId res, core::ConstMultiVecCoordId x, core::ConstMultiVecDerivId v, SReal dt); ///< res = x + v.dt
-    void accFromF(core::MultiVecDerivId a, core::ConstMultiVecDerivId f); ///< a = M^-1 . f
+    void projectPositionAndVelocity(sofa::core::MultiVecCoordId x, sofa::core::MultiVecDerivId v, double time = 0.0);
+    void addMdx(sofa::core::MultiVecDerivId res, sofa::core::MultiVecDerivId dx, SReal factor = 1.0); ///< res += factor M.dx
+    void integrateVelocity(sofa::core::MultiVecDerivId res, sofa::core::ConstMultiVecCoordId x, sofa::core::ConstMultiVecDerivId v, SReal dt); ///< res = x + v.dt
+    void accFromF(sofa::core::MultiVecDerivId a, sofa::core::ConstMultiVecDerivId f); ///< a = M^-1 . f
     /// Compute Energy
     void computeEnergy(SReal &kineticEnergy, SReal &potentialEnergy);
     /// Compute the current force (given the latest propagated position and velocity)
-    void computeForce(core::MultiVecDerivId result, bool clear = true, bool accumulate = true);
+    void computeForce(sofa::core::MultiVecDerivId result, bool clear = true, bool accumulate = true);
     /// Compute the current force delta (given the latest propagated displacement)
-    void computeDf(core::MultiVecDerivId df, bool clear = true, bool accumulate = true);
+    void computeDf(sofa::core::MultiVecDerivId df, bool clear = true, bool accumulate = true);
     /// Compute the current force delta (given the latest propagated velocity)
-    void computeDfV(core::MultiVecDerivId df, bool clear = true, bool accumulate = true);
+    void computeDfV(sofa::core::MultiVecDerivId df, bool clear = true, bool accumulate = true);
     /// accumulate $ df += (m M + b B + k K) dx $ (given the latest propagated displacement)
-    void addMBKdx(core::MultiVecDerivId df, core::MatricesFactors::M m, core::MatricesFactors::B b, core::MatricesFactors::K k, bool clear = true, bool accumulate = true);
+    void addMBKdx(sofa::core::MultiVecDerivId df, sofa::core::MatricesFactors::M m, sofa::core::MatricesFactors::B b, sofa::core::MatricesFactors::K k, bool clear = true, bool accumulate = true);
     /// accumulate $ df += (m M + b B + k K) velocity $
-    void addMBKv(core::MultiVecDerivId df, core::MatricesFactors::M m, core::MatricesFactors::B b, core::MatricesFactors::K k, bool clear = true, bool accumulate = true);
+    void addMBKv(sofa::core::MultiVecDerivId df, sofa::core::MatricesFactors::M m, sofa::core::MatricesFactors::B b, sofa::core::MatricesFactors::K k, bool clear = true, bool accumulate = true);
     /// Add dt*Gravity to the velocity
-    void addSeparateGravity(SReal dt, core::MultiVecDerivId result = core::vec_id::write_access::velocity );
+    void addSeparateGravity(SReal dt, sofa::core::MultiVecDerivId result = sofa::core::vec_id::write_access::velocity );
 
-    void computeContactForce(core::MultiVecDerivId result);
-    void computeContactDf(core::MultiVecDerivId df);
+    void computeContactForce(sofa::core::MultiVecDerivId result);
+    void computeContactDf(sofa::core::MultiVecDerivId df);
 
 
-    void computeAcc(SReal t, core::MultiVecDerivId a, core::MultiVecCoordId x, core::MultiVecDerivId v); ///< Compute a(x,v) at time t. Parameters x and v not const due to propagation through mappings.
-    void computeForce(SReal t, core::MultiVecDerivId f, core::MultiVecCoordId x, core::MultiVecDerivId v);  ///< Compute f(x,v) at time t. Parameters x and v not const due to propagation through mappings.
-    void computeContactAcc(SReal t, core::MultiVecDerivId a, core::MultiVecCoordId x, core::MultiVecDerivId v); // Parameters x and v not const due to propagation through mappings.
+    void computeAcc(SReal t, sofa::core::MultiVecDerivId a, sofa::core::MultiVecCoordId x, sofa::core::MultiVecDerivId v); ///< Compute a(x,v) at time t. Parameters x and v not const due to propagation through mappings.
+    void computeForce(SReal t, sofa::core::MultiVecDerivId f, sofa::core::MultiVecCoordId x, sofa::core::MultiVecDerivId v);  ///< Compute f(x,v) at time t. Parameters x and v not const due to propagation through mappings.
+    void computeContactAcc(SReal t, sofa::core::MultiVecDerivId a, sofa::core::MultiVecCoordId x, sofa::core::MultiVecDerivId v); // Parameters x and v not const due to propagation through mappings.
 
     /// @}
 
@@ -117,7 +118,7 @@ public:
 
     /** Find all the Constraint present in the scene graph, build the constraint equation system, solve and apply the correction
 **/
-    void solveConstraint(sofa::core::MultiVecId id, core::ConstraintOrder order);
+    void solveConstraint(sofa::core::MultiVecId id, sofa::core::ConstraintOrder order);
 
 
 
@@ -133,9 +134,9 @@ public:
 
     void addMBK_ToMatrix(const sofa::core::behavior::MultiMatrixAccessor* matrix, SReal mFact, SReal bFact, SReal kFact);
 
-    void multiVector2BaseVector(core::ConstMultiVecId src, linearalgebra::BaseVector *dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
-    void baseVector2MultiVector(const linearalgebra::BaseVector *src, core::MultiVecId dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
-    void multiVectorPeqBaseVector(core::MultiVecDerivId dest, const linearalgebra::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
+    void multiVector2BaseVector(sofa::core::ConstMultiVecId src, linearalgebra::BaseVector *dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
+    void baseVector2MultiVector(const linearalgebra::BaseVector *src, sofa::core::MultiVecId dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
+    void multiVectorPeqBaseVector(sofa::core::MultiVecDerivId dest, const linearalgebra::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
 
     /// @}
 
@@ -143,38 +144,38 @@ public:
 /// @{
 
     /// Dump the content of the given vector.
-    void print( core::ConstMultiVecId v, std::ostream& out );
-    void printWithElapsedTime( core::ConstMultiVecId v,  unsigned time, std::ostream& out=std::cerr );
+    void print( sofa::core::ConstMultiVecId v, std::ostream& out );
+    void printWithElapsedTime( sofa::core::ConstMultiVecId v,  unsigned time, std::ostream& out=std::cerr );
 
     /// @}
 
 
     SOFA_ATTRIBUTE_DISABLED_MECHANICALOPERATIONS_ADDMBKDX()
-    void addMBKdx(core::MultiVecDerivId df, SReal m, SReal b, SReal k, bool clear = true, bool accumulate = true) = delete;
+    void addMBKdx(sofa::core::MultiVecDerivId df, SReal m, SReal b, SReal k, bool clear = true, bool accumulate = true) = delete;
     SOFA_ATTRIBUTE_DISABLED_MECHANICALOPERATIONS_ADDMBKV()
-    void addMBKv(core::MultiVecDerivId df, SReal m, SReal b, SReal k, bool clear = true, bool accumulate = true) = delete;
+    void addMBKv(sofa::core::MultiVecDerivId df, SReal m, SReal b, SReal k, bool clear = true, bool accumulate = true) = delete;
     SOFA_ATTRIBUTE_DISABLED_MECHANICALOPERATIONS_SETSYSTEMMBKMATRIX_OTHER()
-    void setSystemMBKMatrix(SReal mFact, SReal bFact, SReal kFact, core::behavior::LinearSolver* linearSolver) = delete;
+    void setSystemMBKMatrix(SReal mFact, SReal bFact, SReal kFact, sofa::core::behavior::LinearSolver* linearSolver) = delete;
 
 protected:
     VisitorExecuteFunc executeVisitor;
 
-    void setX(core::MultiVecCoordId& v);
-    void setX(core::ConstMultiVecCoordId& v);
-    void setV(core::MultiVecDerivId& v);
-    void setV(core::ConstMultiVecDerivId& v);
-    void setF(core::MultiVecDerivId& v);
-    void setF(core::ConstMultiVecDerivId& v);
-    void setDx(core::MultiVecDerivId& v);
-    void setDx(core::ConstMultiVecDerivId& v);
-    void setDf(core::MultiVecDerivId& v);
-    void setDf(core::ConstMultiVecDerivId& v);
+    void setX(sofa::core::MultiVecCoordId& v);
+    void setX(sofa::core::ConstMultiVecCoordId& v);
+    void setV(sofa::core::MultiVecDerivId& v);
+    void setV(sofa::core::ConstMultiVecDerivId& v);
+    void setF(sofa::core::MultiVecDerivId& v);
+    void setF(sofa::core::ConstMultiVecDerivId& v);
+    void setDx(sofa::core::MultiVecDerivId& v);
+    void setDx(sofa::core::ConstMultiVecDerivId& v);
+    void setDf(sofa::core::MultiVecDerivId& v);
+    void setDf(sofa::core::ConstMultiVecDerivId& v);
 
     /// Warn the user that a linear solver is required but has not been found
     void showMissingLinearSolverError() const;
 
     /// Store if the "missing linear solver" error message has already been shown for a given context
-    static std::map<core::objectmodel::BaseContext*, bool> hasShownMissingLinearSolverMap;
+    static std::map<sofa::core::objectmodel::BaseContext*, bool> hasShownMissingLinearSolverMap;
 
 };
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MechanicalOperations.h
@@ -107,13 +107,13 @@ public:
     /// @name Matrix operations using LinearSolver components
 /// @{
 
-    void resetSystem(core::behavior::LinearSolver* linearSolver);
-    void setSystemMBKMatrix(core::MatricesFactors::M m, core::MatricesFactors::B b, core::MatricesFactors::K k, core::behavior::LinearSolver* linearSolver);
-    void setSystemRHVector(core::MultiVecDerivId v, core::behavior::LinearSolver* linearSolver);
-    void setSystemLHVector(core::MultiVecDerivId v, core::behavior::LinearSolver* linearSolver);
-    void solveSystem(core::behavior::LinearSolver* linearSolver);
+    void resetSystem(sofa::core::behavior::LinearSolver* linearSolver);
+    void setSystemMBKMatrix(sofa::core::MatricesFactors::M m, sofa::core::MatricesFactors::B b, sofa::core::MatricesFactors::K k, sofa::core::behavior::LinearSolver* linearSolver);
+    void setSystemRHVector(sofa::core::MultiVecDerivId v, sofa::core::behavior::LinearSolver* linearSolver);
+    void setSystemLHVector(sofa::core::MultiVecDerivId v, sofa::core::behavior::LinearSolver* linearSolver);
+    void solveSystem(sofa::core::behavior::LinearSolver* linearSolver);
     void solveSystem(core::behavior::LinearSolver* linearSolver, core::MultiVecDerivId v);
-    void print( std::ostream& out, core::behavior::LinearSolver* linearSolver);
+    void print( std::ostream& out, sofa::core::behavior::LinearSolver* linearSolver);
     /// @}
 
     /** Find all the Constraint present in the scene graph, build the constraint equation system, solve and apply the correction

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Simulation.cpp
@@ -69,6 +69,8 @@ using sofa::simulation::mechanicalvisitor::MechanicalProjectPositionAndVelocityV
 #include <sofa/simulation/mechanicalvisitor/MechanicalPropagateOnlyPositionAndVelocityVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalPropagateOnlyPositionAndVelocityVisitor;
 
+#include <sofa/simulation/MechanicalOperations.h>
+
 namespace sofa::simulation
 {
 
@@ -270,7 +272,9 @@ void reset(Node* root)
     const sofa::core::MechanicalParams mparams(*params);
     root->execute<MechanicalProjectPositionAndVelocityVisitor>(&mparams);
     root->execute<MechanicalPropagateOnlyPositionAndVelocityVisitor>(&mparams);
-    root->execute<UpdateMappingVisitor>(params);
+
+    simulation::common::MechanicalOperations mop(params, root);
+    mop.propagateXAndV(sofa::core::vec_id::write_access::position, sofa::core::vec_id::write_access::velocity, false);
 }
 
 void initTextures(Node* root)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VisitorExecuteFunc.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VisitorExecuteFunc.h
@@ -33,13 +33,13 @@ namespace sofa::simulation::common
 struct VisitorExecuteFunc
 {
 protected:
-    core::objectmodel::BaseContext& ctx;
+    sofa::core::objectmodel::BaseContext& ctx;
 
 public:
 
     bool precomputedTraversalOrder;
 
-    VisitorExecuteFunc(core::objectmodel::BaseContext& context, bool bPrecomputedTraversalOrder=false)
+    VisitorExecuteFunc(sofa::core::objectmodel::BaseContext& context, bool bPrecomputedTraversalOrder=false)
         : ctx(context)
         , precomputedTraversalOrder(bPrecomputedTraversalOrder)
     {}

--- a/Sofa/framework/Simulation/Core/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/test/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Sofa.Simulation.Core_test)
 
 set(SOURCE_FILES
     Colors_test.cpp
+    MappingGraph_test.cpp
     ParallelForEach_test.cpp
     RequiredPlugin_test.cpp
     SceneCheckRegistry_test.cpp

--- a/Sofa/framework/Simulation/Core/test/MappingGraph_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/MappingGraph_test.cpp
@@ -136,7 +136,7 @@ auto chainedMappings(simulation::MappingGraphDirection direction)
 TEST(mappingGraphBreadthFirstTraversal, twoChainedMappingsTopDown)
 {
     const auto [orderedMappings, mapping1, mapping2] =
-        chainedMappings(simulation::MappingGraphDirection::TOP_DOWN);
+        chainedMappings(simulation::MappingGraphDirection::FORWARD);
 
     ASSERT_EQ(orderedMappings.size(), 2);
     EXPECT_EQ(orderedMappings[0], mapping1);
@@ -146,7 +146,7 @@ TEST(mappingGraphBreadthFirstTraversal, twoChainedMappingsTopDown)
 TEST(mappingGraphBreadthFirstTraversal, twoChainedMappingsBottomUp)
 {
     const auto [orderedMappings, mapping1, mapping2] =
-        chainedMappings(simulation::MappingGraphDirection::BOTTOM_UP);
+        chainedMappings(simulation::MappingGraphDirection::BACKWARD);
 
     ASSERT_EQ(orderedMappings.size(), 2);
     EXPECT_EQ(orderedMappings[0], mapping2);

--- a/Sofa/framework/Simulation/Core/test/MappingGraph_test.cpp
+++ b/Sofa/framework/Simulation/Core/test/MappingGraph_test.cpp
@@ -1,0 +1,156 @@
+/******************************************************************************
+ *                 SOFA, Simulation Open-Framework Architecture                *
+ *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+ *                                                                             *
+ * This program is free software; you can redistribute it and/or modify it     *
+ * under the terms of the GNU Lesser General Public License as published by    *
+ * the Free Software Foundation; either version 2.1 of the License, or (at     *
+ * your option) any later version.                                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful, but WITHOUT *
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+ * for more details.                                                           *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+ *******************************************************************************
+ * Authors: The SOFA Team and external contributors (see Authors.txt)          *
+ *                                                                             *
+ * Contact information: contact@sofa-framework.org                             *
+ ******************************************************************************/
+#include <sofa/simpleapi/SimpleApi.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/simulation/MappingGraph.h>
+#include <sofa/testing/BaseTest.h>
+
+namespace sofa
+{
+
+TEST(mappingGraphBreadthFirstTraversal, emptyGraph)
+{
+    auto root = simpleapi::createRootNode(simulation::getSimulation(), "root");
+    sofa::type::vector<core::BaseMapping*> orderedMappings;
+
+    sofa::simulation::mappingGraphBreadthFirstTraversal(root.get(), [&orderedMappings](core::BaseMapping* mapping)
+    {
+        orderedMappings.push_back(mapping);
+    });
+
+    EXPECT_TRUE(orderedMappings.empty());
+}
+
+TEST(mappingGraphBreadthFirstTraversal, oneMapping)
+{
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.StateContainer, Sofa.Component.Mapping.Linear});
+
+    auto root = simpleapi::createRootNode(simulation::getSimulation(), "root");
+    simpleapi::createObject(root, "MechanicalObject", {{"template", "Vec3"}, {"name", "dofs1"}});
+    auto subnode = simpleapi::createChild(root, "subnode");
+    simpleapi::createObject(subnode, "MechanicalObject", {{"template", "Vec3"}, {"name", "dofs2"}});
+    simpleapi::createObject(subnode, "IdentityMapping", {{"template", "Vec3,Vec3"}, {"name", "mapping"},
+        {"input", "@../dofs1"}, {"output", "@dofs2"}});
+
+    sofa::type::vector<core::BaseMapping*> orderedMappings;
+
+    sofa::simulation::mappingGraphBreadthFirstTraversal(root.get(), [&orderedMappings](core::BaseMapping* mapping)
+    {
+        orderedMappings.push_back(mapping);
+    });
+
+    EXPECT_EQ(orderedMappings.size(), 1);
+}
+
+TEST(mappingGraphBreadthFirstTraversal, twoIndependentMappings)
+{
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.StateContainer, Sofa.Component.Mapping.Linear});
+
+    auto root = simpleapi::createRootNode(simulation::getSimulation(), "root");
+
+    {
+        auto subnode1 = simpleapi::createChild(root, "subnode1");
+        simpleapi::createObject(subnode1, "MechanicalObject", {{"template", "Vec3"}, {"name", "dofs1"}});
+
+        auto subsubnode1 = simpleapi::createChild(subnode1, "subsubnode1");
+        simpleapi::createObject(subsubnode1, "MechanicalObject", {{"template", "Vec3"}, {"name", "dofs3"}});
+        simpleapi::createObject(subsubnode1, "IdentityMapping", {{"template", "Vec3,Vec3"}, {"name", "mapping"},
+            {"input", "@../dofs1"}, {"output", "@dofs3"}});
+    }
+
+    {
+        auto subnode2 = simpleapi::createChild(root, "subnode2");
+        simpleapi::createObject(subnode2, "MechanicalObject", {{"template", "Vec3"}, {"name", "dofs2"}});
+
+        auto subsubnode2 = simpleapi::createChild(subnode2, "subsubnode2");
+        simpleapi::createObject(subsubnode2, "MechanicalObject", {{"template", "Vec3"}, {"name", "dofs3"}});
+        simpleapi::createObject(subsubnode2, "IdentityMapping", {{"template", "Vec3,Vec3"}, {"name", "mapping"},
+            {"input", "@../dofs2"}, {"output", "@dofs3"}});
+    }
+
+    sofa::type::vector<core::BaseMapping*> orderedMappings;
+
+    sofa::simulation::mappingGraphBreadthFirstTraversal(root.get(), [&orderedMappings](core::BaseMapping* mapping)
+    {
+        orderedMappings.push_back(mapping);
+    });
+
+    EXPECT_EQ(orderedMappings.size(), 2);
+}
+
+auto chainedMappings(simulation::MappingGraphDirection direction)
+{
+    const auto plugins = sofa::testing::makeScopedPlugin({Sofa.Component.StateContainer, Sofa.Component.Mapping.Linear});
+
+    auto root = simpleapi::createRootNode(simulation::getSimulation(), "root");
+    simpleapi::createObject(root, "MechanicalObject", {{"template", "Vec3"}, {"name", "dofs1"}});
+
+    auto subnode1 = simpleapi::createChild(root, "subnode1");
+    simpleapi::createObject(subnode1, "MechanicalObject",
+                            {{"template", "Vec3"}, {"name", "dofs2"}});
+
+    auto mapping1 = simpleapi::createObject(subnode1, "IdentityMapping",
+                            {{"template", "Vec3,Vec3"},
+                             {"name", "mapping"},
+                             {"input", "@../dofs1"},
+                             {"output", "@dofs2"}});
+
+    auto subsubnode1 = simpleapi::createChild(subnode1, "subsubnode1");
+    simpleapi::createObject(subsubnode1, "MechanicalObject",
+                            {{"template", "Vec3"}, {"name", "dofs3"}});
+    auto mapping2 = simpleapi::createObject(subsubnode1, "IdentityMapping",
+                            {{"template", "Vec3,Vec3"},
+                             {"name", "mapping"},
+                             {"input", "@../dofs2"},
+                             {"output", "@dofs3"}});
+
+    sofa::type::vector<core::BaseMapping*> orderedMappings;
+
+    sofa::simulation::mappingGraphBreadthFirstTraversal(root.get(), [&orderedMappings](core::BaseMapping* mapping)
+    {
+        orderedMappings.push_back(mapping);
+    }, true, direction);
+
+    return std::make_tuple(orderedMappings, mapping1, mapping2);
+}
+
+TEST(mappingGraphBreadthFirstTraversal, twoChainedMappingsTopDown)
+{
+    const auto [orderedMappings, mapping1, mapping2] =
+        chainedMappings(simulation::MappingGraphDirection::TOP_DOWN);
+
+    ASSERT_EQ(orderedMappings.size(), 2);
+    EXPECT_EQ(orderedMappings[0], mapping1);
+    EXPECT_EQ(orderedMappings[1], mapping2);
+}
+
+TEST(mappingGraphBreadthFirstTraversal, twoChainedMappingsBottomUp)
+{
+    const auto [orderedMappings, mapping1, mapping2] =
+        chainedMappings(simulation::MappingGraphDirection::BOTTOM_UP);
+
+    ASSERT_EQ(orderedMappings.size(), 2);
+    EXPECT_EQ(orderedMappings[0], mapping2);
+    EXPECT_EQ(orderedMappings[1], mapping1);
+}
+
+}

--- a/Sofa/framework/Simulation/Graph/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Graph/test/CMakeLists.txt
@@ -10,7 +10,6 @@ set(SOURCE_FILES
     MutationListener_test.cpp
     Node_test.cpp
     Simulation_test.cpp
-    Link_test.cpp
     )
 
 add_executable(${PROJECT_NAME} ${HEADER_FILES} ${SOURCE_FILES})

--- a/Sofa/framework/Simulation/Graph/test/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Graph/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(HEADER_FILES
 )
 
 set(SOURCE_FILES
+    Link_test.cpp
     MutationListener_test.cpp
     Node_test.cpp
     Simulation_test.cpp


### PR DESCRIPTION
An issue in SOFA, is that the mappings (`apply`, `applyJ`, `applyJT` etc) are applied through visitors, which depends on the scene graph. It's up to the user to define the scene graph, and there is a lot of possibilities. In some cases, the user defines a scene graph that does not correspond to the mapping graph, a DAG linking mappings and their input and output.

This PR replaces the mapping visitors by a simple function dedicated to the traversal of the mapping graph.

This solution avoids to refactor the visitor mechanism. Only a sub-part of the mechanical operations is affected.




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
