### PR TITLE
[Config] Introduce CMake function to treat compilation warnings as errors

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -311,6 +311,8 @@ target_link_options(${PROJECT_NAME} PUBLIC "$<${is_c_cxx_release}:${SOFACONFIG_L
 target_link_options(${PROJECT_NAME} PUBLIC "$<${is_c_cxx_debug}:${SOFACONFIG_LINK_OPTIONS_DEBUG}>")
 target_link_options(${PROJECT_NAME} PUBLIC "$<${is_c_cxx}:${SOFACONFIG_LINK_OPTIONS}>")
 
+sofa_treat_warnings_as_errors(${PROJECT_NAME})
+
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 # Attach Sofa Version into properties

--- a/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
@@ -515,3 +515,13 @@ macro(sofa_set_targets_release_only)
 endmacro()
 
 
+function(sofa_treat_warnings_as_errors TARGET)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+        set_property(TARGET ${TARGET} PROPERTY COMPILE_WARNING_AS_ERROR ON)
+    else()
+        target_compile_options(${TARGET} PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/WX>
+            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
+        )
+    endif()
+endfunction()


### PR DESCRIPTION
Treating compilation warnings as errors is a good practice. However, SOFA has so many warnings that we cannot simply turn on this feature for the whole code base. Instead, I suggest to progressively add this feature for individual modules, and privately. For that, I introduced a CMake function.

I activated this feature for Sofa.Config and Sofa.Type. I expect new compilation errors that we will need to fix, before merging this PR.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
