### PR TITLE
[Collision.Geometry] Use StateAccessor and Topology accessor

### DIFF
--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
@@ -26,6 +26,8 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/collision/Intersection.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
+#include <sofa/core/behavior/TopologyAccessor.h>
 
 
 namespace sofa::component::collision::geometry
@@ -73,10 +75,16 @@ public:
 using Line = TLine<sofa::defaulttype::Vec3Types>;
 
 template<class TDataTypes>
-class LineCollisionModel : public core::CollisionModel
+class LineCollisionModel :
+    public core::CollisionModel,
+    public virtual core::behavior::SingleStateAccessor<TDataTypes>,
+    public virtual core::behavior::TopologyAccessor
 {
-public :
-    SOFA_CLASS(SOFA_TEMPLATE(LineCollisionModel, TDataTypes), core::CollisionModel);
+public:
+    SOFA_CLASS3(SOFA_TEMPLATE(LineCollisionModel, TDataTypes),
+        core::CollisionModel,
+        core::behavior::SingleStateAccessor<TDataTypes>,
+        core::behavior::TopologyAccessor);
 
     enum LineFlag
     {
@@ -130,7 +138,7 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate.get(); }
 
     Deriv velocity(sofa::Index index)const;
 
@@ -163,12 +171,9 @@ public:
 
     Data<bool> d_displayFreePosition; ///< Display Collision Model Points free position(in green)
 
-    /// Link to be set to the topology container in the component graph.
-    SingleLink<LineCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
-
 protected:
-    core::behavior::MechanicalState<DataTypes>* mstate;
-    Topology* topology;
+    using sofa::core::behavior::SingleStateAccessor<TDataTypes>::mstate;
+    using sofa::core::behavior::TopologyAccessor::l_topology;
     PointCollisionModel<sofa::defaulttype::Vec3Types>* mpoints;
     int meshRevision;
 };

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
@@ -26,6 +26,8 @@
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
+#include <sofa/core/behavior/TopologyAccessor.h>
 
 namespace sofa::component::collision::geometry
 {
@@ -60,10 +62,16 @@ public:
 using Point = TPoint<sofa::defaulttype::Vec3Types>;
 
 template<class TDataTypes>
-class PointCollisionModel : public core::CollisionModel
+class PointCollisionModel :
+    public core::CollisionModel,
+    public virtual core::behavior::SingleStateAccessor<TDataTypes>,
+    public virtual core::behavior::TopologyAccessor
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(PointCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS3(SOFA_TEMPLATE(PointCollisionModel, TDataTypes),
+        core::CollisionModel,
+        core::behavior::SingleStateAccessor<TDataTypes>,
+        core::behavior::TopologyAccessor);
 
     typedef TDataTypes DataTypes;
     typedef DataTypes InDataTypes;
@@ -129,15 +137,12 @@ public:
 
 protected:
 
-    core::behavior::MechanicalState<DataTypes>* mstate;
+    using sofa::core::behavior::SingleStateAccessor<TDataTypes>::mstate;
 
     Data<bool> d_computeNormals; ///< activate computation of normal vectors (required for some collision detection algorithms)
     Data<bool> d_displayFreePosition; ///< Display Collision Model Points free position(in green)
 
     VecDeriv normals;
-
-    /// Link to be set to the topology container in the component graph.
-    SingleLink<PointCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 };
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.cpp
@@ -70,13 +70,12 @@ void RayCollisionModel::init()
 {
     this->CollisionModel::init();
 
-    mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
-    if (mstate==nullptr)
+    if (!this->isComponentStateInvalid())
     {
-        msg_error() << "RayCollisionModel requires a Vec3 Mechanical Model";
-        return;
+        this->validateMState();
     }
 
+    if (!this->isComponentStateInvalid())
     {
         const int npoints = mstate->getSize();
         resize(npoints);

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
@@ -25,6 +25,7 @@
 #include <sofa/core/CollisionModel.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <set>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 
 namespace sofa::component::collision::response::contact
 {
@@ -52,10 +53,14 @@ public:
     void setL(SReal newL);
 };
 
-class SOFA_COMPONENT_COLLISION_GEOMETRY_API RayCollisionModel : public core::CollisionModel
+class SOFA_COMPONENT_COLLISION_GEOMETRY_API RayCollisionModel :
+    public core::CollisionModel,
+    public virtual sofa::core::behavior::SingleStateAccessor<defaulttype::Vec3Types>
 {
 public:
-    SOFA_CLASS(RayCollisionModel, core::CollisionModel);
+    SOFA_CLASS2(RayCollisionModel,
+        core::CollisionModel,
+        sofa::core::behavior::SingleStateAccessor<defaulttype::Vec3Types>);
 
     typedef sofa::defaulttype::Vec3Types InDataTypes;
     typedef sofa::defaulttype::Vec3Types DataTypes;
@@ -95,7 +100,7 @@ protected:
     Data<SReal> d_defaultLength; ///< The default length for all rays in this collision model
 
     std::set<response::contact::BaseRayContact*> contacts;
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* mstate;
+    using sofa::core::behavior::SingleStateAccessor<defaulttype::Vec3Types>::mstate;
 
 };
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
@@ -26,6 +26,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 
 namespace sofa::component::collision::geometry
 {
@@ -80,10 +81,14 @@ sofa::type::Vec3 TSphere<defaulttype::Vec3Types >::getContactPointWithSurfacePoi
 
 
 template< class TDataTypes>
-class SphereCollisionModel : public core::CollisionModel
+class SphereCollisionModel :
+    public core::CollisionModel,
+    public virtual core::behavior::SingleStateAccessor<TDataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(SphereCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS2(SOFA_TEMPLATE(SphereCollisionModel, TDataTypes),
+        core::CollisionModel,
+        core::behavior::SingleStateAccessor<TDataTypes>);
 
     typedef TDataTypes DataTypes;
     typedef DataTypes InDataTypes;
@@ -170,8 +175,7 @@ public:
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
 
 protected:
-    core::behavior::MechanicalState<DataTypes>* mstate;
-    SingleLink<SphereCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    using sofa::core::behavior::SingleStateAccessor<TDataTypes>::mstate;
 };
 
 template<class DataTypes>

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.inl
@@ -25,6 +25,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/component/collision/geometry/CubeCollisionModel.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/SingleStateAccessor.inl>
 
 #include <sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::ComponentState ;
@@ -37,7 +38,6 @@ SphereCollisionModel<DataTypes>::SphereCollisionModel()
     : d_radius(initData(&d_radius, "listRadius", "Radius of each sphere"))
     , d_defaultRadius(initData(&d_defaultRadius, (SReal)(1.0), "radius", "Default radius"))
     , d_showImpostors(initData(&d_showImpostors, true, "showImpostors", "Draw spheres as impostors instead of \"real\" spheres"))
-    , mstate(nullptr)
 {
     enum_type = SPHERE_TYPE;
 }
@@ -47,7 +47,6 @@ SphereCollisionModel<DataTypes>::SphereCollisionModel(core::behavior::Mechanical
     : d_radius(initData(&d_radius, "listRadius", "Radius of each sphere"))
     , d_defaultRadius(initData(&d_defaultRadius, (SReal)(1.0), "radius", "Default radius"))
     , d_showImpostors(initData(&d_showImpostors, true, "showImpostors", "Draw spheres as impostors instead of \"real\" spheres"))
-    , mstate(_mstate)
 {
     enum_type = SPHERE_TYPE;
 }
@@ -81,24 +80,18 @@ void SphereCollisionModel<DataTypes>::init()
         msg_warning() << "Calling an already fully initialized component. You should use reinit instead." ;
     }
 
-    this->CollisionModel::init();
-    mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (getContext()->getMechanicalState());
-    if (mstate==nullptr)
+    if (!this->isComponentStateInvalid())
     {
-        //TODO(dmarchal): The previous message was saying this only work for a vec3 mechanicalstate but there
-        // it seems that a mechanicalstate will work we well...where is the truth ?
-        msg_error(this) << "Missing a MechanicalObject with template '" << DataTypes::Name() << ". "
-                           "This MechnicalObject stores the position of the spheres. When this one is missing the collision model is deactivated. \n"
-                           "To remove this error message you can add to your scene a line <MechanicalObject template='"<< DataTypes::Name() << "'/>. ";
-        d_componentState.setValue(ComponentState::Invalid) ;
-
-        return;
+        this->validateMState();
     }
 
-    const auto npoints = mstate->getSize();
-    resize(npoints);
+    if (!this->isComponentStateInvalid())
+    {
+        const auto npoints = mstate->getSize();
+        resize(npoints);
 
-    d_componentState.setValue(ComponentState::Valid) ;
+        d_componentState.setValue(ComponentState::Valid) ;
+    }
 }
 
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
@@ -26,6 +26,8 @@
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
+#include <sofa/core/behavior/TopologyAccessor.h>
 
 #include <vector>
 #include <map>
@@ -69,10 +71,16 @@ public:
 
 };
 
-class SOFA_COMPONENT_COLLISION_GEOMETRY_API TetrahedronCollisionModel : public core::CollisionModel
+class SOFA_COMPONENT_COLLISION_GEOMETRY_API TetrahedronCollisionModel :
+    public core::CollisionModel,
+    public virtual core::behavior::SingleStateAccessor<defaulttype::Vec3Types>,
+    public virtual core::behavior::TopologyAccessor
 {
 public:
-    SOFA_CLASS(TetrahedronCollisionModel, core::CollisionModel);
+    SOFA_CLASS3(TetrahedronCollisionModel,
+        core::CollisionModel,
+        core::behavior::SingleStateAccessor<defaulttype::Vec3Types>,
+        core::behavior::TopologyAccessor);
 
     typedef defaulttype::Vec3Types InDataTypes;
     typedef defaulttype::Vec3Types DataTypes;
@@ -94,7 +102,7 @@ protected:
     sofa::type::vector<TetrahedronInfo> elems;
     const sofa::core::topology::BaseMeshTopology::SeqTetrahedra* tetra;
 
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* mstate;
+    using sofa::core::behavior::SingleStateAccessor<defaulttype::Vec3Types>::mstate;
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 
@@ -123,8 +131,7 @@ public:
 
     core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return mstate; }
 
-    /// Link to be set to the topology container in the component graph.
-    SingleLink<TetrahedronCollisionModel, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    using sofa::core::behavior::TopologyAccessor::l_topology;
 
 };
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
@@ -28,6 +28,8 @@
 #include <sofa/core/VecId.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
+#include <sofa/core/behavior/TopologyAccessor.h>
 
 namespace sofa::component::collision::geometry
 {
@@ -102,10 +104,16 @@ using Triangle = TTriangle<sofa::defaulttype::Vec3Types>;
  * The class \sa TTriangle is used to access specific triangle of this collision Model.
  */
 template<class TDataTypes>
-class TriangleCollisionModel : public core::CollisionModel
+class TriangleCollisionModel :
+    public core::CollisionModel,
+    public virtual core::behavior::SingleStateAccessor<TDataTypes>,
+    public virtual core::behavior::TopologyAccessor
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(TriangleCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS3(SOFA_TEMPLATE(TriangleCollisionModel, TDataTypes),
+        core::CollisionModel,
+        core::behavior::SingleStateAccessor<TDataTypes>,
+        core::behavior::TopologyAccessor);
 
     typedef TDataTypes DataTypes;
     typedef DataTypes InDataTypes;
@@ -138,13 +146,10 @@ public:
     Data<bool> d_bothSide; ///< activate collision on both side of the triangle model
     Data<bool> d_computeNormals; ///< set to false to disable computation of triangles normal
     Data<bool> d_useCurvature; ///< use the curvature of the mesh to avoid some self-intersection test
-    
-    /// Link to be set to the topology container in the component graph.
-    SingleLink<TriangleCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
-    core::behavior::MechanicalState<DataTypes>* m_mstate; ///< Pointer to the corresponding MechanicalState
-    sofa::core::topology::BaseMeshTopology* m_topology; ///< Pointer to the corresponding Topology
+    using sofa::core::behavior::SingleStateAccessor<TDataTypes>::mstate;
+    using sofa::core::behavior::TopologyAccessor::l_topology;
 
     VecDeriv m_normals; ///< Vector of normal direction per triangle.
 
@@ -185,8 +190,8 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
-    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return m_mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return mstate; }
+    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return mstate; }
 
     const VecCoord& getX() const { return(getMechanicalState()->read(core::vec_id::read_access::position)->getValue()); }
     const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *m_triangles; }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleModelInRegularGrid.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleModelInRegularGrid.cpp
@@ -61,17 +61,16 @@ void TriangleModelInRegularGrid::init()
     TriangleCollisionModel<sofa::defaulttype::Vec3Types>::init();
 
     _topology = this->getContext()->getMeshTopology();
-    m_mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
 
-    if (!m_mstate) { msg_error() << "TriangleModelInRegularGrid requires a Vec3 Mechanical Model"; return; }
-    if (!m_topology) { msg_error() << "TriangleModelInRegularGrid requires a BaseMeshTopology"; return; }
+    if (!mstate) { msg_error() << "TriangleModelInRegularGrid requires a Vec3 Mechanical Model"; return; }
+    if (!l_topology) { msg_error() << "TriangleModelInRegularGrid requires a BaseMeshTopology"; return; }
 
     // Test if _topology depend on an higher topology (to compute Bounding Tree faster) and get it
     TopologicalMapping* _topoMapping = nullptr;
     vector<TopologicalMapping*> topoVec;
     getContext()->get<TopologicalMapping> ( &topoVec, core::objectmodel::BaseContext::SearchRoot );
-    _higher_topo = m_topology;
-    _higher_mstate = m_mstate;
+    _higher_topo = l_topology;
+    _higher_mstate = mstate;
     bool found = true;
     while ( found )
     {
@@ -111,7 +110,7 @@ void TriangleModelInRegularGrid::computeBoundingTree ( int )
     m_needsUpdate=false;
     Vec3 minElem, maxElem;
     const VecCoord& xHigh =_higher_mstate->read(core::vec_id::read_access::position)->getValue();
-    const VecCoord& x =m_mstate->read(core::vec_id::read_access::position)->getValue();
+    const VecCoord& x =mstate->read(core::vec_id::read_access::position)->getValue();
 
     // no hierarchy
     if ( empty() )

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeCollisionModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeCollisionModel.cpp
@@ -84,16 +84,16 @@ void TriangleOctreeCollisionModel::computeBoundingTree(int maxDepth)
     updateFromTopology();
 
     if (!isMoving() && !cubeModel->empty()) return; // No need to recompute BBox if immobile
-    const std::size_t size2=m_mstate->getSize();
+    const std::size_t size2=mstate->getSize();
     pNorms.resize(size2);
     for(sofa::Size i=0; i<size2; i++)
     {
         pNorms[i]=type::Vec3(0,0,0);
     }
     type::Vec3 minElem, maxElem;
-    maxElem[0]=minElem[0]=m_mstate->read(core::vec_id::read_access::position)->getValue()[0][0];
-    maxElem[1]=minElem[1]=m_mstate->read(core::vec_id::read_access::position)->getValue()[0][1];
-    maxElem[2]=minElem[2]=m_mstate->read(core::vec_id::read_access::position)->getValue()[0][2];
+    maxElem[0]=minElem[0]=mstate->read(core::vec_id::read_access::position)->getValue()[0][0];
+    maxElem[1]=minElem[1]=mstate->read(core::vec_id::read_access::position)->getValue()[0][1];
+    maxElem[2]=minElem[2]=mstate->read(core::vec_id::read_access::position)->getValue()[0][2];
 
     cubeModel->resize(1);  // size = number of triangles
     for (std::size_t i=1; i<size; i++)

--- a/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.h
@@ -42,6 +42,8 @@ public:
     MechanicalState<DataTypes>* getMState();
     const MechanicalState<DataTypes>* getMState() const;
 
+    void validateMState();
+
 protected:
 
     explicit SingleStateAccessor(MechanicalState<DataTypes>* mm = nullptr);

--- a/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/SingleStateAccessor.inl
@@ -31,15 +31,21 @@ void SingleStateAccessor<DataTypes>::init()
 {
     Inherit1::init();
 
-    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
+    if (!this->isComponentStateInvalid())
+    {
+        this->validateMState();
+    }
+}
 
+template <class DataTypes>
+void SingleStateAccessor<DataTypes>::validateMState()
+{
     if (!mstate.get())
     {
         mstate.set(dynamic_cast< MechanicalState<DataTypes>* >(getContext()->getMechanicalState()));
 
         if(!mstate)
         {
-
             msg_error() << "No compatible MechanicalState found in the current context. "
                 "This may be because there is no MechanicalState in the local context, "
                 "or because the type is not compatible";
@@ -67,7 +73,7 @@ auto SingleStateAccessor<DataTypes>::getMState() const -> const MechanicalState<
     return mstate.get(); 
 }
 
-template<class DataTypes>
+template <class DataTypes>
 SingleStateAccessor<DataTypes>::SingleStateAccessor(MechanicalState<DataTypes> *mm)
     : Inherit1()
     , mstate(initLink("mstate", "MechanicalState used by this component"), mm)


### PR DESCRIPTION
This is to factorize the behavior, have the same common variables and expose the links.


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
