### PR TITLE
[GL] Deal with non existing path for ffmprg in VideoRecorderFFMPEG

### DIFF
--- a/Sofa/GL/src/sofa/gl/VideoRecorderFFMPEG.cpp
+++ b/Sofa/GL/src/sofa/gl/VideoRecorderFFMPEG.cpp
@@ -87,22 +87,22 @@ bool VideoRecorderFFMPEG::init(const std::string& ffmpeg_exec_filepath, const st
     m_ffmpegBuffer = new unsigned char [m_ffmpegBufferSize];
 
     m_FrameCount = 0;
-
+    std::string extension;
+#ifdef WIN32
+    extension = ".exe";
+#endif
     m_ffmpegExecPath = ffmpeg_exec_filepath;
     if(m_ffmpegExecPath.empty())
     {
-        std::string extension;
-#ifdef WIN32
-        extension = ".exe";
-#endif
         m_ffmpegExecPath = helper::Utils::getExecutablePath() + "/ffmpeg" + extension;
-        if(!FileSystem::isFile(m_ffmpegExecPath, true))
-        {
-            msg_warning("VideoRecorderFFMPEG")<< "ffmpeg hasn't been found automatically. Falling back to simply calling ffmpeg"<< extension <<" and hope that the OS finds it on its own. " ;
-            // Fallback to a relative FFMPEG (may be in system or exposed in PATH)
-            m_ffmpegExecPath = "ffmpeg" + extension;
-        }
     }
+    if(!FileSystem::isFile(m_ffmpegExecPath, true))
+    {
+        msg_warning("VideoRecorderFFMPEG")<< "ffmpeg hasn't been found automatically. Falling back to simply calling ffmpeg"<< extension <<" and hope that the OS finds it on its own. " ;
+        // Fallback to a relative FFMPEG (may be in system or exposed in PATH)
+        m_ffmpegExecPath = "ffmpeg" + extension;
+    }
+
 
     std::stringstream ss;
     ss << m_ffmpegExecPath
@@ -123,6 +123,7 @@ bool VideoRecorderFFMPEG::init(const std::string& ffmpeg_exec_filepath, const st
 #else
     m_ffmpeg = popen(command_line.c_str(), "w");
 #endif
+
     if (m_ffmpeg == nullptr) {
         msg_error("VideoRecorderFFMPEG") << "ffmpeg process failed to open (error " << errno << "). Command line : " << command_line;
         return false;


### PR DESCRIPTION
Take special case where given path isn't empty but doesn't point to a real file






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
