### PR TITLE
[SofaMatrix] Rollback to metis 5.1.0

### DIFF
--- a/applications/plugins/SofaMatrix/CMakeLists.txt
+++ b/applications/plugins/SofaMatrix/CMakeLists.txt
@@ -11,12 +11,12 @@ sofa_find_package(Eigen3 REQUIRED)
 # - >= 5.2.1
 # - EXACT 5.1.0
 # Versions newer than 5.1 and older than 5.2.1 are known to be broken
-find_package(metis 5.2.1 QUIET)
+find_package(metis 5.1.0 EXACT QUIET)
 if(NOT metis_FOUND AND SOFA_ALLOW_FETCH_DEPENDENCIES)
     message("${PROJECT_NAME}: DEPENDENCY metis NOT FOUND. SOFA_ALLOW_FETCH_DEPENDENCIES is ON, fetching metis...")
     sofa_fetch_dependency(metis
             GIT_REPOSITORY https://github.com/sofa-framework/METIS
-            GIT_TAG v5.2.1-ModernInstall
+            GIT_TAG v5.1.0-ModernInstall
     )
 elseif (NOT metis_FOUND)
     message(FATAL_ERROR "${PROJECT_NAME}: DEPENDENCY metis NOT FOUND. SOFA_ALLOW_FETCH_DEPENDENCIES is OFF and thus cannot be fetched. Install metis (version=5.2.1), or enable SOFA_ALLOW_FETCH_DEPENDENCIES to fix this issue.")


### PR DESCRIPTION
As the v5.2.1 is broken on Windows, we roll back to previous version

[ci-depends-on https://github.com/sofa-framework/Sofa.Metis/pull/18]
[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
