### PR TITLE
[StateContainer] Fix warning in MechanicalObjectVOp_test

### DIFF
--- a/Sofa/Component/StateContainer/tests/MechanicalObjectVOp_test.cpp
+++ b/Sofa/Component/StateContainer/tests/MechanicalObjectVOp_test.cpp
@@ -736,7 +736,6 @@ struct MechanicalObjectVOpTest : public testing::BaseTest
         // v = a-b
         m_mechanicalObject->vOp(nullptr, core::vec_id::write_access::velocity, core::vec_id::read_access::restPosition, core::vec_id::read_access::position, -1_sreal);
 
-        unsigned int index {};
         auto vv = sofa::helper::getReadAccessor(*m_mechanicalObject->read(core::vec_id::read_access::velocity));
         auto va = sofa::helper::getReadAccessor(*m_mechanicalObject->read(core::vec_id::read_access::restPosition));
         auto vb = sofa::helper::getReadAccessor(*m_mechanicalObject->read(core::vec_id::read_access::position));
@@ -750,7 +749,6 @@ struct MechanicalObjectVOpTest : public testing::BaseTest
             {
                 EXPECT_FLOATINGPOINT_EQ(v[j], diff[j])
             }
-            ++index;
         }
 
         checkVecValues<core::vec_id::read_access::position>(positionCoefficient);


### PR DESCRIPTION
Fix unused data


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
