### PR TITLE
[SolidMechanics] Replace dynamic `vector` with static `std::array`

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/TetrahedronHyperelasticityFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/TetrahedronHyperelasticityFEMForceField.inl
@@ -411,8 +411,7 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::updateTangentMatrix()
             Matrix3  M, N;
             MatrixSym outputTensor;
             N.clear();
-            type::vector<MatrixSym> inputTensor;
-            inputTensor.resize(3);
+            std::array<MatrixSym,3> inputTensor;
             //	MatrixSym input1,input2,input3,outputTensor;
             for (int m = 0; m < 3; m++)
             {


### PR DESCRIPTION
Replace dynamic `vector` with static `std::array` for `MatrixSym` in TetrahedronHyperelasticityFEMForceField. It makes no sense to have dynamic vector here. The size is fixed and known at compile-time.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
