### PR TITLE
[Elastic] Load required plugin in test

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
@@ -130,6 +130,9 @@ public:
 
     void checkNoMechanicalObject()
     {
+        this->loadPlugins({
+            Sofa.Component.SolidMechanics.FEM.Elastic,
+        });
         EXPECT_MSG_EMIT(Error);
         
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");


### PR DESCRIPTION
This is required if the test is run without any previous context that loaded the plugin `Sofa.Component.SolidMechanics.FEM.Elastic`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
