### PR TITLE
 [Helper] Remove default value on OptionGroup 

### DIFF
--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
@@ -62,18 +62,33 @@ sofa::helper::OptionsGroup CollisionResponse::initializeResponseOptions(sofa::co
     }
 
     sofa::helper::OptionsGroup responseOptions(listResponse);
-    if (listResponse.contains("PenalityContactForceField"))
-        responseOptions.setSelectedItem("PenalityContactForceField");
-
     return responseOptions;
 }
 
 void CollisionResponse::init()
 {
+
     Inherit1::init();
+
+    if(!d_response.isSet())
+    {
+        msg_error() << "No response method has been set. Default response=\"PenalityContactForceField\"";
+        setDefaultResponseType("PenalityContactForceField");
+        return;
+    }
+
     if (d_response.getValue().size() == 0)
     {
+        msg_error() << "Response method is empty and may have been wrongly set. Option list is: " << initializeResponseOptions(getContext());
         d_response.setValue(initializeResponseOptions(getContext()));
+    }
+    else
+    {
+        sofa::helper::OptionsGroup responseOptions = initializeResponseOptions(getContext());
+        if(!responseOptions.isInOptionsList(d_response.getValue().getSelectedItem()))
+        {
+            msg_error() << "response \"" << d_response.getValue().getSelectedItem() << "\" is not a valid response method. Response can be among the list: " << responseOptions;
+        }
     }
 }
 
@@ -110,7 +125,6 @@ void CollisionResponse::setDefaultResponseType(const std::string &responseT)
         d_response.endEdit();
     }
 }
-
 
 void CollisionResponse::changeInstance(Instance inst)
 {

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.cpp
@@ -87,7 +87,11 @@ void CollisionResponse::init()
         sofa::helper::OptionsGroup responseOptions = initializeResponseOptions(getContext());
         if(!responseOptions.isInOptionsList(d_response.getValue().getSelectedItem()))
         {
-            msg_error() << "response \"" << d_response.getValue().getSelectedItem() << "\" is not a valid response method. Response can be among the list: " << responseOptions;
+            msg_error() << "response method is not a valid response method. Response can be among the list: " << responseOptions.getItemNames();
+        }
+        else
+        {
+            msg_info() << "Valid response method: " << d_response.getValue().getSelectedItem();
         }
     }
 }

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/CollisionResponse.h
@@ -112,7 +112,6 @@ protected:
     /// The number of contacts corresponds to the number of collision models
     /// currently in contact with a collision model.
     void setNumberOfContacts() const;
-
 };
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.cpp
@@ -31,7 +31,6 @@ class OptionsGroup;
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 OptionsGroup::OptionsGroup() : textItems()
 {
-    selectedItem=0;
 }
 ///////////////////////////////////////
 OptionsGroup::OptionsGroup(const OptionsGroup & m_radiotrick) : textItems(m_radiotrick.textItems)
@@ -42,12 +41,15 @@ OptionsGroup::OptionsGroup(const OptionsGroup & m_radiotrick) : textItems(m_radi
 void OptionsGroup::setNbItems(const size_type nbofRadioButton )
 {
     textItems.resize( nbofRadioButton );
-    selectedItem = 0;
 }
 ///////////////////////////////////////
 void OptionsGroup::setItemName(const unsigned int id_item, const std::string& name )
 {
     textItems[id_item] = name;
+}///////////////////////////////////////
+type::vector<std::string> OptionsGroup::getItemNames()
+{
+    return textItems;
 }
 ///////////////////////////////////////
 int OptionsGroup::isInOptionsList(const std::string & tempostring) const

--- a/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
+++ b/Sofa/framework/Helper/src/sofa/helper/OptionsGroup.h
@@ -71,6 +71,9 @@ public :
     ///Set the name of the id-th item
     void setItemName( unsigned int id_item, const std::string& name );
 
+    ///Get the vector of names available
+    type::vector<std::string> getItemNames();
+
     template <class T>
     void setNames(const std::initializer_list<T>& list);
 


### PR DESCRIPTION
Based on https://github.com/sofa-framework/sofa/pull/5604

It seems weird to me that the first entry is by default the selected one.
This was problematic in the case of CollisionReponse `response` data field :
- it gets populated at `parse` using all available response method
- if a wrong value is given by the user, nothing allowed us to identify it since the by-default selected response was the first one (AugmentedLagrangian) which is obviously valid !

Here is my hacky solution. To be discussed :)

Real diff : https://github.com/sofa-framework/sofa/pull/5605/commits/cce486762567e56271f363b991048e2bfbf9b97d
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
