### PR TITLE
[Type] Deprecated determinant for non-square matrices

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -944,6 +944,7 @@ constexpr real determinant(const Mat<1,1,real>& m) noexcept
 /// Generalized-determinant of a 2x3 matrix.
 /// Mirko Radi, "About a Determinant of Rectangular 2×n Matrix and its Geometric Interpretation"
 template<class real>
+SOFA_ATTRIBUTE_DEPRECATED__NONSQUAREDETERMINANT()
 constexpr real determinant(const Mat<2,3,real>& m) noexcept
 {
     return m(0,0)*m(1,1) - m(0,1)*m(1,0) - ( m(0,0)*m(1,2) - m(0,2)*m(1,0) ) + m(0,1)*m(1,2) - m(0,2)*m(1,1);
@@ -952,6 +953,7 @@ constexpr real determinant(const Mat<2,3,real>& m) noexcept
 /// Generalized-determinant of a 3x2 matrix.
 /// Mirko Radi, "About a Determinant of Rectangular 2×n Matrix and its Geometric Interpretation"
 template<class real>
+SOFA_ATTRIBUTE_DEPRECATED__NONSQUAREDETERMINANT()
 constexpr real determinant(const Mat<3,2,real>& m) noexcept
 {
     return m(0,0)*m(1,1) - m(1,0)*m(0,1) - ( m(0,0)*m(2,1) - m(2,0)*m(0,1) ) + m(1,0)*m(2,1) - m(2,0)*m(1,1);

--- a/Sofa/framework/Type/src/sofa/type/config.h.in
+++ b/Sofa/framework/Type/src/sofa/type/config.h.in
@@ -73,3 +73,10 @@
 #define SOFA_ATTRIBUTE_DEPRECATED__VEC_FROM_DIFFERENT_VEC() \
     SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v26.12", "Assignment and construction from a different Vec is being phased out (PR 5675).")
 #endif
+
+#ifdef SOFA_BUILD_SOFA_TYPE
+#define SOFA_ATTRIBUTE_DEPRECATED__NONSQUAREDETERMINANT()
+#else
+#define SOFA_ATTRIBUTE_DEPRECATED__NONSQUAREDETERMINANT() \
+    SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v26.12", "Determinant for non-square matrix is not well-defined.")
+#endif


### PR DESCRIPTION
In https://github.com/sofa-framework/sofa/pull/5876, it has been shown that removing those two functions did not break the compilation. We can deduce that those functions are not used. Moreover, they are not well defined. This PR deprecates both functions.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
