### PR TITLE
[Type] Add determinant tests for 2x2 and 3x3 matrices

### DIFF
--- a/Sofa/framework/Type/test/MatTypes_test.cpp
+++ b/Sofa/framework/Type/test/MatTypes_test.cpp
@@ -418,3 +418,21 @@ TEST(MatTypesTest, assignFromPtr)
     EXPECT_TRUE(comp);
 }
 
+TEST(MatTypesTest, determinant2x2)
+{
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(Matrix2::Identity()), 1_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<2,2,SReal>{{1, 2}, {3, 4}}), -2_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<2,2,SReal>{{2, 0}, {0, 2}}), 4_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<2,2,SReal>{{0, 1}, {1, 0}}), -1_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<2,2,SReal>{{-1, 2}, {3, 4}}), -10_sreal);
+}
+
+TEST(MatTypesTest, determinant3x3)
+{
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(Matrix3::Identity()), 1_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<3,3,SReal>{{2, 0, 0}, {0, 3, 0}, {0, 0, 4}}), 24_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<3,3,SReal>{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}), 0_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<3,3,SReal>{{0, 1, 0}, {0, 0, 1}, {1, 0, 0}}), 1_sreal);
+    EXPECT_DOUBLE_EQ(sofa::type::determinant(sofa::type::Mat<3,3,SReal>{{1, 1, 0}, {1, 0, 1}, {0, 1, 1}}), -2_sreal);
+}
+


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
