### PR TITLE
[DrawToolGL] Frame: fix crash on macOS

### DIFF
--- a/Sofa/GL/src/sofa/gl/Frame.cpp
+++ b/Sofa/GL/src/sofa/gl/Frame.cpp
@@ -1,4 +1,4 @@
-﻿/******************************************************************************
+/******************************************************************************
 *                 SOFA, Simulation Open-Framework Architecture                *
 *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
@@ -366,7 +366,10 @@ void render_coordinate_frame(const CoordinateFrame& frame, const type::Vec3& cen
         rotAxis.y(),
         rotAxis.z());
 
+    // macOS seems to not allow unbinding vertex array (in compat mode at least)
+#ifndef __APPLE__
     glBindVertexArray(0);
+#endif
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_NORMAL_ARRAY);
     constexpr auto gltype = (std::is_same<SReal, double>::value)?GL_DOUBLE:GL_FLOAT;


### PR DESCRIPTION
umpteenth PR on the Frame rendering.

It is crashing on the call of glBindVertexArray(), apparently due to the fact that we should create VAE and everything if we unbind.
This PR is more of an emergency fix and just introduces a quick (and dirty) fix to this problem. Obviously a better fix should be introduced using VAE, but it would need much more time.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
