### PR TITLE
[Lagrangian.Solver] UnbuiltConstraintSolver: Fix resetForUnbuiltResolution (constraint re-ordering)

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
@@ -37,12 +37,13 @@ void UnbuiltConstraintSolver::doBuildSystem( const core::ConstraintParams *cPara
         return;
     }
 
+    // Initialize constraint sequence ONCE before iterating over constraint corrections
+    c_current_cp->constraints_sequence.resize(numConstraints);
+    std::iota(c_current_cp->constraints_sequence.begin(), c_current_cp->constraints_sequence.end(), 0);
+
     for (const auto& cc : l_constraintCorrections)
     {
         if (!cc->isActive()) continue;
-
-        c_current_cp->constraints_sequence.resize(numConstraints);
-        std::iota(c_current_cp->constraints_sequence.begin(), c_current_cp->constraints_sequence.end(), 0);
 
         // some constraint corrections (e.g LinearSolverConstraintCorrection)
         // can change the order of the constraints, to optimize later computations


### PR DESCRIPTION
In a BeamAdapter scene where a catheter is deployed into *deformable* vessels, I got a huge discrepancy between LCPConstraintSolver (unbuilt) and UnbuiltGaussSeidelConstraintSolver (being the slowest).
Whereas the same scene (aka the standard scene [3instruments_collis](https://github.com/sofa-framework/BeamAdapter/blob/master/examples/3instruments_collis.scn) where the catheter is deployed into static vessels, the difference is not that huge (~15-20% slower)

--> very important:  wire_optimization must be *true*  (more on that later)

Bench: 
- 5000 steps on 3instru_collis (static)
```
LCP : 5000 iterations done in 19.9832 s ( 250.21 FPS)
UGS:: 5000 iterations done in 23.5956 s ( 211.904 FPS)

```
- 5000 steps on 3instru_collis (deformable)
```
LCP :5000 iterations done in 43.9782 s ( 113.693 FPS)
UGS: 5000 iterations done in 97.7162 s ( 51.1686 FPS)
```

For reference WITHOUT wire_optimization (set to False)
```
LCP :5000 iterations done in 63.7577 s ( 78.4219 FPS)
UGS: 5000 iterations done in 99.2367 s ( 50.3846 FPS)
```

We can see that  wire_optimization seems to do nothing for UGS.

After investigation (thanks to Claude 🤖) it appeared that the re-ordering of the constraints was cancelled in the case of there is TWO constraint corrections (which is the case for the deformable vessels but not for the static vessels)

The loop calling resetForUnbuiltResolution on each ConstraintCorrection was resetting the ordering on the second iteration of the loop (e.g if the list is { LinearCC, UncoupledCC } then the first iteration will re-order fine but the second loop will reset the list and UncoupledCC do nothing for the re-oredering)

All in all the fix is easy, and set the initialization of the list outside the loop... 🤪

Results:

- 5000 steps on 3instru_collis (deformable)
```
UGS: 5000 iterations done in 49.5163 s ( 100.977 FPS)
```

with the same ~15% difference as with the static vessel case.

✍️ Note that there should not be any difference between LCP and UGS but more to come about that....


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
