### PR TITLE
[all] Deprecate contaminating using declarations of BaseObject

### DIFF
--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/BoxROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/BoxROI.h
@@ -43,7 +43,7 @@ namespace sofa::component::engine::select::boxroi
     using core::topology::BaseMeshTopology ;
     using core::behavior::MechanicalState ;
     using core::objectmodel::BaseContext ;
-    using core::objectmodel::BaseObject ;
+    using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
     using core::visual::VisualParams ;
     using core::objectmodel::Event ;
     using core::ExecParams ;

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BaseVTKReader.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BaseVTKReader.h
@@ -36,7 +36,7 @@ namespace sofa::component::io::mesh::basevtkreader
 /// So that you can access to BaseVTKReader with
 /// sofa::component::loader::BaseVTKReader or sofa::component::loader::basevtkreader::BaseVTKReader
 
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 using sofa::core::objectmodel::BaseData ;
 
 using std::ofstream ;

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.h
@@ -24,7 +24,7 @@
 #include <sofa/component/sceneutility/config.h>
 
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 
 
 namespace sofa::component::sceneutility::_apiversion_

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.h
@@ -32,7 +32,7 @@ namespace sofa::component::sceneutility::infocomponent
 /// fearing it will leak names into the global namespace. When closing this namespace
 /// selected object from this per-file namespace are then imported into their parent namespace.
 /// for ease of use
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 
 /// Despite this component does absolutely nothing... it is very useful as it can be used to
 /// retain information scene graph.

--- a/Sofa/framework/Core/test/objectmodel/BaseLink_test.h
+++ b/Sofa/framework/Core/test/objectmodel/BaseLink_test.h
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 
 #include <sofa/core/objectmodel/BaseNode.h>
 using sofa::core::objectmodel::BaseNode ;

--- a/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.h
+++ b/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.h
@@ -33,7 +33,7 @@
 namespace sofa::simpleapi
 {
 
-using sofa::core::objectmodel::BaseObject;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 using sofa::core::objectmodel::BaseObjectDescription;
 
 using sofa::simulation::Simulation ;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.h
@@ -35,7 +35,7 @@ namespace sofa::simulation
 namespace _basesimulationexporter_
 {
 using sofa::core::objectmodel::Event ;
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 using sofa::core::objectmodel::DataFileName ;
 
 /**

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.h
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.h
@@ -34,7 +34,7 @@
 
 namespace sofa::modeling
 {
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 
 typedef SReal Scalar;
 typedef sofa::defaulttype::Vec3Types::Deriv Deriv3;

--- a/applications/plugins/SofaImplicitField/components/engine/FieldToSurfaceMesh.h
+++ b/applications/plugins/SofaImplicitField/components/engine/FieldToSurfaceMesh.h
@@ -37,7 +37,7 @@ typedef sofa::type::vector<sofa::type::Vec3d> VecCoord;
 
 using sofa::component::geometry::ScalarField;
 using sofa::core::visual::VisualParams ;
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 using sofa::type::Vec3d ;
 
 class FieldToSurfaceMesh : public BaseObject

--- a/applications/plugins/SofaImplicitField/components/geometry/ScalarField.h
+++ b/applications/plugins/SofaImplicitField/components/geometry/ScalarField.h
@@ -38,7 +38,7 @@ namespace sofa::component::geometry
 namespace _scalarfield_
 {
 
-using sofa::core::objectmodel::BaseObject ;
+using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead.")]] = sofa::core::objectmodel::BaseObject;
 using sofa::type::Vec3d ;
 using sofa::type::Mat3x3 ;
 


### PR DESCRIPTION
Not perfectly equivalent, but it is supposed to trigger a warning message if BaseObject is used without its namespace, especially in the global namespace. This is to avoid symbol conflicts and prepare the renaming of BaseObject.

Note that I did not see the messages in the compilation report with MSVC, but I can see it in the IDE.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
