### PR TITLE
[Helper] Add `getName` method to all `MessageHandler` implementations and update related tests

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/logging/PerComponentLoggingMessageHandler.h
+++ b/Sofa/framework/Core/src/sofa/core/logging/PerComponentLoggingMessageHandler.h
@@ -59,6 +59,7 @@ public:
 
     /// Inherited from MessageHandler
     void process(Message& m) override ;
+    std::string getName() const override { return "PerComponentLoggingMessageHandler"; }
 } ;
 
 ///

--- a/Sofa/framework/Core/test/visual/DisplayFlags_test.cpp
+++ b/Sofa/framework/Core/test/visual/DisplayFlags_test.cpp
@@ -61,6 +61,7 @@ public:
     {
         helper::logging::MessageDispatcher::rmHandler(this);
     }
+    std::string getName() const override { return "RAIIPerComponentLoggingMessageHandler"; }
 };
 
 TEST(DisplayFlags, readFromObject)

--- a/Sofa/framework/Helper/src/sofa/helper/logging/ClangMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/ClangMessageHandler.h
@@ -36,6 +36,7 @@ class SOFA_HELPER_API ClangMessageHandler : public MessageHandler
 {
 public:
     void process(Message &m) override ;
+    std::string getName() const override { return "ClangMessageHandler"; }
 };
 } // namespace sofa::helper::logging
 

--- a/Sofa/framework/Helper/src/sofa/helper/logging/ConsoleMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/ConsoleMessageHandler.h
@@ -44,6 +44,7 @@ public:
     /// DefaultStyleMessageFormatter object to format the message.
     ConsoleMessageHandler(MessageFormatter* formatter = nullptr);
     void process(Message &m) override ;
+    std::string getName() const override { return "ConsoleMessageHandler"; }
     void setMessageFormatter( MessageFormatter* formatter );
 
 private:

--- a/Sofa/framework/Helper/src/sofa/helper/logging/CountingMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/CountingMessageHandler.h
@@ -65,6 +65,7 @@ public:
 
     /// Inherited from MessageHandler
     void process(Message& m) override ;
+    std::string getName() const override { return "CountingMessageHandler"; }
 private:
     std::vector<int> m_countMatching ;
 } ;

--- a/Sofa/framework/Helper/src/sofa/helper/logging/ExceptionMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/ExceptionMessageHandler.h
@@ -53,7 +53,7 @@ public:
 
 
     void process(Message &m) override;
-
+    std::string getName() const override { return "ExceptionMessageHandler"; }
 };
 } // namespace sofa::helper::logging
 

--- a/Sofa/framework/Helper/src/sofa/helper/logging/FileMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/FileMessageHandler.h
@@ -46,6 +46,7 @@ public:
 
     ~FileMessageHandler() override;
     void process(Message& m) override ;
+    std::string getName() const override { return "FileMessageHandler"; }
 
     bool isValid(); // is output file ok ?
 

--- a/Sofa/framework/Helper/src/sofa/helper/logging/LoggingMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/LoggingMessageHandler.h
@@ -79,6 +79,8 @@ public:
     /// Inherited from MessageHandler
     void process(Message& m) override ;
 
+    std::string getName() const override { return "LoggingMessageHandler"; }
+
 private:
     int             m_activationCount    {0};
     vector<Message> m_messages ;

--- a/Sofa/framework/Helper/src/sofa/helper/logging/MessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/MessageHandler.h
@@ -40,6 +40,7 @@ class SOFA_HELPER_API MessageHandler
 public:
     virtual ~MessageHandler(){}
     virtual void process(Message& m) = 0 ;
+    virtual std::string getName() const = 0;
 };
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/logging/RoutingMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/RoutingMessageHandler.h
@@ -68,6 +68,7 @@ public:
 
     /// Inherited from MessageHandler
     void process(Message& m) override ;
+    std::string getName() const override { return "RoutingMessageHandler"; }
 
 private:
     std::vector<std::pair<FilterFunction, MessageHandler*> > m_filters;

--- a/Sofa/framework/Helper/src/sofa/helper/logging/SilentMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/SilentMessageHandler.h
@@ -40,6 +40,7 @@ class SOFA_HELPER_API SilentMessageHandler : public MessageHandler
 {
 public:
     void process(Message& /*m*/) override;
+    std::string getName() const override { return "SilentMessageHandler"; }
 };
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.h
+++ b/Sofa/framework/Helper/src/sofa/helper/logging/TracyMessageHandler.h
@@ -42,8 +42,9 @@ public:
     TracyMessageHandler(MessageFormatter* formatter = nullptr);
     void process(Message &m) override ;
     void setMessageFormatter( MessageFormatter* formatter );
+    std::string getName() const override { return "TracyMessageHandler"; }
 
-private:
+   private:
     MessageFormatter *m_formatter { nullptr };
 
 };

--- a/Sofa/framework/Helper/test/logging/logging_test.cpp
+++ b/Sofa/framework/Helper/test/logging/logging_test.cpp
@@ -73,6 +73,8 @@ public:
         m_messages.push_back(m);
     }
 
+    std::string getName() const override { return "MyMessageHandler" ; }
+
     size_t numMessages(){
         return m_messages.size() ;
     }
@@ -89,6 +91,7 @@ TEST(LoggingTest, noHandler)
 {
     // This test does not test anything, except the absence of crash
     MessageDispatcher::clearHandlers() ;
+    ASSERT_EQ(MessageDispatcher::getHandlers().size(), 0);
 
     msg_info("") << " info message with conversion" << 1.5 << "\n" ;
     msg_deprecated("") << " deprecated message with conversion" << 1.5 << "\n" ;
@@ -132,6 +135,20 @@ TEST(LoggingTest, duplicatedHandler)
     msg_error("") << " error message with conversion" << 1.5 << "\n" ;
 
     EXPECT_TRUE( h.numMessages() == 4u) ;
+}
+
+TEST(LoggingTest, rmHandler)
+{
+    MessageDispatcher::clearHandlers();
+
+    MyMessageHandler h;
+
+    // First add is expected to return the handler ID.
+    EXPECT_TRUE(MessageDispatcher::addHandler(&h) == 0);
+
+    EXPECT_EQ(MessageDispatcher::rmHandler(&h), -1);
+
+    EXPECT_EQ(MessageDispatcher::getHandlers().size(), 0);
 }
 
 void f1()

--- a/Sofa/framework/Testing/src/sofa/testing/TestMessageHandler.cpp
+++ b/Sofa/framework/Testing/src/sofa/testing/TestMessageHandler.cpp
@@ -92,6 +92,8 @@ public:
 
     /// Inherited from MessageHandler
     void process(Message& m) override ;
+    std::string getName() const override { return "GtestMessageHandler"; }
+
     void pushFrame(Message::Type type, GtestMessageFrame* frame)  ;
     void popFrame(Message::Type type) ;
 };


### PR DESCRIPTION
It helps for debugging

Breaking because the newly added method is pure virtual.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
