### PR TITLE
[Lagrangian.Model] BilateralLagrangianConstraint: enforce disabled state in getConstraintResolution

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Model/src/sofa/component/constraint/lagrangian/model/BilateralLagrangianConstraint.inl
@@ -277,6 +277,8 @@ void BilateralLagrangianConstraint<DataTypes>::getConstraintResolution(const Con
                                                                         std::vector<ConstraintResolution*>& resTab,
                                                                         unsigned int& offset)
 {
+    if (!d_activate.getValue()) return;
+    
     SOFA_UNUSED(cParams);
     const unsigned minp=std::min(d_m1.getValue().size(), d_m2.getValue().size());
 


### PR DESCRIPTION
if not activated, it was still trying to do getConstraintResolution() and messing with the offset, so it was leading to some crash in getConstraintResolution() of some other constraint.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
