### PR TITLE
[Type] Full support of Mat1x1

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.cpp
+++ b/Sofa/framework/Type/src/sofa/type/Mat.cpp
@@ -26,6 +26,9 @@
 namespace sofa::type
 {
 
+template class SOFA_TYPE_API Mat<1,1,float>;
+template class SOFA_TYPE_API Mat<1,1,double>;
+
 template class SOFA_TYPE_API Mat<2,2,float>;
 template class SOFA_TYPE_API Mat<2,2,double>;
 

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -1403,6 +1403,9 @@ constexpr Mat<3,3,real> multTranspose(const Mat<3,3,real>& m1, const Mat<3,3,rea
 
 #if not defined(SOFA_TYPE_MAT_CPP)
 
+extern template class SOFA_TYPE_API Mat<1,1,float>;
+extern template class SOFA_TYPE_API Mat<1,1,double>;
+
 extern template class SOFA_TYPE_API Mat<2,2,float>;
 extern template class SOFA_TYPE_API Mat<2,2,double>;
 

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -813,6 +813,7 @@ public:
     }
 
     /// Multiplication operator Matrix * Vector considering the matrix as a transformation.
+    template<sofa::Size NbColumn = C, typename = std::enable_if_t<(C > 1)>>
     constexpr Vec<C-1,real> transform(const Vec<C-1,real>& v) const noexcept
     {
         Vec<C-1,real> r(NOINIT);

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -813,7 +813,7 @@ public:
     }
 
     /// Multiplication operator Matrix * Vector considering the matrix as a transformation.
-    template<sofa::Size NbColumn = C, typename = std::enable_if_t<(C > 1)>>
+    template<sofa::Size NbColumn = C, typename = std::enable_if_t<(NbColumn > 1)>>
     constexpr Vec<C-1,real> transform(const Vec<C-1,real>& v) const noexcept
     {
         Vec<C-1,real> r(NOINIT);


### PR DESCRIPTION
- Add explicit template instantiations for Mat1x1
- Fix `transform` method by adding a constraint on the column size


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
