### PR TITLE
[CMake] Remove SofaViscoElastic from supported plugins

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -168,14 +168,6 @@
           "type": "BOOL",
           "value": "ON"
         },
-        "SOFA_FETCH_SOFAVISCOELASTIC": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "PLUGIN_SOFAVISCOELASTIC": {
-          "type": "BOOL",
-          "value": "ON"
-        },
         "PLUGIN_SOFAMATRIX": {
           "type": "BOOL",
           "value": "ON"


### PR DESCRIPTION
Recent push in the master branch of this plugin with deleted then added files made the plugin unstable with no possibility to track changes and thus invalidated the trust we had on the plugin. Proof being that many of the changes I made to fix the examples were reverted in the process. 

Therefore, we remove this plugin from the supported plugin list for now. It'll be included again once the plugin has been validated back and a CI launching scene tests has been added to it.  



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
