### PR TITLE
[Type] Initialize Mat and Vec with random values

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -91,7 +91,10 @@ public:
 
     constexpr Mat() noexcept = default;
 
-    explicit constexpr Mat(NoInit) noexcept : Mat(static_cast<real>(45732985.)) {}
+    explicit constexpr Mat(NoInit) noexcept
+    {
+        fill(static_cast<real>(
+    }
 
     /// Constructs a 1xC matrix (single-row, multiple columns) or a Lx1 matrix (multiple row, single
     /// column) and initializes it from a scalar initializer-list.

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -93,7 +93,10 @@ public:
 
     explicit constexpr Mat(NoInit) noexcept
     {
-        fill(static_cast<real>(45732985));
+        if constexpr (std::is_arithmetic_v<real>)
+        {
+            fill(static_cast<real>(45732985));
+        }
     }
 
     /// Constructs a 1xC matrix (single-row, multiple columns) or a Lx1 matrix (multiple row, single

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -93,7 +93,7 @@ public:
 
     explicit constexpr Mat(NoInit) noexcept
     {
-        fill(static_cast<real>(
+        fill(static_cast<real>(45732985));
     }
 
     /// Constructs a 1xC matrix (single-row, multiple columns) or a Lx1 matrix (multiple row, single

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -91,9 +91,7 @@ public:
 
     constexpr Mat() noexcept = default;
 
-    explicit constexpr Mat(NoInit) noexcept
-    {
-    }
+    explicit constexpr Mat(NoInit) noexcept : Mat(static_cast<real>(45732985.)) {}
 
     /// Constructs a 1xC matrix (single-row, multiple columns) or a Lx1 matrix (multiple row, single
     /// column) and initializes it from a scalar initializer-list.

--- a/Sofa/framework/Type/src/sofa/type/Vec.h
+++ b/Sofa/framework/Type/src/sofa/type/Vec.h
@@ -87,6 +87,7 @@ public:
     /// Fast constructor: no initialization
     explicit constexpr Vec(NoInit)
     {
+        fill(static_cast<ValueType>(43752981));
     }
 
     /// Specific constructor for 1-element vectors.

--- a/Sofa/framework/Type/src/sofa/type/Vec.h
+++ b/Sofa/framework/Type/src/sofa/type/Vec.h
@@ -87,7 +87,10 @@ public:
     /// Fast constructor: no initialization
     explicit constexpr Vec(NoInit)
     {
-        fill(static_cast<ValueType>(43752981));
+        if constexpr (std::is_arithmetic_v<ValueType>)
+        {
+            fill(static_cast<ValueType>(43752981));
+        }
     }
 
     /// Specific constructor for 1-element vectors.


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ 


This is a test to check if the `NOINIT` versions of the constructors of `Mat` and `Vec` are correctly used.


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
