### PR TITLE
[Mass] Add missing Vec2 template to DiagonalMass in the ObjectFactory

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
+++ b/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
@@ -343,6 +343,7 @@ void registerDiagonalMass(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(core::ObjectRegistrationData("Compute a lumped (diagonalized) mass matrix resulting from the space integration of a density over a domain.")
         .add< DiagonalMass<Vec3Types> >()
+        .add< DiagonalMass<Vec2Types> >()
         .add< DiagonalMass<Vec2Types, Vec3Types> >()
         .add< DiagonalMass<Vec1Types> >()
         .add< DiagonalMass<Vec1Types, Vec2Types> >()


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
