### PR TITLE
[Collision.Geometry] SphereModel: remove duplicated return statement

### DIFF
--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineModel.inl
@@ -565,7 +565,8 @@ void LineCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params, 
 {
     SOFA_UNUSED(params);
 
-    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels()) return;
+    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels())
+        return;
 
     static constexpr Real max_real = std::numeric_limits<Real>::max();
     static constexpr Real min_real = std::numeric_limits<Real>::lowest();

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointModel.inl
@@ -293,7 +293,8 @@ void PointCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params,
 {
     SOFA_UNUSED(params);
 
-    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels()) return;
+    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels())
+        return;
 
     const auto npoints = mstate->getSize();
     if (npoints != size)

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereModel.inl
@@ -257,7 +257,7 @@ void SphereCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params
     if(d_componentState.getValue() != ComponentState::Valid)
         return ;
 
-    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels()) return;
+    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels())
         return;
 
     static constexpr Real max_real = std::numeric_limits<Real>::max();

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleModel.inl
@@ -377,7 +377,8 @@ void TriangleCollisionModel<DataTypes>::computeBBox(const core::ExecParams* para
 {
     SOFA_UNUSED(params);
 
-    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels()) return;
+    if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels())
+        return;
 
     // check first that topology didn't changed
     if (m_topology->getRevision() != m_topologyRevision)


### PR DESCRIPTION
copy-paste is bad, m'kay. 

`examples/Benchmark/Render/ManySpheres.scn` had an infinite BBox due to the double-return in SphereCollisionModel's computeBBox (and this scene only draws those spheres)

This PR makes sure it is the same way in the other collision models

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
