### PR TITLE
[Type] Fix type conversion in RGBAColor

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -62,7 +62,13 @@ static int hexval(const char c)
 static void extractValidatedHexaString(std::istream& in, std::string& s)
 {
     s.reserve(9);
-    char c = in.get();
+    char c {};
+    in.get(c);
+
+    if (in.fail())
+    {
+        return;
+    }
 
     if(c!='#')
     {
@@ -71,14 +77,15 @@ static void extractValidatedHexaString(std::istream& in, std::string& s)
     }
 
     s.push_back(c);
-    while(in.get(c)){
-        if( !ishexsymbol(c) )
-            return;
+    while (in.get(c))
+    {
+        if (!ishexsymbol(c)) return;
 
-        s.push_back(c) ;
-        if(s.size()>9){
-            in.setstate(std::ios_base::failbit) ;
-            return ;
+        s.push_back(c);
+        if (s.size() > 9)
+        {
+            in.setstate(std::ios_base::failbit);
+            return;
         }
     }
     /// we need to reset the failbit because it is set by the get function

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -168,11 +168,11 @@ RGBAColor RGBAColor::fromHSVA(const float h, const float s, const float v, const
 /// This function remove the leading space in the stream.
 static std::istream& trimInitialSpaces(std::istream& in)
 {
-    char first=in.peek();
-    while(!in.eof() && !in.fail() && std::isspace(first, std::locale()))
+    int first = in.peek();
+    while (!in.eof() && !in.fail() && std::isspace(first, std::locale()))
     {
         in.get();
-        first=in.peek();
+        first = in.peek();
     }
     return in;
 }

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -220,7 +220,7 @@ SOFA_TYPE_API std::istream& operator>>(std::istream& i, RGBAColor& t)
     if( i.eof() || i.fail() )
         return i;
 
-    const char first = i.peek() ;
+    const int first = i.peek() ;
     if (std::isdigit(first, std::locale()))
     {
         i >> r >> g >> b ;

--- a/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
+++ b/Sofa/framework/Type/src/sofa/type/RGBAColor.cpp
@@ -175,11 +175,11 @@ RGBAColor RGBAColor::fromHSVA(const float h, const float s, const float v, const
 /// This function remove the leading space in the stream.
 static std::istream& trimInitialSpaces(std::istream& in)
 {
-    int first = in.peek();
+    char first = static_cast<char>(in.peek());
     while (!in.eof() && !in.fail() && std::isspace(first, std::locale()))
     {
         in.get();
-        first = in.peek();
+        first = static_cast<char>(in.peek());
     }
     return in;
 }
@@ -220,7 +220,7 @@ SOFA_TYPE_API std::istream& operator>>(std::istream& i, RGBAColor& t)
     if( i.eof() || i.fail() )
         return i;
 
-    const int first = i.peek() ;
+    const char first = static_cast<char>(i.peek()) ;
     if (std::isdigit(first, std::locale()))
     {
         i >> r >> g >> b ;


### PR DESCRIPTION
This is to fix the warnings enabled by W4 (#5913) on Sofa.Type

```
3>RGBAColor.cpp(65,12): Warning C4244 : 'initializing': conversion from 'int' to 'char', possible loss of data
3>RGBAColor.cpp(171,15): Warning C4244 : 'initializing': conversion from 'int' to 'char', possible loss of data
3>RGBAColor.cpp(175,22): Warning C4244 : '=': conversion from 'int' to 'char', possible loss of data
3>RGBAColor.cpp(216,30): Warning C4244 : 'initializing': conversion from 'int' to 'char', possible loss of data
3>RGBAColor.cpp(216,22): Warning C4244 : 'initializing': conversion from 'int' to 'const char', possible loss of data
```

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
