### PR TITLE
[GUI.Common] Fix crash when selecting a MechanicalObject<Rigid>

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/BaseViewer.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/BaseViewer.cpp
@@ -287,7 +287,7 @@ void BaseViewer::drawSelection(sofa::core::visual::VisualParams* vparams)
         return;
 
     drawTool->setPolygonMode(0, false);
-    float screenHeight = vparams->viewport()[4];
+    float screenHeight = vparams->viewport()[3];
 
     for(auto current : currentSelection)
     {


### PR DESCRIPTION
Typical out-of-bounds access.
I think this was not detected quickly because screenHeight is only used when doing stuff with rigids.
But it was easily detected in debug .... 

Note that it is totally not detected at compile-time 🤔 whereas a C-style array would have thrown a warning (with clang at least)
But it can be detected with AdressSanitizer (` -fsanitize=address`)

https://godbolt.org/z/W6dPnGaqq



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
