### PR TITLE
[GUI] Fix compilation with clang and boost 1.89

### DIFF
--- a/Sofa/GUI/Batch/src/sofa/gui/batch/BatchGUI.h
+++ b/Sofa/GUI/Batch/src/sofa/gui/batch/BatchGUI.h
@@ -23,6 +23,7 @@
 
 #include <sofa/gui/batch/config.h>
 #include <sofa/gui/common/BaseGUI.h>
+#include <sofa/simulation/Node.h>
 #include <sofa/simulation/fwd.h>
 #include <string>
 #include <sstream>

--- a/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <sofa/gui/common/config.h>
 
+#include <sofa/simulation/Node.h>
 #include <sofa/simulation/fwd.h>
 
 #include <vector>


### PR DESCRIPTION
Quite a random fix 🤔 
implementation of sptr<Node> to be included BEFORE the fwd declaration seems to be mandatory🤔 

Only happens with clang apparently (clang 20 and apple clang 17) and starting with boost 1.89
No problem with gcc



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
