### PR TITLE
[Plugins] Fix compilation regarding qt code now activated

### DIFF
--- a/applications/plugins/SofaCUDA/src/sofa/gpu/gui/CudaDataWidget.cpp
+++ b/applications/plugins/SofaCUDA/src/sofa/gpu/gui/CudaDataWidget.cpp
@@ -76,4 +76,4 @@ Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec3d> >
 Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec4d> > > DWClass_cudaVectorVec4d("default", true);
 
 
-} // namespace sofa::gui::qt
+} // namespace sofa::qt

--- a/applications/plugins/SofaCUDA/src/sofa/gpu/gui/CudaDataWidget.h
+++ b/applications/plugins/SofaCUDA/src/sofa/gpu/gui/CudaDataWidget.h
@@ -59,4 +59,4 @@ public:
 };
 
 
-} // namespace sofa::gui::qt
+} // namespace sofa::qt

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.cpp
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <SofaMatrix/Qt/BaseMatrixImageViewerWidget.h>
 
-namespace sofa::gui::qt
+namespace sofa::qt
 {
 
 // Add the widget in the DataWidgetFactory with the key 'matrixbitmap', so that a Data< type::BaseMatrixProxy > can call setWidget("matrixbitmap")
@@ -172,4 +172,4 @@ void BaseMatrixImageViewerWidget::readFromData()
     dirty = false;
     counter = baseData->getCounter();
 }
-} // namespace sofa::gui::qt
+} // namespace sofa::qt

--- a/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.h
+++ b/applications/plugins/SofaMatrix/extensions/Qt/src/SofaMatrix/Qt/BaseMatrixImageViewerWidget.h
@@ -23,11 +23,11 @@
 #include <SofaMatrix/Qt/config.h>
 
 #include <QGraphicsView>
-#include <sofa/gui/qt/SimpleDataWidget.h>
+#include <sofa/qt/SimpleDataWidget.h>
 
 #include <SofaMatrix/Qt/BaseMatrixImageProxy.h>
 
-namespace sofa::gui::qt
+namespace sofa::qt
 {
 
 /// A QGraphicsScene showing a QImage
@@ -106,4 +106,4 @@ public:
     void readFromData() override;
 };
 
-} // namespace sofa::gui::qt
+} // namespace sofa::qt

--- a/applications/plugins/image/image_gui/src/image_gui/HistogramWidget.cpp
+++ b/applications/plugins/image/image_gui/src/image_gui/HistogramWidget.cpp
@@ -29,9 +29,6 @@
 namespace sofa
 {
 
-namespace gui
-{
-
 namespace qt
 {
 
@@ -66,7 +63,6 @@ helper::Creator<DataWidgetFactory, HistogramDataWidget< Histogram<bool> > >				D
 #endif
 
 } // qt
-} // gui
 } // sofa
 
 

--- a/applications/plugins/image/image_gui/src/image_gui/HistogramWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/HistogramWidget.h
@@ -42,8 +42,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -381,8 +379,6 @@ public:
         return b;
     }
 };
-
-}
 
 }
 

--- a/applications/plugins/image/image_gui/src/image_gui/HistogramWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/HistogramWidget.h
@@ -23,8 +23,8 @@
 #define SOFA_IMAGE_HISTOGRAMWIDGET_H
 
 #include <image_gui/config.h>
-#include <sofa/gui/qt/DataWidget.h>
-#include <sofa/gui/qt/SimpleDataWidget.h>
+#include <sofa/qt/DataWidget.h>
+#include <sofa/qt/SimpleDataWidget.h>
 
 #include <QLabel>
 #include <QImage>

--- a/applications/plugins/image/image_gui/src/image_gui/ImagePlaneWidget.cpp
+++ b/applications/plugins/image/image_gui/src/image_gui/ImagePlaneWidget.cpp
@@ -29,9 +29,6 @@
 namespace sofa
 {
 
-namespace gui
-{
-
 namespace qt
 {
 
@@ -80,7 +77,6 @@ helper::Creator<DataWidgetFactory, ImagePlaneDataWidget< ImagePlane<bool> > >		D
 #endif
 
 } // qt
-} // gui
 } // sofa
 
 

--- a/applications/plugins/image/image_gui/src/image_gui/ImagePlaneWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/ImagePlaneWidget.h
@@ -23,8 +23,8 @@
 #define SOFA_IMAGE_IMAGEPLANEWIDGET_H
 
 #include <image_gui/config.h>
-#include <sofa/gui/qt/DataWidget.h>
-#include <sofa/gui/qt/SimpleDataWidget.h>
+#include <sofa/qt/DataWidget.h>
+#include <sofa/qt/SimpleDataWidget.h>
 
 #include <image/ImageTypes.h>
 #include <image/ImageViewer.h>

--- a/applications/plugins/image/image_gui/src/image_gui/ImagePlaneWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/ImagePlaneWidget.h
@@ -54,8 +54,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -802,8 +800,6 @@ public:
 
 };
 
-
-}
 
 }
 

--- a/applications/plugins/image/image_gui/src/image_gui/ImageTransformWidget.cpp
+++ b/applications/plugins/image/image_gui/src/image_gui/ImageTransformWidget.cpp
@@ -29,9 +29,6 @@
 namespace sofa
 {
 
-namespace gui
-{
-
 namespace qt
 {
 
@@ -202,7 +199,6 @@ void ImageLPTransformWidget<TransformType>::writeToData()
 }
 
 } // qt
-} // gui
 } // sofa
 
 

--- a/applications/plugins/image/image_gui/src/image_gui/ImageTransformWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/ImageTransformWidget.h
@@ -46,8 +46,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -87,8 +85,6 @@ protected:
 
 };
 
-
-}
 
 }
 

--- a/applications/plugins/image/image_gui/src/image_gui/ImageTransformWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/ImageTransformWidget.h
@@ -23,9 +23,9 @@
 #define SOFA_IMAGE_IMAGETRANSFORMWIDGET_H
 
 #include <image_gui/config.h>
-#include <sofa/gui/qt/DataWidget.h>
-#include <sofa/gui/qt/SimpleDataWidget.h>
-#include <sofa/gui/qt/WDoubleLineEdit.h>
+#include <sofa/qt/DataWidget.h>
+#include <sofa/qt/SimpleDataWidget.h>
+#include <sofa/qt/WDoubleLineEdit.h>
 
 #include <QTextEdit>
 #include <QGroupBox>

--- a/applications/plugins/image/image_gui/src/image_gui/VectorVisualizationWidget.cpp
+++ b/applications/plugins/image/image_gui/src/image_gui/VectorVisualizationWidget.cpp
@@ -8,9 +8,6 @@
 namespace sofa
 {
 
-namespace gui
-{
-
 namespace qt
 {
 
@@ -24,5 +21,4 @@ template class SOFA_IMAGE_GUI_API TDataWidget<VectorVis>;
 helper::Creator<DataWidgetFactory, VectorVisualizationDataWidget< VectorVis > >	DWClass_VectorVis("vectorvis",true);
 
 } // qt
-} // gui
 } // sofa

--- a/applications/plugins/image/image_gui/src/image_gui/VectorVisualizationWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/VectorVisualizationWidget.h
@@ -14,8 +14,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -488,7 +486,6 @@ public:
         return result;
     }
 };
-}
 }
 }
 

--- a/applications/plugins/image/image_gui/src/image_gui/VectorVisualizationWidget.h
+++ b/applications/plugins/image/image_gui/src/image_gui/VectorVisualizationWidget.h
@@ -1,8 +1,8 @@
 #ifndef SOFA_IMAGE_VECTORVISWIDGET_H
 #define SOFA_IMAGE_VECTORVISWIDGET_H
 
-#include <sofa/gui/qt/SimpleDataWidget.h>
-#include <sofa/gui/qt/DataWidget.h>
+#include <sofa/qt/SimpleDataWidget.h>
+#include <sofa/qt/DataWidget.h>
 #include <image_gui/config.h>
 #include <image/VectorVis.h>
 

--- a/applications/plugins/image/imagetoolbox/contour/contourimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/contour/contourimagetoolbox.h
@@ -62,9 +62,9 @@ public:
         addOutput(&d_vecPixCoord);
     }
 
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        return new sofa::gui::qt::ContourImageToolBoxAction(this,parent);
+        return new sofa::qt::ContourImageToolBoxAction(this,parent);
     }
 
 

--- a/applications/plugins/image/imagetoolbox/contour/contourimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/contour/contourimagetoolboxaction.cpp
@@ -6,8 +6,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -385,6 +383,5 @@ void ContourImageToolBoxAction::optionChangeSection(sofa::type::Vec3i v)
 
 
 
-}
 }
 }

--- a/applications/plugins/image/imagetoolbox/contour/contourimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/contour/contourimagetoolboxaction.h
@@ -27,8 +27,6 @@ class SOFA_IMAGE_GUI_API ContourImageToolBoxNoTemplated;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -89,7 +87,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/depth/depthimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/depth/depthimagetoolbox.h
@@ -123,9 +123,9 @@ public:
 
     }
     
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        return new sofa::gui::qt::DepthImageToolBoxAction(this,parent);
+        return new sofa::qt::DepthImageToolBoxAction(this,parent);
     }
 
     void createLayer()

--- a/applications/plugins/image/imagetoolbox/depth/depthimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/depth/depthimagetoolboxaction.cpp
@@ -6,8 +6,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -452,6 +450,5 @@ void DepthImageToolBoxAction::sectionButtonClick()
 
 
 
-}
 }
 }

--- a/applications/plugins/image/imagetoolbox/depth/depthimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/depth/depthimagetoolboxaction.h
@@ -24,8 +24,6 @@ class DepthImageToolBox;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -237,7 +235,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/imagetoolboxbasicactionwidget.h
+++ b/applications/plugins/image/imagetoolbox/imagetoolboxbasicactionwidget.h
@@ -11,8 +11,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -82,7 +80,6 @@ public slots:
 
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/imagetoolboxcentralwidget.h
+++ b/applications/plugins/image/imagetoolbox/imagetoolboxcentralwidget.h
@@ -24,8 +24,8 @@
 ******************************************************************************/
 
 #include <image_gui/config.h>
-#include <sofa/gui/qt/DataWidget.h>
-#include <sofa/gui/qt/SimpleDataWidget.h>
+#include <sofa/qt/DataWidget.h>
+#include <sofa/qt/SimpleDataWidget.h>
 
 #include <QLabel>
 #include <QImage>

--- a/applications/plugins/image/imagetoolbox/imagetoolboxcentralwidget.h
+++ b/applications/plugins/image/imagetoolbox/imagetoolboxcentralwidget.h
@@ -45,8 +45,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -420,7 +418,7 @@ public:
     }
 };
 
-}}}
+}}
 
 
 #endif // IMAGETOOLBOXCENTRALWIDGET_H

--- a/applications/plugins/image/imagetoolbox/imagetoolboxlabelactionwidget.h
+++ b/applications/plugins/image/imagetoolbox/imagetoolboxlabelactionwidget.h
@@ -13,8 +13,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -244,7 +242,6 @@ signals:
     //void updateImage();
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/imagetoolboxlabelactionwidget.h
+++ b/applications/plugins/image/imagetoolbox/imagetoolboxlabelactionwidget.h
@@ -33,7 +33,7 @@ Q_OBJECT
     QString currentVal;
     
     typedef sofa::component::engine::LabelImageToolBox Label;
-    typedef sofa::gui::qt::LabelImageToolBoxAction LabelAction;
+    typedef sofa::qt::LabelImageToolBoxAction LabelAction;
     typedef type::vector<Label*> VecLabel;
     typedef type::vector<LabelAction*> VecLabelAction;
     

--- a/applications/plugins/image/imagetoolbox/imagetoolboxwidget.cpp
+++ b/applications/plugins/image/imagetoolbox/imagetoolboxwidget.cpp
@@ -8,8 +8,6 @@
 namespace sofa
 {
 
-namespace gui
-{
 
 namespace qt
 {
@@ -47,5 +45,4 @@ helper::Creator<DataWidgetFactory, ImageToolBoxWidget< ImageToolBoxData<bool> > 
 #endif
 
 } // qt
-} // gui
 } // sofa

--- a/applications/plugins/image/imagetoolbox/imagetoolboxwidget.h
+++ b/applications/plugins/image/imagetoolbox/imagetoolboxwidget.h
@@ -37,8 +37,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -223,8 +221,6 @@ public:
         return b;
     }
 };
-
-}
 
 }
 

--- a/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolbox.h
@@ -55,9 +55,9 @@ public:
         loadFile();
     }
     
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        return new sofa::gui::qt::LabelBoxImageToolBoxAction(this,parent);
+        return new sofa::qt::LabelBoxImageToolBoxAction(this,parent);
     }
 
 

--- a/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolboxaction.cpp
@@ -7,8 +7,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -341,7 +339,6 @@ void LabelBoxImageToolBoxAction::validView()
 
 
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolboxaction.h
@@ -25,8 +25,6 @@ class SOFA_IMAGE_GUI_API LabelBoxImageToolBox;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -70,7 +68,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelgrid/labelgridimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelgrid/labelgridimagetoolbox.h
@@ -140,9 +140,9 @@ public:
 
     }
     
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        return new sofa::gui::qt::LabelGridImageToolBoxAction(this,parent);
+        return new sofa::qt::LabelGridImageToolBoxAction(this,parent);
     }
 
     type::vector<int> parseVector()

--- a/applications/plugins/image/imagetoolbox/labelgrid/labelgridimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/labelgrid/labelgridimagetoolboxaction.cpp
@@ -7,8 +7,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -350,6 +348,5 @@ void LabelGridImageToolBoxAction::sectionButtonClick()
 
 
 
-}
 }
 }

--- a/applications/plugins/image/imagetoolbox/labelgrid/labelgridimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/labelgrid/labelgridimagetoolboxaction.h
@@ -23,8 +23,6 @@ class SOFA_IMAGE_GUI_API LabelGridImageToolBoxNoTemplated;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -69,7 +67,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelimagetoolbox.h
@@ -43,12 +43,9 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 class SOFA_IMAGE_GUI_API LabelImageToolBoxAction;
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelimagetoolbox.h
@@ -114,7 +114,7 @@ protected:
 
 public:
     
-    virtual sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget* /*parent*/=nullptr )=0;
+    virtual sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget* /*parent*/=nullptr )=0;
 
 };
 

--- a/applications/plugins/image/imagetoolbox/labelimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/labelimagetoolboxaction.cpp
@@ -5,8 +5,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -100,7 +98,6 @@ void LabelImageToolBoxAction::setGraphScene(QGraphicsScene *XY,QGraphicsScene *X
 
 
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/labelimagetoolboxaction.h
@@ -21,8 +21,6 @@ class SOFA_IMAGE_GUI_API LabelImageToolBox;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -112,7 +110,6 @@ private slots:
 
 
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelpoint/labelpointimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelpoint/labelpointimagetoolbox.h
@@ -48,9 +48,9 @@ public:
         
     }
     
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        return new sofa::gui::qt::LabelPointImageToolBoxAction(this,parent);
+        return new sofa::qt::LabelPointImageToolBoxAction(this,parent);
     }
     
 public:

--- a/applications/plugins/image/imagetoolbox/labelpoint/labelpointimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/labelpoint/labelpointimagetoolboxaction.cpp
@@ -15,8 +15,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -172,6 +170,5 @@ void LabelPointImageToolBoxAction::sectionButtonClick()
 
 
 
-}
 }
 }

--- a/applications/plugins/image/imagetoolbox/labelpoint/labelpointimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/labelpoint/labelpointimagetoolboxaction.h
@@ -20,8 +20,6 @@ class SOFA_IMAGE_GUI_API LabelPointImageToolBox;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -55,7 +53,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolbox.h
@@ -38,9 +38,9 @@ class SOFA_IMAGE_GUI_API LabelPointsBySectionImageToolBox: public LabelImageTool
 public:
     SOFA_CLASS(LabelPointsBySectionImageToolBox,LabelImageToolBox);
     
-    typedef sofa::gui::qt::LabelPointsBySectionImageToolBoxAction::Point Point;
-    typedef sofa::gui::qt::LabelPointsBySectionImageToolBoxAction::VecPointSection VecPointSection;
-    typedef sofa::gui::qt::LabelPointsBySectionImageToolBoxAction::MapSection MapSection;
+    typedef sofa::qt::LabelPointsBySectionImageToolBoxAction::Point Point;
+    typedef sofa::qt::LabelPointsBySectionImageToolBoxAction::VecPointSection VecPointSection;
+    typedef sofa::qt::LabelPointsBySectionImageToolBoxAction::MapSection MapSection;
     typedef sofa::core::objectmodel::DataFileName DataFileName;
 
     LabelPointsBySectionImageToolBox():LabelImageToolBox()
@@ -62,9 +62,9 @@ public:
         
     }
     
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        sofa::gui::qt::LabelPointsBySectionImageToolBoxAction * t = new sofa::gui::qt::LabelPointsBySectionImageToolBoxAction(this,parent);
+        sofa::qt::LabelPointsBySectionImageToolBoxAction * t = new sofa::qt::LabelPointsBySectionImageToolBoxAction(this,parent);
 
         return t;
     }

--- a/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolboxaction.cpp
@@ -14,8 +14,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -550,7 +548,6 @@ void LabelPointsBySectionImageToolBoxAction::saveFileData()
 
 
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolboxaction.h
@@ -31,8 +31,6 @@ class SOFA_IMAGE_GUI_API LabelPointsBySectionImageToolBox;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -97,7 +95,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/zonegenerator/distancezoneimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/zonegenerator/distancezoneimagetoolbox.h
@@ -72,9 +72,9 @@ public:
         addOutput(&d_vecPixCoord);*/
     }
     
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        return new sofa::gui::qt::DistanceZoneImageToolBoxAction(this,parent);
+        return new sofa::qt::DistanceZoneImageToolBoxAction(this,parent);
     }
     
     

--- a/applications/plugins/image/imagetoolbox/zonegenerator/distancezoneimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/zonegenerator/distancezoneimagetoolboxaction.cpp
@@ -8,8 +8,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -385,6 +383,5 @@ void DistanceZoneImageToolBoxAction::optionChangeSection(sofa::type::Vec3i /*v*/
 
 
 
-}
 }
 }

--- a/applications/plugins/image/imagetoolbox/zonegenerator/distancezoneimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/zonegenerator/distancezoneimagetoolboxaction.h
@@ -26,8 +26,6 @@ class SOFA_IMAGE_GUI_API ZoneGeneratorImageToolBoxNoTemplated;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -78,7 +76,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/plugins/image/imagetoolbox/zonegenerator/zonegeneratorimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/zonegenerator/zonegeneratorimagetoolbox.h
@@ -71,9 +71,9 @@ public:
         addOutput(&d_vecPixCoord);*/
     }
 
-    sofa::gui::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
+    sofa::qt::LabelImageToolBoxAction* createTBAction(QWidget*parent=nullptr) override
     {
-        return new sofa::gui::qt::ZoneGeneratorImageToolBoxAction(this,parent);
+        return new sofa::qt::ZoneGeneratorImageToolBoxAction(this,parent);
     }
 
 

--- a/applications/plugins/image/imagetoolbox/zonegenerator/zonegeneratorimagetoolboxaction.cpp
+++ b/applications/plugins/image/imagetoolbox/zonegenerator/zonegeneratorimagetoolboxaction.cpp
@@ -8,8 +8,6 @@
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -385,6 +383,5 @@ void ZoneGeneratorImageToolBoxAction::optionChangeSection(sofa::type::Vec3i /*v*
 
 
 
-}
 }
 }

--- a/applications/plugins/image/imagetoolbox/zonegenerator/zonegeneratorimagetoolboxaction.h
+++ b/applications/plugins/image/imagetoolbox/zonegenerator/zonegeneratorimagetoolboxaction.h
@@ -26,8 +26,6 @@ class SOFA_IMAGE_GUI_API ZoneGeneratorImageToolBoxNoTemplated;
 
 namespace sofa
 {
-namespace gui
-{
 namespace qt
 {
 
@@ -78,7 +76,6 @@ private:
     
 };
 
-}
 }
 }
 

--- a/applications/projects/Modeler/exec/Main.cpp
+++ b/applications/projects/Modeler/exec/Main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
     sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
 
 	Q_INIT_RESOURCE(icons);
-    sofa::gui::qt::SofaModeler* sofaModeler = new sofa::gui::qt::SofaModeler();
+    sofa::qt::SofaModeler* sofaModeler = new sofa::qt::SofaModeler();
 
     //application->setMainWidget(sofaModeler);
     sofaModeler->show();

--- a/applications/projects/Modeler/lib/AddPreset.cpp
+++ b/applications/projects/Modeler/lib/AddPreset.cpp
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdlib>
-#include <sofa/gui/qt/FileManagement.h> //static functions to manage opening/ saving of files
+#include <sofa/qt/FileManagement.h> //static functions to manage opening/ saving of files
 #include <sofa/helper/system/SetDirectory.h>
 #include <sofa/helper/system/FileRepository.h>
 

--- a/applications/projects/Modeler/lib/GraphModeler.cpp
+++ b/applications/projects/Modeler/lib/GraphModeler.cpp
@@ -28,7 +28,7 @@
 #include <sofa/core/objectmodel/ConfigurationSetting.h>
 
 #include <sofa/simulation/Simulation.h>
-#include <sofa/gui/qt/FileManagement.h> //static functions to manage opening/ saving of files
+#include <sofa/qt/FileManagement.h> //static functions to manage opening/ saving of files
 
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
@@ -623,7 +623,7 @@ void GraphModeler::globalModification()
     type::vector< Base* > allComponentsSelected;
     for (size_t i=0; i<hierarchySelection.size(); ++i) allComponentsSelected.push_back(getComponent(hierarchySelection[i]));
 
-    sofa::gui::qt::GlobalModification *window=new sofa::gui::qt::GlobalModification(allComponentsSelected, historyManager);
+    sofa::qt::GlobalModification *window=new sofa::qt::GlobalModification(allComponentsSelected, historyManager);
 
     connect(window, SIGNAL(displayMessage(const std::string&)), this, SIGNAL(displayMessage(const std::string&)));
 
@@ -657,7 +657,7 @@ void GraphModeler::linkComponent()
         items.push_back(item);
 
     // create and show the LinkComponent dialog box
-    sofa::gui::qt::LinkComponent *window=new sofa::gui::qt::LinkComponent(this, items, fromItem);
+    sofa::qt::LinkComponent *window=new sofa::qt::LinkComponent(this, items, fromItem);
 
     if(window->loaderNumber() == 0)
     {
@@ -899,7 +899,7 @@ void GraphModeler::updatePresetNode(xml::BaseElement &elem, std::string meshFile
 
 bool GraphModeler::getSaveFilename(std::string &filename)
 {
-    QString s = sofa::gui::qt::getSaveFileName ( this, nullptr, "Scenes (*.scn *.xml)", "save file dialog", "Choose where the scene will be saved" );
+    QString s = sofa::qt::getSaveFileName ( this, nullptr, "Scenes (*.scn *.xml)", "save file dialog", "Choose where the scene will be saved" );
     if ( s.length() >0 )
     {
         std::string extension=sofa::helper::system::SetDirectory::GetExtension(s.toStdString().c_str());

--- a/applications/projects/Modeler/lib/GraphModeler.h
+++ b/applications/projects/Modeler/lib/GraphModeler.h
@@ -30,16 +30,16 @@
 #include "LinkComponent.h"
 #include <sofa/core/SofaLibrary.h>
 
-#include <sofa/gui/qt/ModifyObject.h>
-#include <sofa/gui/qt/QDisplayPropertyWidget.h>
+#include <sofa/qt/ModifyObject.h>
+#include <sofa/qt/QDisplayPropertyWidget.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/Node.h>
 #include <SofaSimulationCommon/xml/BaseElement.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 
-#include <sofa/gui/qt/GraphListenerQListView.h>
-#include <sofa/gui/qt/SofaSceneGraphWidget.h>
+#include <sofa/qt/GraphListenerQListView.h>
+#include <sofa/qt/SofaSceneGraphWidget.h>
 
 
 #include <QTreeWidget>

--- a/applications/projects/Modeler/lib/SofaModeler.cpp
+++ b/applications/projects/Modeler/lib/SofaModeler.cpp
@@ -31,7 +31,7 @@
 #include <sofa/gui/init.h>
 #include <sofa/gui/common/GUIManager.h>
 #include <sofa/gui/common/BaseGUI.h>
-#include <sofa/gui/qt/FileManagement.h>
+#include <sofa/qt/FileManagement.h>
 #include <sofa/helper/system/PluginManager.h>
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/cast.h>
@@ -231,7 +231,7 @@ SofaModeler::SofaModeler():recentlyOpenedFilesManager(Utils::getSofaPathPrefix()
     std::vector< QString > filter;
     const QString path(examplePath.c_str());
     filter.push_back("*.scn"); filter.push_back("*.xml");
-    sofa::gui::qt::getFilesInDirectory(path, exampleQString, true, filter);
+    sofa::qt::getFilesInDirectory(path, exampleQString, true, filter);
 
 
     //----------------------------------------------------------------------
@@ -725,7 +725,7 @@ void SofaModeler::fileSaveAs()
     std::string path;
     if (graph->getFilename().empty()) path=examplePath.c_str();
     else path=sofa::helper::system::SetDirectory::GetParentDir(graph->getFilename().c_str());
-    QString s = sofa::gui::qt::getSaveFileName ( this, QString(path.c_str()), "Scenes (*.scn *.xml)", "save file dialog", "Choose where the scene will be saved" );
+    QString s = sofa::qt::getSaveFileName ( this, QString(path.c_str()), "Scenes (*.scn *.xml)", "save file dialog", "Choose where the scene will be saved" );
     if ( s.length() >0 )
     {
 
@@ -759,7 +759,7 @@ void SofaModeler::fileReload()
 
 void SofaModeler::exportSofaClasses()
 {
-    QString filename = sofa::gui::qt::getSaveFileName(this, QString(binPath.c_str()), "Sofa Classes (*.xml)", "export classes dialog", "Choose where the Sofa classes will be exported");
+    QString filename = sofa::qt::getSaveFileName(this, QString(binPath.c_str()), "Sofa Classes (*.xml)", "export classes dialog", "Choose where the Sofa classes will be exported");
     if(filename.isEmpty())
         return;
 

--- a/applications/projects/Modeler/lib/SofaModeler.h
+++ b/applications/projects/Modeler/lib/SofaModeler.h
@@ -40,9 +40,9 @@
 #include "GraphModeler.h"
 #include "FilterLibrary.h"
 #include "SofaTutorialManager.h"
-#include <sofa/gui/qt/QDisplayPropertyWidget.h>
-#include <sofa/gui/qt/QMenuFilesRecentlyOpened.h>
-#include <sofa/gui/qt/SofaPluginManager.h>
+#include <sofa/qt/QDisplayPropertyWidget.h>
+#include <sofa/qt/QMenuFilesRecentlyOpened.h>
+#include <sofa/qt/SofaPluginManager.h>
 #include <sofa/helper/Factory.h>
 
 #include "QSofaTreeLibrary.h"

--- a/applications/projects/runSofa/cmake/bundle.cmake
+++ b/applications/projects/runSofa/cmake/bundle.cmake
@@ -24,7 +24,7 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/share/ DESTINATION runSofa.app/Contents/Ma
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ DESTINATION runSofa.app/Contents/MacOS/share/sofa/examples COMPONENT BundlePack )
 install(FILES "${_defaultConfigPluginFilePath}" DESTINATION runSofa.app/Contents/MacOS/ COMPONENT BundlePack)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/applications/projects/runSofa/resources/ DESTINATION runSofa.app/Contents/MacOS/share/sofa/gui/runSofa COMPONENT BundlePack)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/applications/sofa/gui/qt/resources/ DESTINATION runSofa.app/Contents/MacOS/share/sofa/gui/qt COMPONENT BundlePack)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/applications/sofa/qt/resources/ DESTINATION runSofa.app/Contents/MacOS/share/sofa/qt COMPONENT BundlePack)
 install(FILES "${CMAKE_BINARY_DIR}/etc/installedSofa.ini" DESTINATION runSofa.app/Contents/MacOS/etc RENAME sofa.ini COMPONENT BundlePack)
 install(FILES "${CMAKE_BINARY_DIR}/etc/installedrunSofa.ini" DESTINATION runSofa.app/Contents/MacOS/etc RENAME runSofa.ini COMPONENT BundlePack)
 install(FILES "${CMAKE_BINARY_DIR}/etc/installedSofaGuiQt.ini" DESTINATION runSofa.app/Contents/MacOS/etc RENAME SofaGuiQt.ini COMPONENT BundlePack)

--- a/examples/Tutorials/StepByStep/TopologicalMapping/0_TopoMapping.html
+++ b/examples/Tutorials/StepByStep/TopologicalMapping/0_TopoMapping.html
@@ -7,7 +7,7 @@
 		
 		<center><h3>Topological Mapping (1/7)</h3>
 		  <br><br>
-		  <img src="../../../../applications/sofa/gui/qt/sofa-logo-alpha-text.png" name="TopologyTetra2TriangleTopologicalMapping" align="middle">
+		  <img src="../../../../applications/sofa/qt/sofa-logo-alpha-text.png" name="TopologyTetra2TriangleTopologicalMapping" align="middle">
 		</center>
 
 		

--- a/examples/Tutorials/Tutorials.html
+++ b/examples/Tutorials/Tutorials.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 	<div id="contenu">		
-	        <center><img src="../../applications/sofa/gui/qt/sofa-logo-alpha-text.png"  name="TutorialBasicCube" align="middle">
+	        <center><img src="../../applications/sofa/qt/sofa-logo-alpha-text.png"  name="TutorialBasicCube" align="middle">
 		  <h3>Tutorials for SOFA</h3></center>
 		<div id="orangeText">Description:</div>
 		<br>


### PR DESCRIPTION
PR https://github.com/sofa-framework/sofa/pull/5621 broke compilation of plugins because it activated parts of code that wasn't activated after the move of Sofa.Qt ou of the sources. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
