### PR TITLE
[Helper] FileSystem: (really) fix compilation on macOS

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
@@ -53,6 +53,7 @@
 
 #if defined(__APPLE__)
 #include <stdio.h>
+#include <spawn.h>
 #endif
 
 #ifdef linux
@@ -525,7 +526,7 @@ bool FileSystem::openFileWithDefaultApplication(const std::string& filename)
 #elif defined(__APPLE__)
         pid_t pid; // points to a buffer that is used to return the process ID of the new child process.
         char* argv[] = {const_cast<char*>("open"), const_cast<char*>(filename.c_str()), nullptr};
-        if (posix_spawn(&pid, "/usr/bin/open", nullptr, nullptr, argv, environ) == 0) 
+        if (posix_spawn(&pid, "/usr/bin/open", nullptr, nullptr, argv, nullptr) == 0)
         {
             int status;
             if (waitpid(pid, &status, 0) != -1 && WIFEXITED(status) && WEXITSTATUS(status) == 0)


### PR DESCRIPTION
- missing include
- `environ` was not defined. actually I dont know where does it come from in the Linux specific code 🤔 
Anyway, if the environ parameter is nullptr, it will inherit those from the parent process.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
