### PR TITLE
[Helper] Match ubuntu implementation of create dir for Windows

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
@@ -184,10 +184,6 @@ bool FileSystem::createDirectory(const std::string& path)
             }
         }
     }
-    else
-    {
-        return false;
-    }
 #else
     int status = mkdir(path.c_str(), 0755);
     if(status)

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
@@ -153,8 +153,40 @@ bool FileSystem::createDirectory(const std::string& path)
     if (CreateDirectory(sofa::helper::widenString(path).c_str(), nullptr) == 0)
     {
         DWORD errorCode = ::GetLastError();
-        msg_error(error) << path << ": " << Utils::GetLastError();
-        return true;
+        if (errorCode != ERROR_ALREADY_EXISTS)
+        {
+            msg_error(error) << path << ": " << Utils::GetLastError();
+            return true;
+        }
+        else
+        {
+            // Check if the existing item is a file or directory
+            DWORD attributes = GetFileAttributes(sofa::helper::widenString(path).c_str());
+            if (attributes != INVALID_FILE_ATTRIBUTES)
+            {
+                if ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
+                {
+                    // It's a file, not a directory - this is an error
+                    msg_error(error) << path << ": File exists and is not a directory";
+                    return true;
+                }
+                else
+                {
+                    // It's already a directory - success
+                    return false;
+                }
+            }
+            else
+            {
+                // Couldn't get attributes - treat as error
+                msg_error(error) << path << ": " << Utils::GetLastError();
+                return true;
+            }
+        }
+    }
+    else
+    {
+        return false;
     }
 #else
     int status = mkdir(path.c_str(), 0755);


### PR DESCRIPTION
Before : On windows, if the folder creation fails because the folder already exists then an error is thrown. Which is not the case on ubuntu
Now: If the path already exists and is indeed a folder then everything is fine.  

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
