### PR TITLE
[Spring] Add empty buildStiffnessMatrix in JointSpringForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/JointSpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/JointSpringForceField.h
@@ -92,8 +92,6 @@ protected:
     // project torsion to Lawfulltorsion according to limitangles
     void projectTorsion(Spring& spring);
 
-
-
     JointSpringForceField(MechanicalState* object1, MechanicalState* object2);
     JointSpringForceField();
 
@@ -122,6 +120,8 @@ public:
                            DataVecDeriv& data_df2,
                            const DataVecDeriv& data_dx1,
                            const DataVecDeriv& data_dx2) override;
+
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
 
     void buildDampingMatrix(core::behavior::DampingMatrix* /*matrix*/) final;
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/JointSpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/JointSpringForceField.inl
@@ -359,6 +359,13 @@ void JointSpringForceField<DataTypes>::addDForce(const core::MechanicalParams *m
 }
 
 template <class DataTypes>
+void JointSpringForceField<DataTypes>::buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix)
+{
+    SOFA_UNUSED(matrix);
+    msg_error() << "buildStiffnessMatrix not implemented (thus only computing explicit forces)";
+}
+
+template <class DataTypes>
 void JointSpringForceField<DataTypes>::buildDampingMatrix(core::behavior::DampingMatrix*)
 {
     // No damping in this ForceField


### PR DESCRIPTION
No that useful but it comes from some investigations related to https://github.com/sofa-framework/sofa/issues/5893



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
