### PR TITLE
[Type] Mat: explicit instanciations and fix methods

### DIFF
--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SOURCE_FILES
     ${SOFATYPESRC_ROOT}/BoundingBox.cpp
     ${SOFATYPESRC_ROOT}/DualQuat.cpp
     ${SOFATYPESRC_ROOT}/Frame.cpp
+    ${SOFATYPESRC_ROOT}/Mat.cpp
     ${SOFATYPESRC_ROOT}/Material.cpp
     ${SOFATYPESRC_ROOT}/PrimitiveGroup.cpp
     ${SOFATYPESRC_ROOT}/Quat.cpp

--- a/Sofa/framework/Type/src/sofa/type/Mat.cpp
+++ b/Sofa/framework/Type/src/sofa/type/Mat.cpp
@@ -1,0 +1,45 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFA_TYPE_MAT_CPP
+
+#include <sofa/type/Mat.h>
+
+namespace sofa::type
+{
+
+template class SOFA_TYPE_API Mat<2,2,float>;
+template class SOFA_TYPE_API Mat<2,2,double>;
+
+template class SOFA_TYPE_API Mat<3,3,float>;
+template class SOFA_TYPE_API Mat<3,3,double>;
+
+template class SOFA_TYPE_API Mat<4,4,float>;
+template class SOFA_TYPE_API Mat<4,4,double>;
+
+template class SOFA_TYPE_API Mat<6,6,float>;
+template class SOFA_TYPE_API Mat<6,6,double>;
+
+template class SOFA_TYPE_API Mat<12,12,float>;
+template class SOFA_TYPE_API Mat<12,12,double>;
+
+
+} // namespace sofa::type

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -346,13 +346,13 @@ public:
     /// Cast into a standard C array of lines (read-only).
     constexpr const Line* lptr() const noexcept
     {
-        return this->elems;
+        return this->elems.data();
     }
 
     /// Cast into a standard C array of lines.
     constexpr Line* lptr() noexcept
     {
-        return this->elems;
+        return this->elems.data();
     }
 
     /// Cast into a standard C array of elements (stored per line) (read-only).
@@ -832,7 +832,7 @@ public:
     // direct access to data
     constexpr const real* data() const noexcept
     {
-        return elems.data();
+        return elems.data()->data();
     }
 
     constexpr typename ArrayLineType::iterator begin() noexcept
@@ -863,11 +863,11 @@ public:
     }
     constexpr reference back()
     {
-        return elems[N - 1];
+        return elems[L - 1];
     }
     constexpr const_reference back() const
     {
-        return elems[N - 1];
+        return elems[L - 1];
     }
 
 };
@@ -1384,5 +1384,24 @@ constexpr Mat<3,3,real> multTranspose(const Mat<3,3,real>& m1, const Mat<3,3,rea
 
     return r;
 }
+
+#if not defined(SOFA_TYPE_MAT_CPP)
+
+extern template class SOFA_TYPE_API Mat<2,2,float>;
+extern template class SOFA_TYPE_API Mat<2,2,double>;
+
+extern template class SOFA_TYPE_API Mat<3,3,float>;
+extern template class SOFA_TYPE_API Mat<3,3,double>;
+
+extern template class SOFA_TYPE_API Mat<4,4,float>;
+extern template class SOFA_TYPE_API Mat<4,4,double>;
+
+extern template class SOFA_TYPE_API Mat<6,6,float>;
+extern template class SOFA_TYPE_API Mat<6,6,double>;
+
+extern template class SOFA_TYPE_API Mat<12,12,float>;
+extern template class SOFA_TYPE_API Mat<12,12,double>;
+
+#endif
 
 } // namespace sofa::type


### PR DESCRIPTION
Like Vec, forcing instanciations in the cpp: the the good side-effect of (forcing) instanciations of Mat was that some methods were not actually compiling 🥴 and back() was wrong (crashing) so this PR fixes these.




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
