### PR TITLE
[SofaCUDA] FixedProjectiveConstraint:  Fix for double templates

### DIFF
--- a/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/constraint/projective/CudaFixedProjectiveConstraint.inl
+++ b/applications/plugins/SofaCUDA/Component/src/SofaCUDA/component/constraint/projective/CudaFixedProjectiveConstraint.inl
@@ -328,7 +328,7 @@ void FixedProjectiveConstraintInternalData<gpu::cuda::CudaVec1fTypes>::projectRe
     const Data& data = *m->data;
     if (m->d_fixAll.getValue())
         FixedProjectiveConstraintCuda1f_projectResponseContiguous(dx.size(), ((float*)dx.deviceWrite()));
-    else if (data.minIndex >= 0)
+    else if (data.minIndex != sofa::InvalidID)
         FixedProjectiveConstraintCuda1f_projectResponseContiguous(data.maxIndex-data.minIndex+1, ((float*)dx.deviceWrite())+data.minIndex);
     else
         FixedProjectiveConstraintCuda1f_projectResponseIndexed(data.cudaIndices.size(), data.cudaIndices.deviceRead(), dx.deviceWrite());
@@ -392,7 +392,7 @@ void FixedProjectiveConstraintInternalData<gpu::cuda::CudaVec3dTypes>::projectRe
     Data& data = *m->data;
     if (m->d_fixAll.getValue())
         FixedProjectiveConstraintCuda3d_projectResponseContiguous(dx.size(), ((double*)dx.deviceWrite()));
-    else if (data.minIndex >= 0)
+    else if (data.minIndex != sofa::InvalidID)
         FixedProjectiveConstraintCuda3d_projectResponseContiguous(data.maxIndex-data.minIndex+1, ((double*)dx.deviceWrite())+3*data.minIndex);
     else
         FixedProjectiveConstraintCuda3d_projectResponseIndexed(data.cudaIndices.size(), data.cudaIndices.deviceRead(), dx.deviceWrite());
@@ -404,7 +404,7 @@ void FixedProjectiveConstraintInternalData<gpu::cuda::CudaVec3d1Types>::projectR
     Data& data = *m->data;
     if (m->d_fixAll.getValue())
         FixedProjectiveConstraintCuda3d1_projectResponseContiguous(dx.size(), ((double*)dx.deviceWrite()));
-    else if (data.minIndex >= 0)
+    else if (data.minIndex != sofa::InvalidID)
         FixedProjectiveConstraintCuda3d1_projectResponseContiguous(data.maxIndex-data.minIndex+1, ((double*)dx.deviceWrite())+4*data.minIndex);
     else
         FixedProjectiveConstraintCuda3d1_projectResponseIndexed(data.cudaIndices.size(), data.cudaIndices.deviceRead(), dx.deviceWrite());
@@ -416,7 +416,7 @@ void FixedProjectiveConstraintInternalData<gpu::cuda::CudaRigid3dTypes>::project
     Data& data = *m->data;
     if (m->d_fixAll.getValue())
         FixedProjectiveConstraintCudaRigid3d_projectResponseContiguous(dx.size(), ((double*)dx.deviceWrite()));
-    else if (data.minIndex >= 0)
+    else if (data.minIndex != sofa::InvalidID)
         FixedProjectiveConstraintCudaRigid3d_projectResponseContiguous(data.maxIndex-data.minIndex+1, ((double*)dx.deviceWrite())+6*data.minIndex);
     else
         FixedProjectiveConstraintCudaRigid3d_projectResponseIndexed(data.cudaIndices.size(), data.cudaIndices.deviceRead(), dx.deviceWrite());

--- a/applications/plugins/SofaCUDA/scenes/cpu-gpu_validation/CudaTetrahedronFEMForceField_cudavec3d_beam10x10x40_implicit.scn
+++ b/applications/plugins/SofaCUDA/scenes/cpu-gpu_validation/CudaTetrahedronFEMForceField_cudavec3d_beam10x10x40_implicit.scn
@@ -1,0 +1,97 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9 0" dt="0.01">
+<RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase BruteForceBroadPhase CollisionPipeline] -->
+<RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [DiscreteIntersection] -->
+<RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
+<RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
+<RequiredPlugin name="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+<RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
+<RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->
+<RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->
+<RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+<RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TetrahedronFEMForceField] -->
+<RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+<RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms TetrahedronSetTopologyContainer TetrahedronSetTopologyModifier TriangleSetGeometryAlgorithms TriangleSetTopologyContainer TriangleSetTopologyModifier] -->
+<RequiredPlugin name="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+<RequiredPlugin name="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping Tetra2TriangleTopologicalMapping] -->
+<RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
+<RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+<RequiredPlugin name="SofaCUDA"/> <!-- Needed to use components [BoxROI DiagonalMass FixedProjectiveConstraint IdentityMapping MechanicalObject TetrahedronFEMForceField TetrahedronSetGeometryAlgorithms TriangleSetGeometryAlgorithms] -->
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+	
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+    <CollisionPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <CollisionResponse response="PenalityContactForceField" />
+    <DiscreteIntersection/>
+    
+    <Node name="Beam">
+        <RegularGridTopology name="grid" n="40 10 10" min="0 6 -2" max="16 10 2" />
+        <TetrahedronSetTopologyContainer name="BeamTopo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+
+        <Hexa2TetraTopologicalMapping input="@grid" output="@BeamTopo" />
+    </Node>
+    
+    
+    <Node name="TetrahedronFEMForceField-GPU-Green">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="20" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="CudaVec3d"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="CudaVec3d" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedProjectiveConstraint indices="@ROI1.indices" />
+        <TetrahedronFEMForceField template="CudaVec3d" name="FEM" computeGlobalMatrix="false" method="large" poissonRatio="0.3" youngModulus="2000" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="CudaVec3d" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="green" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>
+    
+   
+    <Node name="TetrahedronFEMForceField-CPU-red">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="20" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="Vec3"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedProjectiveConstraint indices="@ROI1.indices" />
+        <TetrahedronFEMForceField template="Vec3" name="FEM" computeGlobalMatrix="false" method="large" poissonRatio="0.3" youngModulus="2000" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>   
+</Node>


### PR DESCRIPTION
Based on
- #5961

Bug fixed by Claude 🤖

The beam was not fixed when switching to CudaVec3d.

CudaVec3f (OK)
![tetra_cudavec3f_ok](https://github.com/user-attachments/assets/e77a3207-34e4-45d2-bb40-3ea61bfa56e5)

CudaVec3d (Bug)
![tetra_cudavec3d_bug](https://github.com/user-attachments/assets/f915b71b-eff4-4592-9239-e1ee267de90b)

CudaVec3d (after PR, OK)
![tetra_cudavec3d_ok](https://github.com/user-attachments/assets/e4363767-3884-4d0d-b54b-a737b1968b00)


and added the scene with the cudavec3d example
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
