### PR TITLE
[Mapping] Fix rigid mapping init 

### DIFF
--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.h
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.h
@@ -152,7 +152,7 @@ protected:
     class Loader;
 
     void load(const char* filename);
-    const OutVecCoord& getPoints();
+    const OutVecCoord& getPoints() const;
     void setJMatrixBlock(sofa::Index outIdx, sofa::Index inIdx);
 
     std::unique_ptr<MatrixType> m_matrixJ;

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
@@ -134,7 +134,6 @@ RigidMapping<TIn, TOut>::RigidMapping()
 template <class TIn, class TOut>
 sofa::Index RigidMapping<TIn, TOut>::getRigidIndex(sofa::Index pointIndex ) const
 {
-    // do we really need this crap?
     if( getPoints().size() == d_rigidIndexPerPoint.getValue().size() )
         return d_rigidIndexPerPoint.getValue()[pointIndex];
     else

--- a/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
+++ b/Sofa/Component/Mapping/NonLinear/src/sofa/component/mapping/nonlinear/RigidMapping.inl
@@ -135,7 +135,8 @@ template <class TIn, class TOut>
 sofa::Index RigidMapping<TIn, TOut>::getRigidIndex(sofa::Index pointIndex ) const
 {
     // do we really need this crap?
-    if( d_points.getValue().size() == d_rigidIndexPerPoint.getValue().size() ) return d_rigidIndexPerPoint.getValue()[pointIndex];
+    if( getPoints().size() == d_rigidIndexPerPoint.getValue().size() )
+        return d_rigidIndexPerPoint.getValue()[pointIndex];
     else
     {
         if( !d_indexFromEnd.getValue() ) return d_index.getValue();
@@ -225,6 +226,7 @@ void RigidMapping<TIn, TOut>::init()
     this->reinit();
 
     this->Inherit::init();
+
 }
 
 template <class TIn, class TOut>
@@ -286,7 +288,7 @@ void RigidMapping<TIn, TOut>::setRepartition(sofa::type::vector<sofa::Size> valu
 }
 
 template <class TIn, class TOut>
-const typename RigidMapping<TIn, TOut>::OutVecCoord & RigidMapping<TIn, TOut>::getPoints()
+const typename RigidMapping<TIn, TOut>::OutVecCoord & RigidMapping<TIn, TOut>::getPoints() const
 {
     if (d_useX0.getValue())
     {


### PR DESCRIPTION
Use right vector size for checking. This fixes a crash when the mapping was used with only "useX0=True". 

I know this component needs way more fixing/refactoring. But this is just a fix keeping the ols implementation untouched for now. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
