### PR TITLE
[Helper::Utils] Add method to be able to manually set SOFAPathPrefix to override getExecutablePath if SOFA_ROOT is not set

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
@@ -143,7 +143,11 @@ const std::string& Utils::getExecutableDirectory()
     return path;
 }
 
-static std::string computeSofaPathPrefix()
+/// @brief variable to store custom path set using @sa setSofaCustomPathPrefix to override classical
+/// SOFA_ROOT or getExecutablePath method
+static std::string s_sofaPathPrefix;
+
+std::string computeSofaPathPrefix()
 {
     const char* pathVar = getenv("SOFA_ROOT");
     if (pathVar != nullptr && FileSystem::exists(pathVar))
@@ -168,8 +172,14 @@ static std::string computeSofaPathPrefix()
 
 const std::string& Utils::getSofaPathPrefix()
 {
-    static const std::string prefix = computeSofaPathPrefix();
-    return prefix;
+    if (s_sofaPathPrefix.empty())
+        s_sofaPathPrefix = computeSofaPathPrefix();
+    return s_sofaPathPrefix;
+}
+
+void Utils::setSofaCustomPathPrefix(const std::string& path)
+{
+    s_sofaPathPrefix = FileSystem::cleanPath(path);
 }
 
 const std::string Utils::getSofaPathTo(const std::string& pathFromBuildDir)

--- a/Sofa/framework/Helper/src/sofa/helper/Utils.h
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.h
@@ -96,6 +96,9 @@ static const std::string& getSofaUserLocalDirectory();
 /// @return The ABSOLUTE path of Sofa build dir (or install dir)
 static const std::string& getSofaPathPrefix();
 
+/// @brief Set a custom path to be used by getSofaPathPrefix()
+static void setSofaCustomPathPrefix(const std::string& path);
+
 /// @brief Construct a path based on the build dir path of Sofa
 ///
 /// @warning This function is meant to be used only by the applications that are

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.h
@@ -23,6 +23,7 @@
 #define SOFA_HELPER_SYSTEM_FILEREPOSITORY_H
 
 #include <sofa/helper/config.h>
+#include <sofa/helper/logging/Messaging.h>
 
 #include <string>
 #include <vector>
@@ -165,7 +166,10 @@ public:
         return _flux;
     }
 
-    void displayPaths() const {std::cout<<(*this)<<std::endl;}
+    void displayPaths() const 
+    { 
+        msg_info("FileRepository") << (*this);
+    }
 
     const std::string getTempPath() const;
 


### PR DESCRIPTION
I need this method when I'm shipping SOFA dll which are used froma third party software.

Right now the main mechanism is to set SOFA_ROOT to explicitly define where is the build/install of SOFA with it's internal structure: bin/ data/ and even /etc/sofa/python.d/ which is used by PythonEnvironment to load site-packages
I can't rely on this mechanism as I can't ask all users to set a env variable (especially not IT users). 

The current fallback solution if SOFA_ROOT is not set is to use the current executable path. This solution is not always relevant, for example, inside Unity3D,  the path would be something like: C:/Program Files/Unity/Unity.exe which doesn't correspond to the current project path. 

The method just allows to set a custom path. Then, if the path is set we don't call computeSofaPathPrefix() which is doing the normal mechanism:
```
const char* pathVar = getenv("SOFA_ROOT");
if (pathVar != nullptr && FileSystem::exists(pathVar))
{
    return FileSystem::convertBackSlashesToSlashes(pathVar);
}
else {
    const std::string exePath = Utils::getExecutablePath();
...
```


[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
