### PR TITLE
[Helper] Add default constructor for iota_iterator

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/IotaView.h
+++ b/Sofa/framework/Helper/src/sofa/helper/IotaView.h
@@ -20,6 +20,7 @@ public:
         using reference = T&;
         using pointer = T*;
 
+        iota_iterator() = default;
         explicit iota_iterator(T val) : val_(val) {}
 
         T operator*() const { return val_; }
@@ -27,7 +28,7 @@ public:
         bool operator!=(const iota_iterator& other) const { return val_ != other.val_; }
 
     private:
-        T val_;
+        T val_{};
     };
 
     using iterator = iota_iterator;


### PR DESCRIPTION
This is required if we want to put a `iota_iterator` in a vector, and it's what `std::for_each(std::execution::par, ...)` does.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
