### PR TITLE
[Lagrangian.Solver] Replace raw pointers by unique_ptr for GenericConstraintProblem

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -112,16 +112,6 @@ GenericConstraintSolver::GenericConstraintSolver()
     d_tolerance.setRequired(true);
 }
 
-GenericConstraintSolver::~GenericConstraintSolver()
-{
-    for (unsigned i=0; i< CP_BUFFER_SIZE; ++i)
-    {
-        delete m_cpBuffer[i];
-    }
-}
-
-
-
 void GenericConstraintSolver::  init()
 {
     this->initializeConstraintProblems();
@@ -144,9 +134,9 @@ void GenericConstraintSolver::initializeConstraintProblems()
 {
     for (unsigned i=0; i< CP_BUFFER_SIZE; ++i)
     {
-        m_cpBuffer[i] = new GenericConstraintProblem(this);
+        m_cpBuffer[i] = std::make_unique<GenericConstraintProblem>(this);
     }
-    current_cp = m_cpBuffer[0];
+    current_cp = m_cpBuffer[0].get();
 }
 
 void GenericConstraintSolver::cleanup()
@@ -414,7 +404,7 @@ void GenericConstraintSolver::lockConstraintProblem(sofa::core::objectmodel::Bas
 
     for (unsigned int i = 0; i < CP_BUFFER_SIZE; ++i)
     {
-        GenericConstraintProblem* p = m_cpBuffer[i];
+        GenericConstraintProblem* p = m_cpBuffer[i].get();
         if (p == p1 || p == p2)
         {
             m_cpIsLocked[i] = true;

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -45,7 +45,6 @@ public:
     SOFA_CLASS(GenericConstraintSolver, ConstraintSolverImpl);
 protected:
     GenericConstraintSolver();
-    ~GenericConstraintSolver() override;
 public:
     void init() override;
 
@@ -89,8 +88,8 @@ protected:
     void clearConstraintProblemLocks();
 
     static constexpr auto CP_BUFFER_SIZE = 10;
-    sofa::type::fixed_array<GenericConstraintProblem * , CP_BUFFER_SIZE> m_cpBuffer;
-    sofa::type::fixed_array<bool, CP_BUFFER_SIZE> m_cpIsLocked;
+    sofa::type::fixed_array<std::unique_ptr<GenericConstraintProblem>, CP_BUFFER_SIZE> m_cpBuffer;
+    sofa::type::fixed_array<bool, CP_BUFFER_SIZE> m_cpIsLocked = sofa::type::makeHomogeneousArray<bool, CP_BUFFER_SIZE>(false);
     GenericConstraintProblem *current_cp, *last_cp;
 
     sofa::core::MultiVecDerivId m_lambdaId;

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
@@ -97,9 +97,9 @@ void UnbuiltConstraintSolver::initializeConstraintProblems()
 {
     for (unsigned i=0; i< CP_BUFFER_SIZE; ++i)
     {
-        m_cpBuffer[i] = new UnbuiltConstraintProblem(this);
+        m_cpBuffer[i] = std::make_unique<UnbuiltConstraintProblem>(this);
     }
-    current_cp = m_cpBuffer[0];
+    current_cp = m_cpBuffer[0].get();
 }
 
 


### PR DESCRIPTION
`m_cpBuffer` elements were not initialized with `nullptr`. Therefore, `delete m_cpBuffer[i]` is an undefined behavior.

Fixes https://github.com/sofa-framework/doc/issues/210





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
