### PR TITLE
[CMake] Remove CGALPlugin from supported plugins

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -220,14 +220,6 @@
           "type": "BOOL",
           "value": "ON"
         },
-        "SOFA_FETCH_CGALPLUGIN": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "PLUGIN_CGALPLUGIN": {
-          "type": "BOOL",
-          "value": "ON"
-        },
         "SOFA_FETCH_SOFA_METIS": {
           "type": "BOOL",
           "value": "ON"


### PR DESCRIPTION
As CGaL hasn't been compiling without crash on ubuntu for a long time now, it is time to deactivate it. 
To do this smoothly, I added a nightly here : 
https://github.com/sofa-framework/CGALPlugin/pull/42

And python example on how to replace this plugin by using the CGaL bindings directly here : 
https://github.com/sofa-framework/SofaPython3/pull/567
--> except for the generation from image, as the bindings don't exist for this part of CGaL.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
