### PR TITLE
[CI] CMake & Nix: add tight_inclusion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,8 @@
           devShells.default = pkgs.mkShell { inputsFrom = [ self'.packages.default ]; };
           packages = {
             default = self'.packages.sofa;
-            sofa = pkgs.callPackage ./package.nix { };
+            sofa = pkgs.callPackage ./package.nix { inherit (self'.packages) tight_inclusion; };
+            tight_inclusion = pkgs.callPackage ./tight_inclusion.nix { };
           };
         };
     };

--- a/package.nix
+++ b/package.nix
@@ -12,6 +12,7 @@
   metis,
   nlohmann_json,
   stdenv,
+  tight_inclusion,
   tinyxml-2,
   zlib,
 }:
@@ -56,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     metis
     nlohmann_json
     tinyxml-2
+    tight_inclusion
     zlib
   ];
 

--- a/tight_inclusion.nix
+++ b/tight_inclusion.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+
+  eigen,
+  spdlog,
+}:
+
+let
+  cf = fetchFromGitHub {
+    owner = "conda-forge";
+    repo = "tight-inclusion-feedstock";
+    rev = "ad0bb48ec12aa991ae208252cdd7e61fa37bdc10";
+    hash = "sha256-4v6h1c2fe0DK5z/s86B7oUyUBAYXTnMHzOpBM91NEpY=";
+  };
+
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tight-inclusion";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "Continuous-Collision-Detection";
+    repo = "Tight-Inclusion";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Yq79qShpA5VmPan+QV05GrGrmsoUuVFCrJDK7F207Qs=";
+  };
+
+  patches = [
+    "${cf}/recipe/patches/0001-Export-target-install-header-in-right-dir-still-need.patch"
+    "${cf}/recipe/patches/0002-Export-symbols-on-windows.patch"
+    "${cf}/recipe/patches/0003-patch-for-conda-forge-package.patch"
+    "${cf}/recipe/patches/0004-add-cmake-config-file-homogenize-project-name.patch"
+    "${cf}/recipe/patches/0005-fix-installation-of-configured-config.hpp-file.patch"
+  ];
+
+  postPatch = ''
+    # we don't need the bin
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        "add_subdirectory(app)" \
+        ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
+    eigen
+    spdlog
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DTIGHT_INCLUSION_TOPLEVEL_PROJECT=ON"
+  ];
+
+  meta = {
+    description = "Conservative continuous collision detection (CCD) method with support for minimum separation";
+    homepage = "https://github.com/Continuous-Collision-Detection/Tight-Inclusion";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
This is a quick and dirty temporary workaround, following discussions with @hugtalbot,
but proper packaging should really be contributed upstream.

Do you have plans for this @olivier-roussel @bakpaul ?



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
