### PR TITLE
[SofaCUDA] Link CUDA::cublas to SofaCUDA target

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -397,8 +397,8 @@ if(SofaValidation_FOUND)
 endif()
 
 if(SOFACUDA_CUBLAS)
-    cuda_add_cublas_to_target(${PROJECT_NAME})
-    target_link_libraries(${PROJECT_NAME} ${CUDA_SPARSE_LIBRARY})
+    target_link_libraries(${PROJECT_NAME} ${CUDA_SPARSE_LIBRARY} CUDA::cublas)
+
 endif()
 if(SOFACUDA_CUDPP)
     target_link_libraries(${PROJECT_NAME} cudpp)

--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -397,7 +397,7 @@ if(SofaValidation_FOUND)
 endif()
 
 if(SOFACUDA_CUBLAS)
-    target_link_libraries(${PROJECT_NAME} ${CUDA_SPARSE_LIBRARY} CUDA::cublas)
+    target_link_libraries(${PROJECT_NAME} ${CUDA_cusparse_LIBRARY} CUDA::cublas)
 
 endif()
 if(SOFACUDA_CUDPP)


### PR DESCRIPTION
Linking cuBLAS using modern CMake targets instead of deprecated cuda_add_cublas_to_target






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
