### PR TITLE
[Config] Runs clang-tidy on specific targets during the build

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -310,6 +310,8 @@ target_link_options(${PROJECT_NAME} PUBLIC "$<${is_c_cxx_release}:${SOFACONFIG_L
 target_link_options(${PROJECT_NAME} PUBLIC "$<${is_c_cxx_debug}:${SOFACONFIG_LINK_OPTIONS_DEBUG}>")
 target_link_options(${PROJECT_NAME} PUBLIC "$<${is_c_cxx}:${SOFACONFIG_LINK_OPTIONS}>")
 
+sofa_enable_clang_tidy(${PROJECT_NAME})
+
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
 
 # Attach Sofa Version into properties

--- a/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
+++ b/Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake
@@ -508,3 +508,29 @@ macro(sofa_set_targets_release_only)
 endmacro()
 
 
+
+function(sofa_enable_clang_tidy TARGET_NAME)
+    cmake_parse_arguments(CT "" "CHECKS" "" ${ARGN})
+
+    if(NOT TARGET "${TARGET_NAME}")
+        message(FATAL_ERROR "enable_clang_tidy: '${TARGET_NAME}' is not a target")
+    endif()
+
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy)
+    if(NOT CLANG_TIDY_EXE)
+        message(STATUS "clang-tidy not found; skipping for target '${TARGET_NAME}. Install clang-tidy and add it to your PATH environment variable.'")
+        return()
+    endif()
+
+    set(cmd "${CLANG_TIDY_EXE}")
+    if(CT_CHECKS)
+        list(APPEND cmd "-checks=${CT_CHECKS}")
+    endif()
+
+    # Enable clang-tidy only for this target
+    set_target_properties("${TARGET_NAME}" PROPERTIES
+        C_CLANG_TIDY   "${cmd}"
+        CXX_CLANG_TIDY "${cmd}"
+    )
+endfunction()
+

--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -107,6 +107,7 @@ if(mimalloc_FOUND)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Sofa.Framework) # IDE folder
+sofa_enable_clang_tidy(${PROJECT_NAME})
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}


### PR DESCRIPTION
Unfortunately, I couldn't test it on MSVC. According to [the documentation](https://cmake.org/cmake/help/latest/prop_tgt/LANG_CLANG_TIDY.html), this option is available only for makefile and ninja generators. Therefore, I couldn't test if this option is useful or not. The tool can be configured with `.clang-tidy` file that can be placed at the root of the project.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
