### PR TITLE
[Collision.Geometry] Rename TriangleOctreeModel to TriangleOctreeCollisionModel

### DIFF
--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeModel.h
@@ -33,14 +33,15 @@
 namespace sofa::component::collision::geometry
 {
 
-class SOFA_COMPONENT_COLLISION_GEOMETRY_API TriangleOctreeModel : public  TriangleCollisionModel<sofa::defaulttype::Vec3Types>, public helper::TriangleOctreeRoot
+class SOFA_COMPONENT_COLLISION_GEOMETRY_API TriangleOctreeCollisionModel : public  TriangleCollisionModel<sofa::defaulttype::Vec3Types>, public helper::TriangleOctreeRoot
 {
 public:
-    SOFA_CLASS(TriangleOctreeModel, TriangleCollisionModel<sofa::defaulttype::Vec3Types>);
+    SOFA_CLASS(TriangleOctreeCollisionModel, TriangleCollisionModel<sofa::defaulttype::Vec3Types>);
 protected:
-    TriangleOctreeModel();
+    TriangleOctreeCollisionModel();
     void drawCollisionModel(const core::visual::VisualParams* vparams) override;
 public:
+    Data<bool> d_drawOctree;  ///< draw the octree
 
     /// the normals for each point
     type::vector<type::Vec3> pNorms;
@@ -49,5 +50,9 @@ public:
     /// init the octree creation
     void buildOctree ();
 };
+
+
+using TriangleOctreeModel SOFA_ATTRIBUTE_DEPRECATED__RENAMED_TRIANGLEOCTREEMODEL() = TriangleOctreeCollisionModel;
+
 
 } // namespace sofa::component::collision::geometry

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/config.h.in
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/config.h.in
@@ -44,5 +44,5 @@ namespace sofa::component::collision::geometry
 #define SOFA_ATTRIBUTE_DEPRECATED__RENAMED_TRIANGLEOCTREEMODEL() \
     SOFA_ATTRIBUTE_DEPRECATED( \
         "v25.12", "v26.06", \
-        "TriangleOctreeModel has been renamed to TriangleOctreeCollisionModel in PRXXXX")
+        "TriangleOctreeModel has been renamed to TriangleOctreeCollisionModel in PR5766")
 #endif

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/config.h.in
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/config.h.in
@@ -36,3 +36,13 @@ namespace sofa::component::collision::geometry
 	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
 	constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
 } // namespace sofa::component::collision::geometry
+
+
+#ifdef SOFA_BUILD_SOFA_COMPONENT_COLLISION_GEOMETRY
+#define SOFA_ATTRIBUTE_DEPRECATED__RENAMED_TRIANGLEOCTREEMODEL()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__RENAMED_TRIANGLEOCTREEMODEL() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v25.12", "v26.06", \
+        "TriangleOctreeModel has been renamed to TriangleOctreeCollisionModel in PRXXXX")
+#endif

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -765,7 +765,8 @@ std::map< std::string, Renamed, std::less<> > renamedComponents = {
     {"StiffSpringForceField", Renamed("v24.06","v25.06","SpringForceField")},
     {"ParallelStiffSpringForceField", Renamed("v24.06","v25.06","ParallelSpringForceField")},
     {"ShewchukPCGLinearSolver", Renamed("v24.12","v25.12","PCGLinearSolver")},
-    {"OglCylinderModel", Renamed("v24.12", "v25.06", "CylinderVisualModel")}
+    {"OglCylinderModel", Renamed("v24.12", "v25.06", "CylinderVisualModel")},
+    {"TriangleOctreeModel", Renamed("v25.12", "v26.06", "TriangleOctreeCollisionModel") }
 };
 
 


### PR DESCRIPTION
(with deprecations layer, etc) to be consistent with the other *CollisionModel

and add a Data to optionally display the octree





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
