### PR TITLE
[Defaulttype] RigidDeriv: fix out-of-bounds access in ctor with Vec6

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidDeriv.h
@@ -79,7 +79,7 @@ public:
 
     template<typename real2>
     constexpr RigidDeriv(const type::Vec<6, real2>& v)
-        : vCenter(type::Vec<3, real2>(v[0], v[1], v[2])), vOrientation(type::Vec<3, real2>(v[4], v[5], v[6]))
+        : vCenter(type::Vec<3, real2>(v[0], v[1], v[2])), vOrientation(type::Vec<3, real2>(v[3], v[4], v[5]))
     {}
 
     template<typename real2>


### PR DESCRIPTION
Bug introduced in 
- #5675 

Reported by @EulalieCoevoet 
Apparently this case is not tested through the CI (either unit test or scene tests)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
