### PR TITLE
[Type] Remove non-square determinant

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -941,22 +941,6 @@ constexpr real determinant(const Mat<1,1,real>& m) noexcept
     return m(0, 0);
 }
 
-/// Generalized-determinant of a 2x3 matrix.
-/// Mirko Radi, "About a Determinant of Rectangular 2×n Matrix and its Geometric Interpretation"
-template<class real>
-constexpr real determinant(const Mat<2,3,real>& m) noexcept
-{
-    return m(0,0)*m(1,1) - m(0,1)*m(1,0) - ( m(0,0)*m(1,2) - m(0,2)*m(1,0) ) + m(0,1)*m(1,2) - m(0,2)*m(1,1);
-}
-
-/// Generalized-determinant of a 3x2 matrix.
-/// Mirko Radi, "About a Determinant of Rectangular 2×n Matrix and its Geometric Interpretation"
-template<class real>
-constexpr real determinant(const Mat<3,2,real>& m) noexcept
-{
-    return m(0,0)*m(1,1) - m(1,0)*m(0,1) - ( m(0,0)*m(2,1) - m(2,0)*m(0,1) ) + m(1,0)*m(2,1) - m(2,0)*m(1,1);
-}
-
 // one-norm of a 3 x 3 matrix
 template<class real>
 real oneNorm(const Mat<3,3,real>& A)


### PR DESCRIPTION
This is a test to locate on the CI and all the supported plugins if both removed functions are used somewhere.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
