### PR TITLE
[Visual] Introduce component to visualize a vector field

### DIFF
--- a/Sofa/Component/Visual/CMakeLists.txt
+++ b/Sofa/Component/Visual/CMakeLists.txt
@@ -22,6 +22,8 @@ set(HEADER_FILES
     ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualPointCloud.inl
     ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualStyle.h
     ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualTransform.h
+    ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualVectorField.h
+    ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualVectorField.inl
 )
 
 set(SOURCE_FILES
@@ -40,6 +42,7 @@ set(SOURCE_FILES
     ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualPointCloud.cpp
     ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualStyle.cpp
     ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualTransform.cpp
+    ${SOFACOMPONENTVISUAL_SOURCE_DIR}/VisualVectorField.cpp
 )
 
 sofa_find_package(Sofa.Simulation.Core REQUIRED)

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.cpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/component/visual/VisualVectorField.inl>
+#include <sofa/core/ObjectFactory.h>
+
+namespace sofa::component::visual
+{
+
+void registerVisualVectorField(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(core::ObjectRegistrationData("Render a vector field.")
+        .add<VisualVectorField<defaulttype::Vec3Types>>(true)
+    );
+}
+
+template class SOFA_COMPONENT_VISUAL_API VisualVectorField<defaulttype::Vec3Types>;
+
+}

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
@@ -48,6 +48,7 @@ public:
     Data<VecDeriv> d_vector;
     Data<SReal> d_vectorScale;
     Data<VectorFieldDrawMode> d_drawMode;
+    Data<type::RGBAColor> d_color;
 
     void computeBBox(const core::ExecParams*, bool) override;
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
@@ -27,6 +27,12 @@
 namespace sofa::component::visual
 {
 
+MAKE_SELECTABLE_ITEMS(VectorFieldDrawMode,
+    sofa::helper::Item{.key = "Line", .description = "Coordinates are displayed using lines"},
+    sofa::helper::Item{.key = "Cylinder", .description = "Coordinates are displayed using cylinders"},
+    sofa::helper::Item{.key = "Arrow", .description = "Coordinates are displayed using arrows"},
+);
+
 template <class DataTypes>
 class VisualVectorField : public core::visual::VisualModel
 {
@@ -41,6 +47,7 @@ public:
     Data<VecCoord> d_position;
     Data<VecDeriv> d_vector;
     Data<SReal> d_vectorScale;
+    Data<VectorFieldDrawMode> d_drawMode;
 
     void computeBBox(const core::ExecParams*, bool) override;
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/component/visual/config.h>
+#include <sofa/core/visual/VisualModel.h>
+
+namespace sofa::component::visual
+{
+
+template <class DataTypes>
+class VisualVectorField : public core::visual::VisualModel
+{
+public:
+    SOFA_CLASS(VisualVectorField, core::visual::VisualModel);
+
+private:
+    using VecCoord = VecCoord_t<DataTypes>;
+    using VecDeriv = VecDeriv_t<DataTypes>;
+
+public:
+    Data<VecCoord> d_position;
+    Data<VecDeriv> d_vector;
+    Data<SReal> d_vectorScale;
+
+private:
+    VisualVectorField();
+
+    void doDrawVisual(const core::visual::VisualParams* vparams) override;
+};
+
+
+}  // namespace sofa::component::visual

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.h
@@ -42,6 +42,8 @@ public:
     Data<VecDeriv> d_vector;
     Data<SReal> d_vectorScale;
 
+    void computeBBox(const core::ExecParams*, bool) override;
+
 private:
     VisualVectorField();
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -31,7 +31,8 @@ VisualVectorField<DataTypes>::VisualVectorField()
     : d_position(initData(&d_position, "position", "Starting position of the rendered vectors"))
     , d_vector(initData(&d_vector, "vector", "List of vectors to render"))
     , d_vectorScale(initData(&d_vectorScale, 1.0_sreal, "vectorScale", "Scaling factor applied on vectors for rendering"))
-    , d_drawMode(initData(&d_drawMode, VectorFieldDrawMode("Line"), "drawMode", "Draw mode for the vectors"))
+    , d_drawMode(initData(&d_drawMode, VectorFieldDrawMode("Line"), "drawMode", ("Draw mode for the vectors" + VectorFieldDrawMode::dataDescription()).c_str()))
+    , d_color(initData(&d_color, sofa::type::RGBAColor::white(), "color", "Color of the vectors"))
 {
 }
 
@@ -46,6 +47,7 @@ void VisualVectorField<DataTypes>::doDrawVisual(const core::visual::VisualParams
 
     auto* drawTool = vparams->drawTool();
     const auto drawMode = d_drawMode.getValue();
+    const auto color = d_color.getValue();
 
     for (std::size_t i = 0; i < minSize; ++i)
     {
@@ -54,17 +56,17 @@ void VisualVectorField<DataTypes>::doDrawVisual(const core::visual::VisualParams
 
         if (drawMode == VectorFieldDrawMode("Line"))
         {
-            drawTool->drawLines(std::vector<type::Vec3>{{start, end}}, 1, sofa::type::RGBAColor::white());
+            drawTool->drawLines(std::vector<type::Vec3>{{start, end}}, 1, color);
         }
         else if (drawMode == VectorFieldDrawMode("Cylinder"))
         {
             const float radius = static_cast<float>(vectorScale * vector[i].norm() / 20.f);
-            drawTool->drawCylinder(start, end, radius, sofa::type::RGBAColor::white());
+            drawTool->drawCylinder(start, end, radius, color);
         }
         else if (drawMode == VectorFieldDrawMode("Arrow"))
         {
             const float radius = static_cast<float>(vectorScale * vector[i].norm() / 20.f);
-            drawTool->drawArrow(start, end, radius, sofa::type::RGBAColor::white());
+            drawTool->drawArrow(start, end, radius, color);
         }
     }
 }

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -78,14 +78,16 @@ void VisualVectorField<DataTypes>::computeBBox(const core::ExecParams* exec_para
     const auto vector = sofa::helper::getReadAccessor(d_vector);
 
     const auto minSize = std::min(position.size(), vector.size());
-    if (minSize == 0) return;
+    if (minSize == 0)
+    {
+        return;
+    }
 
     const auto vectorScale = d_vectorScale.getValue();
 
-    SReal p[3];
-    DataTypes::get(p[0], p[1], p[2], position[0]);
-    SReal maxBBox[3] = {p[0], p[1], p[2]};
-    SReal minBBox[3] = {p[0], p[1], p[2]};
+    std::array<SReal, 3> maxBBox;
+    DataTypes::get(maxBBox[0], maxBBox[1], maxBBox[2], position[0]);
+    std::array minBBox(maxBBox);
 
     for (size_t i = 0; i < minSize; i++)
     {
@@ -94,20 +96,17 @@ void VisualVectorField<DataTypes>::computeBBox(const core::ExecParams* exec_para
 
         for (int c = 0; c < 3; c++)
         {
-            if (start[c] > maxBBox[c])
-                maxBBox[c] = p[c];
+            for (const auto& p : {start, end})
+            {
+                if (p[c] > maxBBox[c])
+                    maxBBox[c] = p[c];
 
-            else if (start[c] < minBBox[c])
-                minBBox[c] = p[c];
-
-            if (end[c] > maxBBox[c])
-                maxBBox[c] = p[c];
-
-            else if (end[c] < minBBox[c])
-                minBBox[c] = p[c];
+                else if (start[c] < minBBox[c])
+                    minBBox[c] = p[c];
+            }
         }
     }
-    this->f_bbox.setValue(sofa::type::TBoundingBox(minBBox, maxBBox));
+    this->f_bbox.setValue(sofa::type::TBoundingBox(minBBox.data(), maxBBox.data()));
 }
 
 }  // namespace sofa::component::visual

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -94,7 +94,6 @@ void VisualVectorField<DataTypes>::computeBBox(const core::ExecParams* exec_para
        bbox.wref().include(start);
        bbox.wref().include(end);
     }
-    this->f_bbox.setValue(sofa::type::TBoundingBox(minBBox.data(), maxBBox.data()));
 }
 
 }  // namespace sofa::component::visual

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -1,0 +1,58 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/component/visual/VisualVectorField.h>
+#include <sofa/core/visual/VisualParams.h>
+
+namespace sofa::component::visual
+{
+
+template <class DataTypes>
+VisualVectorField<DataTypes>::VisualVectorField()
+    : d_position(initData(&d_position, "position", "Starting position of the rendered vectors"))
+    , d_vector(initData(&d_vector, "vector", "List of vectors to render"))
+    , d_vectorScale(initData(&d_vectorScale, 1.0_sreal, "vectorScale", "Scaling factor applied on vectors for rendering"))
+{
+}
+
+template <class DataTypes>
+void VisualVectorField<DataTypes>::doDrawVisual(const core::visual::VisualParams* vparams)
+{
+    const auto position = sofa::helper::getReadAccessor(d_position);
+    const auto vector = sofa::helper::getReadAccessor(d_vector);
+
+    const auto minSize = std::min(position.size(), vector.size());
+    const auto vectorScale = d_vectorScale.getValue();
+
+    auto* drawTool = vparams->drawTool();
+
+
+    for (std::size_t i = 0; i < minSize; ++i)
+    {
+        auto start = position[i];
+        auto end = start + vectorScale * vector[i];
+
+        drawTool->drawLines(std::vector<type::Vec3>{{start, end}}, 1, sofa::type::RGBAColor::white());
+    }
+}
+
+}  // namespace sofa::component::visual

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -91,8 +91,8 @@ void VisualVectorField<DataTypes>::computeBBox(const core::ExecParams* exec_para
         const auto& start = position[i];
         const auto end = start + vectorScale * vector[i];
 
-       bbox.include(start);
-       bbox.include(end);
+       bbox.wref().include(start);
+       bbox.wref().include(end);
     }
     this->f_bbox.setValue(sofa::type::TBoundingBox(minBBox.data(), maxBBox.data()));
 }

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -78,7 +78,7 @@ void VisualVectorField<DataTypes>::computeBBox(const core::ExecParams* exec_para
     const auto vector = sofa::helper::getReadAccessor(d_vector);
 
     const auto minSize = std::min(position.size(), vector.size());
-    if (minSize <= 0) return;
+    if (minSize == 0) return;
 
     const auto vectorScale = d_vectorScale.getValue();
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -31,6 +31,7 @@ VisualVectorField<DataTypes>::VisualVectorField()
     : d_position(initData(&d_position, "position", "Starting position of the rendered vectors"))
     , d_vector(initData(&d_vector, "vector", "List of vectors to render"))
     , d_vectorScale(initData(&d_vectorScale, 1.0_sreal, "vectorScale", "Scaling factor applied on vectors for rendering"))
+    , d_drawMode(initData(&d_drawMode, VectorFieldDrawMode("Line"), "drawMode", "Draw mode for the vectors"))
 {
 }
 
@@ -44,14 +45,27 @@ void VisualVectorField<DataTypes>::doDrawVisual(const core::visual::VisualParams
     const auto vectorScale = d_vectorScale.getValue();
 
     auto* drawTool = vparams->drawTool();
-
+    const auto drawMode = d_drawMode.getValue();
 
     for (std::size_t i = 0; i < minSize; ++i)
     {
         const auto& start = position[i];
         const auto end = start + vectorScale * vector[i];
 
-        drawTool->drawLines(std::vector<type::Vec3>{{start, end}}, 1, sofa::type::RGBAColor::white());
+        if (drawMode == VectorFieldDrawMode("Line"))
+        {
+            drawTool->drawLines(std::vector<type::Vec3>{{start, end}}, 1, sofa::type::RGBAColor::white());
+        }
+        else if (drawMode == VectorFieldDrawMode("Cylinder"))
+        {
+            const float radius = static_cast<float>(vectorScale * vector[i].norm() / 20.f);
+            drawTool->drawCylinder(start, end, radius, sofa::type::RGBAColor::white());
+        }
+        else if (drawMode == VectorFieldDrawMode("Arrow"))
+        {
+            const float radius = static_cast<float>(vectorScale * vector[i].norm() / 20.f);
+            drawTool->drawArrow(start, end, radius, sofa::type::RGBAColor::white());
+        }
     }
 }
 

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualVectorField.inl
@@ -83,28 +83,16 @@ void VisualVectorField<DataTypes>::computeBBox(const core::ExecParams* exec_para
         return;
     }
 
-    const auto vectorScale = d_vectorScale.getValue();
+    const auto& vectorScale = d_vectorScale.getValue();
 
-    std::array<SReal, 3> maxBBox;
-    DataTypes::get(maxBBox[0], maxBBox[1], maxBBox[2], position[0]);
-    std::array minBBox(maxBBox);
-
+    auto bbox = sofa::helper::getWriteOnlyAccessor(this->f_bbox);
     for (size_t i = 0; i < minSize; i++)
     {
         const auto& start = position[i];
         const auto end = start + vectorScale * vector[i];
 
-        for (int c = 0; c < 3; c++)
-        {
-            for (const auto& p : {start, end})
-            {
-                if (p[c] > maxBBox[c])
-                    maxBBox[c] = p[c];
-
-                else if (start[c] < minBBox[c])
-                    minBBox[c] = p[c];
-            }
-        }
+       bbox.include(start);
+       bbox.include(end);
     }
     this->f_bbox.setValue(sofa::type::TBoundingBox(minBBox.data(), maxBBox.data()));
 }

--- a/Sofa/Component/Visual/src/sofa/component/visual/init.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/init.cpp
@@ -39,6 +39,7 @@ extern void registerVisualModelImpl(sofa::core::ObjectFactory* factory);
 extern void registerVisualPointCloud(sofa::core::ObjectFactory* factory);
 extern void registerVisualStyle(sofa::core::ObjectFactory* factory);
 extern void registerVisualTransform(sofa::core::ObjectFactory* factory);
+extern void registerVisualVectorField(sofa::core::ObjectFactory* factory);
 
 extern "C" {
     SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
@@ -77,6 +78,7 @@ void registerObjects(sofa::core::ObjectFactory* factory)
     registerVisualPointCloud(factory);
     registerVisualStyle(factory);
     registerVisualTransform(factory);
+    registerVisualVectorField(factory);
 }
 
 void init()

--- a/examples/Component/Visual/VisualVectorField.scn
+++ b/examples/Component/Visual/VisualVectorField.scn
@@ -1,7 +1,7 @@
 <Node name="root" gravity="0 -9.81 0" dt="0.01">
     <DefaultAnimationLoop parallelODESolving="true"/>
     <DefaultVisualManagerLoop name="visualLoop"/>
-    <VisualStyle displayFlags="showVisual" />
+    <VisualStyle displayFlags="showVisual showWireframe showForceFields" />
     <VisualGrid name="grid"/>
     <LineAxis size="@grid.size"/>
 
@@ -16,6 +16,9 @@
         <FixedProjectiveConstraint indices="@box.indices" />
         <HexahedronFEMForceField name="FEM" youngModulus="40000" poissonRatio="0.3" method="large" />
 
-        <VisualVectorField position="@DoFs.position" vector="@DoFs.velocity"/>
+        <Node name="vectors">
+            <VisualStyle displayFlags="showVisual hideWireframe" />
+            <VisualVectorField position="@DoFs.position" vector="@DoFs.velocity" drawMode="Arrow" vectorScale="0.2" color="orange"/>
+        </Node>
     </Node>
 </Node>

--- a/examples/Component/Visual/VisualVectorField.scn
+++ b/examples/Component/Visual/VisualVectorField.scn
@@ -5,7 +5,7 @@
     <VisualGrid name="grid"/>
     <LineAxis size="@grid.size"/>
 
-    <Node name="3d_point">
+    <Node name="beam">
         <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A"/>
         <EigenSimplicialLDLT template="CompressedRowSparseMatrixd"/>
@@ -19,6 +19,7 @@
         <Node name="vectors">
             <VisualStyle displayFlags="showVisual hideWireframe" />
             <VisualVectorField position="@DoFs.position" vector="@DoFs.velocity" drawMode="Arrow" vectorScale="0.2" color="orange"/>
+            <VisualVectorField position="@DoFs.position" vector="@DoFs.force" drawMode="Arrow" vectorScale="0.0005" color="navy"/>
         </Node>
     </Node>
 </Node>

--- a/examples/Component/Visual/VisualVectorField.scn
+++ b/examples/Component/Visual/VisualVectorField.scn
@@ -1,0 +1,21 @@
+<Node name="root" gravity="0 -9.81 0" dt="0.01">
+    <DefaultAnimationLoop parallelODESolving="true"/>
+    <DefaultVisualManagerLoop name="visualLoop"/>
+    <VisualStyle displayFlags="showVisual" />
+    <VisualGrid name="grid"/>
+    <LineAxis size="@grid.size"/>
+
+    <Node name="3d_point">
+        <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A"/>
+        <EigenSimplicialLDLT template="CompressedRowSparseMatrixd"/>
+        <MechanicalObject name="DoFs" template="Vec3" />
+        <UniformMass name="mass" totalMass="320" />
+        <RegularGridTopology name="grid" nx="4" ny="4" nz="10" xmin="-1" xmax="1" ymin="-1" ymax="1" zmin="0" zmax="9" />
+        <BoxROI name="box" box="-2 -2 -0.0001  2 2 0.0001"/>
+        <FixedProjectiveConstraint indices="@box.indices" />
+        <HexahedronFEMForceField name="FEM" youngModulus="40000" poissonRatio="0.3" method="large" />
+
+        <VisualVectorField position="@DoFs.position" vector="@DoFs.velocity"/>
+    </Node>
+</Node>


### PR DESCRIPTION
Similar to https://github.com/sofa-framework/sofa/pull/5588, the feature showing the velocities in a MechanicalObject is extracted in favor of a more generic component.

<img width="518" alt="image" src="https://github.com/user-attachments/assets/20701259-f50f-41b3-9d82-36d75fdd27b3" />

The introduced scene illustrates that it is also possible to visualize other fields, such as the forces.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
