### PR TITLE
[Node] A node name can now be surrounded by quotation marks 

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -508,10 +508,21 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
         }
         else
         {
-            std::size_t p2pos = pathStr.find('/',ppos);
-            if (p2pos == std::string::npos) p2pos = psize;
-            std::string nameStr = pathStr.substr(ppos,p2pos-ppos);
-            ppos = p2pos+1;
+            std::string name;
+            if (pathStr[ppos] == '\'')
+            {
+                std::size_t p2pos = pathStr.find('\'', ppos + 1);
+                if (p2pos == std::string::npos) p2pos = psize;
+                name = pathStr.substr(ppos, p2pos - ppos+1);
+                ppos = p2pos + 2;
+            }
+            else
+            {
+                std::size_t p2pos = pathStr.find('/',ppos);
+                if (p2pos == std::string::npos) p2pos = psize;
+                name = pathStr.substr(ppos,p2pos-ppos);
+                ppos = p2pos+1;
+            }
             if (master)
             {
                 if(DEBUG_LINK)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -508,19 +508,19 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
         }
         else
         {
-            std::string name;
+            std::string nameStr;
             if (pathStr[ppos] == '\'')
             {
                 std::size_t p2pos = pathStr.find('\'', ppos + 1);
                 if (p2pos == std::string::npos) p2pos = psize;
-                name = pathStr.substr(ppos, p2pos - ppos+1);
+                nameStr = pathStr.substr(ppos, p2pos - ppos+1);
                 ppos = p2pos + 2;
             }
             else
             {
                 std::size_t p2pos = pathStr.find('/',ppos);
                 if (p2pos == std::string::npos) p2pos = psize;
-                name = pathStr.substr(ppos,p2pos-ppos);
+                nameStr = pathStr.substr(ppos,p2pos-ppos);
                 ppos = p2pos+1;
             }
             if (master)


### PR DESCRIPTION
(allow node names with / , e.g. \'/universe/base\')

Motivation was to import OpenSim simulation in SOFA, where articulated chain architecture in the scene is described by frames with names such as "/universe/base".
This will be replicated in the SOFA scene using Sofa.RigidBodyDynamics plugin, while trying to stay as close as possible to OpenSim's description for the sake of future comparisons.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
