### PR TITLE
[all] Fix out-of-bounds warnings

### DIFF
--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.inl
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/NearestPointROI.inl
@@ -208,14 +208,17 @@ void NearestPointROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
     const VecCoord& x1 = this->mstate1->read(vecCoordId)->getValue();
     const VecCoord& x2 = this->mstate2->read(vecCoordId)->getValue();
     std::vector<sofa::type::Vec3> vertices;
+    vertices.reserve(indices1.size()*2);
     std::vector<sofa::type::RGBAColor> colors;
+    colors.reserve(indices1.size());
     const float nbrIds = static_cast<float>(indices1.size());
     for (unsigned int i = 0; i < indices1.size(); ++i)
     {
-        auto xId1 = x1[indices1[i]];
-        auto xId2 = x2[indices2[i]];
-        vertices.emplace_back(xId1[0], xId1[1], xId1[2]);
-        vertices.emplace_back(xId2[0], xId2[1], xId2[2]);
+        const auto v1 = type::toVec3(DataTypes::getCPos(x1[indices1[i]]));
+        const auto v2 = type::toVec3(DataTypes::getCPos(x2[indices2[i]]));
+
+        vertices.emplace_back(v1);
+        vertices.emplace_back(v2);
         const float col = static_cast<float>(i) / nbrIds;
         colors.emplace_back(col, 1.f, 0.5f, 1.f);
     }

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/RestShapeSpringsForceField.inl
@@ -413,7 +413,7 @@ void RestShapeSpringsForceField<DataTypes>::addForce(const MechanicalParams*  mp
             // to senting to 0 the rotation axis components along x, y
             // and/or z, depending on the rotations we want to take into
             // account.
-            for (sofa::Size entryId = spatial_dimensions; entryId < coord_total_size; ++entryId)
+            for (sofa::Size entryId = spatial_dimensions; entryId < Deriv::total_size; ++entryId)
             {
                 if (!activeDirections[entryId])
                     dir[entryId-spatial_dimensions] = 0;
@@ -472,7 +472,7 @@ void RestShapeSpringsForceField<DataTypes>::addDForce(const MechanicalParams* mp
             // to senting to 0 the rotation axis components along x, y
             // and/or z, depending on the rotations we want to take into
             // account.
-            for (sofa::Size entryId = spatial_dimensions; entryId < coord_total_size; ++entryId)
+            for (sofa::Size entryId = spatial_dimensions; entryId < Deriv::total_size; ++entryId)
             {
                 if (!activeDirections[entryId])
                     currentSpringRotationalDx[entryId-spatial_dimensions] = 0;

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.inl
@@ -1988,7 +1988,7 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeSegmentTriangulationInte
             sofa::type::vector<Real> tmp_baryCoefs;
 
             const typename DataTypes::Coord cG = computeTriangleCenter(ind_ta);
-            const sofa::type::Vec<3, Real> pG{ cG[0], cG[1], cG[2] };
+            const sofa::type::Vec<3, Real> pG = type::toVec3(cG);
 
             computeSegmentTriangleIntersectionInPlane(pG, ptB, current_triID, tmp_intersectedEdges, tmp_baryCoefs);
             if (tmp_intersectedEdges.size() != 1) // only one edge should be intersected to find the next edge in cut direction

--- a/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSubdividiers_test.cpp
+++ b/Sofa/Component/Topology/Container/Dynamic/tests/TriangleSubdividiers_test.cpp
@@ -240,7 +240,7 @@ bool TriangleSubdividers_test::testSubdivider_2Edge_baryCenter()
 
         // Add new points to the triangle and compute the subdivision
         std::shared_ptr<PointToAdd> newPoint_0 = std::make_shared<PointToAdd>(getUniqueId(ancestors0[0], ancestors0[1]), nbrP, ancestors0, coefs);
-        std::shared_ptr<PointToAdd> newPoint_1 = std::make_shared<PointToAdd>(getUniqueId(ancestors1[1], ancestors1[2]), nbrP+1, ancestors1, coefs);
+        std::shared_ptr<PointToAdd> newPoint_1 = std::make_shared<PointToAdd>(getUniqueId(ancestors1[0], ancestors1[1]), nbrP+1, ancestors1, coefs);
         subdivider0->addPoint(newPoint_0);
         subdivider0->addPoint(newPoint_1);
         subdivider0->subdivide(triToTest.triCoords);


### PR DESCRIPTION
Based on 
- #5675 
(for type::toVec3)

relevant commit https://github.com/sofa-framework/sofa/commit/ef6eb26518819bbcb916a70ae5e2b5d75f605226

As stated in #5675 , compilers can warn about out-of-bounds accesses, if it can know the size of the arrays beforehand.

This PR fixes those erroneous accesses (and more are actually fixed in #5675 and #5676 )

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
