### PR TITLE
[Helper] Add a quiet option for testing methods

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
@@ -209,7 +209,7 @@ bool FileSystem::removeDirectory(const std::string& path)
 }
 
 
-bool FileSystem::exists(const std::string& path)
+bool FileSystem::exists(const std::string& path, bool quiet)
 {
 #if defined(WIN32)
     ::SetLastError(0);
@@ -231,14 +231,15 @@ bool FileSystem::exists(const std::string& path)
         if (errno == ENOENT)    // No such file or directory
             return false;
         else {
-            msg_error("FileSystem::exists()") << path << ": " << strerror(errno);
+            if (!quiet)
+                msg_error("FileSystem::exists()") << path << ": " << strerror(errno);
             return false;
         }
 #endif
 }
 
 
-bool FileSystem::isDirectory(const std::string& path)
+bool FileSystem::isDirectory(const std::string& path, bool quiet)
 {
 #if defined(WIN32)
     const DWORD fileAttrib = GetFileAttributes(sofa::helper::widenString(path).c_str());
@@ -251,7 +252,8 @@ bool FileSystem::isDirectory(const std::string& path)
 #else
     struct stat st_buf;
     if (stat(path.c_str(), &st_buf) != 0) {
-        msg_error("FileSystem::isDirectory()") << path << ": " << strerror(errno);
+        if (!quiet)
+                msg_error("FileSystem::isDirectory()") << path << ": " << strerror(errno);
         return false;
     }
     else
@@ -331,11 +333,11 @@ bool FileSystem::isAbsolute(const std::string& path)
                 || path[0] == '/');
 }
 
-bool FileSystem::isFile(const std::string &path)
+bool FileSystem::isFile(const std::string &path, bool quiet)
 {
     return
-            FileSystem::exists(path) &&
-            !FileSystem::isDirectory(path)
+            FileSystem::exists(path, quiet) &&
+            !FileSystem::isDirectory(path, quiet)
     ;
 }
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.h
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.h
@@ -119,19 +119,19 @@ static void ensureFolderExists(const std::string& pathToFolder);
 /// @note The function assumes that a path to a file is given.
 static void ensureFolderForFileExists(const std::string& pathToFile);
 
-/// @brief Return true if and only if the given file exists.
-static bool exists(const std::string& path);
+/// @brief Return true if and only if the given file exists. The call might display errors if quiet=false.
+static bool exists(const std::string& path, bool quiet = false );
 
-/// @brief Return true if and only if the given file path corresponds to a directory.
+/// @brief Return true if and only if the given file path corresponds to a directory. The call might display errors if quiet=false.
 ///
 /// @warning The path must exist.
-static bool isDirectory(const std::string& path);
+static bool isDirectory(const std::string& path, bool quiet = false);
 
 /// @brief Return true if and only if the given file path is absolute.
 static bool isAbsolute(const std::string& path);
 
-/// @brief Return true if and only if the given file path is an existing file.
-static bool isFile(const std::string& path);
+/// @brief Return true if and only if the given file path is an existing file. The call might display errors if quiet=false.
+static bool isFile(const std::string& path, bool quiet = false );
 
 /// @brief Replace backslashes with slashes.
 static std::string convertBackSlashesToSlashes(const std::string& path);


### PR DESCRIPTION
Those methods are performing test that by essence are unsure, so they might fail and still this might be OK. This option allow to not throw error. 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
