### PR TITLE
[Framework] Fix compilation with clang20

### DIFF
--- a/Sofa/framework/Config/src/sofa/config.h.in
+++ b/Sofa/framework/Config/src/sofa/config.h.in
@@ -53,12 +53,12 @@ typedef double SReal;
 #endif
 
 /// User-defined literals allowing to convert any floating-point to a SReal
-constexpr SReal operator"" _sreal(long double real)
+constexpr SReal operator""_sreal(long double real)
 {
     return static_cast<SReal>(real);
 }
 /// User-defined literals allowing to convert any integer to a SReal
-constexpr SReal operator"" _sreal(unsigned long long int integer)
+constexpr SReal operator""_sreal(unsigned long long int integer)
 {
     return static_cast<SReal>(integer);
 }

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -28,6 +28,7 @@
 #include <sofa/type/Vec.h>
 
 #include <iostream>
+#include <algorithm>
 
 namespace // anonymous
 {


### PR DESCRIPTION
While trying to fix #5664 , stumbled on a compilation error with clang20 with a missing include for std::copy_n

\+ Removing an annoying nagging warning 
`warning: identifier '_sreal' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]`



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
