### PR TITLE
[HyperElastic] Enable the SelfAdjointEigenSolver in Ogden 

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
@@ -81,7 +81,8 @@ public:
 
         // 17/11/2025: Disable /*Eigen::SelfAdjointEigenSolver<EigenMatrix>*/
         // due to incorrect eigenvector computation for 3x3 matrices.
-        Eigen::EigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen, true);
+        //Eigen::EigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen, true);
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen, true);
         if (EigenProblemSolver.info() != Eigen::Success)
         {
             dmsg_warning("Ogden") << "EigenSolver iterations failed to converge";

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
@@ -79,15 +79,16 @@ public:
             for (sofa::Index j = 0; j < 3; ++j) 
                 CEigen(i, j) = C[MatrixSym::voigtID(i, j)];
 
-        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Real,3,3> > EigenProblemSolver(CEigen, Eigen::ComputeEigenvectors);
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Real,3,3> > 
+            EigenProblemSolver(CEigen, Eigen::ComputeEigenvectors);
         if (EigenProblemSolver.info() != Eigen::Success)
         {
             dmsg_warning("Ogden") << "EigenSolver iterations failed to converge";
             return;
         }
 
-        sinfo->Evalue = EigenProblemSolver.eigenvalues().real().eval();
-        sinfo->Evect = EigenProblemSolver.eigenvectors().real().eval();
+        sinfo->Evalue = EigenProblemSolver.eigenvalues();
+        sinfo->Evect = EigenProblemSolver.eigenvectors();
 
         const Real aBy2{alpha1/static_cast<Real>(2)};
         m_trCaBy2 = static_cast<Real>(0);
@@ -192,8 +193,9 @@ public:
                     {
                         if (eJ == eI) continue;
 
-                        const bool isDegenerate = std::fabs(Evalue[eI] - Evalue[eJ]) <
-                                                   std::numeric_limits<Real>::epsilon();
+                        constexpr Real tol = static_cast<Real>(1e-8);
+                        const Real maxEval = std::max(std::fabs(Evalue[eI]), std::fabs(Evalue[eJ]));
+                        const bool isDegenerate = std::fabs(Evalue[eI] - Evalue[eJ]) < maxEval * tol;
                         const Real coefRot = isDegenerate 
                             ? aBy2Minus1 * evalPowI2
                             : (evalPowI - pow(Evalue[eJ], aBy2Minus1))/(Evalue[eI] - Evalue[eJ]);

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
@@ -66,9 +66,7 @@ public:
                                 const MaterialParameters<DataTypes>& param)
     {
         const MatrixSym& C = sinfo->deformationTensor;
-        const Real mu1 = param.parameterArray[0];
         const Real alpha1 = param.parameterArray[1];
-        const Real k0 = param.parameterArray[2];
 
         m_FJ = pow(sinfo->J, -alpha1/static_cast<Real>(3));
         m_logJ = log(sinfo->J);

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
@@ -82,7 +82,7 @@ public:
         // 17/11/2025: Disable /*Eigen::SelfAdjointEigenSolver<EigenMatrix>*/
         // due to incorrect eigenvector computation for 3x3 matrices.
         //Eigen::EigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen, true);
-        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen, true);
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen);//, true);
         if (EigenProblemSolver.info() != Eigen::Success)
         {
             dmsg_warning("Ogden") << "EigenSolver iterations failed to converge";

--- a/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
+++ b/Sofa/Component/SolidMechanics/FEM/HyperElastic/src/sofa/component/solidmechanics/fem/hyperelastic/material/Ogden.h
@@ -79,10 +79,7 @@ public:
             for (sofa::Index j = 0; j < 3; ++j) 
                 CEigen(i, j) = C[MatrixSym::voigtID(i, j)];
 
-        // 17/11/2025: Disable /*Eigen::SelfAdjointEigenSolver<EigenMatrix>*/
-        // due to incorrect eigenvector computation for 3x3 matrices.
-        //Eigen::EigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen, true);
-        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Real, 3, 3> > EigenProblemSolver(CEigen);//, true);
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Real,3,3> > EigenProblemSolver(CEigen, Eigen::ComputeEigenvectors);
         if (EigenProblemSolver.info() != Eigen::Success)
         {
             dmsg_warning("Ogden") << "EigenSolver iterations failed to converge";


### PR DESCRIPTION
Bad use of the `SelfAdjointEigenSolver` in previous changes. It should not be constructed by passing a bool to the constructor. I assumed this was enabling eigenvector computations, as is the case with the general-purpose `EigenSolver`. 

It must have been the case in the old eigen API.

Big thnx to @fredroy for this.

[ci-build][with-all-tests]

Close #5733 