### PR TITLE
[Tools] Fix windows postinstall

### DIFF
--- a/tools/postinstall-fixup/CMakeLists.txt
+++ b/tools/postinstall-fixup/CMakeLists.txt
@@ -3,7 +3,7 @@ if(NOT SOFA_BUILD_RELEASE_PACKAGE AND NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
     return()
 endif()
 
-if(TARGET Sofa.Qt)
+if(TARGET Sofa.Qt AND SOFA_BUILD_RELEASE_PACKAGE)
     find_package(Qt5 COMPONENTS Gui REQUIRED)
     get_target_property(qt5gui_loc Qt5::Gui LOCATION_RELEASE)
     get_filename_component(QT_LIB_DIR "${qt5gui_loc}" DIRECTORY)

--- a/tools/postinstall-fixup/CMakeLists.txt
+++ b/tools/postinstall-fixup/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Post-install scripts
-if(NOT SOFA_BUILD_RELEASE_PACKAGE)
+if(NOT SOFA_BUILD_RELEASE_PACKAGE AND NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
     return()
 endif()
 

--- a/tools/postinstall-fixup/windows-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/windows-postinstall-fixup.sh
@@ -33,8 +33,3 @@ move_metis "$INSTALL_DIR"
 cd "$INSTALL_DIR" && find -name "*.dll" -path "*/plugins/*" | while read lib; do
     cp "$lib" "$INSTALL_DIR_BIN"
 done
-
-# Copy all collection libs in install/bin to make them easily findable
-cd "$INSTALL_DIR" && find -name "*.dll" -path "*/collections/*" | while read lib; do
-    cp "$lib" "$INSTALL_DIR_BIN"
-done


### PR DESCRIPTION
On Windows, all binaries that are linked at compilation stage should be in the same directory (or in some directory in the `PATH` env var, but we do not want to modify it and we should not).
This is already done for release builds at the postinstall step. This is also the case in build directory. But after a build install (i.e. cmake install call) on non-release builds, this was not done. This PR enables the binaries copy as done in releases for all Windows builds.

It also remove the collection related stuff in the postinstall script which are deprecated.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
