### PR TITLE
[AnimationLoop] Deprecated ConstraintAnimationLoop

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
@@ -22,6 +22,8 @@
 #pragma once
 #include <sofa/component/animationloop/config.h>
 
+SOFA_HEADER_DEPRECATED_NOT_REPLACED("v26.06", "v26.12")
+
 
 #include <sofa/helper/map.h>
 #include <sofa/linearalgebra/FullMatrix.h>

--- a/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/ComponentChange.cpp
@@ -30,6 +30,7 @@ std::map<std::string, Deprecated, std::less<> > deprecatedComponents = {
     {"BruteForceDetection", Deprecated("v21.06", "v21.12")},
     {"DirectSAP", Deprecated("v21.06", "v21.12")},
     {"RigidRigidMapping", Deprecated("v23.06", "v23.12", "You can use the component RigidMapping with template='Rigid3,Rigid3' instead.")},
+    {"ConstraintAnimationLoop", Deprecated("v26.06", "v26.12", "Use FreeMotionAnimationLoop instead.")},
 };
 
 std::map<std::string, ComponentChange, std::less<> > movedComponents = {


### PR DESCRIPTION
Should be deprecated according to https://github.com/sofa-framework/sofa/blob/b0886d2087687f3dd1829a2a740e03e129c07689/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp#L247



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
