### PR TITLE
[SofaCUDA] GUI: create extension to use Sofa.GUI with SofaCUDA

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -276,11 +276,6 @@ sofa_find_package(Sofa.Component.Engine.Select REQUIRED)
 sofa_find_package(Sofa.Component.Engine.Transform REQUIRED)
 sofa_find_package(Sofa.Component.MechanicalLoad REQUIRED)
 
-sofa_find_package(Sofa.GUI QUIET)
-if(Sofa.GUI_FOUND)
-    list(APPEND SOURCE_FILES ${SOFACUDACORE_SOURCE_DIR}/sofa/gpu/gui/CudaMouseInteraction.cpp)
-endif()
-
 option(SOFACUDA_VERBOSE_PTXAS "???" OFF)
 
 option(SOFACUDA_CUBLAS "Activate cublas support in CUDA (requires SOFACUDA_DOUBLE)." OFF)
@@ -359,10 +354,6 @@ target_link_libraries(${PROJECT_NAME} CUDA::cudart)
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17 cuda_std_17)
 
-if(Sofa.GUI_FOUND)
-    target_link_libraries(${PROJECT_NAME} Sofa.GUI)
-endif()
-
 if(SOFACUDA_CUBLAS)
     target_link_libraries(${PROJECT_NAME} ${CUDA_cusparse_LIBRARY} CUDA::cublas)
 
@@ -377,3 +368,5 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     RELOCATABLE "plugins"
 )
+
+add_subdirectory(extensions)

--- a/applications/plugins/SofaCUDA/extensions/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/extensions/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.12)
+
+find_package(Sofa.Config)
+
+sofa_add_subdirectory(plugin GUI SofaCUDA.GUI)
+

--- a/applications/plugins/SofaCUDA/extensions/GUI/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/extensions/GUI/CMakeLists.txt
@@ -13,11 +13,11 @@ set(SOURCE_FILES
 )
 
 sofa_find_package(SofaCUDA REQUIRED)
-sofa_find_package(Sofa.GUI REQUIRED)
+sofa_find_package(Sofa.GUI.Common REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaCUDA)
-target_link_libraries(${PROJECT_NAME} Sofa.GUI)
+target_link_libraries(${PROJECT_NAME} Sofa.GUI.Common)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/applications/plugins/SofaCUDA/extensions/GUI/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/extensions/GUI/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.12)
+project(SofaCUDA.GUI LANGUAGES CXX CUDA)
+
+set(SOFACUDAGUI_SOURCE_DIR "src/SofaCUDA/GUI")
+set(HEADER_FILES
+    ${SOFACUDAGUI_SOURCE_DIR}/init.h
+    ${SOFACUDAGUI_SOURCE_DIR}/config.h.in
+)
+
+set(SOURCE_FILES
+    ${SOFACUDAGUI_SOURCE_DIR}/init.cpp
+    ${SOFACUDAGUI_SOURCE_DIR}/CudaMouseInteraction.cpp
+)
+
+sofa_find_package(SofaCUDA REQUIRED)
+sofa_find_package(Sofa.GUI REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} SofaCUDA)
+target_link_libraries(${PROJECT_NAME} Sofa.GUI)
+
+sofa_create_package_with_targets(
+    PACKAGE_NAME ${PROJECT_NAME}
+    PACKAGE_VERSION ${Sofa_VERSION}
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+    INCLUDE_SOURCE_DIR "src"
+    INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
+    RELOCATABLE "plugins"
+)

--- a/applications/plugins/SofaCUDA/extensions/GUI/SofaCUDA.GUIConfig.cmake.in
+++ b/applications/plugins/SofaCUDA/extensions/GUI/SofaCUDA.GUIConfig.cmake.in
@@ -1,0 +1,9 @@
+# CMake package configuration file for the SofaCUDA.GUI library
+
+@PACKAGE_GUARD@
+@PACKAGE_INIT@
+
+find_package(Sofa.GUI QUIET REQUIRED)
+find_package(SofaCUDA QUIET REQUIRED)
+
+check_required_components(SofaCUDA.GUI)

--- a/applications/plugins/SofaCUDA/extensions/GUI/SofaCUDA.GUIConfig.cmake.in
+++ b/applications/plugins/SofaCUDA/extensions/GUI/SofaCUDA.GUIConfig.cmake.in
@@ -3,7 +3,7 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
-find_package(Sofa.GUI QUIET REQUIRED)
+find_package(Sofa.GUI.Common QUIET REQUIRED)
 find_package(SofaCUDA QUIET REQUIRED)
 
 check_required_components(SofaCUDA.GUI)

--- a/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/CudaMouseInteraction.cpp
+++ b/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/CudaMouseInteraction.cpp
@@ -1,9 +1,6 @@
+#include <SofaCUDA/GUI/config.h>
+
 #include <sofa/gpu/cuda/CudaTypes.h>
-#include <SofaCUDA/component/solidmechanics/spring/CudaSpringForceField.inl>
-#include <SofaCUDA/component/statecontainer/CudaMechanicalObject.inl>
-#include <SofaCUDA/component/mapping/linear/CudaIdentityMapping.inl>
-#include <SofaCUDA/component/collision/response/contact/CudaPenalityContactForceField.h>
-#include <SofaCUDA/component/collision/geometry/CudaSphereModel.h>
 #include <sofa/gui/component/performer/MouseInteractor.inl>
 
 #include <SofaCUDA/component/collision/response/mapper/CudaContactMapper.h>
@@ -12,34 +9,28 @@
 #include <sofa/gui/component/performer/FixParticlePerformer.inl>
 #include <sofa/gui/component/performer/BaseAttachBodyPerformer.inl>
 
-#include <sofa/component/collision/detection/intersection/RayDiscreteIntersection.inl>
-#include <sofa/component/collision/detection/intersection/DiscreteIntersection.h>
 
-#include <sofa/component/collision/response/contact/RayContact.h>
-#include <sofa/component/collision/response/mapper/BarycentricContactMapper.inl>
-
-#include <sofa/component/solidmechanics/spring/VectorSpringForceField.h>
-
-#include <sofa/gl/gl.h>
 #include <sofa/helper/Factory.inl>
-#include <sofa/core/Mapping.inl>
-#include <fstream>
+#include <sofa/core/ObjectFactory.h>
+
 
 namespace sofa::gui::component::performer
 {
-template class SOFA_GPU_CUDA_API MouseInteractor<CudaVec3fTypes>;
-template class SOFA_GPU_CUDA_API TComponentMouseInteraction< CudaVec3fTypes >;
-template class SOFA_GPU_CUDA_API AttachBodyPerformer< CudaVec3fTypes >;
-template class SOFA_GPU_CUDA_API FixParticlePerformer< CudaVec3fTypes >;
-
-#ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API MouseInteractor<CudaVec3dTypes>;
-template class SOFA_GPU_CUDA_API TComponentMouseInteraction< CudaVec3dTypes >;
-template class SOFA_GPU_CUDA_API AttachBodyPerformer< CudaVec3dTypes >;
-template class SOFA_GPU_CUDA_API FixParticlePerformer< CudaVec3dTypes >;
-#endif
 
 using namespace sofa::gpu::cuda;
+
+template class SOFACUDA_GUI_API MouseInteractor<CudaVec3fTypes>;
+template class SOFACUDA_GUI_API TComponentMouseInteraction< CudaVec3fTypes >;
+template class SOFACUDA_GUI_API AttachBodyPerformer< CudaVec3fTypes >;
+template class SOFACUDA_GUI_API FixParticlePerformer< CudaVec3fTypes >;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFACUDA_GUI_API MouseInteractor<CudaVec3dTypes>;
+template class SOFACUDA_GUI_API TComponentMouseInteraction< CudaVec3dTypes >;
+template class SOFACUDA_GUI_API AttachBodyPerformer< CudaVec3dTypes >;
+template class SOFACUDA_GUI_API FixParticlePerformer< CudaVec3dTypes >;
+#endif
+
 using namespace sofa::component::collision;
 using namespace sofa::component::collision::geometry;
 using namespace sofa::component::collision::response::mapper;

--- a/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/config.h.in
+++ b/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/config.h.in
@@ -1,0 +1,40 @@
+/******************************************************************************
+*                              BeamAdapter plugin                             *
+*                  (c) 2006 Inria, University of Lille, CNRS                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: see Authors.md                                                     *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/config.h>
+#include <sofa/config/sharedlibrary_defines.h>
+
+#define SOFACUDA_GUI_VERSION @PROJECT_VERSION@
+
+#ifdef SOFA_BUILD_SOFACUDA_GUI
+#  define SOFA_TARGET @PROJECT_NAME@
+#  define SOFACUDA_GUI_API SOFA_EXPORT_DYNAMIC_LIBRARY
+#else
+#  define SOFACUDA_GUI_API SOFA_IMPORT_DYNAMIC_LIBRARY
+#endif
+
+namespace sofa::gpu::cuda::gui
+{
+    constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
+    constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
+} // namespace sofa::gpu::cuda::gui

--- a/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/init.cpp
+++ b/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/init.cpp
@@ -1,0 +1,83 @@
+/******************************************************************************
+*                              BeamAdapter plugin                             *
+*                  (c) 2006 Inria, University of Lille, CNRS                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: see Authors.md                                                     *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaCUDA/GUI/init.h>
+
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/helper/system/PluginManager.h>
+
+namespace sofa::gpu::cuda::gui
+{
+
+extern "C" {
+    SOFACUDA_GUI_API void initExternalModule();
+    SOFACUDA_GUI_API const char* getModuleLicense();
+    SOFACUDA_GUI_API const char* getModuleName();
+    SOFACUDA_GUI_API const char* getModuleVersion();
+    SOFACUDA_GUI_API const char* getModuleDescription();
+    SOFACUDA_GUI_API void registerObjects(sofa::core::ObjectFactory* factory);
+}
+
+void init()
+{
+    static bool first = true;
+    if (first)
+    {
+        // make sure that this plugin is registered into the PluginManager
+        sofa::helper::system::PluginManager::getInstance().registerPlugin(MODULE_NAME);
+        
+        first = false;
+    }
+}
+
+//Here are just several convenient functions to help user to know what contains the plugin
+
+void initExternalModule()
+{
+    init();
+}
+
+const char* getModuleLicense()
+{
+    return "LGPL";
+}
+
+const char* getModuleName()
+{
+    return MODULE_NAME;
+}
+
+const char* getModuleVersion()
+{
+    return MODULE_VERSION;
+}
+
+const char* getModuleDescription()
+{
+    return "OpenGL extension of the SofaCUDA plugin.";
+}
+
+void registerObjects(sofa::core::ObjectFactory* factory)
+{
+    SOFA_UNUSED(factory);
+}
+
+} // namespace sofa::gpu::cuda::gl

--- a/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/init.cpp
+++ b/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/init.cpp
@@ -24,6 +24,14 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/PluginManager.h>
 
+
+namespace sofa::gpu::cuda
+{
+
+extern void registerMouseInteractor(sofa::core::ObjectFactory* factory);
+
+}
+
 namespace sofa::gpu::cuda::gui
 {
 
@@ -77,7 +85,7 @@ const char* getModuleDescription()
 
 void registerObjects(sofa::core::ObjectFactory* factory)
 {
-    SOFA_UNUSED(factory);
+    sofa::gpu::cuda::registerMouseInteractor(factory);
 }
 
 } // namespace sofa::gpu::cuda::gl

--- a/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/init.h
+++ b/applications/plugins/SofaCUDA/extensions/GUI/src/SofaCUDA/GUI/init.h
@@ -1,0 +1,30 @@
+/******************************************************************************
+*                              BeamAdapter plugin                             *
+*                  (c) 2006 Inria, University of Lille, CNRS                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: see Authors.md                                                     *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <SofaCUDA/GUI/config.h>
+
+namespace sofa::gpu::cuda::gui
+{
+
+void SOFACUDA_GUI_API init();
+
+} // namespace sofa::gpu::cuda::gui

--- a/applications/plugins/SofaCUDA/src/SofaCUDA/init.cpp
+++ b/applications/plugins/SofaCUDA/src/SofaCUDA/init.cpp
@@ -122,9 +122,6 @@ extern void registerQuadSetGeometryAlgorithms(sofa::core::ObjectFactory* factory
 extern void registerTetrahedronSetGeometryAlgorithms(sofa::core::ObjectFactory* factory);
 extern void registerHexahedronSetGeometryAlgorithms(sofa::core::ObjectFactory* factory);
 
-// gui::component::performer;
-extern void registerMouseInteractor(sofa::core::ObjectFactory* factory);
-
 // SofaCUDA
 extern void registerTetrahedronTLEDForceField(sofa::core::ObjectFactory* factory);
 extern void registerHexahedronTLEDForceField(sofa::core::ObjectFactory* factory);
@@ -241,7 +238,6 @@ void registerObjects(sofa::core::ObjectFactory* factory)
     registerQuadSetGeometryAlgorithms(factory);
     registerTetrahedronSetGeometryAlgorithms(factory);
     registerHexahedronSetGeometryAlgorithms(factory);
-    registerMouseInteractor(factory);
 }
 
 }


### PR DESCRIPTION
based on 
- #5968 

Move the GUI-related part to an extension plugin SofaCUDA.GUI
and set the dependency on the narrower Sofa.GUI.Common

breaking 'cause one must now loadplugin  SofaCUDA.GUI in their scene
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
