### PR TITLE
[SceneChecking] Add checks for PenalityContactForceField

### DIFF
--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.cpp
@@ -64,7 +64,7 @@ void SceneCheckCollisionResponse::doCheckOn(Node* node)
     {
         if( nbContactManager!= 1 )
         {
-            m_message << "Only one CollisionResponse is needed."<< msgendl;
+            m_message << "Only one CollisionResponse is allowed in the scene."<< msgendl;
         }
         else
         {
@@ -101,6 +101,11 @@ void SceneCheckCollisionResponse::doCheckOn(Node* node)
                     checkIfContactStiffnessIsSet(root);
                 }
             }
+            /// If PenalityContactForceField make sure that contactStiffness is defined
+            else if ( response == "PenalityContactForceField")
+            {
+                checkIfContactStiffnessIsNotSet(root);
+            }
         }
     }
 }
@@ -113,9 +118,24 @@ void SceneCheckCollisionResponse::checkIfContactStiffnessIsSet(const sofa::core:
     {
         if(model->isContactStiffnessSet())
         {
-            m_message <<"The data \"contactStiffness\" is set in the component " << model->getClassName() <<" named " << model->getName() << msgendl;
+            m_message <<"The data \"contactStiffness\" is set in the component " << model->getClassName() <<", named \"" << model->getName() << "\"";
             m_message <<"This data is not used when using a FrictionContactConstraint collision response." << msgendl;
             m_message <<"Remove the data \"contactStiffness\" to remove this warning" << msgendl;
+            break;
+        }
+    }
+}
+
+void SceneCheckCollisionResponse::checkIfContactStiffnessIsNotSet(const sofa::core::objectmodel::BaseContext* root)
+{
+    type::vector<core::CollisionModel*> colModels;
+    root->get<core::CollisionModel>(&colModels, core::objectmodel::BaseContext::SearchDown);
+    for (const auto model : colModels)
+    {
+        if(!model->isContactStiffnessSet())
+        {
+            m_message <<"Using PenalityContactForceField, the contactStiffness should be defined for each CollisionModel" << msgendl;
+            break;
         }
     }
 }

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckCollisionResponse.h
@@ -47,6 +47,7 @@ private:
     std::stringstream m_message;
 
     void checkIfContactStiffnessIsSet(const core::objectmodel::BaseContext *root);
+    void checkIfContactStiffnessIsNotSet(const core::objectmodel::BaseContext *root);
 };
 
 } // namespace sofa::_scenechecking_


### PR DESCRIPTION
This now checks when the contactStiffness is NOT defined in CollisionModels when the response is PenalityContactForceField.

This might cause a lot of scene to emit the warning



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
