### PR TITLE
[CI] Update actions: check label and PR age

### DIFF
--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -20,7 +20,7 @@ jobs:
       
       - name: Check status labels
         id: check_status_labels
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -83,7 +83,7 @@ jobs:
       - name: Check descriptive labels
         if: ${{ always() }}
         id: check_descriptive_labels
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -52,7 +52,7 @@ jobs:
               });
 
               // Set flag to TRUE
-              echo "no_status_label=true" >> $GITHUB_OUTPUT
+              core.setOutput('no_status_label', 'true');
             }
             else if (matchingLabelsCount > 1) {
               const comment = ':warning: :warning: :warning:<br>@'+context.payload.pull_request.user.login+' your PR includes **too many status labels** :label:<br> Make sure to **select only one** (wip, to review or ready).<br>:warning: :warning: :warning:';

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -121,4 +121,15 @@ jobs:
               // Make the action step fail
               core.setFailed('Invalid PR label');
             }
-      
+
+      - name: Check label pr based on previous PR
+        if: ${{ always() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const found = labels.includes("pr: based on previous PR");
+
+            // Make the action step fail
+            core.setFailed("Merge blocked: PR has label 'pr: based on previous PR'");
+

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -17,49 +17,8 @@ jobs:
     if: ${{ github.repository_owner == 'sofa-framework' }}
 
     steps:
-      - name: Check descriptive labels
-        id: check_descriptive_labels
-        uses: actions/github-script@v5
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // Get PR info: id and labels
-            const prNumber = context.payload.pull_request.number;
-            const labels = context.payload.pull_request.labels.map(label => label.name);
-
-            // Define an array of descriptive labels
-            const descriptiveLabels = [
-              'deprecated',
-              'refactoring',
-              'pr: enhancement',
-              'pr: breaking',
-              'pr: clean',
-              'pr: fix',
-              'pr: new feature',
-              'pr: test',
-              'pr: revert(ed)',
-              'pr: project-ci-infrastructure'
-            ];
-
-            // Check if any descriptive label is included in the 'labels' array
-            const hasDescriptiveLabel = labels.some(label => descriptiveLabels.includes(label));
-
-            // If no descriptive label is set, add a comment in the PR and make the action check fail
-            if (!hasDescriptiveLabel) {
-              const comment = ':warning: :warning: :warning:<br>@' + context.payload.pull_request.user.login + ' your PR does not include any **descriptive** label :label:<br> Make sure to add an appropriate [PR label](https://github.com/sofa-framework/sofa/labels) before merge.<br>:warning: :warning: :warning:';
-              github.rest.issues.createComment({
-                issue_number: prNumber,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: comment
-              });
-              
-              // Make the action step fail
-              core.setFailed('Invalid PR label');
-            }
       
       - name: Check status labels
-        if: ${{ always() }}
         id: check_status_labels
         uses: actions/github-script@v5
         with:
@@ -120,3 +79,46 @@ jobs:
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
           LABELS: "pr: status to review"
+          
+      - name: Check descriptive labels
+        if: ${{ always() }}
+        id: check_descriptive_labels
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Get PR info: id and labels
+            const prNumber = context.payload.pull_request.number;
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+
+            // Define an array of descriptive labels
+            const descriptiveLabels = [
+              'deprecated',
+              'refactoring',
+              'pr: enhancement',
+              'pr: breaking',
+              'pr: clean',
+              'pr: fix',
+              'pr: new feature',
+              'pr: test',
+              'pr: revert(ed)',
+              'pr: project-ci-infrastructure'
+            ];
+
+            // Check if any descriptive label is included in the 'labels' array
+            const hasDescriptiveLabel = labels.some(label => descriptiveLabels.includes(label));
+
+            // If no descriptive label is set, add a comment in the PR and make the action check fail
+            if (!hasDescriptiveLabel) {
+              const comment = ':warning: :warning: :warning:<br>@' + context.payload.pull_request.user.login + ' your PR does not include any **descriptive** label :label:<br> Make sure to add an appropriate [PR label](https://github.com/sofa-framework/sofa/labels) before merge.<br>:warning: :warning: :warning:';
+              github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+              
+              // Make the action step fail
+              core.setFailed('Invalid PR label');
+            }
+      

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -64,7 +64,7 @@ jobs:
               });
 
               // Make the action step fail
-              core.setFailed('Too many status PR labels')
+              core.setFailed('Too many status PR labels');
             }
 
             // Print all PR labels in log

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -14,7 +14,6 @@ jobs:
   check_labels:
     name: Check labels
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'sofa-framework' }}
 
     steps:
       

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -130,5 +130,7 @@ jobs:
             const found = labels.includes("pr: based on previous PR");
 
             // Make the action step fail
-            core.setFailed("Merge blocked: PR has label 'pr: based on previous PR'");
+            if (found) {
+              core.setFailed("Merge blocked: PR has label 'pr: based on previous PR'");
+            }
 

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -1,4 +1,3 @@
----
 name: PR check - Labels
 on:
   pull_request:
@@ -18,12 +17,8 @@ jobs:
     if: ${{ github.repository_owner == 'sofa-framework' }}
 
     steps:
-      - name: Delay for 10 Seconds
-        run: |
-          echo "Waiting for 10 seconds in case other labels get changed"
-          sleep 10
-      - name: Check Labels and Add Comment
-        id: check_labels_and_comment
+      - name: Check descriptive labels
+        id: check_descriptive_labels
         uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -58,8 +53,21 @@ jobs:
                 repo: context.repo.repo,
                 body: comment
               });
+              
+              // Make the action step fail
               core.setFailed('Invalid PR label');
             }
+      
+      - name: Check status labels
+        if: ${{ always() }}
+        id: check_status_labels
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Get PR info: id and labels
+            const prNumber = context.payload.pull_request.number;
+            const labels = context.payload.pull_request.labels.map(label => label.name);
 
             // Array of possible labels defining the status of the PR
             const statusLabels = [
@@ -76,24 +84,39 @@ jobs:
 
             // If no descriptive label is set, add a comment in the PR and make the action check fail
             if (matchingLabelsCount === 0) {
-              const comment = ':warning: :warning: :warning:<br>@'+context.repo.owner+' your PR does not include any **status** label :label:<br> Make sure to add one (wip, to review or ready).<br>:warning: :warning: :warning:';
+              const comment = ':information_source: @'+context.payload.pull_request.user.login+' your PR does not include any **status** label :label: The label \"pr: status to review\" is added automatically.';
               github.rest.issues.createComment({
                 issue_number: prNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: comment
               });
-              core.setFailed('Missing status PR label')
-            } else if (matchingLabelsCount > 1) {
-              const comment = ':warning: :warning: :warning:<br>@'+context.repo.owner+' your PR does includes **too many status labels** :label:<br> Make sure to keep only one (wip, to review or ready).<br>:warning: :warning: :warning:';
+
+              // Set flag to TRUE
+              echo "no_status_label=true" >> $GITHUB_OUTPUT
+            }
+            else if (matchingLabelsCount > 1) {
+              const comment = ':warning: :warning: :warning:<br>@'+context.payload.pull_request.user.login+' your PR includes **too many status labels** :label:<br> Make sure to **select only one** (wip, to review or ready).<br>:warning: :warning: :warning:';
               github.rest.issues.createComment({
                 issue_number: prNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: comment
               });
+
+              // Make the action step fail
               core.setFailed('Too many status PR labels')
             }
 
-            // Add all PR labels in log
+            // Print all PR labels in log
             console.log('Labels:', labels.join(', '));
+      
+      - name: Add status label if none given
+        if: ${{ steps.check_status_labels.outputs.no_status_label == 'true' }}
+        run: |
+          gh pr edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: "pr: status to review"

--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -14,6 +14,7 @@ jobs:
   check_labels:
     name: Check labels
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'sofa-framework' }}
 
     steps:
       

--- a/.github/workflows/pr-timing-checker.yml
+++ b/.github/workflows/pr-timing-checker.yml
@@ -11,14 +11,14 @@ on:
 
 jobs:
 
-  check_labels:
-    name: Check labels
+  check_pr_age:
+    name: Check PR age
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'sofa-framework' }}
 
     steps:
-      - name: Check Labels and Age
-        id: check_labels_and_comment
+      - name: Check Age and fast-merge Label
+        id: check_age
         uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Action PR age : make action names clearer
- Action check label :
  - remove the sleep step
  - update version of actions/github-script
  - :heavy_division_sign:  split in two steps : 
    - Check status labels
    - Check descriptive labels
  - :heavy_plus_sign: add two new steps :
    - Add status label if none given
    - Check label pr based on previous PR



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
