### PR TITLE
[BuiltConstraintSolver] Fix for regularization call with empty W and SVD

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/BuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/BuiltConstraintSolver.cpp
@@ -164,7 +164,8 @@ void BuiltConstraintSolver::doBuildSystem( const core::ConstraintParams *cParams
             compliance.assembleMatrix();
         });
 
-    addRegularization(problem->W,  d_regularizationTerm.getValue());
+    if (problem->W.rowSize() || problem->W.colSize())
+        addRegularization(problem->W,  d_regularizationTerm.getValue());
     dmsg_info() << " computeCompliance_done "  ;
 }
 


### PR DESCRIPTION
The `BuiltConstraintSolver` introduced a new class method for SVD regularization. This method doesn't check whether W is empty. If a scene starts without any constraints active, there is an immediate crash:
https://github.com/sofa-framework/sofa/blob/0b57eb7d03e2cd7398de67deb55eb6073a438e80/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/BuiltConstraintSolver.cpp#L62-L65

I added a check to bypass the regularization all together if W is empty. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
