### PR TITLE
[examples] Fix stability in RegularGridTopology.scn

### DIFF
--- a/examples/Component/Topology/Container/Grid/RegularGridTopology.scn
+++ b/examples/Component/Topology/Container/Grid/RegularGridTopology.scn
@@ -1,5 +1,5 @@
 <!-- RegularGrid examples -->
-<Node name="root" dt="0.02">
+<Node name="root" dt="0.002">
     <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
     <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [DiscreteIntersection] -->
     <RequiredPlugin name="Sofa.Component.Collision.Geometry"/> <!-- Needed to use components [SphereCollisionModel] -->
@@ -25,7 +25,7 @@
     <DefaultAnimationLoop/>
     
     <Node name="LiverFFD-lowres">
-        <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <EulerImplicitSolver  />
         <CGLinearSolver iterations="100" tolerance="1e-7" threshold="1e-7"/>
         <MechanicalObject />
         <UniformMass totalMass="100.0" />

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -84,6 +84,7 @@ Component/SolidMechanics/FEM/TriangularFEMForceFieldOptim.scn 100 1e-4 0 1
 Component/SolidMechanics/Spring/FastTriangularBendingSprings.scn 100 1e-4 0 1
 Component/SolidMechanics/Spring/MeshSpringForceField.scn 300 1e-4 0 1
 Component/Topology/Mapping/Mesh2PointTopologicalMapping.scn 100 1e-4 0 1
+Component/Topology/Container/Grid/RegularGridTopology.scn 10000 1e-4 0 1
 Component/Topology/Container/Grid/SparseGridTopology.scn 100 1e-4 0 1
 Component/Topology/Container/Grid/SparseGridRamificationTopology.scn 100 1e-4 0 1
 


### PR DESCRIPTION
The scene RegularGridTopology.scn became unstable since v17.12 (see commit : https://github.com/sofa-framework/sofa/commit/4889770fe900033aaaad1d305e51dec14e3a140f#diff-2816509667eddf8af975da31c0fd3995a996901b828702ee76ba5e2cb25c8016), it seems related to:
- a change of FF (spring to FEM)
- a change of max nb of iteration in CG

Therefore, I suggest in this PR to reach stability by just ensuring a small enough time step (and removing the Rayleigh damping)

[ci-depends-on https://github.com/sofa-framework/Regression/pull/84]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
