### PR TITLE
[Mapping.Linear] BarycentricMappingTopologyContainerMapper: use array for barycentric coefficients

### DIFF
--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
@@ -63,6 +63,7 @@ protected:
 
     virtual type::vector<Edge> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;
+    virtual std::array<SReal, Edge::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     type::vector<SReal> getBaryCoef(const Real fx);
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Edge& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Edge& element) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
@@ -62,9 +62,7 @@ protected:
     ~BarycentricMapperEdgeSetTopology() override = default;
 
     virtual type::vector<Edge> getElements() override;
-    virtual type::vector<SReal> getBaryCoef(const Real* f) override;
     virtual std::array<SReal, Edge::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
-    type::vector<SReal> getBaryCoef(const Real fx);
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Edge& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Edge& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
@@ -62,7 +62,7 @@ protected:
     ~BarycentricMapperEdgeSetTopology() override = default;
 
     virtual type::vector<Edge> getElements() override;
-    virtual std::array<SReal, Edge::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
+    virtual std::array<Real, Edge::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Edge& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Edge& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
@@ -62,7 +62,7 @@ protected:
     ~BarycentricMapperEdgeSetTopology() override = default;
 
     virtual type::vector<Edge> getElements() override;
-    virtual std::array<SReal, Edge::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
+    virtual std::array<SReal, Edge::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Edge& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Edge& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
@@ -61,9 +61,9 @@ type::vector<Edge> BarycentricMapperEdgeSetTopology<In,Out>::getElements()
 }
 
 template <class In, class Out>
-auto BarycentricMapperEdgeSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Edge::NumberOfNodes>
+auto BarycentricMapperEdgeSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Edge::NumberOfNodes>
 {
-    return {1-f[0],f[0]};
+    return {1-barycentricCoordinates[0], barycentricCoordinates[0]};
 }
 
 template <class In, class Out>

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
@@ -61,19 +61,6 @@ type::vector<Edge> BarycentricMapperEdgeSetTopology<In,Out>::getElements()
 }
 
 template <class In, class Out>
-type::vector<SReal> BarycentricMapperEdgeSetTopology<In,Out>::getBaryCoef(const Real* f)
-{
-    return getBaryCoef(f[0]);
-}
-
-template <class In, class Out>
-type::vector<SReal> BarycentricMapperEdgeSetTopology<In,Out>::getBaryCoef(const Real fx)
-{
-    type::vector<SReal> edgeCoef{1-fx,fx};
-    return edgeCoef;
-}
-
-template <class In, class Out>
 auto BarycentricMapperEdgeSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Edge::NumberOfNodes>
 {
     return {1-f[0],f[0]};

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
@@ -74,6 +74,12 @@ type::vector<SReal> BarycentricMapperEdgeSetTopology<In,Out>::getBaryCoef(const 
 }
 
 template <class In, class Out>
+auto BarycentricMapperEdgeSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Edge::NumberOfNodes>
+{
+    return {1-f[0],f[0]};
+}
+
+template <class In, class Out>
 void BarycentricMapperEdgeSetTopology<In,Out>::computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Edge& element)
 {
     //Not implemented for Edge

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
@@ -61,7 +61,7 @@ type::vector<Edge> BarycentricMapperEdgeSetTopology<In,Out>::getElements()
 }
 
 template <class In, class Out>
-auto BarycentricMapperEdgeSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Edge::NumberOfNodes>
+auto BarycentricMapperEdgeSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<Real, Edge::NumberOfNodes>
 {
     return {1-barycentricCoordinates[0], barycentricCoordinates[0]};
 }

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -50,6 +50,7 @@ public:
     virtual type::vector<Hexahedron> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;
     type::vector<SReal> getBaryCoef(const Real fx, const Real fy, const Real fz);
+    virtual std::array<SReal, Hexahedron::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Hexahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Hexahedron& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -48,7 +48,7 @@ public:
 
     ~BarycentricMapperHexahedronSetTopology() override = default;
     virtual type::vector<Hexahedron> getElements() override;
-    virtual std::array<SReal, Hexahedron::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
+    virtual std::array<SReal, Hexahedron::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Hexahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Hexahedron& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -48,7 +48,7 @@ public:
 
     ~BarycentricMapperHexahedronSetTopology() override = default;
     virtual type::vector<Hexahedron> getElements() override;
-    virtual std::array<SReal, Hexahedron::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
+    virtual std::array<Real, Hexahedron::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Hexahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Hexahedron& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -48,8 +48,6 @@ public:
 
     ~BarycentricMapperHexahedronSetTopology() override = default;
     virtual type::vector<Hexahedron> getElements() override;
-    virtual type::vector<SReal> getBaryCoef(const Real* f) override;
-    type::vector<SReal> getBaryCoef(const Real fx, const Real fy, const Real fz);
     virtual std::array<SReal, Hexahedron::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Hexahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Hexahedron& element) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -114,6 +114,19 @@ type::vector<SReal> BarycentricMapperHexahedronSetTopology<In,Out>::getBaryCoef(
     return hexahedronCoef;
 }
 
+template <class In, class Out>
+auto BarycentricMapperHexahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Hexahedron::NumberOfNodes>
+{
+    return {(1-f[0])*(1-f[1])*(1-f[2]),
+        (f[0])*(1-f[1])*(1-f[2]),
+        (f[0])*(f[1])*(1 - f[2]),
+        (1 - f[0])*(f[1])*(1 - f[2]),
+        (1-f[0])*(1-f[1])*(f[2]),
+        (f[0])*(1-f[1])*(f[2]),
+        (f[0])*(f[1])*(f[2]),
+        (1 - f[0])*(f[1])*(f[2])
+    };
+}
 
 template <class In, class Out>
 void BarycentricMapperHexahedronSetTopology<In,Out>::computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Hexahedron& element)

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -91,29 +91,6 @@ type::vector<Hexahedron> BarycentricMapperHexahedronSetTopology<In,Out>::getElem
     return this->m_fromTopology->getHexahedra();
 }
 
-
-template <class In, class Out>
-type::vector<SReal> BarycentricMapperHexahedronSetTopology<In,Out>::getBaryCoef(const Real* f)
-{
-    return getBaryCoef(f[0],f[1],f[2]);
-}
-
-
-template <class In, class Out>
-type::vector<SReal> BarycentricMapperHexahedronSetTopology<In,Out>::getBaryCoef(const Real fx, const Real fy, const Real fz)
-{
-    type::vector<SReal> hexahedronCoef{(1-fx)*(1-fy)*(1-fz),
-                (fx)*(1-fy)*(1-fz),
-                (fx)*(fy)*(1 - fz),
-                (1 - fx)*(fy)*(1 - fz),
-                (1-fx)*(1-fy)*(fz),
-                (fx)*(1-fy)*(fz),
-                (fx)*(fy)*(fz),
-                (1 - fx)*(fy)*(fz)
-    };
-    return hexahedronCoef;
-}
-
 template <class In, class Out>
 auto BarycentricMapperHexahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Hexahedron::NumberOfNodes>
 {

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -92,8 +92,10 @@ type::vector<Hexahedron> BarycentricMapperHexahedronSetTopology<In,Out>::getElem
 }
 
 template <class In, class Out>
-auto BarycentricMapperHexahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Hexahedron::NumberOfNodes>
+auto BarycentricMapperHexahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Hexahedron::NumberOfNodes>
 {
+    const Real* f = barycentricCoordinates; // for better readability
+    
     return {(1-f[0])*(1-f[1])*(1-f[2]),
         (f[0])*(1-f[1])*(1-f[2]),
         (f[0])*(f[1])*(1 - f[2]),

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -92,7 +92,7 @@ type::vector<Hexahedron> BarycentricMapperHexahedronSetTopology<In,Out>::getElem
 }
 
 template <class In, class Out>
-auto BarycentricMapperHexahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Hexahedron::NumberOfNodes>
+auto BarycentricMapperHexahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<Real, Hexahedron::NumberOfNodes>
 {
     const Real* f = barycentricCoordinates; // for better readability
     

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
@@ -53,8 +53,6 @@ protected:
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Quad> getElements() override;
-    virtual type::vector<SReal> getBaryCoef(const Real* f) override;
-    type::vector<SReal> getBaryCoef(const Real fx, const Real fy);
     virtual std::array<SReal, Quad::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Quad& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Quad& element) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
@@ -53,7 +53,7 @@ protected:
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Quad> getElements() override;
-    virtual std::array<SReal, Quad::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
+    virtual std::array<SReal, Quad::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Quad& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Quad& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
@@ -53,7 +53,7 @@ protected:
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Quad> getElements() override;
-    virtual std::array<SReal, Quad::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
+    virtual std::array<Real, Quad::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Quad& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Quad& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.h
@@ -55,6 +55,7 @@ protected:
     virtual type::vector<Quad> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;
     type::vector<SReal> getBaryCoef(const Real fx, const Real fy);
+    virtual std::array<SReal, Quad::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Quad& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Quad& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -77,22 +77,6 @@ type::vector<Quad> BarycentricMapperQuadSetTopology<In,Out>::getElements()
 }
 
 template <class In, class Out>
-type::vector<SReal> BarycentricMapperQuadSetTopology<In,Out>::getBaryCoef(const Real* f)
-{
-    return getBaryCoef(f[0],f[1]);
-}
-
-template <class In, class Out>
-type::vector<SReal> BarycentricMapperQuadSetTopology<In,Out>::getBaryCoef(const Real fx, const Real fy)
-{
-    type::vector<SReal> quadCoef{(1-fx)*(1-fy),
-                (fx)*(1-fy),
-                (fx)*(fy),
-                (1 - fx)*(fy)};
-    return quadCoef;
-}
-
-template <class In, class Out>
 auto BarycentricMapperQuadSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Quad::NumberOfNodes>
 {
     return { (1-f[0])*(1-f[1]), (f[0])*(1-f[1]), (f[0])*(f[1]), (1 - f[0])*(f[1]) };

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -77,7 +77,7 @@ type::vector<Quad> BarycentricMapperQuadSetTopology<In,Out>::getElements()
 }
 
 template <class In, class Out>
-auto BarycentricMapperQuadSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Quad::NumberOfNodes>
+auto BarycentricMapperQuadSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<Real, Quad::NumberOfNodes>
 {
     const Real* f = barycentricCoordinates; // for better readability
     return { (1-f[0])*(1-f[1]), (f[0])*(1-f[1]), (f[0])*(f[1]), (1 - f[0])*(f[1]) };

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -93,6 +93,12 @@ type::vector<SReal> BarycentricMapperQuadSetTopology<In,Out>::getBaryCoef(const 
 }
 
 template <class In, class Out>
+auto BarycentricMapperQuadSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Quad::NumberOfNodes>
+{
+    return { (1-f[0])*(1-f[1]), (f[0])*(1-f[1]), (f[0])*(f[1]), (1 - f[0])*(f[1]) };
+}
+
+template <class In, class Out>
 void BarycentricMapperQuadSetTopology<In,Out>::computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Quad& element)
 {
     Mat3x3d matrixTranspose;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -77,8 +77,9 @@ type::vector<Quad> BarycentricMapperQuadSetTopology<In,Out>::getElements()
 }
 
 template <class In, class Out>
-auto BarycentricMapperQuadSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Quad::NumberOfNodes>
+auto BarycentricMapperQuadSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Quad::NumberOfNodes>
 {
+    const Real* f = barycentricCoordinates; // for better readability
     return { (1-f[0])*(1-f[1]), (f[0])*(1-f[1]), (f[0])*(f[1]), (1 - f[0])*(f[1]) };
 }
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -53,6 +53,7 @@ protected:
     virtual type::vector<Tetrahedron> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;
     type::vector<SReal> getBaryCoef(const Real fx, const Real fy, const Real fz);
+    virtual std::array<SReal, Tetrahedron::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Tetrahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Tetrahedron& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -51,7 +51,7 @@ protected:
     ~BarycentricMapperTetrahedronSetTopology() override = default;
 
     virtual type::vector<Tetrahedron> getElements() override;
-    virtual std::array<SReal, Tetrahedron::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
+    virtual std::array<SReal, Tetrahedron::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Tetrahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Tetrahedron& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -51,7 +51,7 @@ protected:
     ~BarycentricMapperTetrahedronSetTopology() override = default;
 
     virtual type::vector<Tetrahedron> getElements() override;
-    virtual std::array<SReal, Tetrahedron::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
+    virtual std::array<Real, Tetrahedron::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Tetrahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Tetrahedron& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -51,8 +51,6 @@ protected:
     ~BarycentricMapperTetrahedronSetTopology() override = default;
 
     virtual type::vector<Tetrahedron> getElements() override;
-    virtual type::vector<SReal> getBaryCoef(const Real* f) override;
-    type::vector<SReal> getBaryCoef(const Real fx, const Real fy, const Real fz);
     virtual std::array<SReal, Tetrahedron::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Tetrahedron& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Tetrahedron& element) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -66,6 +66,12 @@ type::vector<SReal> BarycentricMapperTetrahedronSetTopology<In,Out>::getBaryCoef
 }
 
 template <class In, class Out>
+auto BarycentricMapperTetrahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Tetrahedron::NumberOfNodes>
+{
+    return {(1-f[0]-f[1]-f[2]),f[0],f[1],f[2]};
+}
+
+template <class In, class Out>
 void BarycentricMapperTetrahedronSetTopology<In,Out>::computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Tetrahedron& element)
 {
     Mat3x3d matrixTranspose;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -53,7 +53,7 @@ type::vector<Tetrahedron> BarycentricMapperTetrahedronSetTopology<In,Out>::getEl
 }
 
 template <class In, class Out>
-auto BarycentricMapperTetrahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Tetrahedron::NumberOfNodes>
+auto BarycentricMapperTetrahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<Real, Tetrahedron::NumberOfNodes>
 {
     const Real* f = barycentricCoordinates; // for better readability
     return {(1-f[0]-f[1]-f[2]),f[0],f[1],f[2]};

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -53,19 +53,6 @@ type::vector<Tetrahedron> BarycentricMapperTetrahedronSetTopology<In,Out>::getEl
 }
 
 template <class In, class Out>
-type::vector<SReal> BarycentricMapperTetrahedronSetTopology<In,Out>::getBaryCoef(const Real* f)
-{
-    return getBaryCoef(f[0],f[1],f[2]);
-}
-
-template <class In, class Out>
-type::vector<SReal> BarycentricMapperTetrahedronSetTopology<In,Out>::getBaryCoef(const Real fx, const Real fy, const Real fz)
-{
-    type::vector<SReal> tetrahedronCoef{(1-fx-fy-fz),fx,fy,fz};
-    return tetrahedronCoef;
-}
-
-template <class In, class Out>
 auto BarycentricMapperTetrahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Tetrahedron::NumberOfNodes>
 {
     return {(1-f[0]-f[1]-f[2]),f[0],f[1],f[2]};

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -53,8 +53,9 @@ type::vector<Tetrahedron> BarycentricMapperTetrahedronSetTopology<In,Out>::getEl
 }
 
 template <class In, class Out>
-auto BarycentricMapperTetrahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Tetrahedron::NumberOfNodes>
+auto BarycentricMapperTetrahedronSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Tetrahedron::NumberOfNodes>
 {
+    const Real* f = barycentricCoordinates; // for better readability
     return {(1-f[0]-f[1]-f[2]),f[0],f[1],f[2]};
 }
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -148,7 +148,7 @@ protected:
     ~BarycentricMapperTopologyContainer() override = default;
 
     virtual type::vector<Element> getElements()=0;
-    virtual std::array<SReal, Element::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates)=0;
+    virtual std::array<Real, Element::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates)=0;
     
     virtual void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Element& element)=0;
     virtual void computeCenter(Vec3& center, const typename In::VecCoord& in, const Element& element)=0;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -148,7 +148,7 @@ protected:
     ~BarycentricMapperTopologyContainer() override = default;
 
     virtual type::vector<Element> getElements()=0;
-    virtual std::array<SReal, Element::NumberOfNodes> getBarycentricCoefficients(const Real* f)=0;
+    virtual std::array<SReal, Element::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates)=0;
     
     virtual void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Element& element)=0;
     virtual void computeCenter(Vec3& center, const typename In::VecCoord& in, const Element& element)=0;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -149,6 +149,8 @@ protected:
 
     virtual type::vector<Element> getElements()=0;
     virtual type::vector<SReal> getBaryCoef(const Real* f)=0;
+    virtual std::array<SReal, Element::NumberOfNodes> getBarycentricCoefficients(const Real* f)=0;
+    
     virtual void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Element& element)=0;
     virtual void computeCenter(Vec3& center, const typename In::VecCoord& in, const Element& element)=0;
     virtual void addPointInElement(const Index elementIndex, const SReal* baryCoords)=0;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -148,7 +148,6 @@ protected:
     ~BarycentricMapperTopologyContainer() override = default;
 
     virtual type::vector<Element> getElements()=0;
-    virtual type::vector<SReal> getBaryCoef(const Real* f)=0;
     virtual std::array<SReal, Element::NumberOfNodes> getBarycentricCoefficients(const Real* f)=0;
     
     virtual void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Element& element)=0;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTopologyContainer.inl
@@ -237,6 +237,7 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::checkDi
 template <class In, class Out, class MappingDataType, class Element>
 void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::applyJT ( typename In::MatrixDeriv& out, const typename Out::MatrixDeriv& in )
 {
+    const auto& map = d_map.getValue();
     typename Out::MatrixDeriv::RowConstIterator rowItEnd = in.end();
     const type::vector< Element >& elements = getElements();
 
@@ -254,10 +255,10 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::applyJT
                 unsigned indexIn = colIt.index();
                 InDeriv data = InDeriv(Out::getDPos(colIt.val()));
 
-                const Element& element = elements[d_map.getValue()[indexIn].in_index];
-
-                type::vector<SReal> baryCoef = getBaryCoef(d_map.getValue()[indexIn].baryCoords);
-                for (unsigned int j=0; j<element.size(); j++)
+                const Element& element = elements[map[indexIn].in_index];
+                
+                const auto baryCoef = getBarycentricCoefficients(map[indexIn].baryCoords);
+                for (unsigned int j=0; j<Element::NumberOfNodes; j++)
                     o.addCol(element[j], data*baryCoef[j]);
             }
         }
@@ -284,9 +285,9 @@ const linearalgebra::BaseMatrix* BarycentricMapperTopologyContainer<In,Out,Mappi
     for( size_t outId=0 ; outId< map.size() ; ++outId)
     {
         const Element& element = elements[map[outId].in_index];
-
-        type::vector<SReal> baryCoef = getBaryCoef(map[outId].baryCoords);
-        for (unsigned int j=0; j<element.size(); j++)
+        
+        const auto baryCoef = getBarycentricCoefficients(map[outId].baryCoords);
+        for (unsigned int j=0; j<Element::NumberOfNodes; j++)
             this->addMatrixContrib(m_matrixJ, int(outId), element[j], baryCoef[j]);
     }
 
@@ -299,16 +300,17 @@ const linearalgebra::BaseMatrix* BarycentricMapperTopologyContainer<In,Out,Mappi
 template <class In, class Out, class MappingDataType, class Element>
 void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::applyJT ( typename In::VecDeriv& out, const typename Out::VecDeriv& in )
 {
+    const auto& map = d_map.getValue();
     const type::vector<Element>& elements = getElements();
 
     for( size_t i=0 ; i<in.size() ; ++i)
     {
-        Index index = d_map.getValue()[i].in_index;
+        const Index index = map[i].in_index;
         const Element& element = elements[index];
 
         const typename Out::DPos inPos = Out::getDPos(in[i]);
-        type::vector<SReal> baryCoef = getBaryCoef(d_map.getValue()[i].baryCoords);
-        for (unsigned int j=0; j<element.size(); j++)
+        const auto baryCoef = getBarycentricCoefficients(map[i].baryCoords);
+        for (unsigned int j=0; j<Element::NumberOfNodes; j++)
         {
             out[element[j]] += inPos * baryCoef[j];
         }
@@ -318,18 +320,19 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::applyJT
 template <class In, class Out, class MappingDataType, class Element>
 void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::applyJ ( typename Out::VecDeriv& out, const typename In::VecDeriv& in )
 {
-    out.resize( d_map.getValue().size() );
+    const auto& map = d_map.getValue();
+    out.resize( map.size() );
 
     const type::vector<Element>& elements = getElements();
 
     for( size_t i=0 ; i<out.size() ; ++i)
     {
-        Index index = d_map.getValue()[i].in_index;
+        const Index index = map[i].in_index;
         const Element& element = elements[index];
 
-        type::vector<SReal> baryCoef = getBaryCoef(d_map.getValue()[i].baryCoords);
+        const auto baryCoef = getBarycentricCoefficients(map[i].baryCoords);
         InDeriv inPos{0.,0.,0.};
-        for (unsigned int j=0; j<element.size(); j++)
+        for (unsigned int j=0; j<Element::NumberOfNodes; j++)
             inPos += in[element[j]] * baryCoef[j];
 
         Out::setDPos(out[i] , inPos);
@@ -354,17 +357,18 @@ bool BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::isEmpty
 template <class In, class Out, class MappingDataType, class Element>
 void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::apply ( typename Out::VecCoord& out, const typename In::VecCoord& in )
 {
-    out.resize( d_map.getValue().size() );
+    const auto& map = d_map.getValue();
+    out.resize( map.size() );
 
     const type::vector<Element>& elements = getElements();
-    for ( unsigned int i=0; i<d_map.getValue().size(); i++ )
+    for ( unsigned int i=0; i<map.size(); i++ )
     {
-        Index index = d_map.getValue()[i].in_index;
+        const Index index = map[i].in_index;
         const Element& element = elements[index];
 
-        type::vector<SReal> baryCoef = getBaryCoef(d_map.getValue()[i].baryCoords);
+        const auto baryCoef = getBarycentricCoefficients(map[i].baryCoords);
         InDeriv inPos{0.,0.,0.};
-        for (unsigned int j=0; j<element.size(); j++)
+        for (unsigned int j=0; j< Element::NumberOfNodes; j++)
             inPos += in[element[j]] * baryCoef[j];
 
         Out::setCPos(out[i] , inPos);
@@ -377,17 +381,19 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::draw  (
                                                                                 const typename Out::VecCoord& out,
                                                                                 const typename In::VecCoord& in )
 {
+    const auto& map = d_map.getValue();
     // Draw line between mapped node (out) and nodes of nearest element (in)
     const type::vector<Element>& elements = getElements();
 
     std::vector< Vec3 > points;
     {
-        for ( unsigned int i=0; i<d_map.getValue().size(); i++ )
+        points.reserve(map.size() * Element::NumberOfNodes);
+        for ( unsigned int i=0; i<map.size(); i++ )
         {
-            Index index = d_map.getValue()[i].in_index;
+            const Index index = map[i].in_index;
             const Element& element = elements[index];
-            type::vector<SReal> baryCoef = getBaryCoef(d_map.getValue()[i].baryCoords);
-            for ( unsigned int j=0; j<element.size(); j++ )
+            const auto baryCoef = getBarycentricCoefficients(map[i].baryCoords);
+            for ( unsigned int j=0; j<Element::NumberOfNodes; j++ )
             {
                 if ( baryCoef[j]<=-0.0001 || baryCoef[j]>=0.0001 )
                 {

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
@@ -54,7 +54,7 @@ protected:
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Triangle> getElements() override;
-    virtual std::array<SReal, Triangle::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
+    virtual std::array<Real, Triangle::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Triangle& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Triangle& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
@@ -54,7 +54,7 @@ protected:
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Triangle> getElements() override;
-    virtual std::array<SReal, Triangle::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
+    virtual std::array<SReal, Triangle::NumberOfNodes> getBarycentricCoefficients(const Real* barycentricCoordinates) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Triangle& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Triangle& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
@@ -54,8 +54,6 @@ protected:
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Triangle> getElements() override;
-    virtual type::vector<SReal> getBaryCoef(const Real* f) override;
-    type::vector<SReal> getBaryCoef(const Real fx, const Real fy);
     virtual std::array<SReal, Triangle::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Triangle& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Triangle& element) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
@@ -56,6 +56,7 @@ protected:
     virtual type::vector<Triangle> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;
     type::vector<SReal> getBaryCoef(const Real fx, const Real fy);
+    virtual std::array<SReal, Triangle::NumberOfNodes> getBarycentricCoefficients(const Real* f) override;
     void computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Triangle& element) override;
     void computeCenter(Vec3& center, const typename In::VecCoord& in, const Triangle& element) override;
     void computeDistance(SReal& d, const Vec3& v) override;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
@@ -78,7 +78,7 @@ type::vector<Triangle> BarycentricMapperTriangleSetTopology<In,Out>::getElements
 }
 
 template <class In, class Out>
-auto BarycentricMapperTriangleSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Triangle::NumberOfNodes>
+auto BarycentricMapperTriangleSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<Real, Triangle::NumberOfNodes>
 {
     return {1-barycentricCoordinates[0]-barycentricCoordinates[1], barycentricCoordinates[0], barycentricCoordinates[1]};
 }

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
@@ -91,6 +91,12 @@ type::vector<SReal> BarycentricMapperTriangleSetTopology<In,Out>::getBaryCoef(co
 }
 
 template <class In, class Out>
+auto BarycentricMapperTriangleSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Triangle::NumberOfNodes>
+{
+    return {1-f[0]-f[1], f[0], f[1]};
+}
+
+template <class In, class Out>
 void BarycentricMapperTriangleSetTopology<In,Out>::computeBase(Mat3x3d& base, const typename In::VecCoord& in, const Triangle& element)
 {
     Mat3x3d mt;

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
@@ -78,9 +78,9 @@ type::vector<Triangle> BarycentricMapperTriangleSetTopology<In,Out>::getElements
 }
 
 template <class In, class Out>
-auto BarycentricMapperTriangleSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Triangle::NumberOfNodes>
+auto BarycentricMapperTriangleSetTopology<In,Out>::getBarycentricCoefficients(const Real* barycentricCoordinates) -> std::array<SReal, Triangle::NumberOfNodes>
 {
-    return {1-f[0]-f[1], f[0], f[1]};
+    return {1-barycentricCoordinates[0]-barycentricCoordinates[1], barycentricCoordinates[0], barycentricCoordinates[1]};
 }
 
 template <class In, class Out>

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
@@ -78,19 +78,6 @@ type::vector<Triangle> BarycentricMapperTriangleSetTopology<In,Out>::getElements
 }
 
 template <class In, class Out>
-type::vector<SReal> BarycentricMapperTriangleSetTopology<In,Out>::getBaryCoef(const Real* f)
-{
-    return getBaryCoef(f[0],f[1]);
-}
-
-template <class In, class Out>
-type::vector<SReal> BarycentricMapperTriangleSetTopology<In,Out>::getBaryCoef(const Real fx, const Real fy)
-{
-    type::vector<SReal> triangleCoef{1-fx-fy, fx, fy};
-    return triangleCoef;
-}
-
-template <class In, class Out>
 auto BarycentricMapperTriangleSetTopology<In,Out>::getBarycentricCoefficients(const Real* f) -> std::array<SReal, Triangle::NumberOfNodes>
 {
     return {1-f[0]-f[1], f[0], f[1]};

--- a/examples/Benchmark/Performance/BarycentricMapping_meshtopology.scn
+++ b/examples/Benchmark/Performance/BarycentricMapping_meshtopology.scn
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<Node name="root" gravity="0 -10 0" dt="0.01">
+
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [LinearSolverConstraintCorrection] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Model"/> <!-- Needed to use components [FixedLagrangianConstraint] -->
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [BarycentricMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedronFEMForceField] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetTopologyContainer] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [SparseGridTopology] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
+    </Node>
+
+    <DefaultAnimationLoop computeBoundingBox="false" />
+    <MeshOBJLoader name="meshLoader" triangulate="true" filename="mesh/raptor_35kp.obj" />
+
+    <Node name="data">
+        <SparseGridTopology n="10 5 10" name="topology" fileTopology="@../meshLoader.filename" />
+        <MechanicalObject name="DOFs" template="Vec3" />
+    </Node>
+
+    <Node name="raptor">
+        <EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.2" />
+        <SparseLDLSolver template="CompressedRowSparseMatrixd"/>
+        <MeshTopology hexahedra="@../data/topology.hexahedra" />
+        <MechanicalObject name="DOFs" template="Vec3" position="@../data/DOFs.position"/>
+        <UniformMass totalMass="1.005"/>
+        <TetrahedronFEMForceField name="FEM" youngModulus="500" poissonRatio='0.3' />
+
+        <BoxROI name='ROI1' box='-5 -1 -3  5 1 3' drawBoxes='true'/>
+        <FixedProjectiveConstraint indices="@ROI1.indices" />
+
+        <Node name="Collision">
+            <MechanicalObject name="collisMecha" src="@../../meshLoader" />
+            <TriangleSetTopologyContainer src="@../../meshLoader" />
+            <TriangleCollisionModel />
+            <LineCollisionModel />
+            <PointCollisionModel />
+            <BarycentricMapping />
+        </Node>
+
+        <Node name="Visualization">
+            <OglModel name="VisualModel1" src="@../../meshLoader" useNormals="0" />
+            <TriangleSetTopologyContainer src="@../../meshLoader" />
+            <BarycentricMapping />
+        </Node>
+    </Node>
+
+</Node>

--- a/examples/Benchmark/Performance/BarycentricMapping_sparsegrid.scn
+++ b/examples/Benchmark/Performance/BarycentricMapping_sparsegrid.scn
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<Node name="root" gravity="0 -10 0" dt="0.01">
+
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [LinearSolverConstraintCorrection] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Model"/> <!-- Needed to use components [FixedLagrangianConstraint] -->
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [BarycentricMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedronFEMForceField] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetTopologyContainer] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [SparseGridTopology] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
+    </Node>
+
+    <DefaultAnimationLoop computeBoundingBox="false" />
+    <MeshOBJLoader name="meshLoader" triangulate="true" filename="mesh/raptor_35kp.obj" />
+
+    <Node name="raptor">
+        <EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.2" />
+        <SparseLDLSolver template="CompressedRowSparseMatrixd"/>
+        <SparseGridTopology n="10 5 10" name="topology" fileTopology="@../meshLoader.filename" />
+        <MechanicalObject name="DOFs" template="Vec3" position="@../data/DOFs.position"/>
+        <UniformMass totalMass="1.005"/>
+        <TetrahedronFEMForceField name="FEM" youngModulus="500" poissonRatio='0.3' />
+
+        <BoxROI name='ROI1' box='-5 -1 -3  5 1 3' drawBoxes='true'/>
+        <FixedProjectiveConstraint indices="@ROI1.indices" />
+
+          <Node name="Collision">
+            <MechanicalObject name="collisMecha" src="@../../meshLoader" />
+            <TriangleSetTopologyContainer src="@../../meshLoader" />
+            <TriangleCollisionModel />
+            <LineCollisionModel />
+            <PointCollisionModel />
+            <BarycentricMapping />
+        </Node>
+
+        <Node name="Visualization">
+            <OglModel name="VisualModel1" src="@../../meshLoader" useNormals="0" />
+            <TriangleSetTopologyContainer src="@../../meshLoader" />
+            <BarycentricMapping />
+        </Node>
+    </Node>
+
+</Node>

--- a/examples/Benchmark/Performance/BarycentricMapping_topologycontainer.scn
+++ b/examples/Benchmark/Performance/BarycentricMapping_topologycontainer.scn
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<Node name="root" gravity="0 -10 0" dt="0.01">
+
+    <Node name="plugins">
+        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshOBJLoader] -->
+        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [LinearSolverConstraintCorrection] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Model"/> <!-- Needed to use components [FixedLagrangianConstraint] -->
+        <RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+        <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
+        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [BarycentricMapping] -->
+        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedronFEMForceField] -->
+        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetTopologyContainer] -->
+        <RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [SparseGridTopology] -->
+        <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [TriangleCollisionModel] -->
+        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
+    </Node>
+
+    <DefaultAnimationLoop computeBoundingBox="false" />
+    <MeshOBJLoader name="meshLoader" triangulate="true" filename="mesh/raptor_35kp.obj" />
+
+    <Node name="data">
+        <SparseGridTopology n="10 5 10" name="topology" fileTopology="@../meshLoader.filename" />
+        <MechanicalObject name="DOFs" template="Vec3" />
+    </Node>
+
+    <Node name="raptor">
+        <EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.2" />
+        <SparseLDLSolver template="CompressedRowSparseMatrixd"/>
+        <HexahedronSetTopologyContainer hexahedra="@../data/topology.hexahedra" />
+        <MechanicalObject name="DOFs" template="Vec3" position="@../data/DOFs.position"/>
+        <UniformMass totalMass="1.005"/>
+        <TetrahedronFEMForceField name="FEM" youngModulus="500" poissonRatio='0.3' />
+
+        <BoxROI name='ROI1' box='-5 -1 -3  5 1 3' drawBoxes='true'/>
+        <FixedProjectiveConstraint indices="@ROI1.indices" />
+
+        <Node name="Collision">
+            <MechanicalObject name="collisMecha" src="@../../meshLoader" />
+            <TriangleSetTopologyContainer src="@../../meshLoader" />
+            <TriangleCollisionModel />
+            <LineCollisionModel />
+            <PointCollisionModel />
+            <BarycentricMapping />
+        </Node>
+
+        <Node name="Visualization">
+            <OglModel name="VisualModel1" src="@../../meshLoader" useNormals="0" />
+            <TriangleSetTopologyContainer src="@../../meshLoader" />
+            <BarycentricMapping />
+        </Node>
+    </Node>
+
+</Node>


### PR DESCRIPTION
All the classes inheriting BarycentricMappingTopologyContainerMapper (EdgeSetTopologyContainer, etc) have to implement a method which returns a vector of barycentric coefficients.
And then it is used in various methods (apply(), etc) where a copy is done for *every element* , which means an alloc and dealloc everytime.
Obviously this causes a big performance loss.

This PR replace the creation of a vector with a fixed array, as we know in advance the size of the array (number of elements). So there would be no need of dynamic alloc/dealloc.
With this PR, the performance of Barycentric Mapping where the "input topology" is a TopologyContainer is closer to "static" topologies such as grids or MeshTopology.

This PR introduces also a scene to emphasize the performance of the BarycentricMapping.

Some numbers (with the raptor, the biggest OBJ file in the repo, 35k vertices, 70k triangles) with 5000 steps:
`topology container master: 5000 iterations done in 24.857 s ( 201.15 FPS)`
`topology container PR : 5000 iterations done in 13.1221 s ( 381.036 FPS)`
`sparsegrid: 5000 iterations done in 11.4556 s ( 436.467 FPS)`
`meshtopology: 5000 iterations done in 11.4605 s ( 436.28 FPS)`

And to illustrate even more the problem, I tried the same scene with the stanford buddha (315k vertices, 630k triangles)
`topology container master: 5000 iterations done in 172.78 s ( 28.9385 FPS)`
`topology container PR: 5000 iterations done in 67.423 s ( 74.1586 FPS)`
`sparsegrid: 5000 iterations done in 51.0929 s ( 97.8609 FPS)`

NOTE: 
 - no compat because I dont think people inherited this mapper thing
 - I changed the name because getBaryCoef did not sound serious to me 🫢

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
