### PR TITLE
[All] add namespace to all BaseObject relying on using declarations

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/tests/CollisionPipeline_test.cpp
@@ -111,7 +111,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithNoAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 
@@ -133,7 +133,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingIntersection()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 
@@ -155,7 +155,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingBroadPhase()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 void TestCollisionPipeline::checkCollisionPipelineWithMissingNarrowPhase()
@@ -176,7 +176,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingNarrowPhase()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 }
 void TestCollisionPipeline::checkCollisionPipelineWithMissingContactManager()
@@ -197,7 +197,7 @@ void TestCollisionPipeline::checkCollisionPipelineWithMissingContactManager()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getObject("pipeline") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getObject("pipeline") ;
     ASSERT_NE(clp, nullptr) ;
 
 }

--- a/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
+++ b/Sofa/Component/Collision/Geometry/tests/Sphere_test.cpp
@@ -434,7 +434,7 @@ void checkAttributes()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
+    sofa::core::objectmodel::BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
     EXPECT_NE(theSphere, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -462,7 +462,7 @@ void checkSceneWithVec3MechanicalModel()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
+    sofa::core::objectmodel::BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
     EXPECT_NE(theSphere, nullptr) ;
 }
 
@@ -481,7 +481,7 @@ void checkSceneWithRigid3dMechanicalModel()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
+    sofa::core::objectmodel::BaseObject* theSphere = root->getTreeNode("Level 1")->getObject("spheremodel") ;
     EXPECT_NE(theSphere, nullptr) ;
 }
 

--- a/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
+++ b/Sofa/Component/Engine/Select/tests/BoxROI_test.cpp
@@ -133,7 +133,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
         EXPECT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
 
-        BaseObject* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
+        sofa::core::objectmodel::BaseObject* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
         EXPECT_NE(boxroi, nullptr);
 
         EXPECT_EQ(boxroi->getComponentState(), ComponentState::Invalid ) << "The component cannot be initialized because it is missing a MechanicalObject. "
@@ -202,7 +202,7 @@ struct BoxROITest :  public sofa::testing::BaseTest
         const Node::SPtr root = SceneLoaderXML::loadFromMemory("testscene", scene.c_str());
         EXPECT_NE(root.get(), nullptr);
         root->init(sofa::core::execparams::defaultInstance());
-        BaseObject* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
+        sofa::core::objectmodel::BaseObject* boxroi = root->getTreeNode("Level 1")->getObject("myBoxROI");
 
         EXPECT_NE(boxroi, nullptr);
         EXPECT_EQ(boxroi->getComponentState(), ComponentState::Valid ) << "The component should succeed in being initialized because there is a MeshLoader and a TopologyContainer in the current context. ";

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BaseVTKReader.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BaseVTKReader.h
@@ -49,10 +49,10 @@ enum class VTKDatasetFormat { IMAGE_DATA, STRUCTURED_POINTS,
                               POLYDATA, UNSTRUCTURED_GRID
                             };
 
-class BaseVTKReader : public BaseObject
+class BaseVTKReader : public sofa::core::objectmodel::BaseObject
 {
 public:
-    class BaseVTKDataIO : public BaseObject
+    class BaseVTKDataIO : public sofa::core::objectmodel::BaseObject
     {
     public:
         string name;

--- a/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
+++ b/Sofa/Component/Mass/tests/DiagonalMass_test.cpp
@@ -115,7 +115,7 @@ public:
             sofa::simulation::node::unload(root);
     }
 
-    void createSceneGraph(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms)
+    void createSceneGraph(VecCoord positions, sofa::core::objectmodel::BaseObject::SPtr topologyContainer, sofa::core::objectmodel::BaseObject::SPtr geometryAlgorithms)
     {
         node = root->createChild("node");
         mstate = New<MechanicalObject<DataTypes> >();
@@ -143,7 +143,7 @@ public:
             EXPECT_NEAR(expectedMass[i], mass->d_vertexMass.getValue()[i], 1e-4);
     }
 
-    void runTest(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms,
+    void runTest(VecCoord positions, sofa::core::objectmodel::BaseObject::SPtr topologyContainer, sofa::core::objectmodel::BaseObject::SPtr geometryAlgorithms,
                  MassType expectedTotalMass, const VecMass& expectedMass)
     {
         createSceneGraph(positions, topologyContainer, geometryAlgorithms);

--- a/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
+++ b/Sofa/Component/Mass/tests/MeshMatrixMass_test.cpp
@@ -118,7 +118,7 @@ public:
             sofa::simulation::node::unload(root);
     }
 
-    void createSceneGraph(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms)
+    void createSceneGraph(VecCoord positions, sofa::core::objectmodel::BaseObject::SPtr topologyContainer, sofa::core::objectmodel::BaseObject::SPtr geometryAlgorithms)
     {
         node = root->createChild("node");
         mstate = New<MechanicalObject<DataTypes> >();
@@ -161,7 +161,7 @@ public:
         }
     }
 
-    void runTest(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms,
+    void runTest(VecCoord positions, sofa::core::objectmodel::BaseObject::SPtr topologyContainer, sofa::core::objectmodel::BaseObject::SPtr geometryAlgorithms,
                  MassType expectedTotalMass, MassType expectedMassDensity, const VecMass& expectedVMass, const VecMass& expectedEMass)
     {
         createSceneGraph(positions, topologyContainer, geometryAlgorithms);

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.h
@@ -30,11 +30,11 @@ using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead."
 namespace sofa::component::sceneutility::_apiversion_
 {
 
-class SOFA_COMPONENT_SCENEUTILITY_API APIVersion : public BaseObject
+class SOFA_COMPONENT_SCENEUTILITY_API APIVersion : public sofa::core::objectmodel::BaseObject
 {
 
 public:
-    SOFA_CLASS(APIVersion, BaseObject);
+    SOFA_CLASS(APIVersion, sofa::core::objectmodel::BaseObject);
 
     const std::string& getApiLevel() ;
     void init() override ;

--- a/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.h
+++ b/Sofa/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.h
@@ -36,10 +36,10 @@ using BaseObject [[deprecated("Use sofa::core::objectmodel::BaseObject instead."
 
 /// Despite this component does absolutely nothing... it is very useful as it can be used to
 /// retain information scene graph.
-class SOFA_COMPONENT_SCENEUTILITY_API InfoComponent : public BaseObject
+class SOFA_COMPONENT_SCENEUTILITY_API InfoComponent : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(InfoComponent, BaseObject);
+    SOFA_CLASS(InfoComponent, sofa::core::objectmodel::BaseObject);
 
     InfoComponent() {}
     ~InfoComponent() override{}

--- a/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
+++ b/Sofa/GL/Component/Rendering2D/tests/OglLabel_test.cpp
@@ -76,7 +76,7 @@ public:
         root->init(sofa::core::execparams::defaultInstance()) ;
 
 
-        BaseObject* lm = root->getObject("label1") ;
+        sofa::core::objectmodel::BaseObject* lm = root->getObject("label1") ;
         ASSERT_NE(nullptr, lm) ;
 
         OglLabel* ogllabel = dynamic_cast<OglLabel*>(lm);
@@ -106,7 +106,7 @@ public:
         ASSERT_NE(nullptr, root.get()) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
-        BaseObject* lm = root->getObject("label1") ;
+        sofa::core::objectmodel::BaseObject* lm = root->getObject("label1") ;
         ASSERT_NE(nullptr, lm) ;
 
         OglLabel* ogllabel = dynamic_cast<OglLabel*>(lm);
@@ -133,7 +133,7 @@ public:
         ASSERT_NE(root.get(), nullptr) ;
         root->init(sofa::core::execparams::defaultInstance()) ;
 
-        BaseObject* lm = root->getObject("label1") ;
+        sofa::core::objectmodel::BaseObject* lm = root->getObject("label1") ;
         ASSERT_NE(lm, nullptr) ;
 
         /// List of the supported attributes the user expect to find

--- a/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
+++ b/Sofa/GL/Component/Rendering3D/tests/ClipPlane_test.cpp
@@ -89,7 +89,7 @@ void TestClipPlane::checkClipPlaneValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
     ASSERT_NE(clp, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -121,7 +121,7 @@ void TestClipPlane::checkClipPlaneAttributesValues(const std::string& dataname, 
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
+    sofa::core::objectmodel::BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
     ASSERT_NE(clp, nullptr) ;
 
     sofa::simulation::node::unload(root);

--- a/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/LightManager_test.cpp
@@ -77,7 +77,7 @@ void checkAttributes()
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     EXPECT_NE(lm, nullptr) ;
 
     /// List of the supported attributes the user expect to find

--- a/Sofa/GL/Component/Shader/tests/Light_test.cpp
+++ b/Sofa/GL/Component/Shader/tests/Light_test.cpp
@@ -80,7 +80,7 @@ void TestLight::checkLightMissingLightManager(const std::string& lighttype)
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseObject* lm = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(lm, nullptr) ;
 
     sofa::simulation::node::unload(root);
@@ -105,10 +105,10 @@ void TestLight::checkPositionalLightValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     ASSERT_NE(lm, nullptr) ;
 
-    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(light, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -146,10 +146,10 @@ void TestLight::checkDirectionalLightValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     ASSERT_NE(lm, nullptr) ;
 
-    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(light, nullptr) ;
 
     /// List of the supported attributes the user expect to find
@@ -187,10 +187,10 @@ void TestLight::checkSpotLightValidAttributes()
     ASSERT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;
 
-    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    sofa::core::objectmodel::BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     ASSERT_NE(lm, nullptr) ;
 
-    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    sofa::core::objectmodel::BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(light, nullptr) ;
 
     /// List of the supported attributes the user expect to find

--- a/Sofa/framework/Core/simutest/objectmodel/Base_test.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/Base_test.cpp
@@ -38,17 +38,17 @@ using sofa::defaulttype::Vec3Types;
 
 namespace customns
 {
-class CustomBaseObject : public BaseObject
+class CustomBaseObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(CustomBaseObject, BaseObject);
+    SOFA_CLASS(CustomBaseObject, sofa::core::objectmodel::BaseObject);
 };
 
 template<class D>
-class CustomBaseObjectT : public BaseObject
+class CustomBaseObjectT : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(CustomBaseObjectT, D), BaseObject);
+    SOFA_CLASS(SOFA_TEMPLATE(CustomBaseObjectT, D), sofa::core::objectmodel::BaseObject);
 
     static const std::string GetCustomClassName() { return "MyFakeClassName"; }
 };
@@ -100,9 +100,9 @@ TEST_F(Base_test , testComponentState )
 
 TEST_F(Base_test , testBaseClass)
 {
-    EXPECT_EQ(CustomBaseObject::GetClass()->className, "CustomBaseObject");
-    EXPECT_EQ(CustomBaseObject::GetClass()->templateName, "");
-    EXPECT_EQ(CustomBaseObject::GetClass()->shortName, "customBaseObject");
+    EXPECT_EQ(customns::CustomBaseObject::GetClass()->className, "CustomBaseObject");
+    EXPECT_EQ(customns::CustomBaseObject::GetClass()->templateName, "");
+    EXPECT_EQ(customns::CustomBaseObject::GetClass()->shortName, "customBaseObject");
 
     EXPECT_EQ(CustomBaseObjectT<Rigid3Types>::GetClass()->className, "MyFakeClassName");
     EXPECT_EQ(CustomBaseObjectT<Rigid3Types>::GetClass()->templateName, Rigid3Types::Name());
@@ -115,7 +115,7 @@ TEST_F(Base_test , testBaseClass)
 
 TEST_F(Base_test , testGetClassName)
 {
-    const CustomBaseObject o;
+    const customns::CustomBaseObject o;
     EXPECT_EQ(o.getClassName(), "CustomBaseObject");
     EXPECT_EQ(o.getTemplateName(), "");
     EXPECT_EQ(o.getTypeName(), "CustomBaseObject");

--- a/Sofa/framework/Core/simutest/objectmodel/PathResolver_simutest.cpp
+++ b/Sofa/framework/Core/simutest/objectmodel/PathResolver_simutest.cpp
@@ -84,13 +84,13 @@ TEST_P(PathResolverToBaseObject, CheckPathToBaseObject)
     auto& t = GetParam();
     if(t[2]=="true")
     {
-        ASSERT_TRUE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_TRUE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
     }
     else
     {
-        ASSERT_FALSE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_FALSE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
     }
 }
 
@@ -111,13 +111,13 @@ TEST_F(PathResolverToBaseObject, DISABLED_CheckPathToBaseObject_tofix)
 
     if (t[2] == "true")
     {
-        ASSERT_TRUE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_TRUE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_TRUE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
     }
     else
     {
-        ASSERT_FALSE(PathResolver::CheckPath(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
-        ASSERT_FALSE(PathResolver::CheckPaths(node, BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPath(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
+        ASSERT_FALSE(PathResolver::CheckPaths(node, sofa::core::objectmodel::BaseObject::GetClass(), t[0])) << t[1] << " " << t[2];
     }
 }
 

--- a/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseClass_test.cpp
@@ -34,10 +34,10 @@ using sofa::testing::BaseTest ;
 namespace sofa{
 namespace another_namespace{
 
-class EmptyObject : public BaseObject
+class EmptyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(EmptyObject, BaseObject) ;
+    SOFA_CLASS(EmptyObject, sofa::core::objectmodel::BaseObject) ;
 };
 
 }
@@ -46,10 +46,10 @@ public:
 namespace sofa{
 namespace numbered_namespace_123{
 
-class NumberedClass123 : public BaseObject
+class NumberedClass123 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(NumberedClass123, BaseObject) ;
+    SOFA_CLASS(NumberedClass123, sofa::core::objectmodel::BaseObject) ;
 };
 
 class NumberedClass456 : public another_namespace::EmptyObject
@@ -58,10 +58,10 @@ public:
     SOFA_CLASS(NumberedClass456, another_namespace::EmptyObject) ;
 };
 
-class CustomName123 : public BaseObject
+class CustomName123 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(CustomName123, BaseObject) ;
+    SOFA_CLASS(CustomName123, sofa::core::objectmodel::BaseObject) ;
 
     static const std::string GetCustomClassName(){ return "ClassWithACustomName"; }
     static const std::string GetCustomTemplateName(){ return "ClassWithACustomTemplate"; }
@@ -70,10 +70,10 @@ public:
     static const std::string className(){ return "TEST TEST"; }
 };
 
-class CustomNameOldWay : public BaseObject
+class CustomNameOldWay : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(CustomNameOldWay, BaseObject) ;
+    SOFA_CLASS(CustomNameOldWay, sofa::core::objectmodel::BaseObject) ;
 
     static const std::string className(const CustomNameOldWay* =nullptr){ return "ClassWithACustomNameOldWay"; }
 
@@ -93,40 +93,40 @@ class DataTwo { public: static std::string Name(){ return "Two" ;} };
 class NotAType {};
 
 template<class DataType1>
-class DefaultTemplate1 : public BaseObject
+class DefaultTemplate1 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(DefaultTemplate1, DataType1), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE(DefaultTemplate1, DataType1), sofa::core::objectmodel::BaseObject) ;
 };
 
 template<class DataType1, class DataType2>
-class DefaultTemplate2 : public BaseObject
+class DefaultTemplate2 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE2(DefaultTemplate2, DataType1, DataType2), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE2(DefaultTemplate2, DataType1, DataType2), sofa::core::objectmodel::BaseObject) ;
 };
 
 template<class DataType1, class DataType2, class NotAType>
-class DefaultTemplate3 : public BaseObject
+class DefaultTemplate3 : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE3(DefaultTemplate3, DataType1, DataType2, NotAType), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE3(DefaultTemplate3, DataType1, DataType2, NotAType), sofa::core::objectmodel::BaseObject) ;
 };
 
 template<class DataType1, class DataType2, class NotAType>
-class NotDefaultTemplate : public BaseObject
+class NotDefaultTemplate : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE3(NotDefaultTemplate, DataType1, DataType2, NotAType), BaseObject) ;
+    SOFA_CLASS(SOFA_TEMPLATE3(NotDefaultTemplate, DataType1, DataType2, NotAType), sofa::core::objectmodel::BaseObject) ;
 
     static const std::string GetCustomTemplateName(){ return "non,oui"; }
 };
 
 template<class TDataType1>
-class OuterClass : public BaseObject
+class OuterClass : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(OuterClass, TDataType1), BaseObject);
+    SOFA_CLASS(SOFA_TEMPLATE(OuterClass, TDataType1), sofa::core::objectmodel::BaseObject);
 
     template<class TDataType2>
     class InnerClass : public BaseObject

--- a/Sofa/framework/Core/test/objectmodel/BaseData_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseData_test.cpp
@@ -50,10 +50,10 @@ public:
     void doEndEditVoidPtr() override { }
 };
 
-class MyObject : public BaseObject
+class MyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(MyObject, BaseObject);
+    SOFA_CLASS(MyObject, sofa::core::objectmodel::BaseObject);
     MyData myData;
     MyObject() :
         myData()

--- a/Sofa/framework/Core/test/objectmodel/BaseLink_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/BaseLink_test.cpp
@@ -38,14 +38,14 @@ using sofa::testing::BaseTest ;
 #include "BaseLink_test.h"
 
 using SingleLinkImplementations = ::testing::Types<
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_STOREPATH>,
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK>>;
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_STOREPATH>,
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_MULTILINK>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(SingleLink, BaseLinkTests, SingleLinkImplementations);
 
 
 using MultiLinkImplementations = ::testing::Types<
-    MultiLink<BaseObject, BaseObject, BaseLink::FLAG_STOREPATH>,
-    MultiLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK>
+    MultiLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_STOREPATH>,
+    MultiLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_MULTILINK>
     >;
 INSTANTIATE_TYPED_TEST_SUITE_P(MultiLink, BaseLinkTests, MultiLinkImplementations);
 

--- a/Sofa/framework/Core/test/objectmodel/BaseLink_test.h
+++ b/Sofa/framework/Core/test/objectmodel/BaseLink_test.h
@@ -36,10 +36,10 @@ using sofa::testing::BaseTest ;
  * inhertited type
  ***********************************************************************************/
 template<class Link>
-class FakeObject : public BaseObject
+class FakeObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    FakeObject() : BaseObject()
+    FakeObject() : sofa::core::objectmodel::BaseObject()
     {       
     }
 };

--- a/Sofa/framework/Core/test/objectmodel/RemovedData_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/RemovedData_test.cpp
@@ -32,10 +32,10 @@ using sofa::core::objectmodel::lifecycle::RemovedData;
 namespace
 {
 
-class MyObject : public BaseObject
+class MyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(MyObject, BaseObject);
+    SOFA_CLASS(MyObject, sofa::core::objectmodel::BaseObject);
 
     DeprecatedData deprecatedData {this, "v23.06", "v23.12", "deprecatedData", "You should now use XXXX"};
     RemovedData removedData {this, "v23.06", "v23.12", "removedData", "You should now use XXXX"};

--- a/Sofa/framework/Core/test/objectmodel/SingleLink_test.cpp
+++ b/Sofa/framework/Core/test/objectmodel/SingleLink_test.cpp
@@ -33,24 +33,24 @@ using sofa::testing::BaseTest ;
 
 #include "BaseLink_test.h"
 
-class EmptyObject : public BaseObject
+class EmptyObject : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(EmptyObject, BaseObject) ;
+    SOFA_CLASS(EmptyObject, sofa::core::objectmodel::BaseObject) ;
 };
 
 class SingleLink_test: public BaseTest
 {
 public:
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH > m_link ;
-    BaseObject::SPtr m_dst ;
-    BaseObject::SPtr m_src ;
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH > m_link ;
+    sofa::core::objectmodel::BaseObject::SPtr m_dst ;
+    sofa::core::objectmodel::BaseObject::SPtr m_src ;
 
     /// Create a link to an object.
     void doSetUp() override
     {
-        m_dst = sofa::core::objectmodel::New<BaseObject>() ;
-        m_src = sofa::core::objectmodel::New<BaseObject>() ;
+        m_dst = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>() ;
+        m_src = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>() ;
 
         m_dst->setName("destination") ;
         m_src->setName("source") ;
@@ -87,14 +87,14 @@ TEST_F(SingleLink_test, checkCounterLogic )
 
 TEST_F(SingleLink_test, checkMultiLink )
 {
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK > smlink ;
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_MULTILINK > smlink ;
     ASSERT_EQ(smlink.size(), size_t(0)) ;
     smlink.add(m_dst.get()) ;
     ASSERT_EQ(smlink.size(), size_t(1)) ;
     smlink.add(m_dst.get()) ;
     ASSERT_EQ(smlink.size(), size_t(1)) ;
 
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > slink ;
+    SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > slink ;
     ASSERT_EQ(slink.size(), size_t(0)) ;
     slink.add(m_dst.get()) ;
     ASSERT_EQ(slink.size(), size_t(1)) ;
@@ -104,10 +104,10 @@ TEST_F(SingleLink_test, checkMultiLink )
 
 TEST_F(SingleLink_test, getOwnerBase)
 {
-    const auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
+    const auto aBaseObject = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
     using sofa::core::objectmodel::BaseNode;
-    const BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
-    const SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
+    const BaseLink::InitLink<sofa::core::objectmodel::BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
+    const SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
     ASSERT_EQ(objectLink.getOwnerBase(), aBaseObject.get());
     // m_link is initialized without an owner.
     // getOwnerBase() should still work and return a nullptr

--- a/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.cpp
+++ b/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.cpp
@@ -93,10 +93,10 @@ NodeSPtr createRootNode(Simulation* s, const std::string& name,
     return root ;
 }
 
-BaseObject::SPtr createObject(Node::SPtr parent, BaseObjectDescription& desc)
+sofa::core::objectmodel::BaseObject::SPtr createObject(Node::SPtr parent, BaseObjectDescription& desc)
 {
     /// Create the object.
-    BaseObject::SPtr obj = ObjectFactory::getInstance()->createObject(parent.get(), &desc);
+    sofa::core::objectmodel::BaseObject::SPtr obj = ObjectFactory::getInstance()->createObject(parent.get(), &desc);
     if (obj == nullptr)
     {
         std::stringstream msg;
@@ -112,7 +112,7 @@ BaseObject::SPtr createObject(Node::SPtr parent, BaseObjectDescription& desc)
     return obj ;
 }
 
-BaseObject::SPtr createObject(Node::SPtr parent, const std::string& type, const std::map<std::string, std::string>& params)
+sofa::core::objectmodel::BaseObject::SPtr createObject(Node::SPtr parent, const std::string& type, const std::map<std::string, std::string>& params)
 {
     /// temporarily, the name is set to the type name.
     /// if a "name" parameter is provided, it will overwrite it.

--- a/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.h
+++ b/Sofa/framework/SimpleApi/src/sofa/simpleapi/SimpleApi.h
@@ -53,11 +53,11 @@ NodeSPtr SOFA_SIMPLEAPI_API createRootNode( Simulation* s, const std::string& na
 ///@brief Create a sofa object in the provided node.
 ///The parameter "params" is for passing specific data argument to the created object including the
 ///object's type.
-sofa::core::sptr<BaseObject> SOFA_SIMPLEAPI_API createObject(NodeSPtr node, BaseObjectDescription& params);
+sofa::core::sptr<sofa::core::objectmodel::BaseObject> SOFA_SIMPLEAPI_API createObject(NodeSPtr node, BaseObjectDescription& params);
 
 ///@brief create a sofa object in the provided node of the given type.
 ///The parameter "params" is for passing specific data argument to the created object.
-sofa::core::sptr<BaseObject> SOFA_SIMPLEAPI_API createObject( NodeSPtr node, const std::string& type,
+sofa::core::sptr<sofa::core::objectmodel::BaseObject> SOFA_SIMPLEAPI_API createObject( NodeSPtr node, const std::string& type,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 ///@brief create a child to the provided nodeof given name.

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseSimulationExporter.h
@@ -42,10 +42,10 @@ using sofa::core::objectmodel::DataFileName ;
     Component that export something from the scene could inherit from this class
     as it implement an uniform handling of the different data attributes.
 */
-class SOFA_SIMULATION_CORE_API BaseSimulationExporter : public virtual BaseObject
+class SOFA_SIMULATION_CORE_API BaseSimulationExporter : public virtual sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_ABSTRACT_CLASS(BaseSimulationExporter, BaseObject);
+    SOFA_ABSTRACT_CLASS(BaseSimulationExporter, sofa::core::objectmodel::BaseObject);
 
     DataFileName       d_filename ;
     Data<unsigned int> d_exportEveryNbSteps;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -227,7 +227,7 @@ void Node::moveChild(BaseNode::SPtr node, BaseNode::SPtr prev_parent)
     doMoveChild(node, prev_parent);
 }
 /// Add an object. Detect the implemented interfaces and add the object to the corresponding lists.
-bool Node::addObject(BaseObject::SPtr obj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
+bool Node::addObject(sofa::core::objectmodel::BaseObject::SPtr obj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
 {
     // If an object we are trying to add already has a context, it is in another node in the
     // graph: we need to remove it from this context before to insert it into the current
@@ -245,7 +245,7 @@ bool Node::addObject(BaseObject::SPtr obj, sofa::core::objectmodel::TypeOfInsert
 }
 
 /// Remove an object
-bool Node::removeObject(BaseObject::SPtr obj)
+bool Node::removeObject(sofa::core::objectmodel::BaseObject::SPtr obj)
 {
     notifyBeginRemoveObject(this, obj);
     const bool ret = doRemoveObject(obj);
@@ -254,7 +254,7 @@ bool Node::removeObject(BaseObject::SPtr obj)
 }
 
 /// Move an object from another node
-void Node::moveObject(BaseObject::SPtr obj)
+void Node::moveObject(sofa::core::objectmodel::BaseObject::SPtr obj)
 {
     Node* prev_parent = down_cast<Node>(obj->getContext()->toBaseNode());
     if (prev_parent)
@@ -421,7 +421,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
         return destType->dynamicCast(link->getOwnerBase());
     }
     Node* node = this;
-    BaseObject* master = nullptr;
+    sofa::core::objectmodel::BaseObject* master = nullptr;
     bool based = false;
     if (ppos < psize && pathStr[ppos] == '[') // relative index in the list of objects
     {
@@ -523,7 +523,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
             {
                 for (;;)
                 {
-                    BaseObject* obj = node->getObject(nameStr);
+                    sofa::core::objectmodel::BaseObject* obj = node->getObject(nameStr);
                     Node* childPtr = node->getChild(nameStr);
                     if (childPtr)
                     {
@@ -568,7 +568,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
         }
         for (ObjectIterator it = node->object.begin(), itend = node->object.end(); it != itend; ++it)
         {
-            BaseObject* obj = it->get();
+            sofa::core::objectmodel::BaseObject* obj = it->get();
             Base *o = destType->dynamicCast(obj);
             if (!o) continue;
             if(DEBUG_LINK)
@@ -600,7 +600,7 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
 }
 
 /// Add an object. Detect the implemented interfaces and add the object to the corresponding lists.
-bool Node::doAddObject(BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
+bool Node::doAddObject(sofa::core::objectmodel::BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfInsertion insertionLocation)
 {
     this->setObjectContext(sobj);
     if(insertionLocation == sofa::core::objectmodel::TypeOfInsertion::AtEnd)
@@ -608,7 +608,7 @@ bool Node::doAddObject(BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfIns
     else
         object.addBegin(sobj);
 
-    BaseObject* obj = sobj.get();
+    sofa::core::objectmodel::BaseObject* obj = sobj.get();
 
     if( !obj->insertInNode( this ) )
     {
@@ -618,13 +618,13 @@ bool Node::doAddObject(BaseObject::SPtr sobj, sofa::core::objectmodel::TypeOfIns
 }
 
 /// Remove an object
-bool Node::doRemoveObject(BaseObject::SPtr sobj)
+bool Node::doRemoveObject(sofa::core::objectmodel::BaseObject::SPtr sobj)
 {
     dmsg_warning_when(sobj == nullptr) << "Trying to remove a nullptr object";
 
     this->clearObjectContext(sobj);
     object.remove(sobj);
-    BaseObject* obj = sobj.get();
+    sofa::core::objectmodel::BaseObject* obj = sobj.get();
 
     if(obj != nullptr && !obj->removeInNode( this ) )
         unsorted.remove(obj);
@@ -632,7 +632,7 @@ bool Node::doRemoveObject(BaseObject::SPtr sobj)
 }
 
 /// Remove an object
-void Node::doMoveObject(BaseObject::SPtr sobj, Node* prev_parent)
+void Node::doMoveObject(sofa::core::objectmodel::BaseObject::SPtr sobj, Node* prev_parent)
 {
     if (prev_parent != nullptr)
         prev_parent->removeObject(sobj);

--- a/Sofa/framework/Simulation/Graph/test/Link_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Link_test.cpp
@@ -45,15 +45,15 @@ struct Link_test : public BaseSimulationTest
     {
         SceneInstance si("root") ;
 
-        auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
+        auto aBaseObject = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         sofa::core::objectmodel::Base* aBasePtr = aBaseObject.get();
         si.root->addObject(aBaseObject);
 
         using sofa::core::objectmodel::BaseNode;
-        BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
-        BaseLink::InitLink<BaseObject> initNodeLink(aBaseObject.get(), "nodelink", "");
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
-        SingleLink<BaseObject, BaseNode, BaseLink::FLAG_NONE > nodeLink(initNodeLink);
+        BaseLink::InitLink<sofa::core::objectmodel::BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
+        BaseLink::InitLink<sofa::core::objectmodel::BaseObject> initNodeLink(aBaseObject.get(), "nodelink", "");
+        SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
+        SingleLink<sofa::core::objectmodel::BaseObject, BaseNode, BaseLink::FLAG_NONE > nodeLink(initNodeLink);
 
         // objectLink.add(aBasePtr); //< not possible because of template type specification
 
@@ -69,14 +69,14 @@ struct Link_test : public BaseSimulationTest
     void read_multilink_test()
     {
         const SceneInstance si("root") ;
-        const BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
-        const BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
-        const BaseObject::SPtr C = sofa::core::objectmodel::New<BaseObject>();
+        const sofa::core::objectmodel::BaseObject::SPtr A = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
+        const sofa::core::objectmodel::BaseObject::SPtr B = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
+        const sofa::core::objectmodel::BaseObject::SPtr C = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         si.root->addObject(A);
         si.root->addObject(B);
 
-        const BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
-        MultiLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
+        const BaseLink::InitLink<sofa::core::objectmodel::BaseObject> il1(B.get(), "l1", "");
+        MultiLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
 
         // 1. test with valid link & owner
         EXPECT_TRUE(withOwner.read("@/B"));
@@ -91,12 +91,12 @@ struct Link_test : public BaseSimulationTest
     void read_test()
     {
         SceneInstance si("root") ;
-        BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
-        BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
+        sofa::core::objectmodel::BaseObject::SPtr A = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
+        sofa::core::objectmodel::BaseObject::SPtr B = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         si.root->addObject(A);
-        BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withoutOwner;
+        BaseLink::InitLink<sofa::core::objectmodel::BaseObject> il1(B.get(), "l1", "");
+        SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
+        SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > withoutOwner;
         withoutOwner.setOwner(nullptr);
 
         // 1. test with invalid link & no owner
@@ -126,12 +126,12 @@ struct Link_test : public BaseSimulationTest
     void read_test_tofix()
     {
         const SceneInstance si("root");
-        const BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
-        const BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
+        const sofa::core::objectmodel::BaseObject::SPtr A = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
+        const sofa::core::objectmodel::BaseObject::SPtr B = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         si.root->addObject(A);
-        const BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1);
-        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withoutOwner;
+        const BaseLink::InitLink<sofa::core::objectmodel::BaseObject> il1(B.get(), "l1", "");
+        SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > withOwner(il1);
+        SingleLink<sofa::core::objectmodel::BaseObject, sofa::core::objectmodel::BaseObject, BaseLink::FLAG_NONE > withoutOwner;
         withoutOwner.setOwner(nullptr);
 
         // Here link is OK, but points to a BaseNode, while the link only accepts BaseObjects. Should return false. But returns true, since findLinkDest returns false in read()

--- a/Sofa/framework/Simulation/Graph/test/MutationListener_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/MutationListener_test.cpp
@@ -51,20 +51,20 @@ class TestMutationListener : public MutationListener
         log += "End Remove " + child->getName() + " from " + parent->getName() + "\n";
     }
 
-    void onBeginAddObject(Node* parent, BaseObject* obj) override
+    void onBeginAddObject(Node* parent, sofa::core::objectmodel::BaseObject* obj) override
     {
         log += "Begin Add " + obj->getName() + " to " + parent->getName() + "\n";
     }
-    void onEndAddObject(Node* parent, BaseObject* obj) override
+    void onEndAddObject(Node* parent, sofa::core::objectmodel::BaseObject* obj) override
     {
         log += "End Add " + obj->getName() + " to " + parent->getName() + "\n";
     }
 
-    void onBeginRemoveObject(Node* parent, BaseObject* obj) override
+    void onBeginRemoveObject(Node* parent, sofa::core::objectmodel::BaseObject* obj) override
     {
         log += "Begin Remove " + obj->getName() + " from " + parent->getName() + "\n";
     }
-    void onEndRemoveObject(Node* parent, BaseObject* obj) override
+    void onEndRemoveObject(Node* parent, sofa::core::objectmodel::BaseObject* obj) override
     {
         log += "End Remove " + obj->getName() + " from " + parent->getName() + "\n";
     }
@@ -85,8 +85,8 @@ struct MutationListener_test : public BaseTest
     Node::SPtr node1_1;
     Node::SPtr node1_2;
     Node::SPtr node2;
-    BaseObject::SPtr obj1;
-    BaseObject::SPtr obj2;
+    sofa::core::objectmodel::BaseObject::SPtr obj1;
+    sofa::core::objectmodel::BaseObject::SPtr obj2;
 
 
     MutationListener_test() {}
@@ -223,13 +223,13 @@ struct MutationListener_test : public BaseTest
     void test_addObject()
     {
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj1->parse(&bod1);
         root->addObject(obj1);
         EXPECT_EQ("Begin Add obj1 to root\nEnd Add obj1 to root\n", listener.log);
         listener.clearLog();
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj2->parse(&bod2);
         root->addObject(obj2);
         EXPECT_EQ("Begin Add obj2 to root\nEnd Add obj2 to root\n", listener.log);
@@ -293,11 +293,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node2 = sofa::core::objectmodel::New<Node>("node2");
         node1->addChild(node2);
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj1->parse(&bod1);
         node2->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj2->parse(&bod2);
         node2->addObject(obj2);
         listener.clearLog();
@@ -315,11 +315,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node2 = sofa::core::objectmodel::New<Node>("node2");
         node1->addChild(node2);
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj1->parse(&bod1);
         node2->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj2->parse(&bod2);
         node2->addObject(obj2);
         root->addChild(node1);
@@ -338,11 +338,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node2 = sofa::core::objectmodel::New<Node>("node2");
         node1->addChild(node2);
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj1->parse(&bod1);
         node2->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj2->parse(&bod2);
         node2->addObject(obj2);
         root->addChild(node1);
@@ -370,11 +370,11 @@ struct MutationListener_test : public BaseTest
         const Node::SPtr node8 = sofa::core::objectmodel::New<Node>("node8");
 
         sofa::core::objectmodel::BaseObjectDescription bod1("obj1", "BaseObject");
-        obj1 = sofa::core::objectmodel::New<BaseObject>();
+        obj1 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj1->parse(&bod1);
         node1->addObject(obj1);
         sofa::core::objectmodel::BaseObjectDescription bod2("obj2", "BaseObject");
-        obj2 = sofa::core::objectmodel::New<BaseObject>();
+        obj2 = sofa::core::objectmodel::New<sofa::core::objectmodel::BaseObject>();
         obj2->parse(&bod2);
         node1->addObject(obj2);
 

--- a/Sofa/framework/Simulation/Graph/test/Node_test.cpp
+++ b/Sofa/framework/Simulation/Graph/test/Node_test.cpp
@@ -55,7 +55,7 @@ TEST( Node_test, getPathName)
     const Node::SPtr root = sofa::simpleapi::createNode("A");
     const Node::SPtr B = createChild(root, "B");
     const Node::SPtr D = createChild(B, "D");
-    const BaseObject::SPtr C = core::objectmodel::New<Dummy>("C");
+    const sofa::core::objectmodel::BaseObject::SPtr C = core::objectmodel::New<Dummy>("C");
     root->addObject(C);
 
     EXPECT_STREQ(root->getPathName().c_str(), "/");
@@ -67,8 +67,8 @@ TEST( Node_test, getPathName)
 TEST(Node_test, addObject)
 {
     const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
-    const BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
-    const BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
+    const sofa::core::objectmodel::BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
+    const sofa::core::objectmodel::BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
 
     root->addObject(A);
 
@@ -83,8 +83,8 @@ TEST(Node_test, addObject)
 TEST(Node_test, addObjectAtFront)
 {
     const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
-    const BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
-    const BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
+    const sofa::core::objectmodel::BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
+    const sofa::core::objectmodel::BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
 
     root->addObject(A);
 
@@ -103,8 +103,8 @@ TEST(Node_test, addObjectPreventingSharedContext)
 
     const sofa::core::sptr<Node> root = sofa::simpleapi::createNode("root");
 
-    const BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
-    const BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
+    const sofa::core::objectmodel::BaseObject::SPtr A = core::objectmodel::New<Dummy>("A");
+    const sofa::core::objectmodel::BaseObject::SPtr B = core::objectmodel::New<Dummy>("B");
 
     const auto child1 = sofa::simpleapi::createChild(root, "child1");
     const auto child2 = sofa::simpleapi::createChild(root, "child2");

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
@@ -184,7 +184,7 @@ Node::SPtr createObstacle(Node::SPtr  parent, const std::string &filenameCollisi
 }
 
 
-Node::SPtr createCollisionNodeVec3(Node::SPtr  parent, BaseObject::SPtr  dof,
+Node::SPtr createCollisionNodeVec3(Node::SPtr  parent, sofa::core::objectmodel::BaseObject::SPtr  dof,
                                    const std::string &filename,
                                    const std::vector<std::string> &elements,
                                    const Deriv3& translation, const Deriv3 &rotation)
@@ -214,7 +214,7 @@ Node::SPtr createCollisionNodeVec3(Node::SPtr  parent, BaseObject::SPtr  dof,
 }
 
 simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr  parent,
-                                            BaseObject::SPtr  dof,
+                                            sofa::core::objectmodel::BaseObject::SPtr  dof,
                                             const std::string &filename, const std::string& color,
                                             const Deriv3& translation, const Deriv3 &rotation,
                                             const MappingType &mappingT)
@@ -259,7 +259,7 @@ simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr  parent,
 
 
 
-Node::SPtr createCollisionNodeRigid(Node::SPtr  parent, BaseObject::SPtr  dofRigid,
+Node::SPtr createCollisionNodeRigid(Node::SPtr  parent, sofa::core::objectmodel::BaseObject::SPtr  dofRigid,
                                     const std::string &filename,
                                     const std::vector<std::string> &elements,
                                     const Deriv3& translation, const Deriv3 &rotation)
@@ -290,7 +290,7 @@ Node::SPtr createCollisionNodeRigid(Node::SPtr  parent, BaseObject::SPtr  dofRig
     return node;
 }
 
-Node::SPtr createVisualNodeRigid(Node::SPtr  parent, BaseObject::SPtr  dofRigid,
+Node::SPtr createVisualNodeRigid(Node::SPtr  parent, sofa::core::objectmodel::BaseObject::SPtr  dofRigid,
                                  const std::string &filename, const std::string& color,
                                  const Deriv3& translation, const Deriv3 &rotation)
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.h
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.h
@@ -65,13 +65,13 @@ SOFA_SCENECREATOR_API simulation::Node::SPtr createObstacle(simulation::Node::SP
 /// Create a collision node using Barycentric Mapping, using a 3d model specified by filename.
 /// elements is a vector of type of collision models (Triangle, Line, Point, Sphere)
 /// an initial transformation can be performed
-SOFA_SCENECREATOR_API simulation::Node::SPtr createCollisionNodeVec3(simulation::Node::SPtr parent, BaseObject::SPtr dof,
+SOFA_SCENECREATOR_API simulation::Node::SPtr createCollisionNodeVec3(simulation::Node::SPtr parent, sofa::core::objectmodel::BaseObject::SPtr dof,
                                                                      const std::string &filename,
                                                                      const std::vector<std::string> &elements,
                                                                      const Deriv3& translation=Deriv3(),
                                                                      const Deriv3 &rotation=Deriv3());
 
-SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr parent, BaseObject::SPtr dof,
+SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeVec3(simulation::Node::SPtr parent, sofa::core::objectmodel::BaseObject::SPtr dof,
                                                                   const std::string &filename, const std::string& color,
                                                                   const Deriv3& translation=Deriv3(),
                                                                   const Deriv3 &rotation=Deriv3(),
@@ -82,14 +82,14 @@ SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeVec3(simulation::No
 /// elements is a vector of type of collision models (Triangle, Line, Point, Sphere)
 /// an initial transformation can be performed
 SOFA_SCENECREATOR_API simulation::Node::SPtr createCollisionNodeRigid(simulation::Node::SPtr parent,
-                                                                      BaseObject::SPtr dofRigid,
+                                                                      sofa::core::objectmodel::BaseObject::SPtr dofRigid,
                                                                       const std::string &filename,
                                                                       const std::vector<std::string> &elements,
                                                                       const Deriv3& translation=Deriv3(),
                                                                       const Deriv3 &rotation=Deriv3());
 
 SOFA_SCENECREATOR_API simulation::Node::SPtr createVisualNodeRigid(simulation::Node::SPtr parent,
-                                                                   BaseObject::SPtr  dofRigid,
+                                                                   sofa::core::objectmodel::BaseObject::SPtr  dofRigid,
                                                                    const std::string &filename,
                                                                    const std::string& color,
                                                                    const Deriv3& translation=Deriv3(),

--- a/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
+++ b/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
@@ -62,10 +62,10 @@ using sofa::core::ExecParams;
 
 #include <sofa/simpleapi/SimpleApi.h>
 
-class ComponentDeprecated : public BaseObject
+class ComponentDeprecated : public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS(ComponentDeprecated, BaseObject);
+    SOFA_CLASS(ComponentDeprecated, sofa::core::objectmodel::BaseObject);
 public:
 
 };


### PR DESCRIPTION
This PR follows #5811. It adds the BaseObject namespace wherever a BaseObject symbol is used using a using declaration.

Note: to locate those symbols, I first deleted all the using declarations in a first  commit. ~~This commit must be reverted to avoid breaking changes.~~
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
