### PR TITLE
[Mass] Fix kinetic energy in MeshMatrixMass when lumped

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -2100,23 +2100,23 @@ SReal MeshMatrixMass<DataTypes, GeometricalTypes>::getKineticEnergy( const core:
 
     helper::ReadAccessor< DataVecDeriv > v = vv;
 
-    const unsigned int nbEdges=l_topology->getNbEdges();
-    unsigned int v0,v1;
+    const sofa::Size nbEdges = l_topology->getNbEdges();
 
     SReal e = 0;
+    const auto lumpingCoef = isLumped() ? m_massLumpingCoeff : static_cast<Real>(1.0);
 
-    for (unsigned int i=0; i<v.size(); i++)
+    for (unsigned int i = 0; i < v.size(); i++)
     {
-        e += dot(v[i],v[i]) * vertexMass[i]; // v[i]*v[i]*masses[i] would be more efficient but less generic
+        e += dot(v[i],v[i]) * vertexMass[i] * lumpingCoef; // v[i]*v[i]*masses[i] would be more efficient but less generic
     }
 
-    for (unsigned int i = 0; i < nbEdges; ++i)
+    if (!isLumped())
     {
-        v0 = l_topology->getEdge(i)[0];
-        v1 = l_topology->getEdge(i)[1];
-
-        e += 2 * dot(v[v0], v[v1])*edgeMass[i];
-
+        for (unsigned int i = 0; i < nbEdges; ++i)
+        {
+            const auto& [v0, v1] = l_topology->getEdge(i).array();
+            e += 2 * dot(v[v0], v[v1]) * edgeMass[i];
+        }
     }
 
     return e/2;


### PR DESCRIPTION
The bug has been spotted with https://github.com/sofa-framework/sofa/pull/5920.

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
