### PR TITLE
[Visual] VisualGrid: do not update bbox

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualGrid.cpp
@@ -80,15 +80,6 @@ void VisualGrid::updateGrid()
     }
 
     buildGrid();
-
-    //bounding box for the camera
-    auto s = d_size.getValue() * 0.5f;
-    sofa::type::Vec3 min(-s, -s, -s);
-    sofa::type::Vec3 max( s,  s,  s);
-    const auto& plane = d_plane.getValue();
-    min[static_cast<unsigned int>(plane)] = -s * 0.2f;
-    max[static_cast<unsigned int>(plane)] =  s * 0.2f;
-    f_bbox.setValue(sofa::type::BoundingBox(min,max));
 }
 
 


### PR DESCRIPTION
**Problem**

We use the `VisualGrid` to understand and visualize the scene distance unit and to quickly measure distances when analyzing a simulation. For aesthetic purposes, our grids are set to be n times larger than the scene bounding box.
Currently, the `VisualGrid` component contributes to the scene bounding box, which I would argue should not be the case in general.

**In this PR**

Removes the bbox update. 
If you prefer, I can add a boolean to choose whether to update the bbox.

**Screenshot**

<img width="3840" height="2231" alt="image" src="https://github.com/user-attachments/assets/9db438ab-cabd-4a83-b092-c5cb0a62f6ca" />





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
