### PR TITLE
[Ordering] Remove deprecated 'ordering' datafield

### DIFF
--- a/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/OrderingMethodAccessor.h
+++ b/Sofa/Component/LinearSolver/Ordering/src/sofa/component/linearsolver/ordering/OrderingMethodAccessor.h
@@ -87,43 +87,6 @@ public:
         }
     }
 
-    void parse(sofa::core::objectmodel::BaseObjectDescription* arg) override
-    {
-        Inherit1::parse(arg);
-
-        //To remove for v24.12:
-        if (arg->getAttribute("ordering"))
-        {
-            //map storing the correspondence between the ordering method name
-            //as a Data, and its associated component
-            static const std::map<std::string, std::string> orderingMethodComponentsMap
-            {
-                {"Natural", "NaturalOrderingMethod"},
-                {"AMD", "AMDOrderingMethod"},
-                {"COLAMD", "COLAMDOrderingMethod"},
-                {"Metis", "MetisOrderingMethod"}
-            };
-
-            std::stringstream message;
-            message << "The Data 'ordering' is deprecated. Instead use a "
-                "component of type OrderingMethod. The list of available methods are: "
-                << core::ObjectFactory::getInstance()->listClassesDerivedFrom<sofa::core::behavior::BaseOrderingMethod>();
-
-            const std::string methodName = arg->getAttribute("ordering");
-            const auto it = orderingMethodComponentsMap.find(methodName);
-            if (it != orderingMethodComponentsMap.end())
-            {
-                desiredMethod = it->second;
-
-                message << ". According to the value of the Data 'ordering', the "
-                           "object factory will try to instantiate the component '"
-                           << desiredMethod << "'.";
-            }
-
-            msg_warning() << message.str();
-        }
-    }
-
 private:
 
     void setupCreatedOrderingMethod(core::behavior::BaseOrderingMethod* createdOrderingMethod)


### PR DESCRIPTION
According to the comment `To remove for v24.12`

[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/577]
[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
