### PR TITLE
[StateContainer] More efficient draw

### DIFF
--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.cpp
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.cpp
@@ -186,10 +186,10 @@ void MechanicalObject<defaulttype::Rigid3Types>::draw(const core::visual::Visual
     const auto stateLifeCycle = vparams->drawTool()->makeStateLifeCycle();
     vparams->drawTool()->setLightingEnabled(false);
 
-	if (showIndices.getValue())
-	{
+    if (showIndices.getValue())
+    {
         drawIndices(vparams);
-	}
+    }
 
     if (showVectors.getValue())
     {
@@ -210,33 +210,13 @@ void MechanicalObject<defaulttype::Rigid3Types>::draw(const core::visual::Visual
             vparams->drawTool()->multMatrix( glTransform );
             vparams->drawTool()->scale ( scale );
 
-			if (getContext()->isSleeping())
-			{
-				vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), sofa::type::RGBAColor::gray());
-			}
-			else switch( drawMode.getValue() )
+            type::RGBAColor color = d_color.getValue();
+            if (getContext()->isSleeping())
             {
-                case 1:
-                    vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), sofa::type::RGBAColor::green());
-                    break;
-                case 2:
-                    vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), sofa::type::RGBAColor::red());
-                    break;
-                case 3:
-                    vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), sofa::type::RGBAColor::blue());
-                    break;
-                case 4:
-                    vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), sofa::type::RGBAColor::yellow());
-                    break;
-                case 5:
-                    vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), sofa::type::RGBAColor::magenta());
-                    break;
-                case 6:
-                    vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), sofa::type::RGBAColor::cyan());
-                    break;
-                default:
-                    vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ) );
+                color = sofa::type::RGBAColor::gray();
             }
+
+            vparams->drawTool()->drawFrame ( type::Vec3(), type::Quat<SReal>(), type::Vec3 ( 1_sreal,1_sreal,1_sreal ), color);
 
             vparams->drawTool()->popMatrix();
         }

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
@@ -108,7 +108,14 @@ public:
     Data< float > showIndicesScale; ///< Scale for indices display. (default=0.02)
     Data< bool >  showVectors; ///< Show velocity. (default=false)
     Data< float > showVectorsScale; ///< Scale for vectors display. (default=0.0001)
-    Data< int > drawMode; ///< The way vectors will be drawn: - 0: Line - 1:Cylinder - 2: Arrow.  The DOFS will be drawn: - 0: point - >1: sphere. (default=0)
+
+    MAKE_SELECTABLE_ITEMS(DrawMode,
+        sofa::helper::Item{"Line", "Velocity vectors are displayed with simple lines"},
+        sofa::helper::Item{"Cylinder", "Velocity vectors are displayed using cylinders"},
+        sofa::helper::Item{"Arrow", "Velocity vectors are displayed using arrows"}
+    );
+
+    Data< DrawMode > drawMode; ///< The way vectors will be drawn
     Data< type::RGBAColor > d_color; ///< Color for object display. (default=[1 1 1 1])
 
     void init() override;

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
@@ -109,13 +109,21 @@ public:
     Data< bool >  showVectors; ///< Show velocity. (default=false)
     Data< float > showVectorsScale; ///< Scale for vectors display. (default=0.0001)
 
-    MAKE_SELECTABLE_ITEMS(DrawMode,
+    MAKE_SELECTABLE_ITEMS(DerivDrawMode,
         sofa::helper::Item{"Line", "Velocity vectors are displayed with simple lines"},
         sofa::helper::Item{"Cylinder", "Velocity vectors are displayed using cylinders"},
         sofa::helper::Item{"Arrow", "Velocity vectors are displayed using arrows"}
     );
 
-    Data< DrawMode > drawMode; ///< The way vectors will be drawn
+    Data< DerivDrawMode > d_derivDrawMode; ///< The way derivative vectors will be drawn
+
+    MAKE_SELECTABLE_ITEMS(CoordDrawMode,
+        sofa::helper::Item{"Point", "Coordinates are displayed with simple points"},
+        sofa::helper::Item{"Cylinder", "Coordinates are displayed using spheres"},
+    );
+
+    Data< CoordDrawMode > d_coordDrawMode; ///< The way coordinates will be drawn
+
     Data< type::RGBAColor > d_color; ///< Color for object display. (default=[1 1 1 1])
 
     void init() override;

--- a/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.h
+++ b/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.h
@@ -193,7 +193,7 @@ public:
 
     virtual void setPolygonMode(int _mode, bool _wireframe) = 0 ;
 
-    virtual void setLightingEnabled(bool _isAnabled) = 0 ;
+    virtual void setLightingEnabled(bool _isEnabled) = 0 ;
     /// @}
 
     virtual void enableBlending() = 0;


### PR DESCRIPTION
`getPX`, `getPY` and `getPZ` should be avoided as they introduce a lot of calls to `.getValue()`. Moreover, they imply the use of a cartesian 3 dimensional DoF.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
