### PR TITLE
[All] Clean task scheduler usage

### DIFF
--- a/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.h
+++ b/Sofa/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.h
@@ -24,6 +24,7 @@
 
 #include <sofa/simulation/CollisionAnimationLoop.h>
 #include <sofa/core/MultiVecId.h>
+#include <sofa/simulation/task/TaskSchedulerUser.h>
 
 namespace sofa::core::behavior
 {
@@ -33,7 +34,8 @@ namespace sofa::core::behavior
 namespace sofa::component::animationloop
 {
 
-class SOFA_COMPONENT_ANIMATIONLOOP_API FreeMotionAnimationLoop : public sofa::simulation::CollisionAnimationLoop
+class SOFA_COMPONENT_ANIMATIONLOOP_API FreeMotionAnimationLoop : public sofa::simulation::CollisionAnimationLoop,
+                                                                 public sofa::simulation::TaskSchedulerUser
 {
 public:
     SOFA_CLASS(FreeMotionAnimationLoop, sofa::simulation::CollisionAnimationLoop);

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/BuiltConstraintSolver.cpp
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/BuiltConstraintSolver.cpp
@@ -42,7 +42,7 @@ void BuiltConstraintSolver::init()
     Inherit1::init();
     if(d_multithreading.getValue())
     {
-        simulation::MainTaskSchedulerFactory::createInRegistry()->init();
+        initTaskScheduler();
     }
 }
 

--- a/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/BuiltConstraintSolver.h
+++ b/Sofa/Component/Constraint/Lagrangian/Solver/src/sofa/component/constraint/lagrangian/solver/BuiltConstraintSolver.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/component/constraint/lagrangian/solver/GenericConstraintSolver.h>
+#include <sofa/simulation/task/TaskSchedulerUser.h>
 
 namespace sofa::component::constraint::lagrangian::solver
 {
@@ -32,7 +33,8 @@ namespace sofa::component::constraint::lagrangian::solver
  *  This component is purely virtual because doSolve is not defined and needs to be defined in the
  *  inherited class
  */
-class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API BuiltConstraintSolver : public GenericConstraintSolver
+class SOFA_COMPONENT_CONSTRAINT_LAGRANGIAN_SOLVER_API BuiltConstraintSolver : public GenericConstraintSolver,
+                                                                              public sofa::simulation::TaskSchedulerUser
 {
 
 public:

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
@@ -25,6 +25,7 @@
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/MechanicalOperations.h>
 #include <sofa/simulation/VectorOperations.h>
+#include <sofa/simulation/task/TaskSchedulerUser.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/component/linearsolver/iterative/GraphScatteredTypes.h>
 #include <sofa/linearalgebra/FullVector.h>
@@ -43,6 +44,7 @@
 #else
 #include <sofa/core/behavior/DefaultMultiMatrixAccessor.h>
 #endif // SOFA_CORE_ENABLE_CRSMULTIMATRIXACCESSOR
+
 
 namespace sofa::component::linearsolver
 {
@@ -174,7 +176,8 @@ template<class Matrix, class Vector, class ThreadManager = NoThreadManager>
 class MatrixLinearSolver;
 
 template<class Matrix, class Vector>
-class MatrixLinearSolver<Matrix,Vector,NoThreadManager> : public BaseMatrixLinearSolver<Matrix, Vector>
+class MatrixLinearSolver<Matrix,Vector,NoThreadManager> : public BaseMatrixLinearSolver<Matrix, Vector>,
+                                                          public simulation::TaskSchedulerUser
 {
 public:
     SOFA_ABSTRACT_CLASS(SOFA_TEMPLATE3(MatrixLinearSolver,Matrix,Vector,NoThreadManager), SOFA_TEMPLATE2(BaseMatrixLinearSolver,Matrix,Vector));

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.inl
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.inl
@@ -62,18 +62,7 @@ MatrixLinearSolver<Matrix,Vector>::MatrixLinearSolver()
         SOFA_UNUSED(tracker);
         if (d_parallelInverseProduct.getValue())
         {
-            simulation::TaskScheduler* taskScheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
-            assert(taskScheduler);
-
-            if (taskScheduler->getThreadCount() < 1)
-            {
-                taskScheduler->init(0);
-                msg_info() << "Task scheduler initialized on " << taskScheduler->getThreadCount() << " threads";
-            }
-            else
-            {
-                msg_info() << "Task scheduler already initialized on " << taskScheduler->getThreadCount() << " threads";
-            }
+            initTaskScheduler();
         }
         return this->d_componentState.getValue();
     },

--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -143,6 +143,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/task/TaskSchedulerRegistry.h
     ${SRC_ROOT}/task/TaskSchedulerUser.h
     ${SRC_ROOT}/task/WorkerThread.h
+    ${SRC_ROOT}/task/TaskSchedulerSettings.h
 )
 
 set(SOURCE_FILES
@@ -278,6 +279,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/task/TaskSchedulerRegistry.cpp
     ${SRC_ROOT}/task/TaskSchedulerUser.cpp
     ${SRC_ROOT}/task/WorkerThread.cpp
+    ${SRC_ROOT}/task/TaskSchedulerSettings.cpp
 )
 
 set(DEPRECATED_DIR "compat/sofa/simulation")

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.cpp
@@ -94,7 +94,7 @@ void DefaultTaskScheduler::init(const unsigned int NbThread )
 {
     if ( m_isInitialized )
     {
-        if ( (!m_isDefaultInitialized && (NbThread < m_threadCount)) || (NbThread==0 && m_threadCount==GetHardwareThreadsCount()) )
+        if ( (NbThread == m_threadCount) || (NbThread==0 && m_threadCount==GetHardwareThreadsCount()) )
         {
             return;
         }
@@ -107,8 +107,6 @@ void DefaultTaskScheduler::init(const unsigned int NbThread )
 void DefaultTaskScheduler::start(const unsigned int NbThread )
 {
     stop();
-
-    m_isDefaultInitialized = (NbThread == 0);
 
     m_isClosing = false;
     m_workerThreadsIdle = true;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.cpp
@@ -94,7 +94,7 @@ void DefaultTaskScheduler::init(const unsigned int NbThread )
 {
     if ( m_isInitialized )
     {
-        if ( (NbThread == m_threadCount) || (NbThread==0 && m_threadCount==GetHardwareThreadsCount()) )
+        if ( (!m_isDefaultInitialized && (NbThread < m_threadCount)) || (NbThread==0 && m_threadCount==GetHardwareThreadsCount()) )
         {
             return;
         }
@@ -107,6 +107,8 @@ void DefaultTaskScheduler::init(const unsigned int NbThread )
 void DefaultTaskScheduler::start(const unsigned int NbThread )
 {
     stop();
+
+    m_isDefaultInitialized = (NbThread == 0);
 
     m_isClosing = false;
     m_workerThreadsIdle = true;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.h
@@ -121,7 +121,6 @@ private:
     void start(unsigned int NbThread);
             
     bool m_isInitialized;
-    bool m_isDefaultInitialized;
 
     unsigned m_workerThreadCount;
             

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/DefaultTaskScheduler.h
@@ -121,7 +121,8 @@ private:
     void start(unsigned int NbThread);
             
     bool m_isInitialized;
-            
+    bool m_isDefaultInitialized;
+
     unsigned m_workerThreadCount;
             
     std::atomic<bool> m_workerThreadsIdle;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.cpp
@@ -19,80 +19,18 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/simulation/init.h>
 
-#include <sofa/core/init.h>
-#include <sofa/helper/init.h>
-
-#include <sofa/simulation/task/MainTaskSchedulerRegistry.h>
-
+#include <sofa/simulation/task/TaskSchedulerSettings.h>
 #include <sofa/core/ObjectFactory.h>
 
 namespace sofa::simulation
 {
 
-extern void registerRequiredPlugin(sofa::core::ObjectFactory* factory);
-extern void registerDefaultVisualManagerLoop(sofa::core::ObjectFactory* factory);
-extern void registerDefaultAnimationLoop(sofa::core::ObjectFactory* factory);
-extern void registerTaskSchedulerSettings(sofa::core::ObjectFactory* factory);
-
-namespace core
+void registerTaskSchedulerSettings(sofa::core::ObjectFactory* factory)
 {
-
-static bool s_initialized = false;
-static bool s_cleanedUp = false;
-
-
-SOFA_SIMULATION_CORE_API void init()
-{
-    if (!s_initialized)
-    {
-        sofa::core::init();
-        s_initialized = true;
-
-        auto* factory = sofa::core::ObjectFactory::getInstance();
-        registerRequiredPlugin(factory);
-        registerDefaultVisualManagerLoop(factory);
-        registerDefaultAnimationLoop(factory);
-        registerTaskSchedulerSettings(factory);
-    }
+    factory->registerObjects(core::ObjectRegistrationData("Set task scheduler globally for the scene.")
+        .add< TaskSchedulerSettings >());
 }
 
-SOFA_SIMULATION_CORE_API bool isInitialized()
-{
-    return s_initialized;
+
 }
-
-SOFA_SIMULATION_CORE_API void cleanup()
-{
-    if (!s_cleanedUp)
-    {
-        sofa::simulation::MainTaskSchedulerRegistry::clear();
-        sofa::core::cleanup();
-        s_cleanedUp = true;
-    }
-}
-
-SOFA_SIMULATION_CORE_API bool isCleanedUp()
-{
-    return s_cleanedUp;
-}
-
-// Detect missing cleanup() call.
-static const struct CleanupCheck
-{
-    CleanupCheck() {}
-    ~CleanupCheck()
-    {
-        if (simulation::core::isInitialized() && !simulation::core::isCleanedUp())
-            helper::printLibraryNotCleanedUpWarning("SofaSimulationCore", "sofa::simulation::core::cleanup()");
-    }
-} check;
-
-} // namespace core
-
-} // namespace sofa::simulation
-
-
-
-

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.h
@@ -1,0 +1,35 @@
+//
+// Created by paul on 20/02/2026.
+//
+
+#pragma once
+
+#include <sofa/simulation/config.h>
+
+#include <sofa/simulation/task/TaskSchedulerUser.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+
+namespace sofa::simulation
+{
+
+class TaskSchedulerSettings : public core::objectmodel::BaseObject,
+                              public TaskSchedulerUser
+{
+public:
+    SOFA_CLASS2(TaskSchedulerSettings, core::objectmodel::BaseObject, TaskSchedulerUser);
+
+    TaskSchedulerSettings() = default;
+
+    void init()
+    {
+        initTaskScheduler();
+    }
+
+    void reInit()
+    {
+        reinitTaskScheduler();
+    }
+};
+
+
+}

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.h
@@ -22,7 +22,7 @@ public:
 
     void init()
     {
-        initTaskScheduler();
+        initTaskScheduler(true);
     }
 
     void reInit()

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerUser.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerUser.cpp
@@ -26,7 +26,7 @@
 namespace sofa::simulation
 {
 
-void TaskSchedulerUser::initTaskScheduler()
+void TaskSchedulerUser::initTaskScheduler(bool forceInit)
 {
     if (!d_taskSchedulerType.isSet() || d_taskSchedulerType.getValue().empty())
     {
@@ -41,7 +41,7 @@ void TaskSchedulerUser::initTaskScheduler()
         return;
     }
 
-    if (m_taskScheduler->getThreadCount() < 1)
+    if (forceInit || m_taskScheduler->getThreadCount() < 1)
     {
         auto nbThreads = sofa::helper::getWriteAccessor(d_nbThreads);
         if (nbThreads <= 0)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerUser.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerUser.h
@@ -39,7 +39,7 @@ protected:
     sofa::simulation::TaskScheduler* m_taskScheduler { nullptr };
 
     TaskSchedulerUser();
-    void initTaskScheduler();
+    void initTaskScheduler(bool forceInit = false);
 
     void reinitTaskScheduler();
     void stopTaskSchduler();

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/linearsolver/iterative/ParallelCGLinearSolver.h
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/linearsolver/iterative/ParallelCGLinearSolver.h
@@ -29,8 +29,7 @@ namespace multithreading::component::linearsolver::iterative
 
 template<class TMatrix, class TVector>
 class ParallelCGLinearSolver :
-    public sofa::component::linearsolver::iterative::CGLinearSolver<TMatrix, TVector>,
-    public sofa::simulation::TaskSchedulerUser
+    public sofa::component::linearsolver::iterative::CGLinearSolver<TMatrix, TVector>
 {
 public:
     SOFA_CLASS2(SOFA_TEMPLATE2(ParallelCGLinearSolver,TMatrix,TVector),

--- a/applications/plugins/MultiThreading/src/MultiThreading/component/linearsolver/iterative/ParallelCGLinearSolver.inl
+++ b/applications/plugins/MultiThreading/src/MultiThreading/component/linearsolver/iterative/ParallelCGLinearSolver.inl
@@ -30,7 +30,7 @@ template <class TMatrix, class TVector>
 void ParallelCGLinearSolver<TMatrix, TVector>::init()
 {
     Inherit1::init();
-    initTaskScheduler();
+    this->initTaskScheduler();
 }
 
 template <class TMatrix, class TVector>

--- a/examples/Demos/SofaScene.scn
+++ b/examples/Demos/SofaScene.scn
@@ -36,18 +36,19 @@
     <!-- Rendering settings -->
     <VisualStyle name="RenderingOptions" displayFlags="showVisualModels" />
     <BackgroundSetting color="0.8 0.8 0.8 1" />
+    <TaskSchedulerSettings name="TaskSchedulerSettings" nbThreads="8" />
 
     <!-- Define Mouse left click as a Bilateral Lagrangian constraint -->
     <ConstraintAttachButtonSetting /> <!-- The presence of this component sets the mouse interaction to Lagrangian-based constraints at the GUI launch -->
 
     <!-- Header of the simulation -->
-    <FreeMotionAnimationLoop name="FreeMotionAnimationLoop" parallelODESolving="true" parallelCollisionDetectionAndFreeMotion="true" />
+    <FreeMotionAnimationLoop name="FreeMotionAnimationLoop" parallelODESolving="true" parallelCollisionDetectionAndFreeMotion="true"  />
     <BlockGaussSeidelConstraintSolver maxIterations="20" _multithreading='true' tolerance="1.0e-4"/>
 
     <!-- Definition of the collision pipeline -->
     <CollisionPipeline name="CollisionPipeline" />
-    <ParallelBruteForceBroadPhase name="CollisionBroadPhase" />
-    <ParallelBVHNarrowPhase name="CollisionNarrowPhase" nbThreads="7"/>
+    <ParallelBruteForceBroadPhase name="CollisionBroadPhase"  />
+    <ParallelBVHNarrowPhase name="CollisionNarrowPhase" />
     <CollisionResponse name="CollisionResponse" response="FrictionContactConstraint" responseParams="mu=0.5" />
     <NewProximityIntersection name="Intersection" alarmDistance="0.3" contactDistance="0.02" />
 
@@ -56,7 +57,7 @@
     <Node name="Logo" >
         <EulerImplicitSolver name="EulerImplicitScheme" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="LDLTLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" nbThreads="3"  linearSystem="@A"/>
+        <EigenSimplicialLDLT name="LDLTLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true"   linearSystem="@A"/>
 
         <MeshVTKLoader name="LogoLoader" filename="mesh/SofaScene/Logo.vtk"  />
         <TetrahedronSetTopologyContainer name="Container" src="@LogoLoader" />
@@ -115,7 +116,7 @@
     <Node name="S" >
         <EulerImplicitSolver name="EulerImplicitScheme" rayleighMass="0.1" rayleighStiffness="0.1" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd" _parallelInverseProduct="true" linearSystem="@A"/>
+        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd" parallelInverseProduct="true" linearSystem="@A"/>
 
         <MeshVTKLoader name="SLoader" filename="mesh/SofaScene/S.vtk"  />
         <TetrahedronSetTopologyContainer name="Container" src="@SLoader" />
@@ -163,7 +164,7 @@
 
         <EulerImplicitSolver name="EulerImplicitScheme" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="precond" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" nbThreads="3"  linearSystem="@A"/>
+        <EigenSimplicialLDLT name="precond" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" linearSystem="@A"/>
 
         <MechanicalObject name="ODOF" position="@HexaTopology.position"  />
         <UniformMass name="Mass" totalMass="0.1" />
@@ -214,7 +215,7 @@
     <Node name="A" >
         <EulerImplicitSolver name="EulerImplicitScheme" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" nbThreads="3"  linearSystem="@A"/>
+        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" linearSystem="@A"/>
 
 
         <MeshVTKLoader name="ALoader" filename="mesh/SofaScene/A.vtk"  />

--- a/examples/Demos/SofaScene.scn
+++ b/examples/Demos/SofaScene.scn
@@ -41,13 +41,13 @@
     <ConstraintAttachButtonSetting /> <!-- The presence of this component sets the mouse interaction to Lagrangian-based constraints at the GUI launch -->
 
     <!-- Header of the simulation -->
-    <FreeMotionAnimationLoop name="FreeMotionAnimationLoop" parallelODESolving="true" parallelCollisionDetectionAndFreeMotion="true"/>
-    <BlockGaussSeidelConstraintSolver maxIterations="20" multithreading='true' tolerance="1.0e-4"/>
+    <FreeMotionAnimationLoop name="FreeMotionAnimationLoop" parallelODESolving="true" parallelCollisionDetectionAndFreeMotion="true" />
+    <BlockGaussSeidelConstraintSolver maxIterations="20" _multithreading='true' tolerance="1.0e-4"/>
 
     <!-- Definition of the collision pipeline -->
     <CollisionPipeline name="CollisionPipeline" />
-    <ParallelBruteForceBroadPhase name="CollisionBroadPhase"/>
-    <ParallelBVHNarrowPhase name="CollisionNarrowPhase"/>
+    <ParallelBruteForceBroadPhase name="CollisionBroadPhase" />
+    <ParallelBVHNarrowPhase name="CollisionNarrowPhase" nbThreads="7"/>
     <CollisionResponse name="CollisionResponse" response="FrictionContactConstraint" responseParams="mu=0.5" />
     <NewProximityIntersection name="Intersection" alarmDistance="0.3" contactDistance="0.02" />
 
@@ -56,7 +56,7 @@
     <Node name="Logo" >
         <EulerImplicitSolver name="EulerImplicitScheme" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="LDLTLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true"  linearSystem="@A"/>
+        <EigenSimplicialLDLT name="LDLTLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" nbThreads="3"  linearSystem="@A"/>
 
         <MeshVTKLoader name="LogoLoader" filename="mesh/SofaScene/Logo.vtk"  />
         <TetrahedronSetTopologyContainer name="Container" src="@LogoLoader" />
@@ -115,7 +115,7 @@
     <Node name="S" >
         <EulerImplicitSolver name="EulerImplicitScheme" rayleighMass="0.1" rayleighStiffness="0.1" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd" parallelInverseProduct="true" linearSystem="@A"/>
+        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd" _parallelInverseProduct="true" linearSystem="@A"/>
 
         <MeshVTKLoader name="SLoader" filename="mesh/SofaScene/S.vtk"  />
         <TetrahedronSetTopologyContainer name="Container" src="@SLoader" />
@@ -163,7 +163,7 @@
 
         <EulerImplicitSolver name="EulerImplicitScheme" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="precond" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true"  linearSystem="@A"/>
+        <EigenSimplicialLDLT name="precond" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" nbThreads="3"  linearSystem="@A"/>
 
         <MechanicalObject name="ODOF" position="@HexaTopology.position"  />
         <UniformMass name="Mass" totalMass="0.1" />
@@ -214,7 +214,7 @@
     <Node name="A" >
         <EulerImplicitSolver name="EulerImplicitScheme" />
         <ConstantSparsityPatternSystem template="CompressedRowSparseMatrixd" name="A" printLog="false"/>
-        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true"  linearSystem="@A"/>
+        <EigenSimplicialLDLT name="LDLLinearSolver" template="CompressedRowSparseMatrixd"  parallelInverseProduct="true" nbThreads="3"  linearSystem="@A"/>
 
 
         <MeshVTKLoader name="ALoader" filename="mesh/SofaScene/A.vtk"  />

--- a/examples/Demos/SofaScene.scn
+++ b/examples/Demos/SofaScene.scn
@@ -43,7 +43,7 @@
 
     <!-- Header of the simulation -->
     <FreeMotionAnimationLoop name="FreeMotionAnimationLoop" parallelODESolving="true" parallelCollisionDetectionAndFreeMotion="true"  />
-    <BlockGaussSeidelConstraintSolver maxIterations="20" _multithreading='true' tolerance="1.0e-4"/>
+    <BlockGaussSeidelConstraintSolver maxIterations="20" multithreading='true' tolerance="1.0e-4"/>
 
     <!-- Definition of the collision pipeline -->
     <CollisionPipeline name="CollisionPipeline" />


### PR DESCRIPTION
Some broadly used components where not using the task scheduler properly (by inheriting from TaskSchedulerUser) and thus forcing the nb of thread at maximum. 

In this PR I do two things : 
1- Use correct inheritance and remove boiler plate code to initialize task scheduler for some components
2- **IF** every component using the task scheduler inherits from TaskSchedulerUser and inits the scheduler through initTaskScheduler, then **the first component** in the scene fixes the nb of thread for everyone. I know this is weak, but it is how it is implemented now. To overcome this, I added a component which goal is only to initialize the thread pool by forcing the number of thread.

I know this PR might be better, coding a real mechanism to fetch every requirement before initialization then create the appropriate nb of threads. But this part of the Core is meant to be totally modified at some point. This PR fixes a real issue where people couldn't really control the number of thread + adds a way to sett those parameters with minimal efforts.

[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
