### PR TITLE
[GUI.Common] Fix invalid intrusive_ptr constructor call

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.h
+++ b/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.h
@@ -66,12 +66,12 @@ public:
     static std::vector<std::string> ListSupportedGUI();
     static std::string ListSupportedGUI(char separator);
     static void RegisterParameters(ArgumentParser* parser);
-    static int createGUI(sofa::simulation::NodeSPtr groot = nullptr, const char* filename = nullptr);
+    static int createGUI(sofa::simulation::NodeSPtr groot = sofa::simulation::NodeSPtr{}, const char* filename = nullptr);
     static void closeGUI();
 
     /// @name Static methods for direct access to GUI
     /// @{
-    static int MainLoop(sofa::simulation::NodeSPtr groot = nullptr, const char* filename = nullptr);
+    static int MainLoop(sofa::simulation::NodeSPtr groot = sofa::simulation::NodeSPtr{}, const char* filename = nullptr);
 
     static void Redraw();
 


### PR DESCRIPTION

An error has been raised by the nightly (conda-based) CI, since boost 1.89 and only occurs with Apple clang (https://github.com/sofa-framework/conda-ci/actions/runs/17087107155/job/48453215393#step:8:5099) and MSVC (https://github.com/sofa-framework/conda-ci/actions/runs/17087107155/job/48453215411#step:8:1672).

In `GUIManager` class, the methods `createGUI` and `MainLoop` expects a `boost::instrusive_ptr` type and a default parameter value of `nullptr` is given, but it seems that unlike `shared_ptr`-like types, `instrusive_ptr` does not have any constructor that take a `nullptr_t` (like `weak_ptr`), only one taking a raw pointer (unlike `weak_ptr`). So, I would have expect that `nullptr` could be casted as raw pointer, but for some reason, this is failing under these circomstances (boost == 1.89 and (Apple-clang or MSVC compiler) ).

Using `intrusive_ptr` defaut constructor solves the problem, but I don't know if this is satisfying enough as there are still things I don't get here about the circumstances of this error.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
