### PR TITLE
[SofaCUDA] adding support for CUDA 13.0: remove deprecated API usage

### DIFF
--- a/applications/plugins/SofaCUDA/src/sofa/gpu/cuda/mycuda.cu
+++ b/applications/plugins/SofaCUDA/src/sofa/gpu/cuda/mycuda.cu
@@ -110,16 +110,26 @@ int mycudaInit(int device)
         cudaMemGetInfo(&free,&total);
 
 #if CUDA_VERSION >= 2010
+    #if CUDA_VERSION < 13000
         mycudaPrintf("CUDA:  %d : \"%s\", %d/%d MB, %d cores at %.3f GHz, revision %d.%d",i,dev.name, free/(1024*1024), dev.totalGlobalMem/(1024*1024), dev.multiProcessorCount*8, dev.clockRate * 1e-6f, dev.major, dev.minor);
         if (dev.kernelExecTimeoutEnabled)
-            mycudaPrintf(", timeout enabled", dev.kernelExecTimeoutEnabled);
+            mycudaPrintf(", timeout enabled");
         mycudaPrintf("\n");
+    #else
+        mycudaPrintf("CUDA:  %d : \"%s\", %d/%d MB, %d cores, revision %d.%d\n",i,dev.name, free/(1024*1024), dev.totalGlobalMem/(1024*1024), dev.multiProcessorCount*8, dev.major, dev.minor);
+    #endif
 #elif CUDA_VERSION >= 2000
+    #if CUDA_VERSION < 13000
         mycudaPrintf("CUDA:  %d : \"%s\", %d/%d MB, %d cores at %.3f GHz, revision %d.%d\n",i,dev.name, free/(1024*1024), dev.totalGlobalMem/(1024*1024), dev.multiProcessorCount*8, dev.clockRate * 1e-6f, dev.major, dev.minor);
+    #else
+        mycudaPrintf("CUDA:  %d : \"%s\", %d/%d MB, %d cores, revision %d.%d\n",i,dev.name, free/(1024*1024), dev.totalGlobalMem/(1024*1024), dev.multiProcessorCount*8, dev.major, dev.minor);
+    #endif
 #else //if CUDA_VERSION >= 1000
+    #if CUDA_VERSION < 13000
         mycudaPrintf("CUDA:  %d : \"%s\", %d/%d MB, cores at %.3f GHz, revision %d.%d\n",i,dev.name, free/(1024*1024), dev.totalGlobalMem/(1024*1024), dev.clockRate * 1e-6f, dev.major, dev.minor);
-//#else
-//		mycudaPrintf("CUDA:  %d : \"%s\", %d/%d MB, revision %d.%d\n",i,(dev.name==NULL?"":dev.name), free/(1024*1024), dev.bytes/(1024*1024), dev.major, dev.minor);
+    #else
+        mycudaPrintf("CUDA:  %d : \"%s\", %d/%d MB, cores, revision %d.%d\n",i,dev.name, free/(1024*1024), dev.totalGlobalMem/(1024*1024), dev.major, dev.minor);
+    #endif
 #endif
     }
     if (device==-1)


### PR DESCRIPTION
This PR updates the codebase to support CUDA 13.0 by removing deprecated API calls:

clockRate was deprecated in CUDA 10.0 and removed in CUDA 13.0

kernelExecTimeoutEnabled was also deprecated and removed in CUDA 13.0

I added conditional checks based on the CUDA version to ensure compatibility

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
