### PR TITLE
[Collision] CompositeCollisionPipeline: propagate reset calls on the sub collision pipelines

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/CompositeCollisionPipeline.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/CompositeCollisionPipeline.cpp
@@ -132,7 +132,10 @@ void CompositeCollisionPipeline::bwdInit()
 
 void CompositeCollisionPipeline::reset()
 {
-
+    for(const auto& subPipeline : l_subCollisionPipelines)
+    {
+        subPipeline->reset();
+    }
 }
 
 /// Delegates collision reset to all sub-pipelines sequentially.


### PR DESCRIPTION
Title.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
