### PR TITLE
[All] Clean uncovered lifecycle codes

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/LinearSolverConstraintCorrection.h
@@ -113,9 +113,6 @@ public:
     void getBlockDiagonalCompliance(linearalgebra::BaseMatrix* W, int begin, int end) override;
 
 protected:
-    //SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v25.12", "Further to #5017 use m_constraintMatrix instead")
-    DeprecatedAndRemoved J; ///< use m_constraintMatrix instead
-
     linearalgebra::SparseMatrix<Real> m_constraintJacobian;
 
     /**

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/TriangleSetGeometryAlgorithms.h
@@ -394,13 +394,13 @@ public:
 
     // compute barycentric coefficients
     // {
-    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v25.12", "Use sofa::component::topology::container::dynamic::TriangleSetGeometryAlgorithms::computeTriangleBarycentricCoordinates")
+    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v26.12", "Use sofa::component::topology::container::dynamic::TriangleSetGeometryAlgorithms::computeTriangleBarycentricCoordinates")
     sofa::type::vector< SReal > computeTriangleBarycoefs(const TriangleID ind_t, const sofa::type::Vec<3, Real>& p) const;
 
-    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v25.12", "Use sofa::component::topology::container::dynamic::TriangleSetGeometryAlgorithms::computeTriangleBarycentricCoordinates with useRestPosition set to true")
+    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v26.12", "Use sofa::component::topology::container::dynamic::TriangleSetGeometryAlgorithms::computeTriangleBarycentricCoordinates with useRestPosition set to true")
     sofa::type::vector< SReal > computeRestTriangleBarycoefs(const TriangleID ind_t, const sofa::type::Vec<3, Real>& p) const;
 
-    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v25.12", "Use sofa::component::topology::container::dynamic::TriangleSetGeometryAlgorithms::computeTriangleBarycentricCoordinates")
+    SOFA_ATTRIBUTE_DEPRECATED("v25.06", "v26.12", "Use sofa::component::topology::container::dynamic::TriangleSetGeometryAlgorithms::computeTriangleBarycentricCoordinates")
     sofa::type::vector< SReal > compute3PointsBarycoefs(const sofa::type::Vec<3, Real>& p,
         PointID ind_p1,
         PointID ind_p2,

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
@@ -397,7 +397,7 @@ public:
 
 // Legacy structure, to keep compatibility with olden code
 // using the singleton to get the instance of ObjectFactory
-class SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT() SOFA_CORE_API RegisterObject
+class SOFA_ATTRIBUTE_DISABLED__REGISTEROBJECT() SOFA_CORE_API RegisterObject
 {
 private:
     ObjectRegistrationData m_objectRegistrationdata;

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
@@ -397,7 +397,7 @@ public:
 
 // Legacy structure, to keep compatibility with olden code
 // using the singleton to get the instance of ObjectFactory
-class SOFA_ATTRIBUTE_DISABLED__REGISTEROBJECT() SOFA_CORE_API RegisterObject
+class SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT() SOFA_CORE_API RegisterObject
 {
 private:
     ObjectRegistrationData m_objectRegistrationdata;

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -63,10 +63,10 @@
 #endif
 
 #ifdef SOFA_BUILD_SOFA_CORE
-#define SOFA_ATTRIBUTE_DISABLED__REGISTEROBJECT()
+#define SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT()
 #else
-#define SOFA_ATTRIBUTE_DISABLED__REGISTEROBJECT() \
-    SOFA_ATTRIBUTE_DISABLED("v24.12", "v25.12", "RegisterObject and the associated implicit registration is being phased out. Use ObjectRegistrationData and explicit registration from now on. See #4429 for more information.")
+#define SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT() \
+    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v26.12", "RegisterObject and the associated implicit registration is being phased out. Use ObjectRegistrationData and explicit registration from now on. See #4429 for more information.")
 #endif
 
 #ifdef SOFA_BUILD_SOFA_CORE

--- a/Sofa/framework/Core/src/sofa/core/config.h.in
+++ b/Sofa/framework/Core/src/sofa/core/config.h.in
@@ -63,10 +63,10 @@
 #endif
 
 #ifdef SOFA_BUILD_SOFA_CORE
-#define SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT()
+#define SOFA_ATTRIBUTE_DISABLED__REGISTEROBJECT()
 #else
-#define SOFA_ATTRIBUTE_DEPRECATED__REGISTEROBJECT() \
-    SOFA_ATTRIBUTE_DEPRECATED("v24.12", "v25.12", "RegisterObject and the associated implicit registration is being phased out. Use ObjectRegistrationData and explicit registration from now on. See #4429 for more information.")
+#define SOFA_ATTRIBUTE_DISABLED__REGISTEROBJECT() \
+    SOFA_ATTRIBUTE_DISABLED("v24.12", "v25.12", "RegisterObject and the associated implicit registration is being phased out. Use ObjectRegistrationData and explicit registration from now on. See #4429 for more information.")
 #endif
 
 #ifdef SOFA_BUILD_SOFA_CORE

--- a/Sofa/framework/Geometry/src/sofa/geometry/Prism.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Prism.h
@@ -35,6 +35,6 @@ struct Prism
     Prism() = delete;
 };
 
-using Pentahedron SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v25.06", "Pentahedron is renamed to Prism") = Prism;
+using Pentahedron SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v26.06", "Pentahedron is renamed to Prism") = Prism;
 
 } // namespace sofa::geometry

--- a/Sofa/framework/Topology/src/sofa/topology/Prism.h
+++ b/Sofa/framework/Topology/src/sofa/topology/Prism.h
@@ -29,7 +29,7 @@ namespace sofa::topology
 {
     using Prism = sofa::topology::Element<sofa::geometry::Prism>;
 
-    using Pentahedron SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v25.06", "Pentahedron is renamed to Prism") = Prism;
+    using Pentahedron SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v26.06", "Pentahedron is renamed to Prism") = Prism;
 
     static constexpr Prism InvalidPrism;
 }


### PR DESCRIPTION
- Disable RegisterObject as it should have been
- Remove data J, m_constraintMatrix to be used instead
- Postpone removal (in TriangleSetGeometryAlgorithms) to give @epernod time to work on it
- Fix error on lifecycle disabling version in Prism 

Possibly to merge before #5888 and #5892

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
