### PR TITLE
[Spring] Fix empty stiffness container

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.h
@@ -44,6 +44,9 @@ class SpringForceFieldInternalData
 public:
 };
 
+inline SReal defaultSpringStiffness = 100.f;
+inline SReal defaultSpringDamping = 5.f;
+
 /// Set of simple springs between particles
 template<class DataTypes>
 class SpringForceField : public core::behavior::PairInteractionForceField<DataTypes>
@@ -150,8 +153,8 @@ protected:
     /// stream to export Potential Energy to gnuplot files
     std::ofstream* m_gnuplotFileEnergy;
 
-    SpringForceField(SReal _ks=100.0, SReal _kd=5.0);
-    SpringForceField(MechanicalState* object1, MechanicalState* object2, SReal _ks=100.0, SReal _kd=5.0);
+    SpringForceField(SReal _ks=defaultSpringStiffness, SReal _kd=defaultSpringDamping);
+    SpringForceField(MechanicalState* object1, MechanicalState* object2, SReal _ks=defaultSpringStiffness, SReal _kd=defaultSpringDamping);
 
     template<class Matrix>
     static void addToMatrix(Matrix* globalMatrix, const unsigned int offsetRow, const unsigned int offsetCol, const Mat& localMatrix);


### PR DESCRIPTION
The function `TriangleBendingSprings<DataTypes>::addSpring` accesses the first element of a container without check. There is now a check.

The empty container is due to `SpringForceField<DataTypes>::clear` which clears everything. Now there is a backup of the input stiffness and damping before calling the clear.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
