### PR TITLE
[Response] Clean init of CollisionResponse

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
@@ -102,7 +102,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithNoAttributes()
              "  <CollisionPipeline name='pipeline'/>                                         \n"
              "  <BruteForceBroadPhase/>                                                      \n"
              "  <BVHNarrowPhase/>                                                            \n"
-             "  <CollisionResponse/>                                                         \n"
+             "  <CollisionResponse response='PenalityContactForceField'/>                    \n"
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
@@ -126,7 +126,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingIntersection()
              "  <CollisionPipeline name='pipeline'/>                                         \n"
              "  <BruteForceBroadPhase/>                                                      \n"
              "  <BVHNarrowPhase/>                                                            \n"
-             "  <CollisionResponse/>                                                         \n"
+             "  <CollisionResponse response='PenalityContactForceField'/>                    \n"
              "</Node>                                                                        \n" ;
 
     root = SceneLoaderXML::loadFromMemory ("testscene", scene.str().c_str());
@@ -147,7 +147,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingBroadPhase()
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
              "  <CollisionPipeline name='pipeline'/>                                         \n"
              "  <BVHNarrowPhase/>                                                            \n"
-             "  <CollisionResponse/>                                                         \n"
+             "  <CollisionResponse response='PenalityContactForceField'/>                    \n"
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
@@ -168,7 +168,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingNarrowPhase()
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
              "  <CollisionPipeline name='pipeline'/>                                         \n"
              "  <BruteForceBroadPhase/>                                                      \n"
-             "  <CollisionResponse/>                                                         \n"
+             "  <CollisionResponse response='PenalityContactForceField'/>                    \n"
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 
@@ -210,7 +210,7 @@ int TestCollisionPipeline::checkCollisionPipelineWithMonkeyValueForDepth(int dva
              "  <CollisionPipeline name='pipeline' depth='"<< dvalue <<"'/>                  \n"
              "  <BruteForceBroadPhase/>                                                      \n"
              "  <BVHNarrowPhase/>                                                            \n"
-             "  <CollisionResponse/>                                                         \n"
+             "  <CollisionResponse response='PenalityContactForceField'/>                    \n"
              "  <DiscreteIntersection name='interaction'/>                                   \n"
              "</Node>                                                                        \n" ;
 

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
@@ -72,8 +72,7 @@ void CollisionResponse::init()
 
     if(!d_response.isSet())
     {
-        msg_error() << "No response method has been set. Default response=\"PenalityContactForceField\"";
-        setDefaultResponseType("PenalityContactForceField");
+        msg_error() << "No response method has been set";
         return;
     }
 

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
@@ -62,18 +62,33 @@ sofa::helper::OptionsGroup CollisionResponse::initializeResponseOptions(sofa::co
     }
 
     sofa::helper::OptionsGroup responseOptions(listResponse);
-    if (listResponse.contains("PenalityContactForceField"))
-        responseOptions.setSelectedItem("PenalityContactForceField");
-
     return responseOptions;
 }
 
 void CollisionResponse::init()
 {
+
     Inherit1::init();
+
+    if(!d_response.isSet())
+    {
+        msg_error() << "No response method has been set. Default response=\"PenalityContactForceField\"";
+        setDefaultResponseType("PenalityContactForceField");
+        return;
+    }
+
     if (d_response.getValue().size() == 0)
     {
+        msg_error() << "Response method is empty and may have been wrongly set. Option list is: " << initializeResponseOptions(getContext());
         d_response.setValue(initializeResponseOptions(getContext()));
+    }
+    else
+    {
+        sofa::helper::OptionsGroup responseOptions = initializeResponseOptions(getContext());
+        if(!responseOptions.isInOptionsList(d_response.getValue().getSelectedItem()))
+        {
+            msg_error() << "response \"" << d_response.getValue().getSelectedItem() << "\" is not a valid response method. Response can be among the list: " << responseOptions;
+        }
     }
 }
 
@@ -110,7 +125,6 @@ void CollisionResponse::setDefaultResponseType(const std::string &responseT)
         d_response.endEdit();
     }
 }
-
 
 void CollisionResponse::changeInstance(Instance inst)
 {

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
@@ -84,7 +84,7 @@ void CollisionResponse::init()
     else
     {
         sofa::helper::OptionsGroup responseOptions = initializeResponseOptions(getContext());
-        if(!responseOptions.isInOptionsList(d_response.getValue().getSelectedItem()))
+        if(responseOptions.isInOptionsList(d_response.getValue().getSelectedItem()) < 0)
         {
             msg_error() << "response \"" << d_response.getValue().getSelectedItem() << "\" is not a valid response method. Response can be among the list: " << responseOptions;
         }

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
@@ -67,7 +67,6 @@ sofa::helper::OptionsGroup CollisionResponse::initializeResponseOptions(sofa::co
 
 void CollisionResponse::init()
 {
-
     Inherit1::init();
 
     if(!d_response.isSet())
@@ -78,16 +77,13 @@ void CollisionResponse::init()
 
     if (d_response.getValue().size() == 0)
     {
-        msg_error() << "Response method is empty and may have been wrongly set. Option list is: " << initializeResponseOptions(getContext());
-        d_response.setValue(initializeResponseOptions(getContext()));
+        sofa::helper::OptionsGroup responseOptions = initializeResponseOptions(getContext());
+        msg_error() << "Response method is wrongly set. Option list is: " << responseOptions.getItemNames();
+        d_response.setValue(responseOptions);
     }
     else
     {
-        sofa::helper::OptionsGroup responseOptions = initializeResponseOptions(getContext());
-        if(responseOptions.isInOptionsList(d_response.getValue().getSelectedItem()) < 0)
-        {
-            msg_error() << "response \"" << d_response.getValue().getSelectedItem() << "\" is not a valid response method. Response can be among the list: " << responseOptions;
-        }
+        msg_info() << "Valid response method: " << d_response.getValue().getSelectedItem();
     }
 }
 

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.h
@@ -112,7 +112,6 @@ protected:
     /// The number of contacts corresponds to the number of collision models
     /// currently in contact with a collision model.
     void setNumberOfContacts() const;
-
 };
 
 

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.h
@@ -52,7 +52,13 @@ public :
         {
             context->addObject(obj);
             sofa::helper::OptionsGroup options = initializeResponseOptions(context);
-            obj->d_response.setValue(options);
+            const std::string responseName = arg->getAttribute("response","");
+            // Check if the response is valid and not empty, only then set the response
+            if(options.isInOptionsList(responseName) >= 0 && responseName != "")
+            {
+                options.setSelectedItem(responseName);
+                obj->d_response.setValue(options);
+            }
         }
 
         if (arg)

--- a/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.cpp
@@ -45,6 +45,11 @@ void OptionsGroup::setNbItems(const size_type nbofRadioButton )
     selectedItem = 0;
 }
 ///////////////////////////////////////
+type::vector<std::string> OptionsGroup::getItemNames()
+{
+    return textItems;
+}
+///////////////////////////////////////
 void OptionsGroup::setItemName(const unsigned int id_item, const std::string& name )
 {
     if(id_item < textItems.size())

--- a/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
+++ b/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
@@ -71,6 +71,9 @@ public :
     ///Set the name of the id-th item
     void setItemName( unsigned int id_item, const std::string& name );
 
+    ///Get the vector of names available
+    type::vector<std::string> getItemNames();
+
     template <class T>
     void setNames(const std::initializer_list<T>& list);
 

--- a/applications/plugins/ArticulatedSystemPlugin/examples/ArticulatedSystemMapping.scn
+++ b/applications/plugins/ArticulatedSystemPlugin/examples/ArticulatedSystemMapping.scn
@@ -15,13 +15,13 @@
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
     <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
     <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
-    <BruteForceBroadPhase/>
-    <BVHNarrowPhase/>
-    <CollisionResponse />
-    <CollisionPipeline />
-    <MinProximityIntersection alarmDistance="1" contactDistance="0.5"/>
     <DefaultAnimationLoop />
     <DefaultVisualManagerLoop />
+    <CollisionPipeline />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <CollisionResponse response="PenalityContactForceField"/>
+    <MinProximityIntersection alarmDistance="1" contactDistance="0.5"/>
     <Node>
         <EulerImplicitSolver name="cg odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="100" name="linear solver" threshold="1e-20" tolerance="1e-20" />

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
@@ -18,7 +18,7 @@
 	<CollisionPipeline verbose="0" />
 	<BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-	<CollisionResponse name="Response" />
+	<CollisionResponse name="Response" response="PenalityContactForceField"/>
 	<NewProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 	<Node name="Floor">
 		<RegularGridTopology

--- a/examples/Component/Mapping/Linear/CenterOfMassMapping.scn
+++ b/examples/Component/Mapping/Linear/CenterOfMassMapping.scn
@@ -16,7 +16,7 @@
     <VisualStyle displayFlags="showVisual showForceFields showCollisionModels showMechanicalMappings showWireframe" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse name="default1" />
+    <CollisionResponse name="default1" response="PenalityContactForceField"/>
     <CollisionPipeline name="default2" />
     <MinProximityIntersection name="default3" alarmDistance="1" contactDistance="0.5"/>
     <DefaultAnimationLoop/>

--- a/examples/Component/Mapping/Linear/SkinningMapping.scn
+++ b/examples/Component/Mapping/Linear/SkinningMapping.scn
@@ -17,7 +17,7 @@
     <VisualStyle displayFlags="showBehaviorModels showCollisionModels" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse name="default1" />
+    <CollisionResponse name="default1" response="PenalityContactForceField"/>
     <CollisionPipeline name="default2" />
     <MinProximityIntersection name="default3" alarmDistance="1" contactDistance="0.5"/>
     <DefaultAnimationLoop/>

--- a/examples/Component/Mapping/Linear/SubsetMapping.scn
+++ b/examples/Component/Mapping/Linear/SubsetMapping.scn
@@ -24,7 +24,7 @@
 	<BruteForceBroadPhase/>
     <BVHNarrowPhase/>
 	<LocalMinDistance name="Proximity"  alarmDistance="0.006" contactDistance="0.001" coneFactor="0.3" angleCone="0.01" filterIntersection="true"/>
-	<CollisionResponse name="Response" response="NeedleContact" response="PenalityContactForceField"/>
+	<CollisionResponse name="Response" response="PenalityContactForceField"/>
 	<DefaultAnimationLoop/>
 
 	<Node name="sutureSoftCubes">

--- a/examples/Component/Mapping/Linear/SubsetMapping.scn
+++ b/examples/Component/Mapping/Linear/SubsetMapping.scn
@@ -24,7 +24,7 @@
 	<BruteForceBroadPhase/>
     <BVHNarrowPhase/>
 	<LocalMinDistance name="Proximity"  alarmDistance="0.006" contactDistance="0.001" coneFactor="0.3" angleCone="0.01" filterIntersection="true"/>
-	<CollisionResponse name="Response" response="NeedleContact"/>
+	<CollisionResponse name="Response" response="NeedleContact" response="PenalityContactForceField"/>
 	<DefaultAnimationLoop/>
 
 	<Node name="sutureSoftCubes">

--- a/examples/Component/MechanicalLoad/EllipsoidForceField.scn
+++ b/examples/Component/MechanicalLoad/EllipsoidForceField.scn
@@ -23,7 +23,7 @@
     <CollisionPipeline verbose="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <NewProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
     <DefaultAnimationLoop/>
 

--- a/examples/Component/MechanicalLoad/InteractionEllipsoidForceField.scn
+++ b/examples/Component/MechanicalLoad/InteractionEllipsoidForceField.scn
@@ -22,7 +22,7 @@
     <CollisionPipeline verbose="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <NewProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
     <Node name="RotatingObstacle">
         <EulerExplicitSolver name="odesolver" printLog="false" />

--- a/examples/Component/SolidMechanics/Spring/QuadBendingSprings.scn
+++ b/examples/Component/SolidMechanics/Spring/QuadBendingSprings.scn
@@ -16,7 +16,7 @@
     <CollisionPipeline verbose="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     <NewProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
     <Node name="SquareCloth1">

--- a/examples/Component/Topology/Container/Grid/SparseGridTopology.scn
+++ b/examples/Component/Topology/Container/Grid/SparseGridTopology.scn
@@ -23,7 +23,7 @@
     <CollisionPipeline verbose="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse name="Response"/>
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DiscreteIntersection/>
     
     <MeshOBJLoader name="loader" filename="mesh/dragon.obj" />

--- a/examples/Demos/fallingBeamAugmentedLagrangianCollision.scn
+++ b/examples/Demos/fallingBeamAugmentedLagrangianCollision.scn
@@ -22,7 +22,6 @@
         <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
         <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
         <RequiredPlugin name="Sofa.GUI.Component"/> <!-- Needed to use components [ConstraintAttachButtonSetting] -->
-    Container,TriangleSetTopologyModifier] -->
     </Node>
 
     <VisualStyle displayFlags="showForceFields"/>
@@ -32,7 +31,7 @@
     <CollisionPipeline name="Pipeline" />
     <BruteForceBroadPhase name="BroadPhase" />
     <BVHNarrowPhase name="NarrowPhase" />
-    <CollisionResponse name="ContactManager" response="AugmentedLagrangian" responseParams="mu=0.5&epsilon=10" />
+    <CollisionResponse name="ContactManager" response="AugmentedLagrangianConstraint" responseParams="mu=0.5&epsilon=10" />
     <NewProximityIntersection name="Intersection" alarmDistance="0.02" contactDistance="0.001" />
 
     <Node name="BEAMVOLUME">
@@ -88,5 +87,3 @@
     </Node>
 
 </Node>
-
-

--- a/examples/Demos/fallingBeamAugmentedLagrangianCollision.scn
+++ b/examples/Demos/fallingBeamAugmentedLagrangianCollision.scn
@@ -31,7 +31,7 @@
     <CollisionPipeline name="Pipeline" />
     <BruteForceBroadPhase name="BroadPhase" />
     <BVHNarrowPhase name="NarrowPhase" />
-    <CollisionResponse name="ContactManager" response="AugmentedLagrangianConstraint" responseParams="mu=0.5&epsilon=10" />
+    <CollisionResponse name="ContactManager" response="AugmentedLagrangianResponseConstraint" responseParams="mu=0.5&epsilon=10" />
     <NewProximityIntersection name="Intersection" alarmDistance="0.02" contactDistance="0.001" />
 
     <Node name="BEAMVOLUME">

--- a/examples/Tutorials/Collision/AdvancedSolversMultipleGroupsSolver.scn
+++ b/examples/Tutorials/Collision/AdvancedSolversMultipleGroupsSolver.scn
@@ -18,7 +18,7 @@
     <CollisionPipeline />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse />
+    <CollisionResponse response="PenalityContactForceField"/>
     <MinProximityIntersection alarmDistance="0.5" contactDistance="0.2" />
     <DefaultAnimationLoop/>
     

--- a/examples/Tutorials/Collision/ModelizationSphereBased.scn
+++ b/examples/Tutorials/Collision/ModelizationSphereBased.scn
@@ -18,7 +18,7 @@
     <CollisionPipeline />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse />
+    <CollisionResponse response="PenalityContactForceField"/>
     <MinProximityIntersection alarmDistance="1" contactDistance="0.5"/>
     <DefaultAnimationLoop/>
 

--- a/examples/Tutorials/Collision/ModelizationTriangleBased.scn
+++ b/examples/Tutorials/Collision/ModelizationTriangleBased.scn
@@ -18,7 +18,7 @@
     <CollisionPipeline />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse />
+    <CollisionResponse response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
 
     <MinProximityIntersection alarmDistance="1" contactDistance="0.5"/>

--- a/examples/Tutorials/Collision/MultipleObjectsTwoCubes.scn
+++ b/examples/Tutorials/Collision/MultipleObjectsTwoCubes.scn
@@ -19,7 +19,7 @@
     <CollisionPipeline />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <CollisionResponse />
+    <CollisionResponse response="PenalityContactForceField"/>
     <MinProximityIntersection alarmDistance="1" contactDistance="0.5"/>
     <DefaultAnimationLoop/>
 

--- a/examples/Tutorials/Topologies/TopologyDynamicSurfaceMesh.scn
+++ b/examples/Tutorials/Topologies/TopologyDynamicSurfaceMesh.scn
@@ -24,7 +24,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
 
     <Node name="Triangles Mesh">

--- a/examples/Tutorials/Topologies/TopologyHexa2QuadTopologicalMapping.scn
+++ b/examples/Tutorials/Topologies/TopologyHexa2QuadTopologicalMapping.scn
@@ -24,7 +24,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     
     <Node name="Cube">

--- a/examples/Tutorials/Topologies/TopologyHexa2TetraTopologicalMapping.scn
+++ b/examples/Tutorials/Topologies/TopologyHexa2TetraTopologicalMapping.scn
@@ -24,7 +24,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     
     <Node name="Hexa Mesh">

--- a/examples/Tutorials/Topologies/TopologyLinearDifferentMesh.scn
+++ b/examples/Tutorials/Topologies/TopologyLinearDifferentMesh.scn
@@ -21,7 +21,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
 
     <Node name="Pendulum Static Mesh">

--- a/examples/Tutorials/Topologies/TopologyLinearMesh.scn
+++ b/examples/Tutorials/Topologies/TopologyLinearMesh.scn
@@ -19,7 +19,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     <Node name="Pendulum Static Mesh">
         <MechanicalObject template="Vec3" name="DOF" position="0 0 4 1 0 4 2 0 4 3 0 4 4 0 4 5 0 4" />

--- a/examples/Tutorials/Topologies/TopologyQuad2TriangleTopologicalMapping.scn
+++ b/examples/Tutorials/Topologies/TopologyQuad2TriangleTopologicalMapping.scn
@@ -24,7 +24,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     
     <Node name="Quads Mesh">

--- a/examples/Tutorials/Topologies/TopologySurfaceDifferentMesh.scn
+++ b/examples/Tutorials/Topologies/TopologySurfaceDifferentMesh.scn
@@ -24,7 +24,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
 	  <DefaultAnimationLoop/>
 
 	  <Node name="Cloth Dynamic Mesh (blue)">

--- a/examples/Tutorials/Topologies/TopologyTetra2TriangleTopologicalMapping.scn
+++ b/examples/Tutorials/Topologies/TopologyTetra2TriangleTopologicalMapping.scn
@@ -24,7 +24,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     
     <Node name="Tetrahedrons Mesh">

--- a/examples/Tutorials/Topologies/TopologyTriangle2EdgeTopologicalMapping.scn
+++ b/examples/Tutorials/Topologies/TopologyTriangle2EdgeTopologicalMapping.scn
@@ -22,7 +22,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     
     <Node name="Triangles Mesh">

--- a/examples/Tutorials/Topologies/TopologyVolumeDifferentMesh.scn
+++ b/examples/Tutorials/Topologies/TopologyVolumeDifferentMesh.scn
@@ -26,7 +26,7 @@
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <CollisionResponse name="Response" />
+    <CollisionResponse name="Response" response="PenalityContactForceField"/>
     <DefaultAnimationLoop/>
     
     <Node name="Cylinder Static Mesh">


### PR DESCRIPTION
These changes come from my will to warn a user when an collision response is set. The OptionsGroup design is not helping much. This PR proposes to :

- clean the init to properly warn the user (reponse data is not set, or wrongly set
- in the `create()` function of the CollisionResponse, the data response is set/selected only if valid
- add a `getItemNames()` in OptionsGroup to get the full list of possibly options

[ci-depends-on https://github.com/sofa-framework/SofaSphFluid/pull/17]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
