### PR TITLE
[SceneChecking] Introduce check on mappings and states in a Node

### DIFF
--- a/applications/plugins/image/examples/loadVolume.scn
+++ b/applications/plugins/image/examples/loadVolume.scn
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<Node 	name="root" gravity="0 0 0" dt="1"  >
+<Node name="root" gravity="0 0 0" dt="1">
     <Node name="plugins">
         <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
         <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
@@ -9,13 +9,16 @@
         <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
         <RequiredPlugin name="image"/> <!-- Needed to use components [ImageContainer ImageViewer] -->
     </Node>
-  <ImageContainer  name="image" filename="data/pelvis_f.raw"/>
-  <ImageViewer  name="viewer" src="@image" plane="50 50 20"/>
-  
-  <EulerImplicitSolver name="cg_odesolver"  printLog="0" rayleighStiffness="0.5"  rayleighMass="0.5" />
-  <CGLinearSolver name="linear solver"  iterations="50"  tolerance="1e-009"  threshold="1e-009" />
-  <MechanicalObject template="Rigid3d" name="DOFs"  rest_position="	0 0 0 0 0 0 1"/>
-  <MeshOBJLoader name="meshLoader_0" filename="data/pelvis_f.obj" handleSeams="1" />
-  <OglModel name="Visual" src="@meshLoader_0" color="1 .4 0.5 1" />
-  <RigidMapping template="Rigid,Vec3d"  input='@.'  output='@Visual' />
+
+    <ImageContainer name="image" filename="data/pelvis_f.raw"/>
+    <ImageViewer name="viewer" src="@image" plane="50 50 20"/>
+
+    <EulerImplicitSolver name="cg_odesolver" printLog="0" rayleighStiffness="0.5" rayleighMass="0.5"/>
+    <CGLinearSolver name="linear solver" iterations="50" tolerance="1e-009" threshold="1e-009"/>
+    <MechanicalObject template="Rigid3d" name="DOFs" rest_position="	0 0 0 0 0 0 1"/>
+    <MeshOBJLoader name="meshLoader_0" filename="data/pelvis_f.obj" handleSeams="1"/>
+    <Node name="visual">
+        <OglModel name="Visual" src="@meshLoader_0" color="1 .4 0.5 1"/>
+        <RigidMapping template="Rigid,Vec3d" input='@.' output='@Visual'/>
+    </Node>
 </Node>

--- a/applications/plugins/image/examples/loadVolume.scn
+++ b/applications/plugins/image/examples/loadVolume.scn
@@ -16,8 +16,8 @@
     <EulerImplicitSolver name="cg_odesolver" printLog="0" rayleighStiffness="0.5" rayleighMass="0.5"/>
     <CGLinearSolver name="linear solver" iterations="50" tolerance="1e-009" threshold="1e-009"/>
     <MechanicalObject template="Rigid3d" name="DOFs" rest_position="	0 0 0 0 0 0 1"/>
-    <MeshOBJLoader name="meshLoader_0" filename="data/pelvis_f.obj" handleSeams="1"/>
     <Node name="visual">
+        <MeshOBJLoader name="meshLoader_0" filename="data/pelvis_f.obj" handleSeams="1"/>
         <OglModel name="Visual" src="@meshLoader_0" color="1 .4 0.5 1"/>
         <RigidMapping template="Rigid,Vec3d" input='@.' output='@Visual'/>
     </Node>

--- a/applications/plugins/image/examples/loadVolume.scn
+++ b/applications/plugins/image/examples/loadVolume.scn
@@ -19,6 +19,6 @@
     <Node name="visual">
         <MeshOBJLoader name="meshLoader_0" filename="data/pelvis_f.obj" handleSeams="1"/>
         <OglModel name="Visual" src="@meshLoader_0" color="1 .4 0.5 1"/>
-        <RigidMapping template="Rigid,Vec3d" input='@.' output='@Visual'/>
+        <RigidMapping template="Rigid,Vec3d" input='@../DOFs' output='@Visual'/>
     </Node>
 </Node>

--- a/applications/plugins/image/examples/loadVolume.scn
+++ b/applications/plugins/image/examples/loadVolume.scn
@@ -15,7 +15,7 @@
 
     <EulerImplicitSolver name="cg_odesolver" printLog="0" rayleighStiffness="0.5" rayleighMass="0.5"/>
     <CGLinearSolver name="linear solver" iterations="50" tolerance="1e-009" threshold="1e-009"/>
-    <MechanicalObject template="Rigid3d" name="DOFs" rest_position="	0 0 0 0 0 0 1"/>
+    <MechanicalObject template="Rigid3d" name="DOFs" rest_position="0 0 0 0 0 0 1"/>
     <Node name="visual">
         <MeshOBJLoader name="meshLoader_0" filename="data/pelvis_f.obj" handleSeams="1"/>
         <OglModel name="Visual" src="@meshLoader_0" color="1 .4 0.5 1"/>

--- a/applications/projects/SceneChecking/CMakeLists.txt
+++ b/applications/projects/SceneChecking/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADER_FILES
     ${SCENECHECK_SRC_DIR}/SceneCheckDeprecatedComponents.h
     ${SCENECHECK_SRC_DIR}/SceneCheckDuplicatedName.h
     ${SCENECHECK_SRC_DIR}/SceneCheckEmptyNodeName.h
+    ${SCENECHECK_SRC_DIR}/SceneCheckMapping.h
     ${SCENECHECK_SRC_DIR}/SceneCheckMissingRequiredPlugin.h
     ${SCENECHECK_SRC_DIR}/SceneCheckUsingAlias.h
     ${SCENECHECK_SRC_DIR}/SceneCheckerListener.h
@@ -29,6 +30,7 @@ set(SOURCE_FILES
     ${SCENECHECK_SRC_DIR}/SceneCheckDeprecatedComponents.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckDuplicatedName.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckEmptyNodeName.cpp
+    ${SCENECHECK_SRC_DIR}/SceneCheckMapping.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckMissingRequiredPlugin.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckUsingAlias.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckerListener.cpp

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
@@ -88,7 +88,7 @@ void SceneCheckMapping::doPrintSummary()
         std::stringstream ss;
         ss << "The following Nodes contain a mapping but no state: " << msgendl;
         showNodes(ss, m_nodesWithMappingNoState);
-        msg_warning(getName()) << ss.str();
+        msg_error(getName()) << ss.str();
     }
 
     if (!m_nodesWithMappingWrongState.empty())
@@ -96,7 +96,7 @@ void SceneCheckMapping::doPrintSummary()
         std::stringstream ss;
         ss << "The following Nodes contain a mapping and a state, and the state is not an output of the mapping: " << msgendl;
         showNodes(ss, m_nodesWithMappingWrongState);
-        msg_warning(getName()) << ss.str();
+        msg_error(getName()) << ss.str();
     }
 }
 

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
@@ -1,0 +1,103 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SceneChecking/SceneCheckMapping.h>
+#include <sofa/core/BaseMapping.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
+
+#include <algorithm>
+
+namespace sofa::scenechecking
+{
+
+const bool SceneCheckMappingRegistered = sofa::simulation::SceneCheckMainRegistry::addToRegistry(SceneCheckMapping::newSPtr());
+
+SceneCheckMapping::~SceneCheckMapping() {}
+const std::string SceneCheckMapping::getName() { return "SceneCheckMapping"; }
+const std::string SceneCheckMapping::getDesc() { return "Check if the mappings and states inside a Node are consistent regarding the visitor logic."; }
+
+void SceneCheckMapping::doInit(sofa::simulation::Node* node)
+{
+    m_nodesWithMappingNoState.clear();
+    m_nodesWithMappingWrongState.clear();
+}
+
+void SceneCheckMapping::doCheckOn(sofa::simulation::Node* node)
+{
+    if (node->mechanicalMapping != nullptr && node->mechanicalMapping->isMechanical())
+    {
+        if (node->mechanicalState == nullptr)
+        {
+            m_nodesWithMappingNoState.push_back(node);
+        }
+        else
+        {
+            const auto mappingOutput = node->mechanicalMapping->getMechTo();
+            if (std::ranges::find(mappingOutput, node->mechanicalState) == mappingOutput.end())
+            {
+                m_nodesWithMappingWrongState.push_back(node);
+            }
+        }
+    }
+}
+
+void SceneCheckMapping::doPrintSummary()
+{
+    const auto showNodes = [](std::stringstream& ss, sofa::type::vector<sofa::simulation::Node*>& nodes)
+    {
+        for (auto node : nodes)
+        {
+            ss << "- " << node->getPathName();
+            if (node->mechanicalMapping != nullptr)
+            {
+                auto mappingOutput = node->mechanicalMapping->getMechTo();
+                std::erase_if(mappingOutput, [](const sofa::core::BaseState* state) { return state == nullptr; });
+                const auto list = sofa::helper::join(mappingOutput.begin(), mappingOutput.end(),
+                    [](const sofa::core::BaseState* state){return state->getPathName();}, ',');
+
+                if (!list.empty())
+                {
+                    ss << " (it is advised to have " << node->mechanicalMapping->getPathName() << " and its output state(s) [" << list << "] in the same Node";
+                }
+            }
+            ss << msgendl;
+        }
+    };
+
+    if (!m_nodesWithMappingNoState.empty())
+    {
+        std::stringstream ss;
+        ss << "The following Nodes contain a mapping but no state: " << msgendl;
+        showNodes(ss, m_nodesWithMappingNoState);
+        msg_warning(getName()) << ss.str();
+    }
+
+    if (!m_nodesWithMappingWrongState.empty())
+    {
+        std::stringstream ss;
+        ss << "The following Nodes contain a mapping and a state, and the state is not an output of the mapping: " << msgendl;
+        showNodes(ss, m_nodesWithMappingWrongState);
+        msg_warning(getName()) << ss.str();
+    }
+}
+
+}  // namespace sofa::scenechecking

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
@@ -43,19 +43,27 @@ void SceneCheckMapping::doInit(sofa::simulation::Node* node)
 
 void SceneCheckMapping::doCheckOn(sofa::simulation::Node* node)
 {
-    if (node->mechanicalMapping != nullptr && node->mechanicalMapping->isMechanical())
+    if (node->mechanicalMapping != nullptr)
     {
-        if (node->mechanicalState == nullptr)
+        const auto mappingOutput = node->mechanicalMapping->getTo();
+
+        if (node->mechanicalState != nullptr)
         {
-            m_nodesWithMappingNoState.push_back(node);
-        }
-        else
-        {
-            const auto mappingOutput = node->mechanicalMapping->getMechTo();
             if (std::ranges::find(mappingOutput, node->mechanicalState) == mappingOutput.end())
             {
                 m_nodesWithMappingWrongState.push_back(node);
             }
+        }
+        else if (node->state != nullptr)
+        {
+            if (std::ranges::find(mappingOutput, node->state) == mappingOutput.end())
+            {
+                m_nodesWithMappingWrongState.push_back(node);
+            }
+        }
+        else
+        {
+            m_nodesWithMappingNoState.push_back(node);
         }
     }
 }
@@ -86,7 +94,7 @@ void SceneCheckMapping::doPrintSummary()
     if (!m_nodesWithMappingNoState.empty())
     {
         std::stringstream ss;
-        ss << "The following Nodes contain a mapping but no state: " << msgendl;
+        ss << "The following Node(s) contain a mapping but no state: " << msgendl;
         showNodes(ss, m_nodesWithMappingNoState);
         msg_error(getName()) << ss.str();
     }
@@ -94,7 +102,7 @@ void SceneCheckMapping::doPrintSummary()
     if (!m_nodesWithMappingWrongState.empty())
     {
         std::stringstream ss;
-        ss << "The following Nodes contain a mapping and a state, and the state is not an output of the mapping: " << msgendl;
+        ss << "The following Node(s) contain a mapping and a state, and the state is not an output of the mapping: " << msgendl;
         showNodes(ss, m_nodesWithMappingWrongState);
         msg_error(getName()) << ss.str();
     }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SceneChecking/config.h>
+#include <sofa/simulation/SceneCheck.h>
+#include <sofa/type/vector.h>
+
+namespace sofa::scenechecking
+{
+
+/**
+ * This SceneCheck is motivated by the visitor mechanism that assumes:
+ * If both a mechanical state and a mapping are present in a Node, the state is considered mapped,
+ * no matter if they are related or not.
+ */
+class SOFA_SCENECHECKING_API SceneCheckMapping : public sofa::simulation::SceneCheck
+{
+public:
+    ~SceneCheckMapping() override;
+    typedef std::shared_ptr<SceneCheckMapping> SPtr;
+    static SPtr newSPtr() { return std::make_shared<SceneCheckMapping>(); }
+    const std::string getName() override;
+    const std::string getDesc() override;
+    void doInit(sofa::simulation::Node* node) override;
+    void doCheckOn(sofa::simulation::Node* node) override;
+    void doPrintSummary() override;
+
+private:
+    sofa::type::vector<sofa::simulation::Node*> m_nodesWithMappingNoState;
+    sofa::type::vector<sofa::simulation::Node*> m_nodesWithMappingWrongState;
+};
+
+}

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.h
@@ -48,6 +48,7 @@ public:
 private:
     sofa::type::vector<sofa::simulation::Node*> m_nodesWithMappingNoState;
     sofa::type::vector<sofa::simulation::Node*> m_nodesWithMappingWrongState;
+    sofa::type::vector<sofa::simulation::Node*> m_nodesWithMappingAndTwoStates;
 };
 
 }


### PR DESCRIPTION
The following scene triggers the newly introduced warning:

```xml
  <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" printLog="true"/>
  <MatrixLinearSystem template="CompressedRowSparseMatrixd" name="system"/>
  <GlobalSystemMatrixImage name="imageA" linearSystem="@system"/>
  <EigenSimplicialLDLT template="CompressedRowSparseMatrixd" linearSystem="@system"/>

  <Node name="red">
      <MechanicalObject name="state" template="Vec1" position="0" showObject="true" showObjectScale="50" showColor="red"/>
      <UniformMass name="mass" totalMass="2"/>
  </Node>

  <Node name="yellow">
      <MechanicalObject name="state" template="Vec1" showObject="true" showObjectScale="25" showColor="yellow"/>
      <ConstantForceField forces="1"/>
  </Node>

  <Node name="cyan">
      <MechanicalObject name="state" template="Vec1" showObject="true" showObjectScale="15" showColor="cyan"/>
      <ConstantForceField forces="-2"/>
  </Node>

  <Node name="mappings">
      <Node name="square">
          <SquareMapping template="Vec1,Vec1" input="@../../red/state" output="@../../yellow/state"/>
      </Node>
      <Node name="id">
          <IdentityMapping template="Vec1,Vec1" input="@../../yellow/state" output="@../../cyan/state"/>
      </Node>
  </Node>
```

The resulting warning message is:

```
[WARNING] [SceneCheckMapping] The following Nodes contain a mapping but no state:   
- /simu/mappings/square (it is advised to have /simu/mappings/square/SquareMapping1 and its output state(s) [/simu/yellow/state] in the same Node
- /simu/mappings/id (it is advised to have /simu/mappings/id/IdentityMapping1 and its output state(s) [/simu/cyan/state] state(s) in the same Node
```

This is motivated by the visitor logic:

https://github.com/sofa-framework/sofa/blob/83276a98be498edc3cac390b860f5e3095f47ae0/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp#L77-L87


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
