### PR TITLE
[Haptics] Double iterations to fix LCPForceFeedback_test

### DIFF
--- a/Sofa/Component/Haptics/tests/LCPForceFeedback_test.cpp
+++ b/Sofa/Component/Haptics/tests/LCPForceFeedback_test.cpp
@@ -251,7 +251,7 @@ bool LCPForceFeedback_test::test_Collision()
     m_LCPFFBack = instruNode->get<LCPRig>(instruNode->SearchDown);
     
     // Force only 2 iteration max for ci tests
-    m_LCPFFBack->d_solverMaxIt.setValue(2);
+    m_LCPFFBack->d_solverMaxIt.setValue(4);
 
     // Check components access
     EXPECT_NE(meca, nullptr);
@@ -354,7 +354,7 @@ bool LCPForceFeedback_test::test_multiThread()
     m_LCPFFBack = instruNode->get<LCPRig>(instruNode->SearchDown);
     
     // Force only 2 iteration max for ci tests
-    m_LCPFFBack->d_solverMaxIt.setValue(2);
+    m_LCPFFBack->d_solverMaxIt.setValue(4);
 
     // Check components access
     EXPECT_NE(meca, nullptr);


### PR DESCRIPTION
LCPForceFeedback_test seems to have precision issues for some time.
This PR is a test to assess whether the iterations of the GS helps.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
