### PR TITLE
[Visual] Update BaseCamera init logic when a camera is set in the scene with custom Data inputs

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/BaseCamera.h
+++ b/Sofa/Component/Visual/src/sofa/component/visual/BaseCamera.h
@@ -87,7 +87,6 @@ public:
 
     void init() override;
     void reinit() override;
-    void bwdInit() override;
 
     void activate();
     void desactivate();


### PR DESCRIPTION
This is just to be able to set manually an Interactive/BaseCamera in the scene with wanted Data for position + orientation or position + lookAt and also set ZNear and ZFar values that is not overridden at start.


Quick Note: Another solution to be able to change ZNear and ZFar values:
Do not add Camera in the scene and use the default one. Save the camera position and then edit the .view file. ZNear and ZFar are specified in it.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
