### PR TITLE
[Lagrangian.Correction] remove debug statement inside loop to improve performances

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.inl
@@ -401,8 +401,6 @@ void LinearSolverConstraintCorrection<DataTypes>::applyContactForce(const linear
         x[i] = x_free[i] + dxi;
         v[i] = v_free[i] + dvi;
         dx[i] = dxi;
-
-        msg_info() << "dx[" << i << "] = " << dx[i] ;
     }
 
     dataDx.endEdit();


### PR DESCRIPTION
`msg_info` is called inside a loop. At each iteration, `f_printLog.getValue()` is called. It may be time consuming. One possibility would be to extract the value of `f_printLog` before the loop, but I chose to remove it.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
