### PR TITLE
[Lagrangian.Solver] UnbuiltConstraintSolver: implement hotstart

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.cpp
@@ -70,6 +70,7 @@ GenericConstraintSolver::GenericConstraintSolver()
     , d_regularizationTerm(initData(&d_regularizationTerm, 0.0_sreal, "regularizationTerm", "Add regularization factor times the identity matrix to the compliance W when solving constraints"))
     , d_scaleTolerance(initData(&d_scaleTolerance, true, "scaleTolerance", "Scale the error tolerance with the number of constraints"))
     , d_allVerified(initData(&d_allVerified, false, "allVerified", "All constraints must be verified (each constraint's error < tolerance)"))
+    , d_initialGuess(initData(&d_initialGuess, true, "initialGuess", "Activate constraint force history to improve convergence (hot start)"))
     , d_computeGraphs(initData(&d_computeGraphs, false, "computeGraphs", "Compute graphs of errors and forces during resolution"))
     , d_graphErrors(initData(&d_graphErrors, "graphErrors", "Sum of the constraints' errors at each iteration"))
     , d_graphConstraints(initData(&d_graphConstraints, "graphConstraints", "Graph of each constraint's error at the end of the resolution"))
@@ -186,8 +187,14 @@ bool GenericConstraintSolver::buildSystem(const core::ConstraintParams *cParams,
     // suppress the constraints that are on DOFS currently concerned by projective constraint
     applyProjectiveConstraintOnConstraintMatrix(cParams);
 
+    // Get constraint info for hot-start BEFORE clear() resets the constraint count check
+    getConstraintInfo(cParams);
+
     //clear and/or resize based on the number of constraints
     current_cp->clear(numConstraints);
+
+    // Restore initial guess from previous timestep AFTER clear() zeros the forces
+    computeInitialGuess();
 
     getConstraintViolation(cParams, &current_cp->dFree);
 
@@ -380,6 +387,9 @@ void GenericConstraintSolver::storeConstraintLambdas(const core::ConstraintParam
 
 bool GenericConstraintSolver::applyCorrection(const core::ConstraintParams *cParams, MultiVecId res1, MultiVecId res2)
 {
+    // Save forces for hot-start in next timestep
+    keepContactForcesValue();
+
     computeAndApplyMotionCorrection(cParams, res1, res2);
     storeConstraintLambdas(cParams);
 
@@ -440,7 +450,108 @@ void GenericConstraintSolver::addRegularization(linearalgebra::BaseMatrix& W, co
     }
 }
 
+void GenericConstraintSolver::getConstraintInfo(const core::ConstraintParams* cparams)
+{
+    if (d_initialGuess.getValue() && (m_numConstraints != 0))
+    {
+        SCOPED_TIMER("GetConstraintInfo");
+        m_constraintBlockInfo.clear();
+        m_constraintIds.clear();
+        simulation::mechanicalvisitor::MechanicalGetConstraintInfoVisitor(cparams, m_constraintBlockInfo, m_constraintIds).execute(getContext());
+    }
+}
 
+void GenericConstraintSolver::computeInitialGuess()
+{
+    if (!d_initialGuess.getValue() || m_numConstraints == 0)
+        return;
+
+    SCOPED_TIMER("InitialGuess");
+
+    SReal* force = current_cp->getF();
+    const int numConstraints = current_cp->getDimension();
+
+    // First, zero all forces
+    for (int c = 0; c < numConstraints; c++)
+    {
+        force[c] = 0.0;
+    }
+
+    // Then restore forces from previous timestep for matching persistent IDs
+    for (const ConstraintBlockInfo& info : m_constraintBlockInfo)
+    {
+        if (!info.parent) continue;
+        if (!info.hasId) continue;
+
+        auto previt = m_previousConstraints.find(info.parent);
+        if (previt == m_previousConstraints.end()) continue;
+
+        const ConstraintBlockBuf& buf = previt->second;
+        const int c0 = info.const0;
+        const int nbl = (info.nbLines < buf.nbLines) ? info.nbLines : buf.nbLines;
+
+        for (int c = 0; c < info.nbGroups; ++c)
+        {
+            auto it = buf.persistentToConstraintIdMap.find(m_constraintIds[info.offsetId + c]);
+            if (it == buf.persistentToConstraintIdMap.end()) continue;
+
+            const int prevIndex = it->second;
+            if (prevIndex >= 0 && prevIndex + nbl <= static_cast<int>(m_previousForces.size()))
+            {
+                for (int l = 0; l < nbl; ++l)
+                {
+                    force[c0 + c * nbl + l] = m_previousForces[prevIndex + l];
+                }
+            }
+        }
+    }
+}
+
+void GenericConstraintSolver::keepContactForcesValue()
+{
+    if (!d_initialGuess.getValue())
+        return;
+
+    SCOPED_TIMER("KeepForces");
+
+    const SReal* force = current_cp->getF();
+    const unsigned int numConstraints = current_cp->getDimension();
+
+    // Store current forces
+    m_previousForces.resize(numConstraints);
+    for (unsigned int c = 0; c < numConstraints; ++c)
+    {
+        m_previousForces[c] = force[c];
+    }
+
+    // Clear previous history (mark all as invalid)
+    for (auto& previousConstraint : m_previousConstraints)
+    {
+        ConstraintBlockBuf& buf = previousConstraint.second;
+        for (auto& it2 : buf.persistentToConstraintIdMap)
+        {
+            it2.second = -1;
+        }
+    }
+
+    // Fill info from current constraint IDs
+    for (const ConstraintBlockInfo& info : m_constraintBlockInfo)
+    {
+        if (!info.parent) continue;
+        if (!info.hasId) continue;
+
+        ConstraintBlockBuf& buf = m_previousConstraints[info.parent];
+        buf.nbLines = info.nbLines;
+
+        for (int c = 0; c < info.nbGroups; ++c)
+        {
+            buf.persistentToConstraintIdMap[m_constraintIds[info.offsetId + c]] = info.const0 + c * info.nbLines;
+        }
+    }
+
+    // Update constraint count for next iteration
+    m_numConstraints = numConstraints;
+}
 
 
 } //namespace sofa::component::constraint::lagrangian::solver

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h
@@ -27,6 +27,7 @@
 #include <sofa/core/behavior/BaseConstraintCorrection.h>
 #include <sofa/core/behavior/BaseLagrangianConstraint.h>
 #include <sofa/helper/map.h>
+#include <sofa/simulation/mechanicalvisitor/MechanicalGetConstraintInfoVisitor.h>
 
 #include <sofa/simulation/task/CpuTask.h>
 #include <sofa/helper/OptionsGroup.h>
@@ -67,6 +68,7 @@ public:
     Data<bool> d_scaleTolerance; ///< Scale the error tolerance with the number of constraints
     Data<bool> d_allVerified; ///< All constraints must be verified (each constraint's error < tolerance)
 
+    Data<bool> d_initialGuess; ///< Activate constraint force history to improve convergence (hot start)
     Data<bool> d_computeGraphs; ///< Compute graphs of errors and forces during resolution
     Data<std::map < std::string, sofa::type::vector<SReal> > > d_graphErrors; ///< Sum of the constraints' errors at each iteration
     Data<std::map < std::string, sofa::type::vector<SReal> > > d_graphConstraints; ///< Graph of each constraint's error at the end of the resolution
@@ -125,7 +127,34 @@ protected:
 
     virtual void addRegularization(linearalgebra::BaseMatrix& W, const SReal regularization);
 
+    // Hot-start mechanism types
+    typedef core::behavior::BaseLagrangianConstraint::ConstraintBlockInfo ConstraintBlockInfo;
+    typedef core::behavior::BaseLagrangianConstraint::PersistentID PersistentID;
+    typedef core::behavior::BaseLagrangianConstraint::VecConstraintBlockInfo VecConstraintBlockInfo;
+    typedef core::behavior::BaseLagrangianConstraint::VecPersistentID VecPersistentID;
 
+    class ConstraintBlockBuf
+    {
+    public:
+        std::map<PersistentID, int> persistentToConstraintIdMap;
+        int nbLines{0}; ///< how many dofs (i.e. lines in the matrix) are used by each constraint
+    };
+
+    /// Compute initial guess for constraint forces from previous timestep
+    void computeInitialGuess();
+
+    /// Save constraint forces for use as initial guess in next timestep
+    void keepContactForcesValue();
+
+    /// Get constraint info (block info and persistent IDs) for hot-start
+    void getConstraintInfo(const core::ConstraintParams* cparams);
+
+    // Hot-start data storage
+    std::map<core::behavior::BaseLagrangianConstraint*, ConstraintBlockBuf> m_previousConstraints;
+    type::vector<SReal> m_previousForces;
+    VecConstraintBlockInfo m_constraintBlockInfo;
+    VecPersistentID m_constraintIds;
+    unsigned int m_numConstraints{0}; ///< Number of constraints from current/previous timestep
 
 private:
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
@@ -37,12 +37,13 @@ void UnbuiltConstraintSolver::doBuildSystem( const core::ConstraintParams *cPara
         return;
     }
 
+    // Initialize constraint sequence ONCE before iterating over constraint corrections
+    c_current_cp->constraints_sequence.resize(numConstraints);
+    std::iota(c_current_cp->constraints_sequence.begin(), c_current_cp->constraints_sequence.end(), 0);
+
     for (const auto& cc : l_constraintCorrections)
     {
         if (!cc->isActive()) continue;
-
-        c_current_cp->constraints_sequence.resize(numConstraints);
-        std::iota(c_current_cp->constraints_sequence.begin(), c_current_cp->constraints_sequence.end(), 0);
 
         // some constraint corrections (e.g LinearSolverConstraintCorrection)
         // can change the order of the constraints, to optimize later computations

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
@@ -31,7 +31,7 @@ namespace sofa::component::constraint::lagrangian::solver
 
 UnbuiltConstraintSolver::UnbuiltConstraintSolver()
 : GenericConstraintSolver()
-, d_initialGuess(initData(&d_initialGuess, true, "initialGuess", "Activate constraint force history to improve convergence (hot start)"))
+, d_initialGuess(initData(&d_initialGuess, false, "initialGuess", "Activate constraint force history to possibly improve convergence (hot start)."))
 {
     
 }
@@ -69,11 +69,9 @@ void UnbuiltConstraintSolver::doBuildSystem( const core::ConstraintParams *cPara
     for (unsigned int i = 0; i < numConstraints; i++)
         c_current_cp->cclist_elems[i].resize(nbCC, nullptr);
 
-    unsigned int nbObjects = 0;
     for (unsigned int c_id = 0; c_id < numConstraints;)
     {
         bool foundCC = false;
-        nbObjects++;
         const unsigned int l = c_current_cp->constraintsResolutions[c_id]->getNbLines();
 
         for (unsigned int j = 0; j < l_constraintCorrections.size(); j++)
@@ -153,7 +151,7 @@ void UnbuiltConstraintSolver::computeInitialGuess()
     {
         force[c] = 0.0;
     }
-
+    
     // Then restore forces from previous timestep for matching persistent IDs
     for (const ConstraintBlockInfo& info : m_constraintBlockInfo)
     {

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
@@ -103,6 +103,9 @@ void UnbuiltConstraintSolver::doBuildSystem( const core::ConstraintParams *cPara
 
 void UnbuiltConstraintSolver::doPreApplyCorrection()
 {
+    if (!d_initialGuess.getValue())
+        return;
+    
     // Save forces for hot-start in next timestep
     keepContactForcesValue();
 }
@@ -184,9 +187,6 @@ void UnbuiltConstraintSolver::computeInitialGuess()
 
 void UnbuiltConstraintSolver::keepContactForcesValue()
 {
-    if (!d_initialGuess.getValue())
-        return;
-
     SCOPED_TIMER("KeepForces");
 
     const SReal* force = current_cp->getF();

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltConstraintSolver.cpp
@@ -24,8 +24,17 @@
 #include <sofa/component/constraint/lagrangian/solver/UnbuiltConstraintProblem.h>
 #include <sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h>
 
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 namespace sofa::component::constraint::lagrangian::solver
 {
+
+UnbuiltConstraintSolver::UnbuiltConstraintSolver()
+: GenericConstraintSolver()
+, d_initialGuess(initData(&d_initialGuess, true, "initialGuess", "Activate constraint force history to improve convergence (hot start)"))
+{
+    
+}
 
 void UnbuiltConstraintSolver::doBuildSystem( const core::ConstraintParams *cParams, GenericConstraintProblem * problem, unsigned int numConstraints)
 {
@@ -94,6 +103,21 @@ void UnbuiltConstraintSolver::doBuildSystem( const core::ConstraintParams *cPara
 
 }
 
+void UnbuiltConstraintSolver::doPreApplyCorrection()
+{
+    // Save forces for hot-start in next timestep
+    keepContactForcesValue();
+}
+void UnbuiltConstraintSolver::doPreClearCorrection(const core::ConstraintParams* cparams)
+{
+    getConstraintInfo(cparams);
+}
+
+void UnbuiltConstraintSolver::doPostClearCorrection()
+{
+    computeInitialGuess();
+}
+
 void UnbuiltConstraintSolver::initializeConstraintProblems()
 {
     for (unsigned i=0; i< CP_BUFFER_SIZE; ++i)
@@ -102,6 +126,111 @@ void UnbuiltConstraintSolver::initializeConstraintProblems()
     }
     current_cp = m_cpBuffer[0].get();
 }
+
+void UnbuiltConstraintSolver::getConstraintInfo(const core::ConstraintParams* cparams)
+{
+    if (d_initialGuess.getValue() && (m_numConstraints != 0))
+    {
+        SCOPED_TIMER("GetConstraintInfo");
+        m_constraintBlockInfo.clear();
+        m_constraintIds.clear();
+        simulation::mechanicalvisitor::MechanicalGetConstraintInfoVisitor(cparams, m_constraintBlockInfo, m_constraintIds).execute(getContext());
+    }
+}
+
+void UnbuiltConstraintSolver::computeInitialGuess()
+{
+    if (!d_initialGuess.getValue() || m_numConstraints == 0)
+        return;
+
+    SCOPED_TIMER("InitialGuess");
+
+    SReal* force = current_cp->getF();
+    const int numConstraints = current_cp->getDimension();
+
+    // First, zero all forces
+    for (int c = 0; c < numConstraints; c++)
+    {
+        force[c] = 0.0;
+    }
+
+    // Then restore forces from previous timestep for matching persistent IDs
+    for (const ConstraintBlockInfo& info : m_constraintBlockInfo)
+    {
+        if (!info.parent) continue;
+        if (!info.hasId) continue;
+
+        auto previt = m_previousConstraints.find(info.parent);
+        if (previt == m_previousConstraints.end()) continue;
+
+        const ConstraintBlockBuf& buf = previt->second;
+        const int c0 = info.const0;
+        const int nbl = (info.nbLines < buf.nbLines) ? info.nbLines : buf.nbLines;
+
+        for (int c = 0; c < info.nbGroups; ++c)
+        {
+            auto it = buf.persistentToConstraintIdMap.find(m_constraintIds[info.offsetId + c]);
+            if (it == buf.persistentToConstraintIdMap.end()) continue;
+
+            const int prevIndex = it->second;
+            if (prevIndex >= 0 && prevIndex + nbl <= static_cast<int>(m_previousForces.size()))
+            {
+                for (int l = 0; l < nbl; ++l)
+                {
+                    force[c0 + c * nbl + l] = m_previousForces[prevIndex + l];
+                }
+            }
+        }
+    }
+}
+
+void UnbuiltConstraintSolver::keepContactForcesValue()
+{
+    if (!d_initialGuess.getValue())
+        return;
+
+    SCOPED_TIMER("KeepForces");
+
+    const SReal* force = current_cp->getF();
+    const unsigned int numConstraints = current_cp->getDimension();
+
+    // Store current forces
+    m_previousForces.resize(numConstraints);
+    for (unsigned int c = 0; c < numConstraints; ++c)
+    {
+        m_previousForces[c] = force[c];
+    }
+
+    // Clear previous history (mark all as invalid)
+    for (auto& previousConstraint : m_previousConstraints)
+    {
+        ConstraintBlockBuf& buf = previousConstraint.second;
+        for (auto& it2 : buf.persistentToConstraintIdMap)
+        {
+            it2.second = -1;
+        }
+    }
+
+    // Fill info from current constraint IDs
+    for (const ConstraintBlockInfo& info : m_constraintBlockInfo)
+    {
+        if (!info.parent) continue;
+        if (!info.hasId) continue;
+
+        ConstraintBlockBuf& buf = m_previousConstraints[info.parent];
+        buf.nbLines = info.nbLines;
+
+        for (int c = 0; c < info.nbGroups; ++c)
+        {
+            buf.persistentToConstraintIdMap[m_constraintIds[info.offsetId + c]] = info.const0 + c * info.nbLines;
+        }
+    }
+
+    // Update constraint count for next iteration
+    m_numConstraints = numConstraints;
+}
+
+
 
 
 }

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltGaussSeidelConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltGaussSeidelConstraintSolver.cpp
@@ -77,16 +77,20 @@ void UnbuiltGaussSeidelConstraintSolver::doSolve(GenericConstraintProblem * prob
     {
         if(!c_current_cp->constraintsResolutions[i])
         {
-            msg_warning() << "Bad size of constraintsResolutions in GenericConstraintSolver" ;
+            msg_warning() << "Bad size of constraintsResolutions" ;
             c_current_cp->setDimension(i);
             break;
         }
         c_current_cp->constraintsResolutions[i]->init(i, w, force);
         i += c_current_cp->constraintsResolutions[i]->getNbLines();
     }
-    // Note: force array is now initialized by GenericConstraintSolver::computeInitialGuess()
-    // for hot-start support. Do not zero forces here.
 
+    // zero forces if cold-start
+    if(!d_initialGuess.getValue())
+    {
+        memset(force, 0, c_current_cp->getDimension() * sizeof(SReal));
+    }
+    
     bool showGraphs = false;
     sofa::type::vector<SReal>* graph_residuals = nullptr;
     std::map < std::string, sofa::type::vector<SReal> > *graph_forces = nullptr, *graph_violations = nullptr;

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltGaussSeidelConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/UnbuiltGaussSeidelConstraintSolver.cpp
@@ -84,8 +84,8 @@ void UnbuiltGaussSeidelConstraintSolver::doSolve(GenericConstraintProblem * prob
         c_current_cp->constraintsResolutions[i]->init(i, w, force);
         i += c_current_cp->constraintsResolutions[i]->getNbLines();
     }
-    memset(force, 0, c_current_cp->getDimension() * sizeof(SReal));	// Erase previous forces for the time being
-
+    // Note: force array is now initialized by GenericConstraintSolver::computeInitialGuess()
+    // for hot-start support. Do not zero forces here.
 
     bool showGraphs = false;
     sofa::type::vector<SReal>* graph_residuals = nullptr;


### PR DESCRIPTION
Based on
- #5871 

in #5871 (and more cases) it was noted that (unbuilt) LCP was *always* faster than UnbuiltGaussSeidelConstraintSolver (in average ~10-20 %) and usually converged in less iterations.
Even if the algorithm is rigorously the same (apparently...)

After investigations, Claude 🤖successfully found that the main difference is UnbuiltGaussSeidelConstraintSolver was always starting its GS with the forces at 0 (cold start), whereas LCP was keeping track of the previous forces.
It also provided the implementation (I could never do that by myself 💩) which... looks good to me at least 🙃

Benches (continuation of #5871)
- 5000 steps on 3instru_collis (deformable), wire_optimization on
```
LCP                : 5000 iterations done in 43.9782 s ( 113.693 FPS)
UGS (w/o hotstart) : 5000 iterations done in 49.5163 s ( 100.977 FPS)
UGS (w hotstart)   : 5000 iterations done in 44.0242 s ( 113.574 FPS)
```

- for the fun, wire_optimization off
```
LCP                : 5000 iterations done in 63.7577 s ( 78.4219 FPS)
UGS (w/o hotstart) : 5000 iterations done in 99.2367 s ( 50.3846 FPS)
UGS (w hotstart)   : 5000 iterations done in 62.5122 s ( 79.9844 FPS)
```

This PR could be considered a little bit... controversial (:vibe:) as Claude-code implemented lots of stuff


[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
