### PR TITLE
[GUI] Invalidate static dangling pointer

### DIFF
--- a/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.cpp
+++ b/Sofa/GUI/Common/src/sofa/gui/common/GUIManager.cpp
@@ -251,6 +251,7 @@ void GUIManager::closeGUI()
     if(currentGUI)
     {
         currentGUI->closeGUI();
+        currentGUI = nullptr;
     }
     else
     {


### PR DESCRIPTION
Consider the following Python script:

```python
# Required import for SOFA within python
import Sofa

# Import the GUI package
import SofaImGui
import Sofa.Gui

def main():
    # Call the SOFA function to create the root node
    root = Sofa.Core.Node("root")

    # Call the createScene function, as runSofa does
    createScene(root)

    # Once defined, initialization of the scene graph
    Sofa.Simulation.initRoot(root)

    # Launch the GUI (imgui is now by default, to use Qt please refer to the example "basic-useQtGui.py")
    Sofa.Gui.GUIManager.Init("myscene", "imgui")
    Sofa.Gui.GUIManager.createGUI(root, __file__)
    Sofa.Gui.GUIManager.SetDimension(1080, 800)

    # Initialization of the scene will be done here
    Sofa.Gui.GUIManager.MainLoop(root)
    Sofa.Gui.GUIManager.closeGUI()

def createScene(rootNode):
    #Doesn't do anything yet
    return rootNode

if __name__ == '__main__':
    # Note the 2 calls to main()
    main()
    main()
```

In the same program, we open twice a new GUI. After closing the first GUI, the static pointer to a GUI is dangling. It must be reinitialized to `nullptr` for a proper behavior (otherwise it crashes).



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
