### PR TITLE
[Simulation.Core] use `getNodeObjects` for cleaner iteration over objects

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/TopologyChangeVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/TopologyChangeVisitor.cpp
@@ -69,10 +69,9 @@ Visitor::Result TopologyChangeVisitor::processNodeTopDown(simulation::Node* node
 #endif
 
     // search for topological mapping, run the mapping first. Do not stop the propagation of parent topology
-    for (simulation::Node::ObjectIterator it = node->object.begin(); it != node->object.end(); ++it)
+    for (auto* obj : node->getNodeObjects<sofa::core::topology::TopologicalMapping>())
     {
-        sofa::core::topology::TopologicalMapping* obj = dynamic_cast<sofa::core::topology::TopologicalMapping*>(it->get());
-        if (obj != nullptr)  // find a TopologicalMapping node among the brothers (it must be the first one written)
+        if (obj != nullptr)
         {
             if(obj->propagateFromInputToOutputModel() && obj->getFrom() == m_source)  //node != root){ // the propagation of topological changes comes (at least) from a father node, not from a brother
             {
@@ -92,10 +91,9 @@ Visitor::Result TopologyChangeVisitor::processNodeTopDown(simulation::Node* node
 
 void TopologyChangeVisitor::processNodeBottomUp(simulation::Node* node)
 {
-    for (simulation::Node::ObjectIterator it = node->object.begin(); it != node->object.end(); ++it)
+    for (auto* obj : node->getNodeObjects<sofa::core::topology::TopologicalMapping>())
     {
-        sofa::core::topology::TopologicalMapping* obj = dynamic_cast<sofa::core::topology::TopologicalMapping*>(it->get());
-        if (obj != nullptr)  // find a TopologicalMapping node among the brothers (it must be the first one written)
+        if (obj != nullptr)
         {
             if(obj->propagateFromOutputToInputModel() && obj->getTo() == m_source)  //node == root){
             {


### PR DESCRIPTION
[with-all-tests]





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
