### PR TITLE
[Collision] Set Data & Links to public in Collision models. Adopt state accessor for mstate

### DIFF
--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CylinderCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CylinderCollisionModel.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/CollisionModel.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 
 namespace sofa::component::collision::geometry
 {
@@ -71,10 +71,10 @@ using Cylinder = TCylinder<sofa::defaulttype::Rigid3Types>;
   *CylinderModel templated by RigidTypes (frames), direction is given by Y direction of the frame.
   */
 template< class TDataTypes>
-class CylinderCollisionModel : public core::CollisionModel
+class CylinderCollisionModel : public core::CollisionModel, public virtual core::behavior::SingleStateAccessor<TDataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(CylinderCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS2(SOFA_TEMPLATE(CylinderCollisionModel, TDataTypes), core::CollisionModel, SOFA_TEMPLATE(core::behavior::SingleStateAccessor, TDataTypes));
 
     typedef TDataTypes DataTypes;
     typedef DataTypes InDataTypes;
@@ -99,7 +99,7 @@ public:
 
 protected:
     CylinderCollisionModel();
-    CylinderCollisionModel(core::behavior::MechanicalState<DataTypes>* mstate );
+    CylinderCollisionModel(core::behavior::MechanicalState<DataTypes>* _mstate );
 
 public:
     void init() override;
@@ -111,7 +111,7 @@ public:
 
     void draw(const core::visual::VisualParams* vparams,sofa::Index index) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
 
     Real radius(sofa::Index index) const;
 
@@ -138,8 +138,6 @@ public:
     Data<VecReal>& writeHeights();
     Data<VecAxisCoord>& writeLocalAxes();
 
-protected:
-    core::behavior::MechanicalState<DataTypes>* m_mstate;
 };
 
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CylinderCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CylinderCollisionModel.h
@@ -111,7 +111,7 @@ public:
 
     void draw(const core::visual::VisualParams* vparams,sofa::Index index) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate; }
 
     Real radius(sofa::Index index) const;
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CylinderCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/CylinderCollisionModel.inl
@@ -40,17 +40,16 @@ CylinderCollisionModel<DataTypes>::CylinderCollisionModel():
       d_cylinder_heights(initData(&d_cylinder_heights,"heights","The cylinder heights")),
       d_default_radius(initData(&d_default_radius,Real(0.5),"defaultRadius","The default radius")),
       d_default_height(initData(&d_default_height,Real(2),"defaultHeight","The default height")),
-      d_default_local_axis(initData(&d_default_local_axis,typename DataTypes::Vec3(0.0, 1.0, 0.0),"defaultLocalAxis", "The default local axis cylinder is modeled around")),
-      m_mstate(nullptr)
+      d_default_local_axis(initData(&d_default_local_axis,typename DataTypes::Vec3(0.0, 1.0, 0.0),"defaultLocalAxis", "The default local axis cylinder is modeled around"))
 {
     enum_type = CYLINDER_TYPE;
 }
 
 template<class DataTypes>
-CylinderCollisionModel<DataTypes>::CylinderCollisionModel(core::behavior::MechanicalState<DataTypes>* mstate)
+CylinderCollisionModel<DataTypes>::CylinderCollisionModel(core::behavior::MechanicalState<DataTypes>* ms)
     : CylinderCollisionModel()
 {
-    m_mstate = mstate;
+    this->mstate = ms;
     enum_type = CYLINDER_TYPE;
 }
 
@@ -101,16 +100,12 @@ void CylinderCollisionModel<DataTypes>::resize(sofa::Size size)
 template<class DataTypes>
 void CylinderCollisionModel<DataTypes>::init()
 {
-    this->CollisionModel::init();
-    m_mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (getContext()->getMechanicalState());
-    if (m_mstate==nullptr)
-    {
-        msg_error() << "CylinderCollisionModel requires a Rigid Mechanical Model";
-        d_componentState.setValue(ComponentState::Invalid);
-        return;
-    }
+    Inherit2::init();
 
-    resize(m_mstate->getSize());
+    if (d_componentState.getValue() == ComponentState::Invalid)
+        return;
+
+    resize(this->mstate->getSize());
 }
 
 
@@ -120,7 +115,7 @@ void CylinderCollisionModel<DataTypes>::computeBoundingTree(int maxDepth)
     using namespace sofa::type;
     using namespace sofa::defaulttype;
     CubeCollisionModel* cubeModel = createPrevious<CubeCollisionModel>();
-    const auto ncyl = m_mstate->getSize();
+    const auto ncyl = this->mstate->getSize();
 
     bool updated = false;
     if (ncyl != size)
@@ -198,7 +193,7 @@ typename CylinderCollisionModel<DataTypes>::Real CylinderCollisionModel< DataTyp
 
 template<class DataTypes>
 const typename CylinderCollisionModel<DataTypes>::Coord & CylinderCollisionModel< DataTypes >::center(sofa::Index i)const{
-    return DataTypes::getCPos((m_mstate->read(core::vec_id::read_access::position)->getValue())[i]);
+    return DataTypes::getCPos((this->mstate->read(core::vec_id::read_access::position)->getValue())[i]);
 }
 
 template<class DataTypes>
@@ -240,7 +235,7 @@ typename TCylinder<DataTypes>::Real TCylinder<DataTypes >::radius() const
 
 template<class DataTypes>
 const typename CylinderCollisionModel<DataTypes>::Coord & CylinderCollisionModel<DataTypes >::velocity(sofa::Index index) const {
-    return DataTypes::getDPos(((m_mstate->read(core::vec_id::read_access::velocity)->getValue()))[index]);
+    return DataTypes::getDPos(((this->mstate->read(core::vec_id::read_access::velocity)->getValue()))[index]);
 }
 
 
@@ -249,7 +244,7 @@ const typename TCylinder<DataTypes>::Coord & TCylinder<DataTypes >::v() const {r
 
 template<class DataTypes>
 const sofa::type::Quat<SReal> CylinderCollisionModel<DataTypes >::orientation(sofa::Index index)const{
-    return m_mstate->read(core::vec_id::read_access::position)->getValue()[index].getOrientation();
+    return this->mstate->read(core::vec_id::read_access::position)->getValue()[index].getOrientation();
 }
 
 template<class DataTypes>

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
@@ -23,6 +23,7 @@
 #include <sofa/component/collision/geometry/config.h>
 #include <sofa/core/fwd.h>
 #include <sofa/core/CollisionModel.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 #include <sofa/core/objectmodel/BaseComponent.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/collision/Intersection.h>
@@ -73,10 +74,10 @@ public:
 using Line = TLine<sofa::defaulttype::Vec3Types>;
 
 template<class TDataTypes>
-class LineCollisionModel : public core::CollisionModel
+class LineCollisionModel : public core::CollisionModel, public virtual core::behavior::SingleStateAccessor<TDataTypes>
 {
 public :
-    SOFA_CLASS(SOFA_TEMPLATE(LineCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS2(SOFA_TEMPLATE(LineCollisionModel, TDataTypes), core::CollisionModel, SOFA_TEMPLATE(core::behavior::SingleStateAccessor, TDataTypes));
 
     enum LineFlag
     {
@@ -130,7 +131,7 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
 
     Deriv velocity(sofa::Index index)const;
 
@@ -166,7 +167,6 @@ public:
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
 
 protected:
-    core::behavior::MechanicalState<DataTypes>* mstate;
     PointCollisionModel<sofa::defaulttype::Vec3Types>* mpoints;
     int meshRevision;
 };

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
@@ -139,6 +139,10 @@ public:
     int getLineFlags(sofa::Index i);
 
     Data<bool> d_bothSide; ///< activate collision on both side of the line model (when surface normals are defined on these lines)
+    Data<bool> d_displayFreePosition; ///< Display Collision Model Points free position(in green)
+
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<LineCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
     /// Pre-construction check method called by ObjectFactory.
     /// Check that DataTypes matches the MechanicalState.
@@ -160,11 +164,6 @@ public:
     }
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
-
-    Data<bool> d_displayFreePosition; ///< Display Collision Model Points free position(in green)
-
-    /// Link to be set to the topology container in the component graph.
-    SingleLink<LineCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
     core::behavior::MechanicalState<DataTypes>* mstate;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
@@ -131,7 +131,7 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate; }
 
     Deriv velocity(sofa::Index index)const;
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
@@ -167,7 +167,6 @@ public:
 
 protected:
     core::behavior::MechanicalState<DataTypes>* mstate;
-    Topology* topology;
     PointCollisionModel<sofa::defaulttype::Vec3Types>* mpoints;
     int meshRevision;
 };

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
@@ -73,21 +73,20 @@ void LineCollisionModel<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    core::topology::BaseMeshTopology *bmt = l_topology.get();
     msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-    if (!bmt)
+    if (!l_topology)
     {
         msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name << ". LineCollisionModel<sofa::defaulttype::Vec3Types> requires a MeshTopology";
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
-    resize( bmt->getNbEdges() );
+    resize( l_topology->getNbEdges() );
 
-    for(core::topology::BaseMeshTopology::EdgeID i = 0; i < bmt->getNbEdges(); i++)
+    for(core::topology::BaseMeshTopology::EdgeID i = 0; i < l_topology->getNbEdges(); i++)
     {
-        elems[i].p[0] = bmt->getEdge(i)[0];
-        elems[i].p[1] = bmt->getEdge(i)[1];
+        elems[i].p[0] = l_topology->getEdge(i)[0];
+        elems[i].p[1] = l_topology->getEdge(i)[1];
     }
 
     updateFromTopology();
@@ -96,23 +95,22 @@ void LineCollisionModel<DataTypes>::init()
 template<class DataTypes>
 void LineCollisionModel<DataTypes>::handleTopologyChange()
 {
-    core::topology::BaseMeshTopology *bmt = l_topology.get();
-    if (bmt)
+    if (l_topology)
     {
-        resize(bmt->getNbEdges());
+        resize(l_topology->getNbEdges());
 
-        for(sofa::Size i = 0; i < bmt->getNbEdges(); i++)
+        for(sofa::Size i = 0; i < l_topology->getNbEdges(); i++)
         {
-            elems[i].p[0] = bmt->getEdge(i)[0];
-            elems[i].p[1] = bmt->getEdge(i)[1];
+            elems[i].p[0] = l_topology->getEdge(i)[0];
+            elems[i].p[1] = l_topology->getEdge(i)[1];
         }
 
         needsUpdate = true;
     }
-    if (bmt)
+    if (l_topology)
     {
-        std::list<const sofa::core::topology::TopologyChange *>::const_iterator itBegin = bmt->beginChange();
-        const std::list<const sofa::core::topology::TopologyChange *>::const_iterator itEnd = bmt->endChange();
+        std::list<const sofa::core::topology::TopologyChange *>::const_iterator itBegin = l_topology->beginChange();
+        const std::list<const sofa::core::topology::TopologyChange *>::const_iterator itEnd = l_topology->endChange();
 
         while( itBegin != itEnd )
         {
@@ -150,9 +148,9 @@ void LineCollisionModel<DataTypes>::handleTopologyChange()
                 sofa::Index last;
                 sofa::Index ind_last;
 
-                if (bmt)
+                if (l_topology)
                 {
-                    last = bmt->getNbEdges() - 1;
+                    last = l_topology->getNbEdges() - 1;
                 }
                 else
                 {
@@ -189,9 +187,9 @@ void LineCollisionModel<DataTypes>::handleTopologyChange()
 
             case core::topology::POINTSREMOVED :
             {
-                if (bmt)
+                if (l_topology)
                 {
-                    sofa::Index last = bmt->getNbPoints() - 1;
+                    sofa::Index last = l_topology->getNbPoints() - 1;
 
                     sofa::Index i,j;
                     const auto& tab = ( static_cast< const core::topology::PointsRemoved * >( *itBegin ) )->getArray();
@@ -217,7 +215,7 @@ void LineCollisionModel<DataTypes>::handleTopologyChange()
                             lastIndexVec[i_next] = lastIndexVec[i];
                         }
 
-                        const auto &shell = bmt->getEdgesAroundVertex(lastIndexVec[i]);
+                        const auto &shell = l_topology->getEdgesAroundVertex(lastIndexVec[i]);
 
                         for (j = 0; j < shell.size(); ++j)
                         {
@@ -244,7 +242,7 @@ void LineCollisionModel<DataTypes>::handleTopologyChange()
 
             case core::topology::POINTSRENUMBERING:
             {
-                if (bmt)
+                if (l_topology)
                 {
                     sofa::Index i;
 
@@ -273,24 +271,23 @@ void LineCollisionModel<DataTypes>::handleTopologyChange()
 template<class DataTypes>
 void LineCollisionModel<DataTypes>::updateFromTopology()
 {
-    core::topology::BaseMeshTopology *bmt = l_topology.get();
-    if (bmt)
+    if (l_topology)
     {
-        const int revision = bmt->getRevision();
+        const int revision = l_topology->getRevision();
         if (revision == meshRevision)
             return;
 
         needsUpdate = true;
 
         const sofa::Size nbPoints = mstate->getSize();
-        const sofa::Size nbLines = bmt->getNbEdges();
+        const sofa::Size nbLines = l_topology->getNbEdges();
 
         resize( nbLines );
         sofa::Index index = 0;
 
         for (sofa::Size i = 0; i < nbLines; i++)
         {
-            core::topology::BaseMeshTopology::Line idx = bmt->getEdge(i);
+            core::topology::BaseMeshTopology::Line idx = l_topology->getEdge(i);
 
             if (idx[0] >= nbPoints || idx[1] >= nbPoints)
             {
@@ -359,7 +356,6 @@ bool LineCollisionModel<DataTypes>::canCollideWithElement(sofa::Index index, Col
 {
     if (!this->bSelfCollision.getValue()) return true;
     if (this->getContext() != model2->getContext()) return true;
-    core::topology::BaseMeshTopology *topology = l_topology.get();
     /*
         TODO : separate 2 case: the model is only composed of lines or is composed of triangles
     */
@@ -367,13 +363,13 @@ bool LineCollisionModel<DataTypes>::canCollideWithElement(sofa::Index index, Col
     sofa::Index p12 = elems[index].p[1];
 
 
-    if (!topology)
+    if (!l_topology)
     {
         msg_error() << "no topology found";
         return true;
     }
-    const auto& EdgesAroundVertex11 =topology->getEdgesAroundVertex(p11);
-    const auto& EdgesAroundVertex12 =topology->getEdgesAroundVertex(p12);
+    const auto& EdgesAroundVertex11 = l_topology->getEdgesAroundVertex(p11);
+    const auto& EdgesAroundVertex12 = l_topology->getEdgesAroundVertex(p12);
 
     if (model2 == this)
     {
@@ -386,8 +382,8 @@ bool LineCollisionModel<DataTypes>::canCollideWithElement(sofa::Index index, Col
 
 
         // in the neighborhood, if we find a segment in common, we cancel the collision
-        const auto& EdgesAroundVertex21 =topology->getEdgesAroundVertex(p21);
-        const auto& EdgesAroundVertex22 =topology->getEdgesAroundVertex(p22);
+        const auto& EdgesAroundVertex21 = l_topology->getEdgesAroundVertex(p21);
+        const auto& EdgesAroundVertex22 = l_topology->getEdgesAroundVertex(p22);
 
         for (sofa::Size i1=0; i1<EdgesAroundVertex11.size(); i1++)
         {

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
@@ -37,7 +37,8 @@ using core::topology::BaseMeshTopology;
 
 template<class DataTypes>
 LineCollisionModel<DataTypes>::LineCollisionModel()
-    : d_bothSide(initData(&d_bothSide, false, "bothSide", "activate collision on both side of the line model (when surface normals are defined on these lines)") )
+    : needsUpdate(true)
+    , d_bothSide(initData(&d_bothSide, false, "bothSide", "activate collision on both side of the line model (when surface normals are defined on these lines)") )
     , d_displayFreePosition(initData(&d_displayFreePosition, false, "displayFreePosition", "Display Collision Model Points free position(in green)") )
     , l_topology(initLink("topology", "link to the topology container"))
     , mstate(nullptr), topology(nullptr), meshRevision(-1)

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
@@ -584,21 +584,21 @@ template<class DataTypes>
 inline sofa::Index TLine<DataTypes>::i2() const { return this->model->elems[this->index].p[1]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TLine<DataTypes>::p1() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[0]]; }
+inline const typename DataTypes::Coord& TLine<DataTypes>::p1() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[0]]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TLine<DataTypes>::p2() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[1]]; }
+inline const typename DataTypes::Coord& TLine<DataTypes>::p2() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[1]]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Coord& TLine<DataTypes>::p(Index i) const {
-    return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[i]];
+    return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[i]];
 }
 
 template<class DataTypes>
 inline const typename DataTypes::Coord& TLine<DataTypes>::p1Free() const
 {
     if (hasFreePosition())
-        return this->model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[0]];
+        return this->model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[0]];
     else
         return p1();
 }
@@ -607,16 +607,16 @@ template<class DataTypes>
 inline const typename DataTypes::Coord& TLine<DataTypes>::p2Free() const
 {
     if (hasFreePosition())
-        return this->model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[1]];
+        return this->model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[1]];
     else
         return p2();
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TLine<DataTypes>::v1() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[0]]; }
+inline const typename DataTypes::Deriv& TLine<DataTypes>::v1() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[0]]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TLine<DataTypes>::v2() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[1]]; }
+inline const typename DataTypes::Deriv& TLine<DataTypes>::v2() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[1]]; }
 
 template<class DataTypes>
 inline typename DataTypes::Deriv TLine<DataTypes>::n() const {return (this->model->mpoints->getNormal(this->i1()) + this->model->mpoints->getNormal( this->i2())).normalized();}
@@ -628,7 +628,7 @@ template<class DataTypes>
 inline int TLine<DataTypes>::flags() const { return this->model->getLineFlags(this->index); }
 
 template<class DataTypes>
-inline bool TLine<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TLine<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 
 } //namespace sofa::component::collision::geometry

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
@@ -41,7 +41,7 @@ LineCollisionModel<DataTypes>::LineCollisionModel()
     , d_bothSide(initData(&d_bothSide, false, "bothSide", "activate collision on both side of the line model (when surface normals are defined on these lines)") )
     , d_displayFreePosition(initData(&d_displayFreePosition, false, "displayFreePosition", "Display Collision Model Points free position(in green)") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , mstate(nullptr), meshRevision(-1)
+    , meshRevision(-1)
 {
     enum_type = LINE_TYPE;
 }
@@ -57,15 +57,11 @@ void LineCollisionModel<DataTypes>::resize(sofa::Size size)
 template<class DataTypes>
 void LineCollisionModel<DataTypes>::init()
 {
-    this->CollisionModel::init();
-    mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (getContext()->getMechanicalState());
+    Inherit2::init();
     this->getContext()->get(mpoints);
 
-    if (mstate==nullptr)
-    {
-        msg_error() << "LineModel requires a Vec3 Mechanical Model";
+    if (this->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
         return;
-    }
 
     if (l_topology.empty())
     {
@@ -279,7 +275,7 @@ void LineCollisionModel<DataTypes>::updateFromTopology()
 
         needsUpdate = true;
 
-        const sofa::Size nbPoints = mstate->getSize();
+        const sofa::Size nbPoints = this->mstate->getSize();
         const sofa::Size nbLines = l_topology->getNbEdges();
 
         resize( nbLines );
@@ -588,21 +584,21 @@ template<class DataTypes>
 inline sofa::Index TLine<DataTypes>::i2() const { return this->model->elems[this->index].p[1]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TLine<DataTypes>::p1() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[0]]; }
+inline const typename DataTypes::Coord& TLine<DataTypes>::p1() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[0]]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TLine<DataTypes>::p2() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[1]]; }
+inline const typename DataTypes::Coord& TLine<DataTypes>::p2() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[1]]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Coord& TLine<DataTypes>::p(Index i) const {
-    return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[i]];
+    return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->model->elems[this->index].p[i]];
 }
 
 template<class DataTypes>
 inline const typename DataTypes::Coord& TLine<DataTypes>::p1Free() const
 {
     if (hasFreePosition())
-        return this->model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[0]];
+        return this->model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[0]];
     else
         return p1();
 }
@@ -611,28 +607,28 @@ template<class DataTypes>
 inline const typename DataTypes::Coord& TLine<DataTypes>::p2Free() const
 {
     if (hasFreePosition())
-        return this->model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[1]];
+        return this->model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[this->model->elems[this->index].p[1]];
     else
         return p2();
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TLine<DataTypes>::v1() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[0]]; }
+inline const typename DataTypes::Deriv& TLine<DataTypes>::v1() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[0]]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TLine<DataTypes>::v2() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[1]]; }
+inline const typename DataTypes::Deriv& TLine<DataTypes>::v2() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->model->elems[this->index].p[1]]; }
 
 template<class DataTypes>
 inline typename DataTypes::Deriv TLine<DataTypes>::n() const {return (this->model->mpoints->getNormal(this->i1()) + this->model->mpoints->getNormal( this->i2())).normalized();}
 
 template<class DataTypes>
-inline typename LineCollisionModel<DataTypes>::Deriv LineCollisionModel<DataTypes>::velocity(sofa::Index index) const { return (mstate->read(core::vec_id::read_access::velocity)->getValue()[elems[index].p[0]] + mstate->read(core::vec_id::read_access::velocity)->getValue()[elems[index].p[1]])/((Real)(2.0)); }
+inline typename LineCollisionModel<DataTypes>::Deriv LineCollisionModel<DataTypes>::velocity(sofa::Index index) const { return (this->mstate->read(core::vec_id::read_access::velocity)->getValue()[elems[index].p[0]] + this->mstate->read(core::vec_id::read_access::velocity)->getValue()[elems[index].p[1]])/((Real)(2.0)); }
 
 template<class DataTypes>
 inline int TLine<DataTypes>::flags() const { return this->model->getLineFlags(this->index); }
 
 template<class DataTypes>
-inline bool TLine<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TLine<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 
 } //namespace sofa::component::collision::geometry

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.inl
@@ -41,7 +41,7 @@ LineCollisionModel<DataTypes>::LineCollisionModel()
     , d_bothSide(initData(&d_bothSide, false, "bothSide", "activate collision on both side of the line model (when surface normals are defined on these lines)") )
     , d_displayFreePosition(initData(&d_displayFreePosition, false, "displayFreePosition", "Display Collision Model Points free position(in green)") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , mstate(nullptr), topology(nullptr), meshRevision(-1)
+    , mstate(nullptr), meshRevision(-1)
 {
     enum_type = LINE_TYPE;
 }
@@ -542,15 +542,15 @@ template<class DataTypes>
 int LineCollisionModel<DataTypes>::getLineFlags(sofa::Index i)
 {
     int f = 0;
-    if (topology)
+    if (l_topology)
     {
         sofa::core::topology::BaseMeshTopology::Edge e(elems[i].p[0], elems[i].p[1]);
         i = getElemEdgeIndex(i);
-        if (i < topology->getNbEdges())
+        if (i < l_topology->getNbEdges())
         {
             for (sofa::Index j=0; j<2; ++j)
             {
-                const auto& eav = topology->getEdgesAroundVertex(e[j]);
+                const auto& eav = l_topology->getEdgesAroundVertex(e[j]);
                 if (eav[0] == (sofa::core::topology::BaseMeshTopology::EdgeID)i)
                     f |= (FLAG_P1 << j);
                 if (eav.size() == 1)

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
@@ -97,9 +97,9 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
 
-    Deriv getNormal(sofa::Index index){ return (normals.size()) ? normals[index] : Deriv();}
+    Deriv getNormal(sofa::Index index){ return (m_normals.size()) ? m_normals[index] : Deriv();}
 
     const Deriv& velocity(sofa::Index index) const;
 
@@ -127,18 +127,16 @@ public:
         return l_topology.get();
     }
 
-protected:
-
-    core::behavior::MechanicalState<DataTypes>* mstate;
-
     Data<bool> d_computeNormals; ///< activate computation of normal vectors (required for some collision detection algorithms)
     Data<bool> d_displayFreePosition; ///< Display Collision Model Points free position(in green)
-
-    VecDeriv normals;
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<PointCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
+protected:
+
+    core::behavior::MechanicalState<DataTypes>* m_mstate; ///< Pointer to the corresponding MechanicalState
+    VecDeriv m_normals;
 };
 
 
@@ -157,28 +155,28 @@ inline TPoint<DataTypes>::TPoint(const core::CollisionElementIterator& i)
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TPoint<DataTypes>::p() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index]; }
+inline const typename DataTypes::Coord& TPoint<DataTypes>::p() const { return this->model->m_mstate->read(core::vec_id::read_access::position)->getValue()[this->index]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Coord& TPoint<DataTypes>::pFree() const
 {
     if (hasFreePosition())
-        return this->model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->index];
+        return this->model->m_mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->index];
     else
         return p();
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TPoint<DataTypes>::v() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->index]; }
+inline const typename DataTypes::Deriv& TPoint<DataTypes>::v() const { return this->model->m_mstate->read(core::vec_id::read_access::velocity)->getValue()[this->index]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& PointCollisionModel<DataTypes>::velocity(sofa::Index index) const { return mstate->read(core::vec_id::read_access::velocity)->getValue()[index]; }
+inline const typename DataTypes::Deriv& PointCollisionModel<DataTypes>::velocity(sofa::Index index) const { return m_mstate->read(core::vec_id::read_access::velocity)->getValue()[index]; }
 
 template<class DataTypes>
-inline typename DataTypes::Deriv TPoint<DataTypes>::n() const { return ((unsigned)this->index<this->model->normals.size()) ? this->model->normals[this->index] : Deriv(); }
+inline typename DataTypes::Deriv TPoint<DataTypes>::n() const { return ((unsigned)this->index<this->model->m_normals.size()) ? this->model->m_normals[this->index] : Deriv(); }
 
 template<class DataTypes>
-inline bool TPoint<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TPoint<DataTypes>::hasFreePosition() const { return this->model->m_mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 #if !defined(SOFA_COMPONENT_COLLISION_POINTCOLLISIONMODEL_CPP)
 extern template class SOFA_COMPONENT_COLLISION_GEOMETRY_API PointCollisionModel<defaulttype::Vec3Types>;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
@@ -99,7 +99,7 @@ public:
 
     core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate; }
 
-    Deriv getNormal(sofa::Index index){ return (m_normals.size()) ? m_normals[index] : Deriv();}
+    Deriv getNormal(sofa::Index index){ return (normals.size()) ? normals[index] : Deriv();}
 
     const Deriv& velocity(sofa::Index index) const;
 
@@ -135,7 +135,7 @@ public:
 
 protected:
 
-    VecDeriv m_normals;
+    VecDeriv normals;
 };
 
 
@@ -172,7 +172,7 @@ template<class DataTypes>
 inline const typename DataTypes::Deriv& PointCollisionModel<DataTypes>::velocity(sofa::Index index) const { return this->mstate->read(core::vec_id::read_access::velocity)->getValue()[index]; }
 
 template<class DataTypes>
-inline typename DataTypes::Deriv TPoint<DataTypes>::n() const { return ((unsigned)this->index<this->model->m_normals.size()) ? this->model->m_normals[this->index] : Deriv(); }
+inline typename DataTypes::Deriv TPoint<DataTypes>::n() const { return ((unsigned)this->index<this->model->normals.size()) ? this->model->normals[this->index] : Deriv(); }
 
 template<class DataTypes>
 inline bool TPoint<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
@@ -97,7 +97,7 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate; }
 
     Deriv getNormal(sofa::Index index){ return (m_normals.size()) ? m_normals[index] : Deriv();}
 
@@ -154,19 +154,19 @@ inline TPoint<DataTypes>::TPoint(const core::CollisionElementIterator& i)
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TPoint<DataTypes>::p() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index]; }
+inline const typename DataTypes::Coord& TPoint<DataTypes>::p() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Coord& TPoint<DataTypes>::pFree() const
 {
     if (hasFreePosition())
-        return this->model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[this->index];
+        return this->model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->index];
     else
         return p();
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TPoint<DataTypes>::v() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->index]; }
+inline const typename DataTypes::Deriv& TPoint<DataTypes>::v() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->index]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Deriv& PointCollisionModel<DataTypes>::velocity(sofa::Index index) const { return this->mstate->read(core::vec_id::read_access::velocity)->getValue()[index]; }
@@ -175,7 +175,7 @@ template<class DataTypes>
 inline typename DataTypes::Deriv TPoint<DataTypes>::n() const { return ((unsigned)this->index<this->model->m_normals.size()) ? this->model->m_normals[this->index] : Deriv(); }
 
 template<class DataTypes>
-inline bool TPoint<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TPoint<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 #if !defined(SOFA_COMPONENT_COLLISION_POINTCOLLISIONMODEL_CPP)
 extern template class SOFA_COMPONENT_COLLISION_GEOMETRY_API PointCollisionModel<defaulttype::Vec3Types>;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
@@ -23,7 +23,7 @@
 #include <sofa/component/collision/geometry/config.h>
 
 #include <sofa/core/CollisionModel.h>
-#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
 
@@ -60,10 +60,10 @@ public:
 using Point = TPoint<sofa::defaulttype::Vec3Types>;
 
 template<class TDataTypes>
-class PointCollisionModel : public core::CollisionModel
+class PointCollisionModel : public core::CollisionModel, public virtual core::behavior::SingleStateAccessor<TDataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(PointCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS2(SOFA_TEMPLATE(PointCollisionModel, TDataTypes), core::CollisionModel, SOFA_TEMPLATE(core::behavior::SingleStateAccessor, TDataTypes));
 
     typedef TDataTypes DataTypes;
     typedef DataTypes InDataTypes;
@@ -97,7 +97,7 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
 
     Deriv getNormal(sofa::Index index){ return (m_normals.size()) ? m_normals[index] : Deriv();}
 
@@ -135,7 +135,6 @@ public:
 
 protected:
 
-    core::behavior::MechanicalState<DataTypes>* m_mstate; ///< Pointer to the corresponding MechanicalState
     VecDeriv m_normals;
 };
 
@@ -155,28 +154,28 @@ inline TPoint<DataTypes>::TPoint(const core::CollisionElementIterator& i)
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TPoint<DataTypes>::p() const { return this->model->m_mstate->read(core::vec_id::read_access::position)->getValue()[this->index]; }
+inline const typename DataTypes::Coord& TPoint<DataTypes>::p() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Coord& TPoint<DataTypes>::pFree() const
 {
     if (hasFreePosition())
-        return this->model->m_mstate->read(core::vec_id::read_access::freePosition)->getValue()[this->index];
+        return this->model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[this->index];
     else
         return p();
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TPoint<DataTypes>::v() const { return this->model->m_mstate->read(core::vec_id::read_access::velocity)->getValue()[this->index]; }
+inline const typename DataTypes::Deriv& TPoint<DataTypes>::v() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->index]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& PointCollisionModel<DataTypes>::velocity(sofa::Index index) const { return m_mstate->read(core::vec_id::read_access::velocity)->getValue()[index]; }
+inline const typename DataTypes::Deriv& PointCollisionModel<DataTypes>::velocity(sofa::Index index) const { return this->mstate->read(core::vec_id::read_access::velocity)->getValue()[index]; }
 
 template<class DataTypes>
 inline typename DataTypes::Deriv TPoint<DataTypes>::n() const { return ((unsigned)this->index<this->model->m_normals.size()) ? this->model->m_normals[this->index] : Deriv(); }
 
 template<class DataTypes>
-inline bool TPoint<DataTypes>::hasFreePosition() const { return this->model->m_mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TPoint<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 #if !defined(SOFA_COMPONENT_COLLISION_POINTCOLLISIONMODEL_CPP)
 extern template class SOFA_COMPONENT_COLLISION_GEOMETRY_API PointCollisionModel<defaulttype::Vec3Types>;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
@@ -35,7 +35,7 @@ namespace sofa::component::collision::geometry
 template<class DataTypes>
 PointCollisionModel<DataTypes>::PointCollisionModel()
     : d_bothSide(initData(&d_bothSide, false, "bothSide", "activate collision on both side of the point model (when surface normals are defined on these points)") )
-    , mstate(nullptr)
+    , m_mstate(nullptr)
     , d_computeNormals(initData(&d_computeNormals, false, "computeNormals", "activate computation of normal vectors (required for some collision detection algorithms)") )
     , d_displayFreePosition(initData(&d_displayFreePosition, false, "displayFreePosition", "Display Collision Model Points free position(in green)") )
     , l_topology(initLink("topology", "link to the topology container"))
@@ -53,9 +53,9 @@ template<class DataTypes>
 void PointCollisionModel<DataTypes>::init()
 {
     this->CollisionModel::init();
-    mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (getContext()->getMechanicalState());
+    m_mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (getContext()->getMechanicalState());
 
-    if (mstate==nullptr)
+    if (m_mstate==nullptr)
     {
         msg_error() << "PointModel requires a Vec3 Mechanical Model";
         return;
@@ -67,7 +67,7 @@ void PointCollisionModel<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    const int npoints = mstate->getSize();
+    const int npoints = m_mstate->getSize();
     resize(npoints);
     if (d_computeNormals.getValue()) updateNormals();
 }
@@ -115,7 +115,7 @@ template<class DataTypes>
 void PointCollisionModel<DataTypes>::computeBoundingTree(int maxDepth)
 {
     CubeCollisionModel* cubeModel = createPrevious<CubeCollisionModel>();
-    const auto npoints = mstate->getSize();
+    const auto npoints = m_mstate->getSize();
     bool updated = false;
     if (npoints != size)
     {
@@ -130,7 +130,7 @@ void PointCollisionModel<DataTypes>::computeBoundingTree(int maxDepth)
     cubeModel->resize(size);
     if (!empty())
     {
-        //VecCoord& x =mstate->read(core::vec_id::read_access::position)->getValue();
+        //VecCoord& x =m_mstate->read(core::vec_id::read_access::position)->getValue();
         const SReal distance = this->d_contactDistance.getValue();
         for (sofa::Size i=0; i<size; i++)
         {
@@ -146,7 +146,7 @@ template<class DataTypes>
 void PointCollisionModel<DataTypes>::computeContinuousBoundingTree(SReal dt, ContinuousIntersectionTypeFlag continuousIntersectionFlag , int maxDepth)
 {
     CubeCollisionModel* cubeModel = createPrevious<CubeCollisionModel>();
-    const auto npoints = mstate->getSize();
+    const auto npoints = m_mstate->getSize();
     bool updated = false;
     if (npoints != size)
     {
@@ -162,8 +162,8 @@ void PointCollisionModel<DataTypes>::computeContinuousBoundingTree(SReal dt, Con
     cubeModel->resize(size);
     if (!empty())
     {
-        //VecCoord& x =mstate->read(core::vec_id::read_access::position)->getValue();
-        //VecDeriv& v = mstate->read(core::vec_id::read_access::velocity)->getValue();
+        //VecCoord& x =m_mstate->read(core::vec_id::read_access::position)->getValue();
+        //VecDeriv& v = m_mstate->read(core::vec_id::read_access::velocity)->getValue();
         const SReal distance = (SReal)this->d_contactDistance.getValue();
         for (sofa::Size i=0; i<size; i++)
         {
@@ -190,12 +190,12 @@ void PointCollisionModel<DataTypes>::computeContinuousBoundingTree(SReal dt, Con
 template<class DataTypes>
 void PointCollisionModel<DataTypes>::updateNormals()
 {
-    const VecCoord& x = this->mstate->read(core::vec_id::read_access::position)->getValue();
+    const VecCoord& x = this->m_mstate->read(core::vec_id::read_access::position)->getValue();
     auto n = x.size();
-    normals.resize(n);
+    m_normals.resize(n);
     for (sofa::Index i=0; i<n; ++i)
     {
-        normals[i].clear();
+        m_normals[i].clear();
     }
     core::topology::BaseMeshTopology* mesh = l_topology.get();
     if (mesh->getNbTetrahedra()+mesh->getNbHexahedra() > 0)
@@ -210,10 +210,10 @@ void PointCollisionModel<DataTypes>::updateNormals()
                 const Coord& p2 = x[e[1]];
                 const Coord& p3 = x[e[2]];
                 const Coord& p4 = x[e[3]];
-                Coord& n1 = normals[e[0]];
-                Coord& n2 = normals[e[1]];
-                Coord& n3 = normals[e[2]];
-                Coord& n4 = normals[e[3]];
+                Coord& n1 = m_normals[e[0]];
+                Coord& n2 = m_normals[e[1]];
+                Coord& n3 = m_normals[e[2]];
+                Coord& n4 = m_normals[e[3]];
                 Coord n;
                 n = cross(p3-p1,p2-p1); n.normalize();
                 n1 += n;
@@ -246,9 +246,9 @@ void PointCollisionModel<DataTypes>::updateNormals()
                 const Coord& p1 = x[e[0]];
                 const Coord& p2 = x[e[1]];
                 const Coord& p3 = x[e[2]];
-                Coord& n1 = normals[e[0]];
-                Coord& n2 = normals[e[1]];
-                Coord& n3 = normals[e[2]];
+                Coord& n1 = m_normals[e[0]];
+                Coord& n2 = m_normals[e[1]];
+                Coord& n3 = m_normals[e[2]];
                 Coord n;
                 n = cross(p2-p1,p3-p1); n.normalize();
                 n1 += n;
@@ -266,10 +266,10 @@ void PointCollisionModel<DataTypes>::updateNormals()
                 const Coord& p2 = x[e[1]];
                 const Coord& p3 = x[e[2]];
                 const Coord& p4 = x[e[3]];
-                Coord& n1 = normals[e[0]];
-                Coord& n2 = normals[e[1]];
-                Coord& n3 = normals[e[2]];
-                Coord& n4 = normals[e[3]];
+                Coord& n1 = m_normals[e[0]];
+                Coord& n2 = m_normals[e[1]];
+                Coord& n3 = m_normals[e[2]];
+                Coord& n4 = m_normals[e[3]];
                 Coord n;
                 n = cross(p3-p1,p4-p2); n.normalize();
                 n1 += n;
@@ -281,11 +281,11 @@ void PointCollisionModel<DataTypes>::updateNormals()
     }
     for (sofa::Index i=0; i<n; ++i)
     {
-        const SReal l = normals[i].norm();
+        const SReal l = m_normals[i].norm();
         if (l > 1.0e-3)
-            normals[i] *= 1/l;
+            m_normals[i] *= 1/l;
         else
-            normals[i].clear();
+            m_normals[i].clear();
     }
 }
 
@@ -297,7 +297,7 @@ void PointCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params,
     if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels())
         return;
 
-    const auto npoints = mstate->getSize();
+    const auto npoints = m_mstate->getSize();
     if (npoints != size)
         return;
 
@@ -332,7 +332,7 @@ void PointCollisionModel<DataTypes>::drawCollisionModel(const core::visual::Visu
     }
 
     // Check topological modifications
-    const auto npoints = mstate->getSize();
+    const auto npoints = m_mstate->getSize();
     if (npoints != size) return;
 
     std::vector<type::Vec3> pointsP;
@@ -343,10 +343,10 @@ void PointCollisionModel<DataTypes>::drawCollisionModel(const core::visual::Visu
         if (p.isActive())
         {
             pointsP.push_back(p.p());
-            if (i < sofa::Size(normals.size()))
+            if (i < sofa::Size(m_normals.size()))
             {
                 pointsL.push_back(p.p());
-                pointsL.push_back(p.p() + normals[i] * 0.1f);
+                pointsL.push_back(p.p() + m_normals[i] * 0.1f);
             }
         }
     }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
@@ -38,7 +38,6 @@ PointCollisionModel<DataTypes>::PointCollisionModel()
     , d_computeNormals(initData(&d_computeNormals, false, "computeNormals", "activate computation of normal vectors (required for some collision detection algorithms)") )
     , d_displayFreePosition(initData(&d_displayFreePosition, false, "displayFreePosition", "Display Collision Model Points free position(in green)") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_mstate(nullptr)
 {
     enum_type = POINT_TYPE;
 }
@@ -52,14 +51,10 @@ void PointCollisionModel<DataTypes>::resize(sofa::Size size)
 template<class DataTypes>
 void PointCollisionModel<DataTypes>::init()
 {
-    this->CollisionModel::init();
-    m_mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (getContext()->getMechanicalState());
+    Inherit2::init();
 
-    if (m_mstate==nullptr)
-    {
-        msg_error() << "PointModel requires a Vec3 Mechanical Model";
+    if (this->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
         return;
-    }
 
     if (l_topology.empty())
     {
@@ -67,7 +62,7 @@ void PointCollisionModel<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    const int npoints = m_mstate->getSize();
+    const int npoints = this->mstate->getSize();
     resize(npoints);
     if (d_computeNormals.getValue()) updateNormals();
 }
@@ -114,7 +109,7 @@ template<class DataTypes>
 void PointCollisionModel<DataTypes>::computeBoundingTree(int maxDepth)
 {
     CubeCollisionModel* cubeModel = createPrevious<CubeCollisionModel>();
-    const auto npoints = m_mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     bool updated = false;
     if (npoints != size)
     {
@@ -129,7 +124,7 @@ void PointCollisionModel<DataTypes>::computeBoundingTree(int maxDepth)
     cubeModel->resize(size);
     if (!empty())
     {
-        //VecCoord& x =m_mstate->read(core::vec_id::read_access::position)->getValue();
+        //VecCoord& x =this->mstate->read(core::vec_id::read_access::position)->getValue();
         const SReal distance = this->d_contactDistance.getValue();
         for (sofa::Size i=0; i<size; i++)
         {
@@ -145,7 +140,7 @@ template<class DataTypes>
 void PointCollisionModel<DataTypes>::computeContinuousBoundingTree(SReal dt, ContinuousIntersectionTypeFlag continuousIntersectionFlag , int maxDepth)
 {
     CubeCollisionModel* cubeModel = createPrevious<CubeCollisionModel>();
-    const auto npoints = m_mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     bool updated = false;
     if (npoints != size)
     {
@@ -161,8 +156,8 @@ void PointCollisionModel<DataTypes>::computeContinuousBoundingTree(SReal dt, Con
     cubeModel->resize(size);
     if (!empty())
     {
-        //VecCoord& x =m_mstate->read(core::vec_id::read_access::position)->getValue();
-        //VecDeriv& v = m_mstate->read(core::vec_id::read_access::velocity)->getValue();
+        //VecCoord& x =this->mstate->read(core::vec_id::read_access::position)->getValue();
+        //VecDeriv& v = this->mstate->read(core::vec_id::read_access::velocity)->getValue();
         const SReal distance = (SReal)this->d_contactDistance.getValue();
         for (sofa::Size i=0; i<size; i++)
         {
@@ -189,7 +184,7 @@ void PointCollisionModel<DataTypes>::computeContinuousBoundingTree(SReal dt, Con
 template<class DataTypes>
 void PointCollisionModel<DataTypes>::updateNormals()
 {
-    const VecCoord& x = this->m_mstate->read(core::vec_id::read_access::position)->getValue();
+    const VecCoord& x = this->mstate->read(core::vec_id::read_access::position)->getValue();
     auto n = x.size();
     m_normals.resize(n);
     for (sofa::Index i=0; i<n; ++i)
@@ -298,7 +293,7 @@ void PointCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params,
     if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels())
         return;
 
-    const auto npoints = m_mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     if (npoints != size)
         return;
 
@@ -333,7 +328,7 @@ void PointCollisionModel<DataTypes>::drawCollisionModel(const core::visual::Visu
     }
 
     // Check topological modifications
-    const auto npoints = m_mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     if (npoints != size) return;
 
     std::vector<type::Vec3> pointsP;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
@@ -35,10 +35,10 @@ namespace sofa::component::collision::geometry
 template<class DataTypes>
 PointCollisionModel<DataTypes>::PointCollisionModel()
     : d_bothSide(initData(&d_bothSide, false, "bothSide", "activate collision on both side of the point model (when surface normals are defined on these points)") )
-    , m_mstate(nullptr)
     , d_computeNormals(initData(&d_computeNormals, false, "computeNormals", "activate computation of normal vectors (required for some collision detection algorithms)") )
     , d_displayFreePosition(initData(&d_displayFreePosition, false, "displayFreePosition", "Display Collision Model Points free position(in green)") )
     , l_topology(initLink("topology", "link to the topology container"))
+    , m_mstate(nullptr)
 {
     enum_type = POINT_TYPE;
 }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
@@ -186,10 +186,10 @@ void PointCollisionModel<DataTypes>::updateNormals()
 {
     const VecCoord& x = this->mstate->read(core::vec_id::read_access::position)->getValue();
     auto n = x.size();
-    m_normals.resize(n);
+    normals.resize(n);
     for (sofa::Index i=0; i<n; ++i)
     {
-        m_normals[i].clear();
+        normals[i].clear();
     }
     if (!l_topology)
         return;
@@ -206,10 +206,10 @@ void PointCollisionModel<DataTypes>::updateNormals()
                 const Coord& p2 = x[e[1]];
                 const Coord& p3 = x[e[2]];
                 const Coord& p4 = x[e[3]];
-                Coord& n1 = m_normals[e[0]];
-                Coord& n2 = m_normals[e[1]];
-                Coord& n3 = m_normals[e[2]];
-                Coord& n4 = m_normals[e[3]];
+                Coord& n1 = normals[e[0]];
+                Coord& n2 = normals[e[1]];
+                Coord& n3 = normals[e[2]];
+                Coord& n4 = normals[e[3]];
                 Coord n;
                 n = cross(p3-p1,p2-p1); n.normalize();
                 n1 += n;
@@ -242,9 +242,9 @@ void PointCollisionModel<DataTypes>::updateNormals()
                 const Coord& p1 = x[e[0]];
                 const Coord& p2 = x[e[1]];
                 const Coord& p3 = x[e[2]];
-                Coord& n1 = m_normals[e[0]];
-                Coord& n2 = m_normals[e[1]];
-                Coord& n3 = m_normals[e[2]];
+                Coord& n1 = normals[e[0]];
+                Coord& n2 = normals[e[1]];
+                Coord& n3 = normals[e[2]];
                 Coord n;
                 n = cross(p2-p1,p3-p1); n.normalize();
                 n1 += n;
@@ -262,10 +262,10 @@ void PointCollisionModel<DataTypes>::updateNormals()
                 const Coord& p2 = x[e[1]];
                 const Coord& p3 = x[e[2]];
                 const Coord& p4 = x[e[3]];
-                Coord& n1 = m_normals[e[0]];
-                Coord& n2 = m_normals[e[1]];
-                Coord& n3 = m_normals[e[2]];
-                Coord& n4 = m_normals[e[3]];
+                Coord& n1 = normals[e[0]];
+                Coord& n2 = normals[e[1]];
+                Coord& n3 = normals[e[2]];
+                Coord& n4 = normals[e[3]];
                 Coord n;
                 n = cross(p3-p1,p4-p2); n.normalize();
                 n1 += n;
@@ -277,11 +277,11 @@ void PointCollisionModel<DataTypes>::updateNormals()
     }
     for (sofa::Index i=0; i<n; ++i)
     {
-        const SReal l = m_normals[i].norm();
+        const SReal l = normals[i].norm();
         if (l > 1.0e-3)
-            m_normals[i] *= 1/l;
+            normals[i] *= 1/l;
         else
-            m_normals[i].clear();
+            normals[i].clear();
     }
 }
 
@@ -339,10 +339,10 @@ void PointCollisionModel<DataTypes>::drawCollisionModel(const core::visual::Visu
         if (p.isActive())
         {
             pointsP.push_back(p.p());
-            if (i < sofa::Size(m_normals.size()))
+            if (i < sofa::Size(normals.size()))
             {
                 pointsL.push_back(p.p());
-                pointsL.push_back(p.p() + m_normals[i] * 0.1f);
+                pointsL.push_back(p.p() + normals[i] * 0.1f);
             }
         }
     }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.inl
@@ -86,11 +86,10 @@ bool PointCollisionModel<DataTypes>::canCollideWithElement(sofa::Index index, Co
         if (index<=index2) // to avoid to have two times the same auto-collision we only consider the case when index > index2
             return false;
 
-        sofa::core::topology::BaseMeshTopology* topology = l_topology.get();
 
         // in the neighborhood, if we find a point in common, we cancel the collision
-        const auto& verticesAroundVertex1 =topology->getVerticesAroundVertex(index);
-        const auto& verticesAroundVertex2 =topology->getVerticesAroundVertex(index2);
+        const auto& verticesAroundVertex1 = l_topology->getVerticesAroundVertex(index);
+        const auto& verticesAroundVertex2 = l_topology->getVerticesAroundVertex(index2);
 
         for (sofa::Index i1=0; i1<verticesAroundVertex1.size(); i1++)
         {
@@ -197,12 +196,14 @@ void PointCollisionModel<DataTypes>::updateNormals()
     {
         m_normals[i].clear();
     }
-    core::topology::BaseMeshTopology* mesh = l_topology.get();
-    if (mesh->getNbTetrahedra()+mesh->getNbHexahedra() > 0)
+    if (!l_topology)
+        return;
+
+    if (l_topology->getNbTetrahedra()+l_topology->getNbHexahedra() > 0)
     {
-        if (mesh->getNbTetrahedra()>0)
+        if (l_topology->getNbTetrahedra()>0)
         {
-            const core::topology::BaseMeshTopology::SeqTetrahedra &elems = mesh->getTetrahedra();
+            const core::topology::BaseMeshTopology::SeqTetrahedra &elems = l_topology->getTetrahedra();
             for (sofa::Index i=0; i < elems.size(); ++i)
             {
                 const core::topology::BaseMeshTopology::Tetra &e = elems[i];
@@ -235,11 +236,11 @@ void PointCollisionModel<DataTypes>::updateNormals()
         }
         /// @todo Hexahedra
     }
-    else if (mesh->getNbTriangles()+mesh->getNbQuads() > 0)
+    else if (l_topology->getNbTriangles()+l_topology->getNbQuads() > 0)
     {
-        if (mesh->getNbTriangles()>0)
+        if (l_topology->getNbTriangles()>0)
         {
-            const core::topology::BaseMeshTopology::SeqTriangles &elems = mesh->getTriangles();
+            const core::topology::BaseMeshTopology::SeqTriangles &elems = l_topology->getTriangles();
             for (sofa::Index i=0; i < elems.size(); ++i)
             {
                 const core::topology::BaseMeshTopology::Triangle &e = elems[i];
@@ -256,9 +257,9 @@ void PointCollisionModel<DataTypes>::updateNormals()
                 n3 += n;
             }
         }
-        if (mesh->getNbQuads()>0)
+        if (l_topology->getNbQuads()>0)
         {
-            const core::topology::BaseMeshTopology::SeqQuads &elems = mesh->getQuads();
+            const core::topology::BaseMeshTopology::SeqQuads &elems = l_topology->getQuads();
             for (sofa::Index i=0; i < elems.size(); ++i)
             {
                 const core::topology::BaseMeshTopology::Quad &e = elems[i];

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.cpp
@@ -40,7 +40,6 @@ using namespace sofa::defaulttype;
 
 RayCollisionModel::RayCollisionModel(SReal length)
     : d_defaultLength(initData(&d_defaultLength, length, "defaultLength", "The default length for all rays in this collision model"))
-    , mstate(nullptr)
 {
     this->contactResponse.setValue("RayContact"); // use RayContact response class
 }
@@ -69,19 +68,12 @@ void RayCollisionModel::resize(sofa::Size size)
 
 void RayCollisionModel::init()
 {
-    this->CollisionModel::init();
+    Inherit2::init();
 
-    mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
-    if (mstate==nullptr)
-    {
-        msg_error() << "RayCollisionModel requires a Vec3 Mechanical Model";
+    if (d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
         return;
-    }
 
-    {
-        const int npoints = mstate->getSize();
-        resize(npoints);
-    }
+    resize(this->mstate->getSize());
 }
 
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.cpp
@@ -40,6 +40,7 @@ using namespace sofa::defaulttype;
 
 RayCollisionModel::RayCollisionModel(SReal length)
     : d_defaultLength(initData(&d_defaultLength, length, "defaultLength", "The default length for all rays in this collision model"))
+    , mstate(nullptr)
 {
     this->contactResponse.setValue("RayContact"); // use RayContact response class
 }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
@@ -23,6 +23,7 @@
 #include <sofa/component/collision/geometry/config.h>
 #include <sofa/core/fwd.h>
 #include <sofa/core/CollisionModel.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <set>
 
@@ -52,10 +53,10 @@ public:
     void setL(SReal newL);
 };
 
-class SOFA_COMPONENT_COLLISION_GEOMETRY_API RayCollisionModel : public core::CollisionModel
+class SOFA_COMPONENT_COLLISION_GEOMETRY_API RayCollisionModel : public core::CollisionModel, public virtual core::behavior::SingleStateAccessor<defaulttype::Vec3Types>
 {
 public:
-    SOFA_CLASS(RayCollisionModel, core::CollisionModel);
+    SOFA_CLASS2(RayCollisionModel, core::CollisionModel, SOFA_TEMPLATE(core::behavior::SingleStateAccessor, defaulttype::Vec3Types));
 
     typedef sofa::defaulttype::Vec3Types InDataTypes;
     typedef sofa::defaulttype::Vec3Types DataTypes;
@@ -73,7 +74,7 @@ public:
 
     void draw(const core::visual::VisualParams*, sofa::Index index) override;
 
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return mstate; }
+    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return getMState(); }
     // ----------------------------
     int addRay(const type::Vec3& origin, const type::Vec3& direction, SReal length);
     Ray getRay(int index) { return Ray(this, index); }
@@ -95,7 +96,6 @@ protected:
     sofa::type::vector<type::Vec3> direction;
 
     std::set<response::contact::BaseRayContact*> contacts;
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* mstate;
 
 };
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
@@ -88,11 +88,11 @@ public:
 
     virtual const std::set<response::contact::BaseRayContact*> &getContacts() const { return contacts;}
 
+    Data<SReal> d_defaultLength; ///< The default length for all rays in this collision model
+
 protected:
     sofa::type::vector<SReal> length;
     sofa::type::vector<type::Vec3> direction;
-
-    Data<SReal> d_defaultLength; ///< The default length for all rays in this collision model
 
     std::set<response::contact::BaseRayContact*> contacts;
     core::behavior::MechanicalState<defaulttype::Vec3Types>* mstate;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/RayCollisionModel.h
@@ -74,7 +74,7 @@ public:
 
     void draw(const core::visual::VisualParams*, sofa::Index index) override;
 
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return getMState(); }
+    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return mstate; }
     // ----------------------------
     int addRay(const type::Vec3& origin, const type::Vec3& direction, SReal length);
     Ray getRay(int index) { return Ray(this, index); }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/CollisionModel.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 
 namespace sofa::component::collision::geometry
@@ -80,10 +80,10 @@ sofa::type::Vec3 TSphere<defaulttype::Vec3Types >::getContactPointWithSurfacePoi
 
 
 template< class TDataTypes>
-class SphereCollisionModel : public core::CollisionModel
+class SphereCollisionModel : public core::CollisionModel, public virtual core::behavior::SingleStateAccessor<TDataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(SphereCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS2(SOFA_TEMPLATE(SphereCollisionModel, TDataTypes), core::CollisionModel, SOFA_TEMPLATE(core::behavior::SingleStateAccessor, TDataTypes));
 
     typedef TDataTypes DataTypes;
     typedef DataTypes InDataTypes;
@@ -114,7 +114,7 @@ public:
 
     void draw(const core::visual::VisualParams*, sofa::Index index) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
 
     const VecReal& getR() const { return this->d_radius.getValue(); }
 
@@ -170,9 +170,6 @@ public:
     SingleLink<SphereCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
-
-protected:
-    core::behavior::MechanicalState<DataTypes>* mstate;
 };
 
 template<class DataTypes>
@@ -187,28 +184,28 @@ inline TSphere<DataTypes>::TSphere(const core::CollisionElementIterator& i)
 }
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::center() const { return DataTypes::getCPos(this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::center() const { return DataTypes::getCPos(this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index]); }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord & TSphere<DataTypes>::rigidCenter() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index];}
+inline const typename DataTypes::Coord & TSphere<DataTypes>::rigidCenter() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index];}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::p() const { return DataTypes::getCPos(this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index]);}
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::p() const { return DataTypes::getCPos(this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index]);}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::pFree() const { return DataTypes::getCPos((*this->model->mstate->read(core::vec_id::read_access::freePosition)).getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::pFree() const { return DataTypes::getCPos((*this->model->getMState()->read(core::vec_id::read_access::freePosition)).getValue()[this->index]); }
 
 template<class DataTypes>
-inline const typename SphereCollisionModel<DataTypes>::Coord& SphereCollisionModel<DataTypes>::velocity(sofa::Index index) const { return DataTypes::getDPos(mstate->read(core::vec_id::read_access::velocity)->getValue()[index]);}
+inline const typename SphereCollisionModel<DataTypes>::Coord& SphereCollisionModel<DataTypes>::velocity(sofa::Index index) const { return DataTypes::getDPos(this->mstate->read(core::vec_id::read_access::velocity)->getValue()[index]);}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::v() const { return DataTypes::getDPos(this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::v() const { return DataTypes::getDPos(this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->index]); }
 
 template<class DataTypes>
 inline typename DataTypes::Real TSphere<DataTypes>::r() const { return (Real) this->model->getRadius((unsigned)this->index); }
 
 template<class DataTypes>
-inline bool TSphere<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TSphere<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 using Sphere = TSphere<sofa::defaulttype::Vec3Types>;
 using RigidSphere = TSphere<sofa::defaulttype::Rigid3Types>;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
@@ -166,12 +166,13 @@ public:
     Data< SReal > d_defaultRadius; ///< Default radius
     Data< bool > d_showImpostors; ///< Draw spheres as impostors instead of "real" spheres
 
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<SphereCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
 
 protected:
     core::behavior::MechanicalState<DataTypes>* mstate;
-    SingleLink<SphereCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 };
 
 template<class DataTypes>

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
@@ -114,7 +114,7 @@ public:
 
     void draw(const core::visual::VisualParams*, sofa::Index index) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate; }
 
     const VecReal& getR() const { return this->d_radius.getValue(); }
 
@@ -184,28 +184,28 @@ inline TSphere<DataTypes>::TSphere(const core::CollisionElementIterator& i)
 }
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::center() const { return DataTypes::getCPos(this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::center() const { return DataTypes::getCPos(this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index]); }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord & TSphere<DataTypes>::rigidCenter() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index];}
+inline const typename DataTypes::Coord & TSphere<DataTypes>::rigidCenter() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index];}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::p() const { return DataTypes::getCPos(this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[this->index]);}
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::p() const { return DataTypes::getCPos(this->model->mstate->read(core::vec_id::read_access::position)->getValue()[this->index]);}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::pFree() const { return DataTypes::getCPos((*this->model->getMState()->read(core::vec_id::read_access::freePosition)).getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::pFree() const { return DataTypes::getCPos((*this->model->mstate->read(core::vec_id::read_access::freePosition)).getValue()[this->index]); }
 
 template<class DataTypes>
 inline const typename SphereCollisionModel<DataTypes>::Coord& SphereCollisionModel<DataTypes>::velocity(sofa::Index index) const { return DataTypes::getDPos(this->mstate->read(core::vec_id::read_access::velocity)->getValue()[index]);}
 
 template<class DataTypes>
-inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::v() const { return DataTypes::getDPos(this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[this->index]); }
+inline const typename TSphere<DataTypes>::Coord& TSphere<DataTypes>::v() const { return DataTypes::getDPos(this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[this->index]); }
 
 template<class DataTypes>
 inline typename DataTypes::Real TSphere<DataTypes>::r() const { return (Real) this->model->getRadius((unsigned)this->index); }
 
 template<class DataTypes>
-inline bool TSphere<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TSphere<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 using Sphere = TSphere<sofa::defaulttype::Vec3Types>;
 using RigidSphere = TSphere<sofa::defaulttype::Rigid3Types>;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.inl
@@ -37,17 +37,16 @@ SphereCollisionModel<DataTypes>::SphereCollisionModel()
     : d_radius(initData(&d_radius, "listRadius", "Radius of each sphere"))
     , d_defaultRadius(initData(&d_defaultRadius, (SReal)(1.0), "radius", "Default radius"))
     , d_showImpostors(initData(&d_showImpostors, true, "showImpostors", "Draw spheres as impostors instead of \"real\" spheres"))
-    , mstate(nullptr)
 {
     enum_type = SPHERE_TYPE;
 }
 
 template<class DataTypes>
-SphereCollisionModel<DataTypes>::SphereCollisionModel(core::behavior::MechanicalState<DataTypes>* _mstate )
-    : d_radius(initData(&d_radius, "listRadius", "Radius of each sphere"))
+SphereCollisionModel<DataTypes>::SphereCollisionModel(core::behavior::MechanicalState<DataTypes>* ms )
+    : core::behavior::SingleStateAccessor<DataTypes>(ms)
+    , d_radius(initData(&d_radius, "listRadius", "Radius of each sphere"))
     , d_defaultRadius(initData(&d_defaultRadius, (SReal)(1.0), "radius", "Default radius"))
     , d_showImpostors(initData(&d_showImpostors, true, "showImpostors", "Draw spheres as impostors instead of \"real\" spheres"))
-    , mstate(_mstate)
 {
     enum_type = SPHERE_TYPE;
 }
@@ -81,24 +80,13 @@ void SphereCollisionModel<DataTypes>::init()
         msg_warning() << "Calling an already fully initialized component. You should use reinit instead." ;
     }
 
-    this->CollisionModel::init();
-    mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (getContext()->getMechanicalState());
-    if (mstate==nullptr)
-    {
-        //TODO(dmarchal): The previous message was saying this only work for a vec3 mechanicalstate but there
-        // it seems that a mechanicalstate will work we well...where is the truth ?
-        msg_error(this) << "Missing a MechanicalObject with template '" << DataTypes::Name() << ". "
-                           "This MechnicalObject stores the position of the spheres. When this one is missing the collision model is deactivated. \n"
-                           "To remove this error message you can add to your scene a line <MechanicalObject template='"<< DataTypes::Name() << "'/>. ";
-        d_componentState.setValue(ComponentState::Invalid) ;
+    Inherit2::init();
 
+    if (d_componentState.getValue() == ComponentState::Invalid)
         return;
-    }
 
-    const auto npoints = mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     resize(npoints);
-
-    d_componentState.setValue(ComponentState::Valid) ;
 }
 
 
@@ -124,7 +112,7 @@ void SphereCollisionModel<DataTypes>::drawCollisionModel(const core::visual::Vis
     vparams->drawTool()->setPolygonMode(0, false);
 
     // Check topological modifications
-    const auto npoints = mstate->getSize();
+    const auto npoints = this->mstate->getSize();
 
     std::vector<Vec3> points;
     std::vector<float> radius;
@@ -162,7 +150,7 @@ void SphereCollisionModel<DataTypes>::computeBoundingTree(int maxDepth)
         return ;
 
     CubeCollisionModel* cubeModel = createPrevious<CubeCollisionModel>();
-    const auto npoints = mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     bool updated = false;
     if (npoints != size)
     {
@@ -202,7 +190,7 @@ void SphereCollisionModel<DataTypes>::computeContinuousBoundingTree(SReal dt, Co
         return ;
 
     CubeCollisionModel* cubeModel = createPrevious<CubeCollisionModel>();
-    const auto npoints = mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     bool updated = false;
     if (npoints != size)
     {
@@ -261,7 +249,7 @@ void SphereCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params
     if( onlyVisible && !sofa::core::visual::VisualParams::defaultInstance()->displayFlags().getShowCollisionModels())
         return;
 
-    const auto npoints = mstate->getSize();
+    const auto npoints = this->mstate->getSize();
     type::BoundingBox bbox;
 
     for(sofa::Size i = 0 ; i < npoints ; ++i )

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.cpp
@@ -42,7 +42,6 @@ void registerTetrahedronCollisionModel(sofa::core::ObjectFactory* factory)
 
 TetrahedronCollisionModel::TetrahedronCollisionModel()
     : tetra(nullptr)
-    , mstate(nullptr)
     , m_topology(nullptr)
     , m_topologyRevision(-1)
     , l_topology(initLink("topology", "link to the topology container"))
@@ -59,6 +58,8 @@ void TetrahedronCollisionModel::resize(sofa::Size size)
 
 void TetrahedronCollisionModel::init()
 {
+    Inherit2::init();
+
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
@@ -72,15 +73,6 @@ void TetrahedronCollisionModel::init()
     {
         msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name << ". TetrahedronCollisionModel requires a BaseMeshTopology";
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
-        return;
-    }
-
-    this->CollisionModel::init();
-    mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
-
-    if (mstate==nullptr)
-    {
-        msg_error() << "TetrahedronCollisionModel requires a Vec3 Mechanical Model";
         return;
     }
 

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
@@ -118,7 +118,7 @@ public:
 
     void draw(const core::visual::VisualParams*, sofa::Index index) override;
 
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return getMState(); }
+    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return mstate; }
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<TetrahedronCollisionModel, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
@@ -133,25 +133,25 @@ inline Tetrahedron::Tetrahedron(const core::CollisionElementIterator& i)
     : core::TCollisionElementIterator<TetrahedronCollisionModel>(static_cast<TetrahedronCollisionModel*>(i.getCollisionModel()), i.getIndex())
 {}
 
-inline const type::Vec3& Tetrahedron::p1() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][0]]; }
-inline const type::Vec3& Tetrahedron::p2() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][1]]; }
-inline const type::Vec3& Tetrahedron::p3() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][2]]; }
-inline const type::Vec3& Tetrahedron::p4() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][3]]; }
+inline const type::Vec3& Tetrahedron::p1() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][0]]; }
+inline const type::Vec3& Tetrahedron::p2() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][1]]; }
+inline const type::Vec3& Tetrahedron::p3() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][2]]; }
+inline const type::Vec3& Tetrahedron::p4() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][3]]; }
 
-inline const type::Vec3& Tetrahedron::p1Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][0]]; }
-inline const type::Vec3& Tetrahedron::p2Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][1]]; }
-inline const type::Vec3& Tetrahedron::p3Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][2]]; }
-inline const type::Vec3& Tetrahedron::p4Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][3]]; }
+inline const type::Vec3& Tetrahedron::p1Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][0]]; }
+inline const type::Vec3& Tetrahedron::p2Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][1]]; }
+inline const type::Vec3& Tetrahedron::p3Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][2]]; }
+inline const type::Vec3& Tetrahedron::p4Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][3]]; }
 
 inline int Tetrahedron::p1Index() const { return (*(model->tetra))[index][0]; }
 inline int Tetrahedron::p2Index() const { return (*(model->tetra))[index][1]; }
 inline int Tetrahedron::p3Index() const { return (*(model->tetra))[index][2]; }
 inline int Tetrahedron::p4Index() const { return (*(model->tetra))[index][3]; }
 
-inline const type::Vec3& Tetrahedron::v1() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][0]]; }
-inline const type::Vec3& Tetrahedron::v2() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][1]]; }
-inline const type::Vec3& Tetrahedron::v3() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][2]]; }
-inline const type::Vec3& Tetrahedron::v4() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][3]]; }
+inline const type::Vec3& Tetrahedron::v1() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][0]]; }
+inline const type::Vec3& Tetrahedron::v2() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][1]]; }
+inline const type::Vec3& Tetrahedron::v3() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][2]]; }
+inline const type::Vec3& Tetrahedron::v4() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][3]]; }
 
 inline type::Vec3 Tetrahedron::getBary(const type::Vec3& p) const { return model->elems[index].coord2bary*(p-model->elems[index].coord0); }
 inline type::Vec3 Tetrahedron::getDBary(const type::Vec3& v) const { return model->elems[index].coord2bary*(v); }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
@@ -100,8 +100,6 @@ protected:
 
     int m_topologyRevision; ///< internal revision number to check if topology has changed.
 
-protected:
-
     TetrahedronCollisionModel();
 
     virtual void updateFromTopology();

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TetrahedronCollisionModel.h
@@ -23,7 +23,7 @@
 #include <sofa/component/collision/geometry/config.h>
 
 #include <sofa/core/CollisionModel.h>
-#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
 
@@ -69,10 +69,10 @@ public:
 
 };
 
-class SOFA_COMPONENT_COLLISION_GEOMETRY_API TetrahedronCollisionModel : public core::CollisionModel
+class SOFA_COMPONENT_COLLISION_GEOMETRY_API TetrahedronCollisionModel : public core::CollisionModel, public virtual core::behavior::SingleStateAccessor<defaulttype::Vec3Types>
 {
 public:
-    SOFA_CLASS(TetrahedronCollisionModel, core::CollisionModel);
+    SOFA_CLASS2(TetrahedronCollisionModel, core::CollisionModel, SOFA_TEMPLATE(core::behavior::SingleStateAccessor, defaulttype::Vec3Types));
 
     typedef defaulttype::Vec3Types InDataTypes;
     typedef defaulttype::Vec3Types DataTypes;
@@ -94,7 +94,6 @@ protected:
     sofa::type::vector<TetrahedronInfo> elems;
     const sofa::core::topology::BaseMeshTopology::SeqTetrahedra* tetra;
 
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* mstate;
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 
@@ -119,7 +118,7 @@ public:
 
     void draw(const core::visual::VisualParams*, sofa::Index index) override;
 
-    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return mstate; }
+    core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return getMState(); }
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<TetrahedronCollisionModel, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
@@ -134,25 +133,25 @@ inline Tetrahedron::Tetrahedron(const core::CollisionElementIterator& i)
     : core::TCollisionElementIterator<TetrahedronCollisionModel>(static_cast<TetrahedronCollisionModel*>(i.getCollisionModel()), i.getIndex())
 {}
 
-inline const type::Vec3& Tetrahedron::p1() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][0]]; }
-inline const type::Vec3& Tetrahedron::p2() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][1]]; }
-inline const type::Vec3& Tetrahedron::p3() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][2]]; }
-inline const type::Vec3& Tetrahedron::p4() const { return model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][3]]; }
+inline const type::Vec3& Tetrahedron::p1() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][0]]; }
+inline const type::Vec3& Tetrahedron::p2() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][1]]; }
+inline const type::Vec3& Tetrahedron::p3() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][2]]; }
+inline const type::Vec3& Tetrahedron::p4() const { return model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(model->tetra))[index][3]]; }
 
-inline const type::Vec3& Tetrahedron::p1Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][0]]; }
-inline const type::Vec3& Tetrahedron::p2Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][1]]; }
-inline const type::Vec3& Tetrahedron::p3Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][2]]; }
-inline const type::Vec3& Tetrahedron::p4Free() const { return model->mstate->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][3]]; }
+inline const type::Vec3& Tetrahedron::p1Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][0]]; }
+inline const type::Vec3& Tetrahedron::p2Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][1]]; }
+inline const type::Vec3& Tetrahedron::p3Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][2]]; }
+inline const type::Vec3& Tetrahedron::p4Free() const { return model->getMState()->read(core::vec_id::read_access::freePosition)->getValue()[(*(model->tetra))[index][3]]; }
 
 inline int Tetrahedron::p1Index() const { return (*(model->tetra))[index][0]; }
 inline int Tetrahedron::p2Index() const { return (*(model->tetra))[index][1]; }
 inline int Tetrahedron::p3Index() const { return (*(model->tetra))[index][2]; }
 inline int Tetrahedron::p4Index() const { return (*(model->tetra))[index][3]; }
 
-inline const type::Vec3& Tetrahedron::v1() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][0]]; }
-inline const type::Vec3& Tetrahedron::v2() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][1]]; }
-inline const type::Vec3& Tetrahedron::v3() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][2]]; }
-inline const type::Vec3& Tetrahedron::v4() const { return model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][3]]; }
+inline const type::Vec3& Tetrahedron::v1() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][0]]; }
+inline const type::Vec3& Tetrahedron::v2() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][1]]; }
+inline const type::Vec3& Tetrahedron::v3() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][2]]; }
+inline const type::Vec3& Tetrahedron::v4() const { return model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(model->tetra))[index][3]]; }
 
 inline type::Vec3 Tetrahedron::getBary(const type::Vec3& p) const { return model->elems[index].coord2bary*(p-model->elems[index].coord0); }
 inline type::Vec3 Tetrahedron::getDBary(const type::Vec3& v) const { return model->elems[index].coord2bary*(v); }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
@@ -184,8 +184,8 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
-    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return this->getMState(); }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->mstate; }
+    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return this->mstate; }
 
     const VecCoord& getX() const { return(getMechanicalState()->read(core::vec_id::read_access::position)->getValue()); }
     const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *m_triangles; }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
@@ -27,7 +27,7 @@
 #include <sofa/core/CollisionModel.h>
 #include <sofa/core/VecId.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/SingleStateAccessor.h>
 
 namespace sofa::component::collision::geometry
 {
@@ -102,10 +102,10 @@ using Triangle = TTriangle<sofa::defaulttype::Vec3Types>;
  * The class \sa TTriangle is used to access specific triangle of this collision Model.
  */
 template<class TDataTypes>
-class TriangleCollisionModel : public core::CollisionModel
+class TriangleCollisionModel : public core::CollisionModel, public virtual core::behavior::SingleStateAccessor<TDataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(TriangleCollisionModel, TDataTypes), core::CollisionModel);
+    SOFA_CLASS2(SOFA_TEMPLATE(TriangleCollisionModel, TDataTypes), core::CollisionModel, SOFA_TEMPLATE(core::behavior::SingleStateAccessor, TDataTypes));
 
     typedef TDataTypes DataTypes;
     typedef DataTypes InDataTypes;
@@ -143,7 +143,6 @@ public:
     SingleLink<TriangleCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
-    core::behavior::MechanicalState<DataTypes>* m_mstate; ///< Pointer to the corresponding MechanicalState
     sofa::core::topology::BaseMeshTopology* m_topology; ///< Pointer to the corresponding Topology
 
     VecDeriv m_normals; ///< Vector of normal direction per triangle.
@@ -185,8 +184,8 @@ public:
 
     bool canCollideWithElement(sofa::Index index, CollisionModel* model2, sofa::Index index2) override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
-    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return m_mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return this->getMState(); }
+    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return this->getMState(); }
 
     const VecCoord& getX() const { return(getMechanicalState()->read(core::vec_id::read_access::position)->getValue()); }
     const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *m_triangles; }

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.inl
@@ -451,26 +451,26 @@ void TriangleCollisionModel<DataTypes>::drawCollisionModel(const core::visual::V
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::p(Index i) const {
-    return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
+    return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
 }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::operator[](Index i) const {
-    return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
+    return this->model->mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (this->model->getMState()->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (this->model->mstate->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (this->model->getMState()->read(sofa::core::vec_id::read_access::freePosition)->getValue())[((*this->model->m_triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (this->model->mstate->read(sofa::core::vec_id::read_access::freePosition)->getValue())[((*this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (this->model->getMState()->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (this->model->mstate->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][2]]; }
 
 template<class DataTypes>
 inline typename TTriangle<DataTypes>::Index TTriangle<DataTypes>::p1Index() const { return (*(this->model->m_triangles))[this->index][0]; }
@@ -480,13 +480,13 @@ template<class DataTypes>
 inline typename TTriangle<DataTypes>::Index TTriangle<DataTypes>::p3Index() const { return (*(this->model->m_triangles))[this->index][2]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->mstate->read(core::vec_id::read_access::velocity)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(Index i) const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][i]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(Index i) const { return this->model->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][i]]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Deriv& TTriangle<DataTypes>::n() const { return this->model->m_normals[this->index]; }
@@ -497,7 +497,7 @@ template<class DataTypes>
 inline int TTriangle<DataTypes>::flags() const { return this->model->getTriangleFlags(this->index); }
 
 template<class DataTypes>
-inline bool TTriangle<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TTriangle<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 template<class DataTypes>
 inline typename DataTypes::Deriv TriangleCollisionModel<DataTypes>::velocity(sofa::Index index) const { return (this->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][0]] + this->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][1]] +

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.inl
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.inl
@@ -39,7 +39,6 @@ TriangleCollisionModel<DataTypes>::TriangleCollisionModel()
     , d_computeNormals(initData(&d_computeNormals, true, "computeNormals", "set to false to disable computation of triangles normal"))
     , d_useCurvature(initData(&d_useCurvature, false, "useCurvature", "use the curvature of the mesh to avoid some self-intersection test"))
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_mstate(nullptr)
     , m_topology(nullptr)
     , m_needsUpdate(true)
     , m_topologyRevision(-1)
@@ -59,6 +58,8 @@ void TriangleCollisionModel<DataTypes>::resize(sofa::Size size)
 template<class DataTypes>
 void TriangleCollisionModel<DataTypes>::init()
 {
+    Inherit2::init();
+
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
@@ -75,23 +76,10 @@ void TriangleCollisionModel<DataTypes>::init()
         return;
     }
 
-    // TODO epernod 2019-01-21: Check if this call super is needed.
-    this->CollisionModel::init();
-    m_mstate = dynamic_cast< core::behavior::MechanicalState<DataTypes>* > (this->getContext()->getMechanicalState());
-
     this->getContext()->get(m_pointModels);
 
-    // Check object pointer access
-    bool modelsOk = true;
-    if (m_mstate == nullptr)
+    if (this->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
     {
-        msg_error() << "No MechanicalState found. TriangleCollisionModel<sofa::defaulttype::Vec3Types> requires a Vec3 MechanicalState in the same Node.";
-        modelsOk = false;
-    }
-
-    if (!modelsOk)
-    {
-        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
 
@@ -145,7 +133,7 @@ void TriangleCollisionModel<DataTypes>::updateFromTopology()
     else
     {
         const sofa::Size newsize = ntris+2*nquads;
-        const sofa::Size npoints = m_mstate->getSize();
+        const sofa::Size npoints = this->mstate->getSize();
 
         m_triangles = &m_internalTriangles;
         m_internalTriangles.resize(newsize);
@@ -232,7 +220,7 @@ void TriangleCollisionModel<DataTypes>::computeBoundingTree(int maxDepth)
     m_needsUpdate=false;
 
     type::Vec3 minElem, maxElem;
-    const VecCoord& x = this->m_mstate->read(core::vec_id::read_access::position)->getValue();
+    const VecCoord& x = this->mstate->read(core::vec_id::read_access::position)->getValue();
 
     const bool calcNormals = d_computeNormals.getValue();
 
@@ -384,7 +372,7 @@ void TriangleCollisionModel<DataTypes>::computeBBox(const core::ExecParams* para
     if (m_topology->getRevision() != m_topologyRevision)
         updateFromTopology();
 
-    const auto& positions = this->m_mstate->read(core::vec_id::read_access::position)->getValue();
+    const auto& positions = this->mstate->read(core::vec_id::read_access::position)->getValue();
     type::BoundingBox bbox;
 
     for(const auto& triangle : (*this->m_triangles))
@@ -463,26 +451,26 @@ void TriangleCollisionModel<DataTypes>::drawCollisionModel(const core::visual::V
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->m_mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->m_mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->m_mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::p(Index i) const {
-    return this->model->m_mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
+    return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
 }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::operator[](Index i) const {
-    return this->model->m_mstate->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
+    return this->model->getMState()->read(core::vec_id::read_access::position)->getValue()[(*(this->model->m_triangles))[this->index][i]];
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (this->model->m_mstate->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (this->model->getMState()->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (this->model->m_mstate->read(sofa::core::vec_id::read_access::freePosition)->getValue())[((*this->model->m_triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (this->model->getMState()->read(sofa::core::vec_id::read_access::freePosition)->getValue())[((*this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (this->model->m_mstate->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (this->model->getMState()->read(sofa::core::vec_id::read_access::freePosition)->getValue())[(*(this->model->m_triangles))[this->index][2]]; }
 
 template<class DataTypes>
 inline typename TTriangle<DataTypes>::Index TTriangle<DataTypes>::p1Index() const { return (*(this->model->m_triangles))[this->index][0]; }
@@ -492,13 +480,13 @@ template<class DataTypes>
 inline typename TTriangle<DataTypes>::Index TTriangle<DataTypes>::p3Index() const { return (*(this->model->m_triangles))[this->index][2]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->m_mstate->read(core::vec_id::read_access::velocity)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->m_mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->m_mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(Index i) const { return this->model->m_mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][i]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(Index i) const { return this->model->getMState()->read(core::vec_id::read_access::velocity)->getValue()[(*(this->model->m_triangles))[this->index][i]]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Deriv& TTriangle<DataTypes>::n() const { return this->model->m_normals[this->index]; }
@@ -509,11 +497,11 @@ template<class DataTypes>
 inline int TTriangle<DataTypes>::flags() const { return this->model->getTriangleFlags(this->index); }
 
 template<class DataTypes>
-inline bool TTriangle<DataTypes>::hasFreePosition() const { return this->model->m_mstate->read(core::vec_id::read_access::freePosition)->isSet(); }
+inline bool TTriangle<DataTypes>::hasFreePosition() const { return this->model->getMState()->read(core::vec_id::read_access::freePosition)->isSet(); }
 
 template<class DataTypes>
-inline typename DataTypes::Deriv TriangleCollisionModel<DataTypes>::velocity(sofa::Index index) const { return (m_mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][0]] + m_mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][1]] +
-                                                                                                m_mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][2]])/((Real)(3.0)); }
+inline typename DataTypes::Deriv TriangleCollisionModel<DataTypes>::velocity(sofa::Index index) const { return (this->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][0]] + this->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][1]] +
+                                                                                                this->mstate->read(core::vec_id::read_access::velocity)->getValue()[(*(m_triangles))[index][2]])/((Real)(3.0)); }
 
 
 } //namespace sofa::component::collision::geometry

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleModelInRegularGrid.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleModelInRegularGrid.cpp
@@ -61,9 +61,8 @@ void TriangleModelInRegularGrid::init()
     TriangleCollisionModel<sofa::defaulttype::Vec3Types>::init();
 
     _topology = this->getContext()->getMeshTopology();
-    m_mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
 
-    if (!m_mstate) { msg_error() << "TriangleModelInRegularGrid requires a Vec3 Mechanical Model"; return; }
+    if (this->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid) return;
     if (!m_topology) { msg_error() << "TriangleModelInRegularGrid requires a BaseMeshTopology"; return; }
 
     // Test if _topology depend on an higher topology (to compute Bounding Tree faster) and get it
@@ -71,7 +70,7 @@ void TriangleModelInRegularGrid::init()
     vector<TopologicalMapping*> topoVec;
     getContext()->get<TopologicalMapping> ( &topoVec, core::objectmodel::BaseContext::SearchRoot );
     _higher_topo = m_topology;
-    _higher_mstate = m_mstate;
+    _higher_mstate = this->mstate;
     bool found = true;
     while ( found )
     {
@@ -111,7 +110,7 @@ void TriangleModelInRegularGrid::computeBoundingTree ( int )
     m_needsUpdate=false;
     Vec3 minElem, maxElem;
     const VecCoord& xHigh =_higher_mstate->read(core::vec_id::read_access::position)->getValue();
-    const VecCoord& x =m_mstate->read(core::vec_id::read_access::position)->getValue();
+    const VecCoord& x =this->mstate->read(core::vec_id::read_access::position)->getValue();
 
     // no hierarchy
     if ( empty() )

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeCollisionModel.cpp
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleOctreeCollisionModel.cpp
@@ -83,16 +83,16 @@ void TriangleOctreeCollisionModel::computeBoundingTree(int maxDepth)
     updateFromTopology();
 
     if (!isMoving() && !cubeModel->empty()) return; // No need to recompute BBox if immobile
-    const std::size_t size2=m_mstate->getSize();
+    const std::size_t size2=this->mstate->getSize();
     pNorms.resize(size2);
     for(sofa::Size i=0; i<size2; i++)
     {
         pNorms[i]=type::Vec3(0,0,0);
     }
     type::Vec3 minElem, maxElem;
-    maxElem[0]=minElem[0]=m_mstate->read(core::vec_id::read_access::position)->getValue()[0][0];
-    maxElem[1]=minElem[1]=m_mstate->read(core::vec_id::read_access::position)->getValue()[0][1];
-    maxElem[2]=minElem[2]=m_mstate->read(core::vec_id::read_access::position)->getValue()[0][2];
+    maxElem[0]=minElem[0]=this->mstate->read(core::vec_id::read_access::position)->getValue()[0][0];
+    maxElem[1]=minElem[1]=this->mstate->read(core::vec_id::read_access::position)->getValue()[0][1];
+    maxElem[2]=minElem[2]=this->mstate->read(core::vec_id::read_access::position)->getValue()[0][2];
 
     cubeModel->resize(1);  // size = number of triangles
     for (std::size_t i=1; i<size; i++)


### PR DESCRIPTION
A bit of an inconsistency since the topology link (and Data) are mostly public in other model classes. Same with Sphere coli model.
Was this by design? Let's keep one consistent style for all models.
What do you think? should they be public or private?