### PR TITLE
[helper/system] FileRepository: adds findAllFilesInRepository method

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
@@ -304,6 +304,46 @@ bool FileRepository::findFileFromFile(std::string& filename, const std::string& 
     return findFile(filename, SetDirectory::GetParentDir(basefile.c_str()), errlog);
 }
 
+void FileRepository::findAllFilesInRepository(const std::string& path, std::vector<std::string>& files, const std::vector<std::string>& extensions, bool recursive)
+{
+    for (std::vector<std::string>::const_iterator it = vpath.begin(); it != vpath.end(); ++it)
+    {
+        // Get the full / absolute path (vpath + path)
+        const std::string fullPath = SetDirectory::GetRelativeFromDir(path.c_str(), it->c_str());
+        fs::path p = fs::path(fullPath);
+
+        if (fs::exists(p) && fs::is_directory(p))
+        {
+            if (recursive)
+            {
+                for (auto& entry : fs::recursive_directory_iterator(p))
+                {
+                    if (fs::is_regular_file(entry.path()))
+                    {
+                        if (extensions.empty() || std::find(extensions.begin(), extensions.end(), entry.path().extension()) != extensions.end())
+                        {
+                            files.push_back(entry.path().string());
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (auto& entry : fs::directory_iterator(p))
+                {
+                    if (fs::is_regular_file(entry.path()))
+                    {
+                        if (extensions.empty() || std::find(extensions.begin(), extensions.end(), entry.path().extension()) != extensions.end())
+                        {
+                            files.push_back(entry.path().string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 void FileRepository::print()
 {
     for (std::vector<std::string>::const_iterator it = vpath.begin(); it != vpath.end(); ++it)

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
@@ -306,6 +306,17 @@ bool FileRepository::findFileFromFile(std::string& filename, const std::string& 
 
 void FileRepository::findAllFilesInRepository(const std::string& path, std::vector<std::string>& files, const std::vector<std::string>& extensions, bool recursive)
 {
+    auto addToFiles = [&files, extensions](const std::filesystem::directory_entry& entry)
+    {
+        if (fs::is_regular_file(entry.path()))
+        {
+            if (extensions.empty() || std::find(extensions.begin(), extensions.end(), entry.path().extension()) != extensions.end())
+            {
+                files.push_back(entry.path().string());
+            }
+        }
+    };
+
     for (std::vector<std::string>::const_iterator it = vpath.begin(); it != vpath.end(); ++it)
     {
         // Get the full / absolute path (vpath + path)
@@ -318,26 +329,14 @@ void FileRepository::findAllFilesInRepository(const std::string& path, std::vect
             {
                 for (auto& entry : fs::recursive_directory_iterator(p))
                 {
-                    if (fs::is_regular_file(entry.path()))
-                    {
-                        if (extensions.empty() || std::find(extensions.begin(), extensions.end(), entry.path().extension()) != extensions.end())
-                        {
-                            files.push_back(entry.path().string());
-                        }
-                    }
+                    addToFiles(entry);
                 }
             }
             else
             {
                 for (auto& entry : fs::directory_iterator(p))
                 {
-                    if (fs::is_regular_file(entry.path()))
-                    {
-                        if (extensions.empty() || std::find(extensions.begin(), extensions.end(), entry.path().extension()) != extensions.end())
-                        {
-                            files.push_back(entry.path().string());
-                        }
-                    }
+                    addToFiles(entry);
                 }
             }
         }

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.h
@@ -135,12 +135,19 @@ public:
         findFile(filename, basedir, errlog);
         return filename;
     }
-
+    
     /// Find file using the stored set of paths.
     /// @param basefile override current directory by using the parent directory of the given file
     /// @param filename requested file as input, resolved file path as output
     /// @return true if the file was found in one of the directories, false otherwise
     bool findFileFromFile(std::string& filename, const std::string& basefile, std::ostream* errlog=&std::cerr);
+
+    /// Find all files in the repository under the given path.
+    /// @param path Path in vpath to search into.
+    /// @param files Output vector of found files.
+    /// @param extensions Extension filter (e.g. ".txt"), empty string means no filter.
+    /// @param recursive Indicates whether to search recursively into sub-directories.
+    void findAllFilesInRepository(const std::string& path, std::vector<std::string>& files, const std::vector<std::string> &extensions, bool recursive=true);
 
     /// Print the list of path to std::cout
     void print();


### PR DESCRIPTION
This PR adds the method `findAllFilesInRepository()` to the class `FileRepository`.
This allow for instance to list examples in the Components window of the GUI.

<img width="3840" height="2236" alt="image" src="https://github.com/user-attachments/assets/b3f4abb9-8a00-4fcf-8c26-2bc46114b242" />


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
