### PR TITLE
[Core] Start renaming BaseObject to BaseComponent

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
@@ -29,7 +29,6 @@ using std::string;
 using sofa::core::execparams::defaultInstance;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/component/collision/detection/algorithm/CollisionPipeline.h>
 using sofa::component::collision::detection::algorithm::CollisionPipeline ;
@@ -111,7 +110,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithNoAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 
@@ -133,7 +132,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingIntersection()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseComponent* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 
@@ -155,7 +154,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingBroadPhase()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseComponent* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 void TestCollisionPipeline::checkCollisionPipelineWithMissingNarrowPhase()
@@ -176,7 +175,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingNarrowPhase()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseComponent* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 void TestCollisionPipeline::checkCollisionPipelineWithMissingContactManager()
@@ -197,7 +196,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingContactManager()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseComponent* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 
 }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
@@ -150,7 +150,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     sofa::core::topology::BaseMeshTopology* getCollisionTopology() override

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
@@ -116,7 +116,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
@@ -134,7 +134,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     template<class T>

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
@@ -207,7 +207,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;

--- a/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
+++ b/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
@@ -30,7 +30,6 @@ using std::vector;
 using std::string;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include<sofa/simulation/Node.h>
 using sofa::simulation::Node ;
@@ -434,7 +433,7 @@ void checkAttributes()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
+    sofa::core::objectmodel::BaseComponent* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
     EXPECT_NE(theSphere, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -462,7 +461,7 @@ void checkSceneWithVec3MechanicalModel()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
+    sofa::core::objectmodel::BaseComponent* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
     EXPECT_NE(theSphere, nullptr) ;
 }
 
@@ -481,7 +480,7 @@ void checkSceneWithRigid3dMechanicalModel()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
+    sofa::core::objectmodel::BaseComponent* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
     EXPECT_NE(theSphere, nullptr) ;
 }
 

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactListener.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactListener.h
@@ -104,7 +104,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     template<class T>

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/BoxROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/BoxROI.h
@@ -43,8 +43,7 @@ namespace sofa::component::engine::select::boxroi
     using core::topology::BaseMeshTopology ;
     using core::behavior::MechanicalState ;
     using core::objectmodel::BaseContext ;
-    using core::objectmodel::BaseObject ;
-    using core::visual::VisualParams ;
+        using core::visual::VisualParams ;
     using core::objectmodel::Event ;
     using core::ExecParams ;
     using core::DataEngine ;

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PairBoxRoi.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PairBoxRoi.h
@@ -84,7 +84,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.h
@@ -88,7 +88,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.h
@@ -82,7 +82,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 public:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.h
@@ -89,7 +89,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.h
@@ -86,7 +86,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
@@ -42,7 +42,6 @@ using sofa::simulation::Simulation;
 using sofa::simulation::graph::DAGSimulation;
 #include <sofa/simulation/Node.h>
 using sofa::simulation::Node;
-using sofa::core::objectmodel::BaseObject;
 using sofa::core::objectmodel::BaseData;
 using sofa::core::objectmodel::New;
 using sofa::defaulttype::Vec3Types;
@@ -133,7 +132,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
         EXPECT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
-        BaseObject* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
+        sofa::core::objectmodel::BaseComponent* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
         EXPECT_NE(boxroi, nullptr);
 
         EXPECT_EQ(boxroi->getComponentState(), ComponentState::Invalid ) << "The component cannot be initialized because it is missing a MechanicalObject. "
@@ -202,7 +201,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
         const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.c_str());
         EXPECT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
-        BaseObject* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
+        sofa::core::objectmodel::BaseComponent* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
 
         EXPECT_NE(boxroi, nullptr);
         EXPECT_EQ(boxroi->getComponentState(), ComponentState::Valid ) << "The component should succeed in being initialized because there is a MeshLoader and a TopologyContainer in the current context. ";

--- a/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.h
+++ b/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.h
@@ -104,7 +104,7 @@ public:
             return false;
         }
 
-        return core::objectmodel::BaseObject::canCreate(obj, context, arg);
+        return core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Override method to lock or unlock the force feedback computation. According to parameter, value == true (resp. false) will lock (resp. unlock) mutex @sa lockForce

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BaseVTKReader.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BaseVTKReader.h
@@ -36,7 +36,6 @@ namespace sofa::component::io::mesh::basevtkreader
 /// So that you can access to BaseVTKReader with
 /// sofa::component::loader::BaseVTKReader or sofa::component::loader::basevtkreader::BaseVTKReader
 
-using sofa::core::objectmodel::BaseObject ;
 using sofa::core::objectmodel::BaseData ;
 
 using std::ofstream ;
@@ -49,10 +48,10 @@ enum class VTKDatasetFormat { IMAGE_DATA, STRUCTURED_POINTS,
                               POLYDATA, UNSTRUCTURED_GRID
                             };
 
-class BaseVTKReader : public BaseObject
+class BaseVTKReader : public sofa::core::objectmodel::BaseObject
 {
 public:
-    class BaseVTKDataIO : public BaseObject
+    class BaseVTKDataIO : public sofa::core::objectmodel::BaseObject
     {
     public:
         string name;

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
@@ -105,7 +105,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 };
 

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshVTKLoader.cpp
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/MeshVTKLoader.cpp
@@ -51,7 +51,6 @@ using namespace sofa::defaulttype;
 using namespace sofa::helper;
 using sofa::core::objectmodel::ComponentState;
 using sofa::core::objectmodel::BaseData ;
-using sofa::core::objectmodel::BaseObject ;
 using sofa::type::Vec3 ;
 using sofa::type::Vec ;
 using std::istringstream;

--- a/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/MeshExporter_test.cpp
@@ -31,7 +31,6 @@ using std::string;
 using sofa::testing::BaseSimulationTest;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 using sofa::simulation::graph::DAGSimulation ;

--- a/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/STLExporter_test.cpp
@@ -29,7 +29,6 @@ using std::string;
 using sofa::testing::BaseSimulationTest;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 using sofa::simulation::graph::DAGSimulation ;

--- a/Sofa/Component/IO/Mesh/tests/VisualModelOBJExporter_test.cpp
+++ b/Sofa/Component/IO/Mesh/tests/VisualModelOBJExporter_test.cpp
@@ -29,7 +29,6 @@ using std::string;
 using sofa::testing::BaseSimulationTest;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 using sofa::simulation::graph::DAGSimulation ;

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
@@ -141,7 +141,7 @@ public:
             arg->logError(std::string("No mechanical state with the datatype '") + TDataTypes::Name() + "' found in the context node.");
             return false;
         }
-        return sofa::core::objectmodel::BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected :

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapper.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/BarycentricMappers/BarycentricMapper.h
@@ -60,10 +60,10 @@ public:
 
 public:
 
-    using BaseObject::init;
+    using BaseComponent::init;
     virtual void init(const typename Out::VecCoord& out, const typename In::VecCoord& in) = 0;
 
-    using BaseObject::draw;
+    using BaseComponent::draw;
     virtual void draw(const core::visual::VisualParams*, const typename Out::VecCoord& out, const typename In::VecCoord& in) = 0;
 
     virtual void apply( typename Out::VecCoord& out, const typename In::VecCoord& in ) = 0;

--- a/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
+++ b/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
@@ -62,7 +62,6 @@ using namespace sofa::defaulttype;
 using namespace sofa::component::topology::container::dynamic;
 
 using sofa::core::objectmodel::New;
-using sofa::core::objectmodel::BaseObject;
 using sofa::component::mass::DiagonalMass;
 using sofa::component::statecontainer::MechanicalObject;
 
@@ -115,7 +114,7 @@ public:
             sofa::simulation::node::unload(root);
     }
 
-    void createSceneGraph(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms)
+    void createSceneGraph(VecCoord positions, sofa::core::objectmodel::BaseComponent::SPtr topologyContainer, sofa::core::objectmodel::BaseComponent::SPtr geometryAlgorithms)
     {
         node = root->createChild("node");
         mstate = New<MechanicalObject<DataTypes> >();
@@ -143,7 +142,7 @@ public:
             EXPECT_NEAR(expectedMass[i], mass->d_vertexMass.getValue()[i], 1e-4);
     }
 
-    void runTest(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms,
+    void runTest(VecCoord positions, sofa::core::objectmodel::BaseComponent::SPtr topologyContainer, sofa::core::objectmodel::BaseComponent::SPtr geometryAlgorithms,
                  MassType expectedTotalMass, const VecMass& expectedMass)
     {
         createSceneGraph(positions, topologyContainer, geometryAlgorithms);

--- a/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
+++ b/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
@@ -65,7 +65,6 @@ using namespace sofa::defaulttype;
 using namespace sofa::component::topology::container::dynamic;
 
 using sofa::core::objectmodel::New;
-using sofa::core::objectmodel::BaseObject;
 using sofa::component::mass::MeshMatrixMass;
 using sofa::component::statecontainer::MechanicalObject;
 
@@ -118,7 +117,7 @@ public:
             sofa::simulation::node::unload(root);
     }
 
-    void createSceneGraph(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms)
+    void createSceneGraph(VecCoord positions, sofa::core::objectmodel::BaseComponent::SPtr topologyContainer, sofa::core::objectmodel::BaseComponent::SPtr geometryAlgorithms)
     {
         node = root->createChild("node");
         mstate = New<MechanicalObject<DataTypes> >();
@@ -161,7 +160,7 @@ public:
         }
     }
 
-    void runTest(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms,
+    void runTest(VecCoord positions, sofa::core::objectmodel::BaseComponent::SPtr topologyContainer, sofa::core::objectmodel::BaseComponent::SPtr geometryAlgorithms,
                  MassType expectedTotalMass, MassType expectedMassDensity, const VecMass& expectedVMass, const VecMass& expectedEMass)
     {
         createSceneGraph(positions, topologyContainer, geometryAlgorithms);

--- a/Sofa/Component/MechanicalLoad/tests/PlaneForceField_test.cpp
+++ b/Sofa/Component/MechanicalLoad/tests/PlaneForceField_test.cpp
@@ -27,7 +27,6 @@ using sofa::testing::BaseSimulationTest;
 using sofa::simulation::Simulation ;
 using sofa::simulation::graph::DAGSimulation ;
 using sofa::simulation::Node ;
-using sofa::core::objectmodel::BaseObject ;
 using sofa::core::objectmodel::BaseData ;
 using sofa::core::objectmodel::New ;
 using sofa::core::execparams::defaultInstance; 

--- a/Sofa/Component/Playback/src/sofa/component/playback/CompareState.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/CompareState.h
@@ -57,7 +57,7 @@ public:
             arg->logError("No mechanical state found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Return the total errors (position and velocity)

--- a/Sofa/Component/Playback/src/sofa/component/playback/CompareTopology.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/CompareTopology.h
@@ -57,7 +57,7 @@ public:
             arg->logError("Cannot find a mesh topology in the current context");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Return the total number of errors

--- a/Sofa/Component/Playback/src/sofa/component/playback/ReadState.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/ReadState.h
@@ -91,7 +91,7 @@ public:
             arg->logError("No mechanical state found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 

--- a/Sofa/Component/Playback/src/sofa/component/playback/ReadTopology.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/ReadTopology.h
@@ -90,7 +90,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 

--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteState.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteState.h
@@ -103,7 +103,7 @@ public:
             arg->logError("No mechanical state found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 };

--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteTopology.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteTopology.h
@@ -93,7 +93,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
 };

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.h
@@ -24,17 +24,16 @@
 #include <sofa/component/sceneutility/config.h>
 
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 
 namespace sofa::component::sceneutility::_apiversion_
 {
 
-class SOFA_COMPONENT_SCENEUTILITY_API APIVersion : public BaseObject
+class SOFA_COMPONENT_SCENEUTILITY_API APIVersion : public sofa::core::objectmodel::BaseObject
 {
 
 public:
-    SOFA_CLASS(APIVersion, BaseObject);
+    SOFA_CLASS(APIVersion, sofa::core::objectmodel::BaseObject);
 
     const std::string& getApiLevel() ;
     void init() override ;

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.h
@@ -32,14 +32,13 @@ namespace sofa::component::sceneutility::infocomponent
 /// fearing it will leak names into the global namespace. When closing this namespace
 /// selected object from this per-file namespace are then imported into their parent namespace.
 /// for ease of use
-using sofa::core::objectmodel::BaseObject ;
 
 /// Despite this component does absolutely nothing... it is very useful as it can be used to
 /// retain information scene graph.
-class SOFA_COMPONENT_SCENEUTILITY_API InfoComponent : public BaseObject
+class SOFA_COMPONENT_SCENEUTILITY_API InfoComponent : public sofa::core::objectmodel::BaseComponent
 {
 public:
-    SOFA_CLASS(InfoComponent, BaseObject);
+    SOFA_CLASS(InfoComponent, sofa::core::objectmodel::BaseComponent);
 
     InfoComponent() {}
     ~InfoComponent() override{}

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.cpp
@@ -65,7 +65,7 @@ MessageHandlerComponent::MessageHandlerComponent() :
 
 void MessageHandlerComponent::parse ( core::objectmodel::BaseObjectDescription* arg )
 {
-    BaseObject::parse(arg) ;
+    BaseComponent::parse(arg) ;
 
     const char* type=arg->getAttribute("handler") ;
     if(type==nullptr){
@@ -123,7 +123,7 @@ FileMessageHandlerComponent::~FileMessageHandlerComponent()
 
 void FileMessageHandlerComponent::parse ( core::objectmodel::BaseObjectDescription* arg )
 {
-    BaseObject::parse(arg) ;
+    BaseComponent::parse(arg) ;
 
     const char* type=arg->getAttribute("filename") ;
     if(type==nullptr){

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/PauseAnimation.cpp
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/PauseAnimation.cpp
@@ -37,7 +37,7 @@ PauseAnimation::~PauseAnimation()
 
 void PauseAnimation::init()
 {
-    BaseObject::init();
+    BaseComponent::init();
     const simulation::Node *context = dynamic_cast<simulation::Node *>(this->getContext());
     root = dynamic_cast<simulation::Node *>(context->getRootContext());
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -21,17 +21,19 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h>
-#include <sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl>
-#include <sofa/core/behavior/ForceField.inl>
-#include <sofa/core/behavior/MultiMatrixAccessor.h>
-#include <sofa/linearalgebra/RotationMatrix.h>
-#include <sofa/core/visual/VisualParams.h>
 #include <sofa/component/topology/container/grid/GridTopology.h>
+#include <sofa/core/behavior/BaseLocalForceFieldMatrix.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/helper/decompose.h>
 #include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <sofa/linearalgebra/RotationMatrix.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
-#include <sofa/core/behavior/BaseLocalForceFieldMatrix.h>
+
+#include <sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl>
+#include <sofa/core/behavior/ForceField.inl>
 
 namespace sofa::component::solidmechanics::fem::elastic
 {
@@ -293,6 +295,7 @@ void TetrahedronFEMForceField<DataTypes>::computeMaterialStiffness(Index i, Inde
 template<class DataTypes>
 inline void TetrahedronFEMForceField<DataTypes>::computeForce( Displacement &F, const Displacement &Depl, VoigtTensor &plasticStrain, const MaterialStiffness &K, const StrainDisplacement &J )
 {
+    SCOPED_TIMER_TR("computeForce");
 
     // Unit of K = unit of youngModulus / unit of volume = Pa / m^3 = kg m^-4 s^-2
     // Unit of J = m^2

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -21,19 +21,17 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h>
-#include <sofa/component/topology/container/grid/GridTopology.h>
-#include <sofa/core/behavior/BaseLocalForceFieldMatrix.h>
-#include <sofa/core/behavior/MultiMatrixAccessor.h>
-#include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/ScopedAdvancedTimer.h>
-#include <sofa/helper/decompose.h>
-#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
-#include <sofa/linearalgebra/RotationMatrix.h>
-#include <sofa/simulation/AnimateBeginEvent.h>
-#include <sofa/simulation/AnimateEndEvent.h>
-
 #include <sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.inl>
 #include <sofa/core/behavior/ForceField.inl>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
+#include <sofa/linearalgebra/RotationMatrix.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/component/topology/container/grid/GridTopology.h>
+#include <sofa/helper/decompose.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <sofa/simulation/AnimateBeginEvent.h>
+#include <sofa/simulation/AnimateEndEvent.h>
+#include <sofa/core/behavior/BaseLocalForceFieldMatrix.h>
 
 namespace sofa::component::solidmechanics::fem::elastic
 {
@@ -295,7 +293,6 @@ void TetrahedronFEMForceField<DataTypes>::computeMaterialStiffness(Index i, Inde
 template<class DataTypes>
 inline void TetrahedronFEMForceField<DataTypes>::computeForce( Displacement &F, const Displacement &Depl, VoigtTensor &plasticStrain, const MaterialStiffness &K, const StrainDisplacement &J )
 {
-    SCOPED_TIMER_TR("computeForce");
 
     // Unit of K = unit of youngModulus / unit of volume = Pa / m^3 = kg m^-4 s^-2
     // Unit of J = m^2

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/BaseMaterial.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/BaseMaterial.h
@@ -42,7 +42,7 @@ public:
 
     void init() override
     {
-        this->core::objectmodel::BaseObject::init();
+        this->core::objectmodel::BaseComponent::init();
     }
 
 

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.h
@@ -101,7 +101,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     /** \brief Called by the state change callback to initialize added

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.h
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/GridTopology.h
@@ -158,7 +158,7 @@ public:
     /// get Z from Point index @param i, will call @sa getPoint
     SReal getPZ(Index i) const override { return getPoint(i)[2]; }
 
-    /// Overload method from \sa BaseObject::parse . /// Parse the given description to assign values to this object's fields and potentially other parameters
+    /// Overload method from \sa BaseComponent::parse . /// Parse the given description to assign values to this object's fields and potentially other parameters
     void parse(core::objectmodel::BaseObjectDescription* arg) override ;
 
     /// Overload Method from @sa MeshTopology::getNbHexahedra

--- a/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.h
+++ b/Sofa/Component/Topology/Container/Grid/src/sofa/component/topology/container/grid/RegularGridTopology.h
@@ -59,7 +59,7 @@ public:
     /// BaseObject method should be overwritten by children
     void reinit() override;
 
-    /// Overload method from \sa BaseObject::parse . /// Parse the given description to assign values to this object's fields and potentially other parameters
+    /// Overload method from \sa BaseComponent::parse . /// Parse the given description to assign values to this object's fields and potentially other parameters
     void parse(core::objectmodel::BaseObjectDescription* arg) override;
 
     /** \brief Overload method of @sa GridTopology::getPointInGrid.

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologicalChangeProcessor.h
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologicalChangeProcessor.h
@@ -127,7 +127,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     void draw(const core::visual::VisualParams* vparams) override;

--- a/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
+++ b/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
@@ -29,7 +29,6 @@ using std::string;
 using sofa::testing::BaseTest;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 using sofa::simulation::Simulation ;
@@ -76,7 +75,7 @@ public:
         root->init(sofa::core::execparams::defaultInstance()) ;
 
 
-        BaseObject* lm = root->getObject("label1") ;
+        sofa::core::objectmodel::BaseComponent* lm = root->getObject("label1") ;
         ASSERT_NE(nullptr, lm) ;
 
         OglLabel* ogllabel = dynamic_cast<OglLabel*>(lm);
@@ -106,7 +105,7 @@ public:
         ASSERT_NE(nullptr, root.get()) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
-        BaseObject* lm = root->getObject("label1") ;
+        sofa::core::objectmodel::BaseComponent* lm = root->getObject("label1") ;
         ASSERT_NE(nullptr, lm) ;
 
         OglLabel* ogllabel = dynamic_cast<OglLabel*>(lm);
@@ -133,7 +132,7 @@ public:
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
-        BaseObject* lm = root->getObject("label1") ;
+        sofa::core::objectmodel::BaseComponent* lm = root->getObject("label1") ;
         ASSERT_NE(lm, nullptr) ;
 
         /// List of the supported attributes the user expect to find

--- a/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
+++ b/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
@@ -29,7 +29,6 @@ using std::string;
 using sofa::testing::BaseTest;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 using sofa::simulation::Simulation ;
@@ -89,7 +88,7 @@ void TestClipPlane::checkClipPlaneValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
     ASSERT_NE(clp, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -121,7 +120,7 @@ void TestClipPlane::checkClipPlaneAttributesValues(const std::string& dataname, 
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
     ASSERT_NE(clp, nullptr) ;
 
     sofa::simulation::node::unload(root);

--- a/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
@@ -29,7 +29,6 @@ using std::string;
 using sofa::testing::BaseTest;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 using sofa::simulation::graph::DAGSimulation ;
@@ -77,7 +76,7 @@ void checkAttributes()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     EXPECT_NE(lm, nullptr) ;
 
     /// List of the supported attributes the user expect to find

--- a/Sofa/GL/Component/Shader/tests/Light_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/Light_test.cpp
@@ -8,7 +8,6 @@ using std::string;
 using sofa::testing::BaseTest;
 
 #include<sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/simulation/graph/DAGSimulation.h>
 using sofa::simulation::graph::DAGSimulation ;
@@ -18,7 +17,7 @@ using sofa::simulation::Node ;
 
 #include <sofa/simulation/common/SceneLoaderXML.h>
 using sofa::simulation::SceneLoaderXML ;
-using sofa::core::execparams::defaultInstance; 
+using sofa::core::execparams::defaultInstance;
 
 #include <sofa/helper/BackTrace.h>
 using sofa::helper::BackTrace ;
@@ -80,7 +79,7 @@ void TestLight::checkLightMissingLightManager(const std::string& lighttype)
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseComponent* lm = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(lm, nullptr) ;
 
     sofa::simulation::node::unload(root);
@@ -105,10 +104,10 @@ void TestLight::checkPositionalLightValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseComponent* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     ASSERT_NE(lm, nullptr) ;
 
-    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseComponent* light = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(light, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -146,10 +145,10 @@ void TestLight::checkDirectionalLightValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseComponent* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     ASSERT_NE(lm, nullptr) ;
 
-    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseComponent* light = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(light, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -187,10 +186,10 @@ void TestLight::checkSpotLightValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseComponent* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     ASSERT_NE(lm, nullptr) ;
 
-    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseComponent* light = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(light, nullptr) ;
 
     /// List of the supported attributes the user expect to find

--- a/Sofa/framework/Core/simutest/objectmodel/BaseLink_simutest.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/BaseLink_simutest.cpp
@@ -30,7 +30,6 @@ using sofa::testing::BaseSimulationTest ;
 using sofa::simulation::Node ;
 
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject;
 
 #include <sofa/core/PathResolver.h>
 using sofa::core::PathResolver;

--- a/Sofa/framework/Core/simutest/objectmodel/Base_test.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/Base_test.cpp
@@ -28,7 +28,6 @@ using sofa::testing::BaseSimulationTest ;
 using sofa::simulation::Node ;
 
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject;
 
 #include <sofa/defaulttype/RigidTypes.h>
 using sofa::defaulttype::Rigid3Types;
@@ -38,17 +37,17 @@ using sofa::defaulttype::Vec3Types;
 
 namespace customns
 {
-class CustomBaseObject : public BaseObject
+class CustomBaseObject : public sofa::core::objectmodel::BaseComponent
 {
 public:
-    SOFA_CLASS(CustomBaseObject, BaseObject);
+    SOFA_CLASS(CustomBaseObject, sofa::core::objectmodel::BaseComponent);
 };
 
 template<class D>
-class CustomBaseObjectT : public BaseObject
+class CustomBaseObjectT : public sofa::core::objectmodel::BaseComponent
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(CustomBaseObjectT, D), BaseObject);
+    SOFA_CLASS(SOFA_TEMPLATE(CustomBaseObjectT, D), sofa::core::objectmodel::BaseComponent);
 
     static const std::string GetCustomClassName() { return "MyFakeClassName"; }
 };

--- a/Sofa/framework/Core/simutest/objectmodel/PathResolver_simutest.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/PathResolver_simutest.cpp
@@ -28,7 +28,6 @@ using sofa::testing::BaseSimulationTest ;
 using sofa::simulation::Node ;
 
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject;
 
 #include <sofa/core/PathResolver.h>
 using sofa::core::PathResolver;
@@ -84,13 +83,13 @@ TEST_P(PathResolverToBaseObject, CheckPathToBaseObject)
     auto& t = GetParam();
     if(t[2]=="true")
     {
-        ASSERT_TRUE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_TRUE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseComponent::GetClass(), t[0])) << t[1] << " " << t[2];
     }
     else
     {
-        ASSERT_FALSE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_FALSE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseComponent::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseComponent::GetClass(), t[0])) << t[1] << " " << t[2];
     }
 }
 
@@ -111,13 +110,13 @@ TEST_F(PathResolverToBaseObject, DISABLED_CheckPathToBaseObject_tofix)
 
     if (t[2] == "true")
     {
-        ASSERT_TRUE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_TRUE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseComponent::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseComponent::GetClass(), t[0])) << t[1] << " " << t[2];
     }
     else
     {
-        ASSERT_FALSE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_FALSE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseComponent::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseComponent::GetClass(), t[0])) << t[1] << " " << t[2];
     }
 }
 

--- a/Sofa/framework/Core/src/sofa/core/Mapping.h
+++ b/Sofa/framework/Core/src/sofa/core/Mapping.h
@@ -222,7 +222,7 @@ public:
             return false;
         }
 
-        if (dynamic_cast<BaseObject*>(stin) == dynamic_cast<BaseObject*>(stout))
+        if (dynamic_cast<BaseComponent*>(stin) == dynamic_cast<BaseComponent*>(stout))
         {
             // we should refuse to create mappings with the same input and output model, which may happen if a State object is missing in the child node
             arg->logError("Both the input and the output point to the same mechanical state ('"+stin->getName()+"').");

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.h
@@ -150,7 +150,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     void setMState(MechanicalState<DataTypes> *_mstate)

--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
@@ -223,7 +223,7 @@ public:
                 }
             }
 
-            return BaseObject::canCreate(obj, context, arg);
+            return BaseComponent::canCreate(obj, context, arg);
         }
         return false;
     }

--- a/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.h
@@ -115,7 +115,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     virtual type::vector<std::string> getBaseConstraintIdentifiers() override final

--- a/Sofa/framework/Core/src/sofa/core/behavior/ProjectiveConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ProjectiveConstraintSet.h
@@ -153,7 +153,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 };
 

--- a/Sofa/framework/Core/src/sofa/core/fwd.h
+++ b/Sofa/framework/Core/src/sofa/core/fwd.h
@@ -72,7 +72,8 @@ SOFA_CORE_API SReal dt(const sofa::core::MechanicalParams*);
 namespace sofa::core::objectmodel
 {
 class Base;
-class BaseObject;
+class BaseComponent;
+using BaseObject = BaseComponent;
 class BaseNode;
 class BaseContext;
 class BaseData;
@@ -263,7 +264,7 @@ SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::core::BaseMapping);
 SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::core::BehaviorModel);
 SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::core::CollisionModel);
 
-SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::core::objectmodel::BaseObject);
+SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::core::objectmodel::BaseComponent);
 SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::core::objectmodel::ContextObject);
 SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::core::objectmodel::ConfigurationSetting);
 

--- a/Sofa/framework/Core/src/sofa/core/fwd.h
+++ b/Sofa/framework/Core/src/sofa/core/fwd.h
@@ -73,7 +73,6 @@ namespace sofa::core::objectmodel
 {
 class Base;
 class BaseComponent;
-using BaseObject = BaseComponent;
 class BaseNode;
 class BaseContext;
 class BaseData;

--- a/Sofa/framework/Core/src/sofa/core/loader/BaseLoader.cpp
+++ b/Sofa/framework/Core/src/sofa/core/loader/BaseLoader.cpp
@@ -39,7 +39,7 @@ BaseLoader::~BaseLoader()
 
 void BaseLoader::parse(sofa::core::objectmodel::BaseObjectDescription *arg)
 {
-    objectmodel::BaseObject::parse(arg);
+    objectmodel::BaseComponent::parse(arg);
 
     bool success = false;
     if (canLoad())

--- a/Sofa/framework/Core/src/sofa/core/loader/MeshLoader.cpp
+++ b/Sofa/framework/Core/src/sofa/core/loader/MeshLoader.cpp
@@ -183,7 +183,7 @@ void MeshLoader::clearBuffers()
 
 void MeshLoader::parse(sofa::core::objectmodel::BaseObjectDescription* arg)
 {
-    objectmodel::BaseObject::parse(arg);
+    objectmodel::BaseComponent::parse(arg);
 
     if (arg->getAttribute("scale"))
     {

--- a/Sofa/framework/Core/src/sofa/core/loader/SceneLoader.cpp
+++ b/Sofa/framework/Core/src/sofa/core/loader/SceneLoader.cpp
@@ -34,7 +34,7 @@ SceneLoader::SceneLoader() : BaseLoader()
 
 void SceneLoader::parse(sofa::core::objectmodel::BaseObjectDescription* arg)
 {
-    objectmodel::BaseObject::parse(arg);
+    objectmodel::BaseComponent::parse(arg);
 
     if (canLoad())
         load(/*d_filename.getFullPath().c_str()*/);

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h
@@ -410,7 +410,7 @@ public:
     SOFA_BASE_CAST_DEFINITION( core,        CollisionModel                         )
     SOFA_BASE_CAST_DEFINITION( core,        DataEngine                             )
     SOFA_BASE_CAST_DEFINITION( objectmodel, BaseContext                            )
-    SOFA_BASE_CAST_DEFINITION( objectmodel, BaseObject                             )
+    SOFA_BASE_CAST_DEFINITION( objectmodel, BaseComponent                          )
     SOFA_BASE_CAST_DEFINITION( objectmodel, BaseNode                               )
     SOFA_BASE_CAST_DEFINITION( objectmodel, ContextObject                          )
     SOFA_BASE_CAST_DEFINITION( objectmodel, ConfigurationSetting                   )

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h
@@ -188,9 +188,9 @@ public:
     /// Returns a list of object of type passed as a parameter. There should be no
     /// Copy constructor because of Return Value Optimization.
     /// eg:
-    ///    for(BaseObject* o : context->getObjects() ){ ... }
+    ///    for(BaseComponent* o : context->getObjects() ){ ... }
     ///    for(VisualModel* o : context->getObjects<VisualModel>() ){ ... }
-    template<class Object=sofa::core::objectmodel::BaseObject>
+    template<class Object=sofa::core::objectmodel::BaseComponent>
     std::vector<Object*> getObjects(SearchDirection dir = SearchUp){
         std::vector<Object*> o;
         getObjects(o, dir) ;
@@ -338,11 +338,11 @@ public:
     /// @{
 
     /// Mechanical Degrees-of-Freedom
-    virtual void setMechanicalState( BaseObject* )
+    virtual void setMechanicalState( BaseComponent* )
     { }
 
     /// Topology
-    virtual void setTopology( BaseObject* )
+    virtual void setTopology( BaseComponent* )
     { }
 
     /// @}
@@ -362,13 +362,13 @@ public:
     /// @{
 
     /// Add an object, or return false if not supported
-    virtual bool addObject( sptr<BaseObject> /*obj*/, TypeOfInsertion = TypeOfInsertion::AtEnd)
+    virtual bool addObject( sptr<BaseComponent> /*obj*/, TypeOfInsertion = TypeOfInsertion::AtEnd)
     {
         return false;
     }
 
     /// Remove an object, or return false if not supported
-    virtual bool removeObject( sptr<BaseObject> /*obj*/ )
+    virtual bool removeObject( sptr<BaseComponent> /*obj*/ )
     {
         return false;
     }
@@ -393,9 +393,9 @@ public:
     /// @name Notifications for graph change listeners
     /// @{
 
-    virtual void notifyAddSlave(core::objectmodel::BaseObject* master, core::objectmodel::BaseObject* slave);
-    virtual void notifyRemoveSlave(core::objectmodel::BaseObject* master, core::objectmodel::BaseObject* slave);
-    virtual void notifyMoveSlave(core::objectmodel::BaseObject* previousMaster, core::objectmodel::BaseObject* master, core::objectmodel::BaseObject* slave);
+    virtual void notifyAddSlave(core::objectmodel::BaseComponent* master, core::objectmodel::BaseComponent* slave);
+    virtual void notifyRemoveSlave(core::objectmodel::BaseComponent* master, core::objectmodel::BaseComponent* slave);
+    virtual void notifyMoveSlave(core::objectmodel::BaseComponent* previousMaster, core::objectmodel::BaseComponent* master, core::objectmodel::BaseComponent* slave);
 
     /// @}
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
@@ -209,8 +209,8 @@ std::string BaseLink::CreateString(const std::string& path, const std::string& d
 std::string BaseLink::CreateStringPath(Base* dest, Base* from)
 {
     if (!dest || dest == from) return std::string("[]");
-    BaseObject* o = dest->toBaseObject();
-    BaseObject* f = from->toBaseObject();
+    BaseObject* o = dest->toBaseComponent();
+    BaseObject* f = from->toBaseComponent();
     const BaseContext* ctx = from->toBaseContext();
     if (!ctx && f) ctx = f->getContext();
     if (o)

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.cpp
@@ -32,7 +32,7 @@
 namespace sofa::core::objectmodel
 {
 
-BaseObject::BaseObject()
+BaseComponent::BaseComponent()
     : Base()
     , f_listening(initData( &f_listening, false, "listening", "if true, handle the events, otherwise ignore the events"))
     , l_context(initLink("context","Graph Node containing this object (or BaseContext::getDefault() if no graph is used)"))
@@ -48,7 +48,7 @@ BaseObject::BaseObject()
     f_listening.setAutoLink(false);
 }
 
-BaseObject::~BaseObject()
+BaseComponent::~BaseComponent()
 {
     assert(l_master.get() == nullptr); // an object that is still a slave should not be able to be deleted, as at least one smart pointer points to it
     for(auto& slave : l_slaves)
@@ -62,7 +62,7 @@ BaseObject::~BaseObject()
 
 // This method insures that context is never nullptr (using BaseContext::getDefault() instead)
 // and that all slaves of an object share its context
-void BaseObject::changeContextLink(BaseContext* before, BaseContext*& after)
+void BaseComponent::changeContextLink(BaseContext* before, BaseContext*& after)
 {
     if (!after) after = BaseContext::getDefault();
     if (before == after) return;
@@ -81,14 +81,14 @@ void BaseObject::changeContextLink(BaseContext* before, BaseContext*& after)
 }
 
 /// This method insures that slaves objects have master and context links set correctly
-void BaseObject::changeSlavesLink(BaseObject::SPtr ptr, std::size_t /*index*/, bool add)
+void BaseComponent::changeSlavesLink(BaseComponent::SPtr ptr, std::size_t /*index*/, bool add)
 {
     if (!ptr) return;
     if (add) { ptr->l_master.set(this); ptr->l_context.set(getContext()); }
     else     { ptr->l_master.reset(); ptr->l_context.reset(); }
 }
 
-void BaseObject::parse( BaseObjectDescription* arg )
+void BaseComponent::parse( BaseObjectDescription* arg )
 {
     if (arg->getAttribute("src"))
     {
@@ -117,13 +117,13 @@ void BaseObject::parse( BaseObjectDescription* arg )
     Base::parse(arg);
 }
 
-void BaseObject::setSrc(const std::string &valueString, std::vector< std::string > *attributeList)
+void BaseComponent::setSrc(const std::string &valueString, std::vector< std::string > *attributeList)
 {
     std::size_t posAt = valueString.rfind('@');
     if (posAt == std::string::npos) posAt = 0;
 
     const std::string objectName = valueString.substr(posAt + 1);
-    const BaseObject* loader = getContext()->get<BaseObject>(objectName);
+    const BaseComponent* loader = getContext()->get<BaseComponent>(objectName);
     if (!loader)
     {
         msg_error() << "Source object \"" << valueString << "\" NOT FOUND.";
@@ -132,9 +132,9 @@ void BaseObject::setSrc(const std::string &valueString, std::vector< std::string
     setSrc(valueString, loader, attributeList);
 }
 
-void BaseObject::setSrc(const std::string &valueString, const BaseObject *loader, std::vector< std::string > *attributeList)
+void BaseComponent::setSrc(const std::string &valueString, const BaseComponent *loader, std::vector< std::string > *attributeList)
 {
-    BaseObject::MapData dataLoaderMap = loader->m_aliasData;
+    BaseComponent::MapData dataLoaderMap = loader->m_aliasData;
 
     if (attributeList != nullptr)
     {
@@ -175,7 +175,7 @@ void BaseObject::setSrc(const std::string &valueString, const BaseObject *loader
     }
 }
 
-Base* BaseObject::findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link)
+Base* BaseComponent::findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link)
 {
     if (this->getContext() == BaseContext::getDefault())
         return nullptr;
@@ -184,32 +184,32 @@ Base* BaseObject::findLinkDestClass(const BaseClass* destType, const std::string
 }
 
 
-const BaseContext* BaseObject::getContext() const
+const BaseContext* BaseComponent::getContext() const
 {
     return l_context.get();
 }
 
-BaseContext* BaseObject::getContext()
+BaseContext* BaseComponent::getContext()
 {
     return l_context.get();
 }
 
-const BaseObject* BaseObject::getMaster() const
+const BaseComponent* BaseComponent::getMaster() const
 {
     return l_master.get();
 }
 
-BaseObject* BaseObject::getMaster()
+BaseComponent* BaseComponent::getMaster()
 {
     return l_master.get();
 }
 
-const BaseObject::VecSlaves& BaseObject::getSlaves() const
+const BaseComponent::VecSlaves& BaseComponent::getSlaves() const
 {
     return l_slaves.getValue();
 }
 
-BaseObject* BaseObject::getSlave(const std::string& name) const
+BaseComponent* BaseComponent::getSlave(const std::string& name) const
 {
     for (auto slave : l_slaves)
     {
@@ -219,9 +219,9 @@ BaseObject* BaseObject::getSlave(const std::string& name) const
     return nullptr;
 }
 
-void BaseObject::addSlave(BaseObject::SPtr s)
+void BaseComponent::addSlave(BaseComponent::SPtr s)
 {
-    const BaseObject::SPtr previous = s->getMaster();
+    const BaseComponent::SPtr previous = s->getMaster();
     if (previous == this) return;
     if (previous)
         previous->l_slaves.remove(s);
@@ -232,7 +232,7 @@ void BaseObject::addSlave(BaseObject::SPtr s)
         this->getContext()->notifyAddSlave(this, s.get());
 }
 
-void BaseObject::removeSlave(BaseObject::SPtr s)
+void BaseComponent::removeSlave(BaseComponent::SPtr s)
 {
     if (l_slaves.remove(s))
     {
@@ -240,7 +240,7 @@ void BaseObject::removeSlave(BaseObject::SPtr s)
     }
 }
 
-void BaseObject::init()
+void BaseComponent::init()
 {
     for(const auto data: this->m_vecData)
     {
@@ -258,15 +258,15 @@ void BaseObject::init()
     }
 }
 
-void BaseObject::bwdInit()
+void BaseComponent::bwdInit()
 {
 }
 
-void BaseObject::reinit()
+void BaseComponent::reinit()
 {
 }
 
-void BaseObject::updateInternal()
+void BaseComponent::updateInternal()
 {
     const auto& mapTrackedData = m_internalDataTracker.getMapTrackedData();
     for( auto const& it : mapTrackedData )
@@ -281,17 +281,17 @@ void BaseObject::updateInternal()
     }
 }
 
-void BaseObject::trackInternalData(const objectmodel::BaseData& data)
+void BaseComponent::trackInternalData(const objectmodel::BaseData& data)
 {
     m_internalDataTracker.trackData(data);
 }
 
-void BaseObject::cleanTracker()
+void BaseComponent::cleanTracker()
 {
     m_internalDataTracker.clean();
 }
 
-bool BaseObject::hasDataChanged(const objectmodel::BaseData& data)
+bool BaseComponent::hasDataChanged(const objectmodel::BaseData& data)
 {
     bool dataFoundinTracker = false;
     const auto& mapTrackedData = m_internalDataTracker.getMapTrackedData();
@@ -314,22 +314,22 @@ bool BaseObject::hasDataChanged(const objectmodel::BaseData& data)
     return m_internalDataTracker.hasChanged(data);
 }
 
-void BaseObject::doUpdateInternal()
+void BaseComponent::doUpdateInternal()
 { }
 
-void BaseObject::storeResetState()
+void BaseComponent::storeResetState()
 { }
 
-void BaseObject::reset()
+void BaseComponent::reset()
 { }
 
-void BaseObject::cleanup()
+void BaseComponent::cleanup()
 { }
 
-void BaseObject::handleEvent( Event* /*e*/ )
+void BaseComponent::handleEvent( Event* /*e*/ )
 { }
 
-void BaseObject::handleTopologyChange(core::topology::Topology* t)
+void BaseComponent::handleTopologyChange(core::topology::Topology* t)
 {
     if (t == this->getContext()->getTopology())
     {
@@ -337,12 +337,12 @@ void BaseObject::handleTopologyChange(core::topology::Topology* t)
     }
 }
 
-SReal BaseObject::getTime() const
+SReal BaseComponent::getTime() const
 {
     return getContext()->getTime();
 }
 
-std::string BaseObject::getPathName() const
+std::string BaseComponent::getPathName() const
 {
     auto node = dynamic_cast<const BaseNode*>(getContext());
     if(!node)

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
@@ -236,5 +236,7 @@ public:
     virtual bool removeInNode( BaseNode* /*node*/ ) { return false; }
 };
 
+using BaseObject = BaseComponent;
+
 } // namespace sofa::core::objectmodel
 

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObject.h
@@ -37,16 +37,16 @@ namespace sofa::core::objectmodel
  *  It is able to process events, if listening enabled (default is false).
  *
  */
-class SOFA_CORE_API BaseObject : public virtual Base
+class SOFA_CORE_API BaseComponent : public virtual Base
 {
 public:
-    SOFA_CLASS(BaseObject, Base);
-    SOFA_BASE_CAST_IMPLEMENTATION(BaseObject)
+    SOFA_CLASS(BaseComponent, Base);
+    SOFA_BASE_CAST_IMPLEMENTATION(BaseComponent)
 
 protected:
-    BaseObject();
+    BaseComponent();
 
-    ~BaseObject() override;
+    ~BaseComponent() override;
 
 public:
 
@@ -126,21 +126,21 @@ public:
 
     BaseContext* getContext();
 
-    const BaseObject* getMaster() const;
+    const BaseComponent* getMaster() const;
 
-    BaseObject* getMaster();
+    BaseComponent* getMaster();
 
 
-    typedef sofa::core::objectmodel::MultiLink<BaseObject, BaseObject, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK> LinkSlaves;
+    typedef sofa::core::objectmodel::MultiLink<BaseComponent, BaseComponent, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK> LinkSlaves;
     typedef LinkSlaves::Container VecSlaves;
 
     const VecSlaves& getSlaves() const;
 
-    BaseObject* getSlave(const std::string& name) const;
+    BaseComponent* getSlave(const std::string& name) const;
 
-    virtual void addSlave(BaseObject::SPtr s);
+    virtual void addSlave(BaseComponent::SPtr s);
 
-    virtual void removeSlave(BaseObject::SPtr s);
+    virtual void removeSlave(BaseComponent::SPtr s);
     /// @}
 
     /// @name data access
@@ -180,7 +180,7 @@ public:
 
     /// Sets a source Object and parses it to collect dependent Data
     /// Use it before scene graph insertion
-    void setSrc(const std::string &v, const BaseObject *loader, std::vector< std::string > *attributeList=nullptr);
+    void setSrc(const std::string &v, const BaseComponent *loader, std::vector< std::string > *attributeList=nullptr);
 
     Base* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link) override;
 
@@ -205,9 +205,9 @@ protected:
     ///@}
     ///
 
-    SingleLink<BaseObject, BaseContext, BaseLink::FLAG_DOUBLELINK> l_context;
+    SingleLink<BaseComponent, BaseContext, BaseLink::FLAG_DOUBLELINK> l_context;
     LinkSlaves l_slaves;
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_DOUBLELINK> l_master;
+    SingleLink<BaseComponent, BaseComponent, BaseLink::FLAG_DOUBLELINK> l_master;
 
     /// Implementation of the internal update
     virtual void doUpdateInternal();
@@ -217,7 +217,7 @@ protected:
     void changeContextLink(BaseContext* before, BaseContext*& after);
 
     /// This method insures that slaves objects have master and context links set correctly
-    void changeSlavesLink(BaseObject::SPtr ptr, std::size_t /*index*/, bool add);
+    void changeSlavesLink(BaseComponent::SPtr ptr, std::size_t /*index*/, bool add);
 
     /// BaseNode can set the context of its own objects
     friend class BaseNode;

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
@@ -145,14 +145,14 @@ public:
             return false;
         }
 
-        if (dynamic_cast<BaseObject*>(stin) == dynamic_cast<BaseObject*>(stout))
+        if (dynamic_cast<BaseComponent*>(stin) == dynamic_cast<BaseComponent*>(stout))
         {
             // we should refuse to create mappings with the same input and output model, which may happen if a State object is missing in the child node
             arg->logError("Both the input mesh and the output mesh points to the same mesh topology ('"+stin->getName()+"').");
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Construction method called by ObjectFactory.

--- a/Sofa/framework/Core/test/ObjectFactoryJson_test.cpp
+++ b/Sofa/framework/Core/test/ObjectFactoryJson_test.cpp
@@ -50,10 +50,10 @@ TEST(ObjectFactoryJson, oneObject)
 }
 
 template<class T>
-class DummyComponent : public core::objectmodel::BaseObject
+class DummyComponent : public core::objectmodel::BaseComponent
 {
 public:
-    SOFA_CLASS(DummyComponent<T>, BaseObject);
+    SOFA_CLASS(DummyComponent<T>, core::objectmodel::BaseComponent);
 };
 
 TEST(ObjectFactoryJson, oneTemplatedObject)

--- a/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 using sofa::core::objectmodel::Base ;
 
 #include <sofa/helper/NameDecoder.h>
@@ -34,10 +33,10 @@ using sofa::testing::BaseTest ;
 namespace sofa{
 namespace another_namespace{
 
-class EmptyObject : public BaseObject
+class EmptyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(EmptyObject, BaseObject) ;
+    SOFA_CLASS(EmptyObject, sofa::core::objectmodel::BaseObject) ;
 };
 
 }
@@ -46,10 +45,10 @@ public:
 namespace sofa{
 namespace numbered_namespace_123{
 
-class NumberedClass123 : public BaseObject
+class NumberedClass123 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(NumberedClass123, BaseObject) ;
+    SOFA_CLASS(NumberedClass123, sofa::core::objectmodel::BaseObject) ;
 };
 
 class NumberedClass456 : public another_namespace::EmptyObject
@@ -58,10 +57,10 @@ public:
     SOFA_CLASS(NumberedClass456, another_namespace::EmptyObject) ;
 };
 
-class CustomName123 : public BaseObject
+class CustomName123 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(CustomName123, BaseObject) ;
+    SOFA_CLASS(CustomName123, sofa::core::objectmodel::BaseObject) ;
 
     static const std::string GetCustomClassName(){ return "ClassWithACustomName"; }
     static const std::string GetCustomTemplateName(){ return "ClassWithACustomTemplate"; }
@@ -70,10 +69,10 @@ public:
     static const std::string className(){ return "TEST TEST"; }
 };
 
-class CustomNameOldWay : public BaseObject
+class CustomNameOldWay : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(CustomNameOldWay, BaseObject) ;
+    SOFA_CLASS(CustomNameOldWay, sofa::core::objectmodel::BaseObject) ;
 
     static const std::string className(const CustomNameOldWay* =nullptr){ return "ClassWithACustomNameOldWay"; }
 
@@ -93,46 +92,46 @@ class DataTwo { public: static std::string Name(){ return "Two" ;} };
 class NotAType {};
 
 template<class DataType1>
-class DefaultTemplate1 : public BaseObject
+class DefaultTemplate1 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(DefaultTemplate1, DataType1), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE(DefaultTemplate1, DataType1), sofa::core::objectmodel::BaseObject) ;
 };
 
 template<class DataType1, class DataType2>
-class DefaultTemplate2 : public BaseObject
+class DefaultTemplate2 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE2(DefaultTemplate2, DataType1, DataType2), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE2(DefaultTemplate2, DataType1, DataType2), sofa::core::objectmodel::BaseObject) ;
 };
 
 template<class DataType1, class DataType2, class NotAType>
-class DefaultTemplate3 : public BaseObject
+class DefaultTemplate3 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE3(DefaultTemplate3, DataType1, DataType2, NotAType), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE3(DefaultTemplate3, DataType1, DataType2, NotAType), sofa::core::objectmodel::BaseObject) ;
 };
 
 template<class DataType1, class DataType2, class NotAType>
-class NotDefaultTemplate : public BaseObject
+class NotDefaultTemplate : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE3(NotDefaultTemplate, DataType1, DataType2, NotAType), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE3(NotDefaultTemplate, DataType1, DataType2, NotAType), sofa::core::objectmodel::BaseObject) ;
 
     static const std::string GetCustomTemplateName(){ return "non,oui"; }
 };
 
 template<class TDataType1>
-class OuterClass : public BaseObject
+class OuterClass : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(OuterClass, TDataType1), BaseObject);
+    SOFA_CLASS(SOFA_TEMPLATE(OuterClass, TDataType1), sofa::core::objectmodel::BaseObject);
 
     template<class TDataType2>
-    class InnerClass : public BaseObject
+    class InnerClass : public sofa::core::objectmodel::BaseObject
     {
     public:
-        SOFA_CLASS(SOFA_TEMPLATE(InnerClass, TDataType2), BaseObject);
+        SOFA_CLASS(SOFA_TEMPLATE(InnerClass, TDataType2), sofa::core::objectmodel::BaseObject);
     };
 };
 

--- a/Sofa/framework/Core/test/objectmodel/BaseData_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseData_test.cpp
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/testing/BaseTest.h>
 using sofa::testing::BaseTest;
@@ -50,10 +49,10 @@ public:
     void doEndEditVoidPtr() override { }
 };
 
-class MyObject : public BaseObject
+class MyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(MyObject, BaseObject);
+    SOFA_CLASS(MyObject, sofa::core::objectmodel::BaseObject);
     MyData myData;
     MyObject() :
         myData()

--- a/Sofa/framework/Core/test/objectmodel/BaseLink_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseLink_test.cpp
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/core/objectmodel/BaseNode.h>
 using sofa::core::objectmodel::BaseNode ;
@@ -38,14 +37,14 @@ using sofa::testing::BaseTest ;
 #include "BaseLink_test.h"
 
 using SingleLinkImplementations = ::testing::Types<
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_STOREPATH>,
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK>>;
+    SingleLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_STOREPATH>,
+    SingleLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_MULTILINK>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(SingleLink, BaseLinkTests, SingleLinkImplementations);
 
 
 using MultiLinkImplementations = ::testing::Types<
-    MultiLink<BaseObject, BaseObject, BaseLink::FLAG_STOREPATH>,
-    MultiLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK>
+    MultiLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_STOREPATH>,
+    MultiLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_MULTILINK>
     >;
 INSTANTIATE_TYPED_TEST_SUITE_P(MultiLink, BaseLinkTests, MultiLinkImplementations);
 

--- a/Sofa/framework/Core/test/objectmodel/BaseLink_test.h
+++ b/Sofa/framework/Core/test/objectmodel/BaseLink_test.h
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/core/objectmodel/BaseNode.h>
 using sofa::core::objectmodel::BaseNode ;
@@ -33,13 +32,13 @@ using sofa::testing::BaseTest ;
 
 /***********************************************************************************
  * This is checking that the predicates about BaseLink are still valid in an
- * inhertited type
+ * inherited type
  ***********************************************************************************/
 template<class Link>
-class FakeObject : public BaseObject
+class FakeObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    FakeObject() : BaseObject()
+    FakeObject() : sofa::core::objectmodel::BaseObject()
     {       
     }
 };

--- a/Sofa/framework/Core/test/objectmodel/MultiLink_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/MultiLink_test.cpp
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 #include <sofa/core/objectmodel/BaseNode.h>
 using sofa::core::objectmodel::BaseNode ;
 

--- a/Sofa/framework/Core/test/objectmodel/RemovedData_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/RemovedData_test.cpp
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 
 #include <sofa/testing/BaseTest.h>
 using sofa::testing::BaseTest;
@@ -32,10 +31,10 @@ using sofa::core::objectmodel::lifecycle::RemovedData;
 namespace
 {
 
-class MyObject : public BaseObject
+class MyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(MyObject, BaseObject);
+    SOFA_CLASS(MyObject, sofa::core::objectmodel::BaseObject);
 
     DeprecatedData deprecatedData {this, "v23.06", "v23.12", "deprecatedData", "You should now use XXXX"};
     RemovedData removedData {this, "v23.06", "v23.12", "removedData", "You should now use XXXX"};

--- a/Sofa/framework/Core/test/objectmodel/SingleLink_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/SingleLink_test.cpp
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 #include <sofa/core/objectmodel/BaseNode.h>
 using sofa::core::objectmodel::BaseNode ;
 
@@ -33,24 +32,24 @@ using sofa::testing::BaseTest ;
 
 #include "BaseLink_test.h"
 
-class EmptyObject : public BaseObject
+class EmptyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(EmptyObject, BaseObject) ;
+    SOFA_CLASS(EmptyObject, sofa::core::objectmodel::BaseObject) ;
 };
 
 class SingleLink_test: public BaseTest
 {
 public:
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH > m_link ;
-    BaseObject::SPtr m_dst ;
-    BaseObject::SPtr m_src ;
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH > m_link ;
+    sofa::core::objectmodel::BaseObject::SPtr m_dst ;
+    sofa::core::objectmodel::BaseObject::SPtr m_src ;
 
     /// Create a link to an object.
     void doSetUp() override
     {
-        m_dst = sofa::core::objectmodel::New<BaseObject>() ;
-        m_src = sofa::core::objectmodel::New<BaseObject>() ;
+        m_dst = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>() ;
+        m_src = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>() ;
 
         m_dst->setName("destination") ;
         m_src->setName("source") ;
@@ -87,14 +86,14 @@ TEST_F(SingleLink_test, checkCounterLogic )
 
 TEST_F(SingleLink_test, checkMultiLink )
 {
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK > smlink ;
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_MULTILINK > smlink ;
     ASSERT_EQ(smlink.size(), size_t(0)) ;
     smlink.add(m_dst.get()) ;
     ASSERT_EQ(smlink.size(), size_t(1)) ;
     smlink.add(m_dst.get()) ;
     ASSERT_EQ(smlink.size(), size_t(1)) ;
 
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > slink ;
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > slink ;
     ASSERT_EQ(slink.size(), size_t(0)) ;
     slink.add(m_dst.get()) ;
     ASSERT_EQ(slink.size(), size_t(1)) ;
@@ -104,10 +103,10 @@ TEST_F(SingleLink_test, checkMultiLink )
 
 TEST_F(SingleLink_test, getOwnerBase)
 {
-    const auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
+    const auto aBaseObject = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
     using sofa::core::objectmodel::BaseNode;
-    const BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
-    const SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
+    const BaseLink::InitLink<sofa::core::objectmodel::BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
+    const SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
     ASSERT_EQ(objectLink.getOwnerBase(), aBaseObject.get());
     // m_link is initialized without an owner.
     // getOwnerBase() should still work and return a nullptr

--- a/Sofa/framework/Helper/src/sofa/helper/MatEigen.h
+++ b/Sofa/framework/Helper/src/sofa/helper/MatEigen.h
@@ -43,6 +43,12 @@ Eigen::Matrix<Real, NumRows, NumCols> eigenMat( const type::Mat< NumRows, NumCol
 }
 
 template <Size NumRows, Size NumCols, class Real>
+Eigen::Map<Eigen::Matrix<Real, NumRows, NumCols>> eigenMatMap(const type::Mat< NumRows, NumCols, Real>& mat)
+{
+    return { mat.data() };
+}
+
+template <Size NumRows, Size NumCols, class Real>
 type::Mat<NumRows, NumCols, Real>  sofaMat( const Eigen::Matrix<Real, NumRows, NumCols>& emat )
 {
     type::Mat<NumRows, NumCols, Real> mat;
@@ -68,6 +74,12 @@ Eigen::Matrix<Real, NumRows, 1>  eigenVec( const type::Vec<NumRows, Real>& vec )
     for(Size i=0; i<NumRows; i++)
         evec(i)  = vec[i];
     return evec;
+}
+
+template <Size NumRows, class Real>
+Eigen::Map<Eigen::Matrix<Real, NumRows, 1>> eigenVecMap(const type::Vec<NumRows, Real>& vec)
+{
+    return { vec.data() };
 }
 
 }

--- a/Sofa/framework/Helper/src/sofa/helper/MatEigen.h
+++ b/Sofa/framework/Helper/src/sofa/helper/MatEigen.h
@@ -43,12 +43,6 @@ Eigen::Matrix<Real, NumRows, NumCols> eigenMat( const type::Mat< NumRows, NumCol
 }
 
 template <Size NumRows, Size NumCols, class Real>
-Eigen::Map<Eigen::Matrix<Real, NumRows, NumCols>> eigenMatMap(const type::Mat< NumRows, NumCols, Real>& mat)
-{
-    return { mat.data() };
-}
-
-template <Size NumRows, Size NumCols, class Real>
 type::Mat<NumRows, NumCols, Real>  sofaMat( const Eigen::Matrix<Real, NumRows, NumCols>& emat )
 {
     type::Mat<NumRows, NumCols, Real> mat;
@@ -74,12 +68,6 @@ Eigen::Matrix<Real, NumRows, 1>  eigenVec( const type::Vec<NumRows, Real>& vec )
     for(Size i=0; i<NumRows; i++)
         evec(i)  = vec[i];
     return evec;
-}
-
-template <Size NumRows, class Real>
-Eigen::Map<Eigen::Matrix<Real, NumRows, 1>> eigenVecMap(const type::Vec<NumRows, Real>& vec)
-{
-    return { vec.data() };
 }
 
 }

--- a/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.cpp
+++ b/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.cpp
@@ -93,10 +93,10 @@ NodeSPtr createRootNode(Simulation* s, const std::string& name,
     return root ;
 }
 
-BaseObject::SPtr createObject(Node::SPtr parent, BaseObjectDescription& desc)
+BaseComponent::SPtr createObject(Node::SPtr parent, BaseObjectDescription& desc)
 {
     /// Create the object.
-    BaseObject::SPtr obj = ObjectFactory::getInstance()->createObject(parent.get(), &desc);
+    BaseComponent::SPtr obj = ObjectFactory::getInstance()->createObject(parent.get(), &desc);
     if (obj == nullptr)
     {
         std::stringstream msg;
@@ -112,7 +112,7 @@ BaseObject::SPtr createObject(Node::SPtr parent, BaseObjectDescription& desc)
     return obj ;
 }
 
-BaseObject::SPtr createObject(Node::SPtr parent, const std::string& type, const std::map<std::string, std::string>& params)
+BaseComponent::SPtr createObject(Node::SPtr parent, const std::string& type, const std::map<std::string, std::string>& params)
 {
     /// temporarily, the name is set to the type name.
     /// if a "name" parameter is provided, it will overwrite it.

--- a/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.h
+++ b/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.h
@@ -33,7 +33,7 @@
 namespace sofa::simpleapi
 {
 
-using sofa::core::objectmodel::BaseObject;
+using sofa::core::objectmodel::BaseComponent;
 using sofa::core::objectmodel::BaseObjectDescription;
 
 using sofa::simulation::Simulation ;
@@ -53,11 +53,11 @@ NodeSPtr SOFA_SIMPLEAPI_API createRootNode( Simulation* s, const std::string& na
 ///@brief Create a sofa object in the provided node.
 ///The parameter "params" is for passing specific data argument to the created object including the
 ///object's type.
-sofa::core::sptr<BaseObject> SOFA_SIMPLEAPI_API createObject(NodeSPtr node, BaseObjectDescription& params);
+sofa::core::sptr<BaseComponent> SOFA_SIMPLEAPI_API createObject(NodeSPtr node, BaseObjectDescription& params);
 
 ///@brief create a sofa object in the provided node of the given type.
 ///The parameter "params" is for passing specific data argument to the created object.
-sofa::core::sptr<BaseObject> SOFA_SIMPLEAPI_API createObject( NodeSPtr node, const std::string& type,
+sofa::core::sptr<BaseComponent> SOFA_SIMPLEAPI_API createObject( NodeSPtr node, const std::string& type,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 ///@brief create a child to the provided nodeof given name.

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.cpp
@@ -95,7 +95,7 @@ void BaseSimulationExporter::handleEvent(Event *event){
         }
     }
 
-    BaseObject::handleEvent(event) ;
+    sofa::core::objectmodel::BaseObject::handleEvent(event) ;
 }
 
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.h
@@ -35,17 +35,16 @@ namespace sofa::simulation
 namespace _basesimulationexporter_
 {
 using sofa::core::objectmodel::Event ;
-using sofa::core::objectmodel::BaseObject ;
 using sofa::core::objectmodel::DataFileName ;
 
 /**
     Component that export something from the scene could inherit from this class
     as it implement an uniform handling of the different data attributes.
 */
-class SOFA_SIMULATION_CORE_API BaseSimulationExporter : public virtual BaseObject
+class SOFA_SIMULATION_CORE_API BaseSimulationExporter : public virtual sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_ABSTRACT_CLASS(BaseSimulationExporter, BaseObject);
+    SOFA_ABSTRACT_CLASS(BaseSimulationExporter, sofa::core::objectmodel::BaseObject);
 
     DataFileName       d_filename ;
     Data<unsigned int> d_exportEveryNbSteps;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.h
@@ -32,7 +32,7 @@ namespace sofa::simulation
 
 /** Initialize a newly created (or modified) scene graph.
 
-    Forward: simulation::Node::initialize() This method puts the OdeSolver, if any, first in the list of components. Then BaseObject::init() for all components.
+    Forward: simulation::Node::initialize() This method puts the OdeSolver, if any, first in the list of components. Then BaseComponent::init() for all components.
 
     Backward: OdeSolver::bwdInit()
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -69,7 +69,6 @@
 namespace sofa::simulation
 {
 using core::objectmodel::BaseNode;
-using core::objectmodel::BaseObject;
 
 Node::Node(const std::string& nodename, Node* parent)
     : core::objectmodel::BaseNode()
@@ -227,7 +226,7 @@ void Node::moveChild(BaseNode::SPtr node, BaseNode::SPtr prev_parent)
     doMoveChild(node, prev_parent);
 }
 /// Add an object. Detect the implemented interfaces and add the object to the corresponding lists.
-bool Node::addObject(BaseObject::SPtr obj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
+bool Node::addObject(sofa::core::objectmodel::BaseObject::SPtr obj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
 {
     // If an object we are trying to add already has a context, it is in another node in the
     // graph: we need to remove it from this context before to insert it into the current
@@ -245,7 +244,7 @@ bool Node::addObject(BaseObject::SPtr obj, sofa::core::objectmodel::TypeOfInsert
 }
 
 /// Remove an object
-bool Node::removeObject(BaseObject::SPtr obj)
+bool Node::removeObject(sofa::core::objectmodel::BaseObject::SPtr obj)
 {
     notifyBeginRemoveObject(this, obj);
     const bool ret = doRemoveObject(obj);
@@ -254,7 +253,7 @@ bool Node::removeObject(BaseObject::SPtr obj)
 }
 
 /// Move an object from another node
-void Node::moveObject(BaseObject::SPtr obj)
+void Node::moveObject(sofa::core::objectmodel::BaseObject::SPtr obj)
 {
     Node* prev_parent = down_cast<Node>(obj->getContext()->toBaseNode());
     if (prev_parent)
@@ -421,7 +420,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
         return destType->dynamicCast(link->getOwnerBase());
     }
     Node* node = this;
-    BaseObject* master = nullptr;
+    sofa::core::objectmodel::BaseObject* master = nullptr;
     bool based = false;
     if (ppos < psize && pathStr[ppos] == '[') // relative index in the list of objects
     {
@@ -523,7 +522,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
             {
                 for (;;)
                 {
-                    BaseObject* obj = node->getObject(nameStr);
+                    sofa::core::objectmodel::BaseObject* obj = node->getObject(nameStr);
                     Node* childPtr = node->getChild(nameStr);
                     if (childPtr)
                     {
@@ -568,7 +567,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
         }
         for (ObjectIterator it = node->object.begin(), itend = node->object.end(); it != itend; ++it)
         {
-            BaseObject* obj = it->get();
+            sofa::core::objectmodel::BaseObject* obj = it->get();
             Base *o = destType->dynamicCast(obj);
             if (!o) continue;
             if(DEBUG_LINK)
@@ -600,7 +599,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
 }
 
 /// Add an object. Detect the implemented interfaces and add the object to the corresponding lists.
-bool Node::doAddObject(BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
+bool Node::doAddObject(sofa::core::objectmodel::BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
 {
     this->setObjectContext(sobj);
     if(insertionLocation == sofa::core::objectmodel::TypeOfInsertion::AtEnd)
@@ -608,7 +607,7 @@ bool Node::doAddObject(BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfIns
     else
         object.addBegin(sobj);
 
-    BaseObject* obj = sobj.get();
+    sofa::core::objectmodel::BaseObject* obj = sobj.get();
 
     if( !obj->insertInNode( this ) )
     {
@@ -618,13 +617,13 @@ bool Node::doAddObject(BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfIns
 }
 
 /// Remove an object
-bool Node::doRemoveObject(BaseObject::SPtr sobj)
+bool Node::doRemoveObject(sofa::core::objectmodel::BaseObject::SPtr sobj)
 {
     dmsg_warning_when(sobj == nullptr) << "Trying to remove a nullptr object";
 
     this->clearObjectContext(sobj);
     object.remove(sobj);
-    BaseObject* obj = sobj.get();
+    sofa::core::objectmodel::BaseObject* obj = sobj.get();
 
     if(obj != nullptr && !obj->removeInNode( this ) )
         unsorted.remove(obj);
@@ -632,7 +631,7 @@ bool Node::doRemoveObject(BaseObject::SPtr sobj)
 }
 
 /// Remove an object
-void Node::doMoveObject(BaseObject::SPtr sobj, Node* prev_parent)
+void Node::doMoveObject(sofa::core::objectmodel::BaseObject::SPtr sobj, Node* prev_parent)
 {
     if (prev_parent != nullptr)
         prev_parent->removeObject(sobj);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/PropagateEventVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/PropagateEventVisitor.h
@@ -43,7 +43,7 @@ public:
     ~PropagateEventVisitor() override;
 
     Visitor::Result processNodeTopDown(simulation::Node* node) override;
-    void processObject(simulation::Node*, core::objectmodel::BaseObject* obj);
+    void processObject(simulation::Node*, core::objectmodel::BaseComponent* obj);
 
     const char* getClassName() const override { return "PropagateEventVisitor"; }
     virtual std::string getInfos() const override { return std::string(m_event->getClassName());  }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/ResetVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/ResetVisitor.h
@@ -33,7 +33,7 @@ class SOFA_SIMULATION_CORE_API ResetVisitor : public Visitor
 public:
     ResetVisitor(const core::ExecParams* eparams) : Visitor(eparams) {}
 
-    void processObject(core::objectmodel::BaseObject* obj);
+    void processObject(core::objectmodel::BaseComponent* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;
@@ -48,7 +48,7 @@ class SOFA_SIMULATION_CORE_API StoreResetStateVisitor : public Visitor
 public:
     StoreResetStateVisitor(const core::ExecParams* eparams) : Visitor(eparams) {}
 
-    void processObject(core::objectmodel::BaseObject* obj);
+    void processObject(core::objectmodel::BaseComponent* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TopologyChangeVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TopologyChangeVisitor.h
@@ -36,7 +36,7 @@ public:
 
     ~TopologyChangeVisitor() override {}
 
-    virtual void processTopologyChange(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj);
+    virtual void processTopologyChange(simulation::Node* node, sofa::core::objectmodel::BaseComponent* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateInternalDataVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateInternalDataVisitor.h
@@ -39,7 +39,7 @@ class SOFA_SIMULATION_CORE_API UpdateInternalDataVisitor : public Visitor
 public:
     UpdateInternalDataVisitor(const core::ExecParams* eparams): Visitor(eparams) {}
 
-    void processUpdateInternalData(simulation::Node* node, sofa::core::objectmodel::BaseObject* baseObj);
+    void processUpdateInternalData(simulation::Node* node, sofa::core::objectmodel::BaseComponent* baseObj);
     Result processNodeTopDown(simulation::Node* node) override;
 
     /// Specify whether this action can be parallelized.

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateLinksVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateLinksVisitor.h
@@ -33,7 +33,7 @@ class SOFA_SIMULATION_CORE_API UpdateLinksVisitor : public Visitor
 public:
     UpdateLinksVisitor(const core::ExecParams* eparams) : Visitor(eparams) {}
 
-    void processObject(core::objectmodel::BaseObject* obj);
+    void processObject(core::objectmodel::BaseComponent* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Visitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Visitor.h
@@ -91,8 +91,8 @@ public:
     virtual std::string getInfos() const { return ""; }
 
 protected:
-    void debug_write_state_before( sofa::core::objectmodel::BaseObject* obj ) ;
-    void debug_write_state_after( sofa::core::objectmodel::BaseObject* obj ) ;
+    void debug_write_state_before( sofa::core::objectmodel::BaseComponent* obj ) ;
+    void debug_write_state_after( sofa::core::objectmodel::BaseComponent* obj ) ;
 
     /// Function to be called when a visitor executes a main task
     /// It surrounds the task function with debug information
@@ -131,28 +131,28 @@ public:
     //method to compare the tags of the object with the ones of the visitor
     // return true if the object has all the tags of the visitor
     // or if no tag is set to the visitor
-    bool testTags(sofa::core::objectmodel::BaseObject* obj);
+    bool testTags(sofa::core::objectmodel::BaseComponent* obj);
 
     /// Alias for context->executeVisitor(this)
     virtual void execute(sofa::core::objectmodel::BaseContext* node, bool precomputedOrder=false);
 
     /// Optional helper method to call before handling an object if not using the for_each method.
     /// It currently takes care of time logging, but could be extended (step-by-step execution for instance)
-    virtual ctime_t begin(simulation::Node *node, sofa::core::objectmodel::BaseObject *obj,
+    virtual ctime_t begin(simulation::Node *node, sofa::core::objectmodel::BaseComponent *obj,
                           const std::string &typeInfo = std::string("type"));
 
     /// Optional helper method to call after handling an object if not using the for_each method.
     /// It currently takes care of time logging, but could be extended (step-by-step execution for instance)
-    virtual void end(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj, ctime_t t0);
+    virtual void end(simulation::Node* node, sofa::core::objectmodel::BaseComponent* obj, ctime_t t0);
 
     /// Optional helper method to call before handling an object if not using the for_each method.
     /// It currently takes care of time logging, but could be extended (step-by-step execution for instance)
-    virtual ctime_t begin(simulation::Visitor::VisitorContext *node, sofa::core::objectmodel::BaseObject *obj,
+    virtual ctime_t begin(simulation::Visitor::VisitorContext *node, sofa::core::objectmodel::BaseComponent *obj,
                   const std::string &typeInfo = std::string("type"));
 
     /// Optional helper method to call after handling an object if not using the for_each method.
     /// It currently takes care of time logging, but could be extended (step-by-step execution for instance)
-    virtual void end(simulation::Visitor::VisitorContext* node, sofa::core::objectmodel::BaseObject* obj, ctime_t t0);
+    virtual void end(simulation::Visitor::VisitorContext* node, sofa::core::objectmodel::BaseComponent* obj, ctime_t t0);
 
     /// Specify whether this visitor can be parallelized.
     virtual bool isThreadSafe() const { return false; }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/XMLPrintVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/XMLPrintVisitor.h
@@ -45,7 +45,7 @@ public:
     template<class Seq>
     void processObjects(Seq& list);
 
-    void processBaseObject(sofa::core::objectmodel::BaseObject* obj);
+    void processBaseObject(sofa::core::objectmodel::BaseComponent* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;

--- a/Sofa/framework/Simulation/Graph/test/Link_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Link_test.cpp
@@ -28,7 +28,6 @@ using namespace sofa::simpleapi ;
 #include "Node_test.h"
 
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
 #include <sofa/core/objectmodel/BaseNode.h>
 using sofa::core::objectmodel::BaseNode ;
 
@@ -45,15 +44,15 @@ struct Link_test : public BaseSimulationTest
     {
         SceneInstance si("root") ;
 
-        auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
+        auto aBaseObject = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         sofa::core::objectmodel::Base* aBasePtr = aBaseObject.get();
         si.root->addObject(aBaseObject);
 
         using sofa::core::objectmodel::BaseNode;
-        BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
-        BaseLink::InitLink<BaseObject> initNodeLink(aBaseObject.get(), "nodelink", "");
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
-        SingleLink<BaseObject, BaseNode, BaseLink::FLAG_NONE > nodeLink(initNodeLink);
+        BaseLink::InitLink<sofa::core::objectmodel::BaseComponent> initObjectLink(aBaseObject.get(), "objectlink", "");
+        BaseLink::InitLink<sofa::core::objectmodel::BaseComponent> initNodeLink(aBaseObject.get(), "nodelink", "");
+        SingleLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
+        SingleLink<sofa::core::objectmodel::BaseComponent, BaseNode, BaseLink::FLAG_NONE > nodeLink(initNodeLink);
 
         // objectLink.add(aBasePtr); //< not possible because of template type specification
 
@@ -69,14 +68,14 @@ struct Link_test : public BaseSimulationTest
     void read_multilink_test()
     {
         const SceneInstance si("root") ;
-        const BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
-        const BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
-        const BaseObject::SPtr C = sofa::core::objectmodel::New<BaseObject>();
+        const sofa::core::objectmodel::BaseComponent::SPtr A = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
+        const sofa::core::objectmodel::BaseComponent::SPtr B = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
+        const sofa::core::objectmodel::BaseComponent::SPtr C = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         si.root->addObject(A);
         si.root->addObject(B);
 
-        const BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
-        MultiLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
+        const BaseLink::InitLink<sofa::core::objectmodel::BaseComponent> il1(B.get(), "l1", "");
+        MultiLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_NONE > withOwner(il1) ;
 
         // 1. test with valid link & owner
         EXPECT_TRUE(withOwner.read("@/B"));
@@ -91,12 +90,12 @@ struct Link_test : public BaseSimulationTest
     void read_test()
     {
         SceneInstance si("root") ;
-        BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
-        BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
+        sofa::core::objectmodel::BaseComponent::SPtr A = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
+        sofa::core::objectmodel::BaseComponent::SPtr B = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         si.root->addObject(A);
-        BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withoutOwner;
+        BaseLink::InitLink<sofa::core::objectmodel::BaseComponent> il1(B.get(), "l1", "");
+        SingleLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_NONE > withOwner(il1) ;
+        SingleLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_NONE > withoutOwner;
         withoutOwner.setOwner(nullptr);
 
         // 1. test with invalid link & no owner
@@ -126,12 +125,12 @@ struct Link_test : public BaseSimulationTest
     void read_test_tofix()
     {
         const SceneInstance si("root");
-        const BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
-        const BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
+        const sofa::core::objectmodel::BaseComponent::SPtr A = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
+        const sofa::core::objectmodel::BaseComponent::SPtr B = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         si.root->addObject(A);
-        const BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1);
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withoutOwner;
+        const BaseLink::InitLink<sofa::core::objectmodel::BaseComponent> il1(B.get(), "l1", "");
+        SingleLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_NONE > withOwner(il1);
+        SingleLink<sofa::core::objectmodel::BaseComponent, sofa::core::objectmodel::BaseComponent, BaseLink::FLAG_NONE > withoutOwner;
         withoutOwner.setOwner(nullptr);
 
         // Here link is OK, but points to a BaseNode, while the link only accepts BaseObjects. Should return false. But returns true, since findLinkDest returns false in read()

--- a/Sofa/framework/Simulation/Graph/test/MutationListener_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/MutationListener_test.cpp
@@ -27,7 +27,6 @@ using sofa::testing::BaseTest;
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/MutationListener.h>
 using sofa::simulation::MutationListener;
-using sofa::core::objectmodel::BaseObject;
 using sofa::simulation::Simulation;
 using sofa::simulation::Node;
 
@@ -51,20 +50,20 @@ class TestMutationListener : public MutationListener
         log += "End Remove " + child->getName() + " from " + parent->getName() + "\n";
     }
 
-    void onBeginAddObject(Node* parent, BaseObject* obj) override
+    void onBeginAddObject(Node* parent, sofa::core::objectmodel::BaseComponent* obj) override
     {
         log += "Begin Add " + obj->getName() + " to " + parent->getName() + "\n";
     }
-    void onEndAddObject(Node* parent, BaseObject* obj) override
+    void onEndAddObject(Node* parent, sofa::core::objectmodel::BaseComponent* obj) override
     {
         log += "End Add " + obj->getName() + " to " + parent->getName() + "\n";
     }
 
-    void onBeginRemoveObject(Node* parent, BaseObject* obj) override
+    void onBeginRemoveObject(Node* parent, sofa::core::objectmodel::BaseComponent* obj) override
     {
         log += "Begin Remove " + obj->getName() + " from " + parent->getName() + "\n";
     }
-    void onEndRemoveObject(Node* parent, BaseObject* obj) override
+    void onEndRemoveObject(Node* parent, sofa::core::objectmodel::BaseComponent* obj) override
     {
         log += "End Remove " + obj->getName() + " from " + parent->getName() + "\n";
     }
@@ -85,8 +84,8 @@ struct MutationListener_test : public BaseTest
     Node::SPtr node1_1;
     Node::SPtr node1_2;
     Node::SPtr node2;
-    BaseObject::SPtr obj1;
-    BaseObject::SPtr obj2;
+    sofa::core::objectmodel::BaseComponent::SPtr obj1;
+    sofa::core::objectmodel::BaseComponent::SPtr obj2;
 
 
     MutationListener_test() {}
@@ -223,13 +222,13 @@ struct MutationListener_test : public BaseTest
     void test_addObject()
     {
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj1->parse(&bod1);
         root->addObject(obj1);
         EXPECT_EQ("Begin Add obj1 to root\nEnd Add obj1 to root\n", listener.log);
         listener.clearLog();
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj2->parse(&bod2);
         root->addObject(obj2);
         EXPECT_EQ("Begin Add obj2 to root\nEnd Add obj2 to root\n", listener.log);
@@ -293,11 +292,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node2 = sofa::core::objectmodel::New<Node>("node2");
         node1->addChild(node2);
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj1->parse(&bod1);
         node2->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj2->parse(&bod2);
         node2->addObject(obj2);
         listener.clearLog();
@@ -315,11 +314,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node2 = sofa::core::objectmodel::New<Node>("node2");
         node1->addChild(node2);
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj1->parse(&bod1);
         node2->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj2->parse(&bod2);
         node2->addObject(obj2);
         root->addChild(node1);
@@ -338,11 +337,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node2 = sofa::core::objectmodel::New<Node>("node2");
         node1->addChild(node2);
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj1->parse(&bod1);
         node2->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj2->parse(&bod2);
         node2->addObject(obj2);
         root->addChild(node1);
@@ -370,11 +369,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node8 = sofa::core::objectmodel::New<Node>("node8");
 
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj1->parse(&bod1);
         node1->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseComponent>();
         obj2->parse(&bod2);
         node1->addObject(obj2);
 

--- a/Sofa/framework/Simulation/Graph/test/Node_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Node_test.cpp
@@ -55,7 +55,7 @@ TEST( Node_test, getPathName)
     const Node::SPtr root = sofa::simpleapi::createNode("A");
     const Node::SPtr B = createChild(root, "B");
     const Node::SPtr D = createChild(B, "D");
-    const BaseObject::SPtr C = core::objectmodel::New<Dummy>("C");
+    const sofa::core::objectmodel::BaseComponent::SPtr C = core::objectmodel::New<Dummy>("C");
     root->addObject(C);
 
     EXPECT_STREQ(root->getPathName().c_str(), "/");
@@ -67,8 +67,8 @@ TEST( Node_test, getPathName)
 TEST(Node_test, addObject)
 {
     const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
-    const BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
-    const BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
+    const sofa::core::objectmodel::BaseComponent::SPtr A = core::objectmodel::New<Dummy>("A");
+    const sofa::core::objectmodel::BaseComponent::SPtr B = core::objectmodel::New<Dummy>("B");
 
     root->addObject(A);
 
@@ -83,8 +83,8 @@ TEST(Node_test, addObject)
 TEST(Node_test, addObjectAtFront)
 {
     const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
-    const BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
-    const BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
+    const sofa::core::objectmodel::BaseComponent::SPtr A = core::objectmodel::New<Dummy>("A");
+    const sofa::core::objectmodel::BaseComponent::SPtr B = core::objectmodel::New<Dummy>("B");
 
     root->addObject(A);
 
@@ -103,8 +103,8 @@ TEST(Node_test, addObjectPreventingSharedContext)
 
     const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
 
-    const BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
-    const BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
+    const core::objectmodel::BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
+    const core::objectmodel::BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
 
     const auto child1 = sofa::simpleapi::createChild(root, "child1");
     const auto child2 = sofa::simpleapi::createChild(root, "child2");

--- a/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/DataExchange.inl
@@ -28,7 +28,7 @@ namespace sofa::core
 
 template <class DataTypes>
 DataExchange<DataTypes>::DataExchange( const char* from, const char* to )
-    : BaseObject()
+    : BaseComponent()
     , mSource(initData(&mSource,"from","source object to copy"))
     , mDestination(initData(&mDestination,"to","destination object to copy"))
     , mSourcePtr(nullptr)

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
@@ -62,7 +62,6 @@ using sofa::helper::system::DataRepository ;
 
 static sofa::simulation::Node::SPtr root = nullptr;
 
-using sofa::core::objectmodel::BaseObject ;
 
 
 Node::SPtr createRootWithCollisionPipeline(const std::string& responseType)
@@ -184,7 +183,7 @@ Node::SPtr createObstacle(Node::SPtr  parent, const std::string &filenameCollisi
 }
 
 
-Node::SPtr createCollisionNodeVec3(Node::SPtr  parent, BaseObject::SPtr  dof,
+Node::SPtr createCollisionNodeVec3(Node::SPtr  parent, sofa::core::objectmodel::BaseObject::SPtr  dof,
                                    const std::string &filename,
                                    const std::vector<std::string> &elements,
                                    const Deriv3& translation, const Deriv3 &rotation)
@@ -214,7 +213,7 @@ Node::SPtr createCollisionNodeVec3(Node::SPtr  parent, BaseObject::SPtr  dof,
 }
 
 simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr  parent,
-                                            BaseObject::SPtr  dof,
+                                            sofa::core::objectmodel::BaseObject::SPtr  dof,
                                             const std::string &filename, const std::string& color,
                                             const Deriv3& translation, const Deriv3 &rotation,
                                             const MappingType &mappingT)
@@ -259,7 +258,7 @@ simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr  parent,
 
 
 
-Node::SPtr createCollisionNodeRigid(Node::SPtr  parent, BaseObject::SPtr  dofRigid,
+Node::SPtr createCollisionNodeRigid(Node::SPtr  parent, sofa::core::objectmodel::BaseObject::SPtr  dofRigid,
                                     const std::string &filename,
                                     const std::vector<std::string> &elements,
                                     const Deriv3& translation, const Deriv3 &rotation)
@@ -290,7 +289,7 @@ Node::SPtr createCollisionNodeRigid(Node::SPtr  parent, BaseObject::SPtr  dofRig
     return node;
 }
 
-Node::SPtr createVisualNodeRigid(Node::SPtr  parent, BaseObject::SPtr  dofRigid,
+Node::SPtr createVisualNodeRigid(Node::SPtr  parent, sofa::core::objectmodel::BaseObject::SPtr  dofRigid,
                                  const std::string &filename, const std::string& color,
                                  const Deriv3& translation, const Deriv3 &rotation)
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.h
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.h
@@ -34,7 +34,6 @@
 
 namespace sofa::modeling
 {
-using sofa::core::objectmodel::BaseObject ;
 
 typedef SReal Scalar;
 typedef sofa::defaulttype::Vec3Types::Deriv Deriv3;
@@ -65,13 +64,13 @@ SOFA_SCENECREATOR_API simulation::Node::SPtr createObstacle(simulation::Node::SP
 /// Create a collision node using Barycentric Mapping, using a 3d model specified by filename.
 /// elements is a vector of type of collision models (Triangle, Line, Point, Sphere)
 /// an initial transformation can be performed
-SOFA_SCENECREATOR_API simulation::Node::SPtr createCollisionNodeVec3(simulation::Node::SPtr parent, BaseObject::SPtr dof,
+SOFA_SCENECREATOR_API simulation::Node::SPtr createCollisionNodeVec3(simulation::Node::SPtr parent, sofa::core::objectmodel::BaseObject::SPtr dof,
                                                                      const std::string &filename,
                                                                      const std::vector<std::string> &elements,
                                                                      const Deriv3& translation=Deriv3(),
                                                                      const Deriv3 &rotation=Deriv3());
 
-SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr parent, BaseObject::SPtr dof,
+SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr parent, sofa::core::objectmodel::BaseObject::SPtr dof,
                                                                   const std::string &filename, const std::string& color,
                                                                   const Deriv3& translation=Deriv3(),
                                                                   const Deriv3 &rotation=Deriv3(),
@@ -82,14 +81,14 @@ SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeVec3(simulation::No
 /// elements is a vector of type of collision models (Triangle, Line, Point, Sphere)
 /// an initial transformation can be performed
 SOFA_SCENECREATOR_API simulation::Node::SPtr createCollisionNodeRigid(simulation::Node::SPtr parent,
-                                                                      BaseObject::SPtr dofRigid,
+                                                                      sofa::core::objectmodel::BaseObject::SPtr dofRigid,
                                                                       const std::string &filename,
                                                                       const std::vector<std::string> &elements,
                                                                       const Deriv3& translation=Deriv3(),
                                                                       const Deriv3 &rotation=Deriv3());
 
 SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeRigid(simulation::Node::SPtr parent,
-                                                                   BaseObject::SPtr  dofRigid,
+                                                                   sofa::core::objectmodel::BaseObject::SPtr  dofRigid,
                                                                    const std::string &filename,
                                                                    const std::string& color,
                                                                    const Deriv3& translation=Deriv3(),

--- a/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
+++ b/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
@@ -51,7 +51,6 @@ using sofa::core::execparams::defaultInstance;
 /// This component is only for testing the APIVersion system.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject;
 using sofa::core::objectmodel::Base;
 
 #include <sofa/core/ObjectFactory.h>
@@ -60,10 +59,10 @@ using sofa::core::ExecParams;
 
 #include <sofa/simpleapi/SimpleApi.h>
 
-class ComponentDeprecated : public BaseObject
+class ComponentDeprecated : public sofa::core::objectmodel::BaseComponent
 {
 public:
-    SOFA_CLASS(ComponentDeprecated, BaseObject);
+    SOFA_CLASS(ComponentDeprecated, sofa::core::objectmodel::BaseComponent);
 public:
 
 };


### PR DESCRIPTION
A not-working PR to start the discussion on renaming BaseObject to BaseComponent. It makes more sense for me as we name the classes in the factory 'Component'.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
