### PR TITLE
[tools] Remove autoload of Sofa.Metis for windows

### DIFF
--- a/tools/postinstall-fixup/common.sh
+++ b/tools/postinstall-fixup/common.sh
@@ -41,7 +41,7 @@ function clean_default_plugins()
       ; do
       disabled_plugins=$disabled_plugins'\|'$plugin
   done
-  grep -v $disabled_plugins "$1/plugin_list.conf.default" >> "$1/plugin_list.conf"
+  grep -v $disabled_plugins$2 "$1/plugin_list.conf.default" >> "$1/plugin_list.conf"
 }
 
 function move_metis()

--- a/tools/postinstall-fixup/windows-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/windows-postinstall-fixup.sh
@@ -25,7 +25,7 @@ echo "INSTALL_DIR = $INSTALL_DIR"
 echo "INSTALL_DIR_BIN = $INSTALL_DIR_BIN"
 
 source $SCRIPT_DIR/common.sh
-clean_default_plugins "$INSTALL_DIR_BIN"
+clean_default_plugins "$INSTALL_DIR_BIN" "'\|'Sofa.Metis"
 
 move_metis "$INSTALL_DIR"
 


### PR DESCRIPTION
Metis crashes on the release on windows for some scene (e.g. examples/Demos/SofaScene.scn), so we need to avoid auto-loading it on windows. 

This PR is only on the release branch in hope that we fix this for the next release. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
