### PR TITLE
[GitHub] Add write permissions to filter_build job

### DIFF
--- a/.github/workflows/trigger-build-and-tests.yml
+++ b/.github/workflows/trigger-build-and-tests.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Run when PR is opened or a commit is pushed in a PR
         if: ${{ github.event_name == 'pull_request' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FILTER_BUILD_ACTION_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           OWNER_NAME: ${{ github.event.pull_request.head.repo.owner.login }}
           PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Regarding some [filter_build jobs](https://github.com/sofa-framework/sofa/actions/runs/20313353699/job/58404539222) it appears that permission errors are thrown : 

```
❌ Failed to update status
Status: 403 | Response: {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/commits/statuses#create-a-commit-status","status":"403"}
❌ Failed to post comment to PR #5663
Status: 403 | Response: {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/issues/comments#create-an-issue-comment","status":"403"}
```

[force-full-build]




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
