### PR TITLE
[CImgPlugin] Fix configuration when cmake is reloaded without the fetched dir

### DIFF
--- a/applications/plugins/CImgPlugin/cmake/FindCImg.cmake
+++ b/applications/plugins/CImgPlugin/cmake/FindCImg.cmake
@@ -37,6 +37,13 @@ The following cache variables may also be set:
 
 cmake_minimum_required(VERSION 3.9)
 
+if(NOT "${CIMG_H_DIR}" STREQUAL "" AND NOT EXISTS "${CIMG_H_DIR}/CImg.h")
+    unset(CIMG_H_DIR CACHE)
+endif()
+if(NOT "${CIMG_PLUGINS_H_DIR}" STREQUAL "" AND NOT EXISTS "${CIMG_H_DIR}/plugins/skeleton.h")
+    unset(CIMG_PLUGINS_H_DIR CACHE)
+endif()
+
 find_path(CIMG_H_DIR
     NAMES CImg.h
     HINTS ${CMAKE_INSTALL_PREFIX} ${CIMG_DIR}


### PR DESCRIPTION
A "random" CMake configuration failure was happening on the CI. This actually wasn't as random as felt: it only happened after a rebuild, without forcing full build. 

This is because when a rebuild without force full build is done, the CMakeCache stays but CI scripts delete the directory `${BUILD_DIR}/external_directories` for some reason. This lead to internal cached data (namely `CIMG_H_DIR` and `CIMG_PLUGINS_H_DIR`) pointing to deleted paths.  

This is an expected behavior, find_path caching those variable for future reloading. But we were in a special case where those paths were getting deleted in between... 

Now if the variables are cached I verify that they are still holding files as expected otherwise I unset them, forcing find_path to actually find the paths. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
