### PR TITLE
[Topology.Mapping] Refactor Hexa2TetraTopologicalMapping to improve readability and add unit tests

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -1339,34 +1339,33 @@ void TetrahedronFEMForceField<DataTypes>::init()
             if (!((i%nx)&1))
             {
                 // swap all points on the X edges
-                std::swap(c[0],c[1]);
-                std::swap(c[3],c[2]);
-                std::swap(c[4],c[5]);
-                std::swap(c[7],c[6]);
+                for (const auto [v0, v1] : sofa::geometry::Hexahedron::xEdges)
+                {
+                    std::swap(c[v0], c[v1]);
+                }
             }
             if (((i/nx)%ny)&1)
             {
                 // swap all points on the Y edges
-                std::swap(c[0],c[3]);
-                std::swap(c[1],c[2]);
-                std::swap(c[4],c[7]);
-                std::swap(c[5],c[6]);
+                for (const auto [v0, v1] : sofa::geometry::Hexahedron::yEdges)
+                {
+                    std::swap(c[v0], c[v1]);
+                }
             }
             if ((i/(nx*ny))&1)
             {
                 // swap all points on the Z edges
-                std::swap(c[0],c[4]);
-                std::swap(c[1],c[5]);
-                std::swap(c[2],c[6]);
-                std::swap(c[3],c[7]);
+                for (const auto [v0, v1] : sofa::geometry::Hexahedron::zEdges)
+                {
+                    std::swap(c[v0], c[v1]);
+                }
             }
-            typedef core::topology::BaseMeshTopology::Tetra Tetra;
-            tetrahedra->push_back(Tetra(c[0],c[5],c[1],c[6]));
-            tetrahedra->push_back(Tetra(c[0],c[1],c[3],c[6]));
-            tetrahedra->push_back(Tetra(c[1],c[3],c[6],c[2]));
-            tetrahedra->push_back(Tetra(c[6],c[3],c[0],c[7]));
-            tetrahedra->push_back(Tetra(c[6],c[7],c[0],c[5]));
-            tetrahedra->push_back(Tetra(c[7],c[5],c[4],c[0]));
+            tetrahedra->emplace_back(c[0],c[5],c[1],c[6]);
+            tetrahedra->emplace_back(c[0],c[1],c[3],c[6]);
+            tetrahedra->emplace_back(c[1],c[3],c[6],c[2]);
+            tetrahedra->emplace_back(c[6],c[3],c[0],c[7]);
+            tetrahedra->emplace_back(c[6],c[7],c[0],c[5]);
+            tetrahedra->emplace_back(c[7],c[5],c[4],c[0]);
         }
        _indexedElements = tetrahedra;
     }

--- a/Sofa/Component/Topology/Mapping/CMakeLists.txt
+++ b/Sofa/Component/Topology/Mapping/CMakeLists.txt
@@ -46,3 +46,11 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
 )
+
+# Tests
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(SOFA_COMPONENT_TOPOLOGY_MAPPING_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(SOFA_COMPONENT_TOPOLOGY_MAPPING_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Hexa2TetraTopologicalMapping.cpp
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Hexa2TetraTopologicalMapping.cpp
@@ -51,15 +51,13 @@ void registerHexa2TetraTopologicalMapping(sofa::core::ObjectFactory* factory)
 }
 
 Hexa2TetraTopologicalMapping::Hexa2TetraTopologicalMapping()
-    : sofa::core::topology::TopologicalMapping()
-    , d_swapping(initData(&d_swapping, false, "swapping", "Boolean enabling to swapp hexa-edges\n in order to avoid bias effect"))
+    : sofa::core::topology::TopologicalMapping(),
+      d_swapping(initData(&d_swapping, false, "swapping",
+                          "Boolean enabling to swap edges to hexahedrons based on their grid "
+                          "position in order to avoid numerical bias effect"))
 {
     m_inputType = geometry::ElementType::HEXAHEDRON;
     m_outputType = geometry::ElementType::TETRAHEDRON;
-}
-
-Hexa2TetraTopologicalMapping::~Hexa2TetraTopologicalMapping()
-{
 }
 
 void Hexa2TetraTopologicalMapping::init()
@@ -87,88 +85,122 @@ void Hexa2TetraTopologicalMapping::init()
     Loc2GlobVec.clear();
     Glob2LocMap.clear();
 
-    const size_t nbcubes = fromModel->getNbHexahedra();
+    const sofa::Size nbCubes = fromModel->getNbHexahedra();
 
     // These values are only correct if the mesh is a grid topology
     int nx = 2;
     int ny = 1;
-    //int nz = 1;
+    // int nz = 1;
     {
         const auto* grid = dynamic_cast<container::grid::GridTopology*>(fromModel.get());
         if (grid != nullptr)
         {
-            nx = grid->getNx()-1;
-            ny = grid->getNy()-1;
-            //nz = grid->getNz()-1;
+            nx = grid->getNx() - 1;
+            ny = grid->getNy() - 1;
+            // nz = grid->getNz()-1;
         }
     }
 
     static constexpr int numberTetraInHexa = 6;
-    Loc2GlobVec.reserve(nbcubes*numberTetraInHexa);
+    Loc2GlobVec.reserve(nbCubes * numberTetraInHexa);
 
     const bool swapping = d_swapping.getValue();
 
     // Tessellation of each cube into 6 tetrahedra
-    for (size_t i = 0; i < nbcubes; ++i)
+    for (sofa::Index i = 0; i < nbCubes; ++i)
     {
-        core::topology::BaseMeshTopology::Hexa c = fromModel->getHexahedron(i);
+        // take a copy of the hexahedron in case vertices must be swapped
+        sofa::topology::Hexahedron c = fromModel->getHexahedron(i);
 
         bool swapped = false;
 
-        if(swapping)
+        if (swapping)
         {
-            if (!((i%nx)&1))
+            // Check if hexahedron is at an even x-position in the grid
+            if (!((i % nx) & 1))
             {
-                // swap all points on the X edges
-                std::swap(c[0],c[1]);
-                std::swap(c[3],c[2]);
-                std::swap(c[4],c[5]);
-                std::swap(c[7],c[6]);
+                // swap all nodes on the X edges
+                //     Y  n3---------n2             Y  n2---------n3
+                //     ^  /          /|             ^  /          /|
+                //     | /          / |             | /          / |
+                //     n7---------n6  |             n6---------n7  |
+                //     |          |   |             |          |   |
+                //     |  n0------|--n1      =>     |  n1------|--n0
+                //     | /        | /               | /        | /
+                //     |/         |/                |/         |/
+                //     n4---------n5-->X            n5---------n4-->X
+                //    /                            /
+                //   /                            /
+                //  Z                            Z
+                for (const auto [v0, v1] : sofa::geometry::Hexahedron::xEdges)
+                {
+                    std::swap(c[v0], c[v1]);
+                }
                 swapped = !swapped;
             }
-            if (((i/nx)%ny)&1)
+            // Check if hexahedron is at an odd y-position in the grid
+            if (((i / nx) % ny) & 1)
             {
-                // swap all points on the Y edges
-                std::swap(c[0],c[3]);
-                std::swap(c[1],c[2]);
-                std::swap(c[4],c[7]);
-                std::swap(c[5],c[6]);
+                // swap all nodes on the Y edges
+                //     Y  n3---------n2             Y  n0---------n1
+                //     ^  /          /|             ^  /          /|
+                //     | /          / |             | /          / |
+                //     n7---------n6  |             n4---------n5  |
+                //     |          |   |             |          |   |
+                //     |  n0------|--n1      =>     |  n3------|--n2
+                //     | /        | /               | /        | /
+                //     |/         |/                |/         |/
+                //     n4---------n5-->X            n7---------n6-->X
+                //    /                            /
+                //   /                            /
+                //  Z                            Z
+                for (const auto [v0, v1] : sofa::geometry::Hexahedron::yEdges)
+                {
+                    std::swap(c[v0], c[v1]);
+                }
                 swapped = !swapped;
             }
-            if ((i/(nx*ny))&1)
+            // Check if hexahedron is at an odd z-position in the grid
+            if ((i / (nx * ny)) & 1)
             {
-                // swap all points on the Z edges
-                std::swap(c[0],c[4]);
-                std::swap(c[1],c[5]);
-                std::swap(c[2],c[6]);
-                std::swap(c[3],c[7]);
+                // swap all nodes on the Z edges
+                //     Y  n3---------n2             Y  n7---------n6
+                //     ^  /          /|             ^  /          /|
+                //     | /          / |             | /          / |
+                //     n7---------n6  |             n3---------n2  |
+                //     |          |   |             |          |   |
+                //     |  n0------|--n1      =>     |  n4------|--n5
+                //     | /        | /               | /        | /
+                //     |/         |/                |/         |/
+                //     n4---------n5-->X            n0---------n1-->X
+                //    /                            /
+                //   /                            /
+                //  Z                            Z
+                for (const auto [v0, v1] : sofa::geometry::Hexahedron::zEdges)
+                {
+                    std::swap(c[v0], c[v1]);
+                }
                 swapped = !swapped;
             }
         }
 
-        if(!swapped)
+        static constexpr std::array<std::array<sofa::Index, 4>, 6> nonSwappedPattern{
+            {{0, 5, 1, 6}, {0, 1, 3, 6}, {1, 3, 6, 2}, {6, 3, 0, 7}, {6, 7, 0, 5}, {7, 5, 4, 0}}};
+
+        static constexpr std::array<std::array<sofa::Index, 4>, 6> swappedPattern{
+            {{0, 5, 6, 1}, {0, 1, 6, 3}, {1, 3, 2, 6}, {6, 3, 7, 0}, {6, 7, 5, 0}, {7, 5, 0, 4}}};
+
+        const auto& pattern = swapped ? swappedPattern : nonSwappedPattern;
+        for (const auto& id : pattern)
         {
-            toModel->addTetra(c[0],c[5],c[1],c[6]);
-            toModel->addTetra(c[0],c[1],c[3],c[6]);
-            toModel->addTetra(c[1],c[3],c[6],c[2]);
-            toModel->addTetra(c[6],c[3],c[0],c[7]);
-            toModel->addTetra(c[6],c[7],c[0],c[5]);
-            toModel->addTetra(c[7],c[5],c[4],c[0]);
+            toModel->addTetra(c[id[0]], c[id[1]], c[id[2]], c[id[3]]);
         }
-        else
-        {
-            toModel->addTetra(c[0],c[5],c[6],c[1]);
-            toModel->addTetra(c[0],c[1],c[6],c[3]);
-            toModel->addTetra(c[1],c[3],c[2],c[6]);
-            toModel->addTetra(c[6],c[3],c[7],c[0]);
-            toModel->addTetra(c[6],c[7],c[5],c[0]);
-            toModel->addTetra(c[7],c[5],c[0],c[4]);
-        }
+
         for (int j = 0; j < numberTetraInHexa; j++)
         {
             Loc2GlobVec.push_back(i);
         }
-        Glob2LocMap[i] = static_cast<unsigned int>(Loc2GlobVec.size()) -1;
+        Glob2LocMap[i] = static_cast<unsigned int>(Loc2GlobVec.size()) - 1;
     }
 
     // Need to fully init the target topology
@@ -177,16 +209,14 @@ void Hexa2TetraTopologicalMapping::init()
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
-Index Hexa2TetraTopologicalMapping::getFromIndex(Index /*ind*/)
-{
-    return sofa::InvalidID;
-}
-
 void Hexa2TetraTopologicalMapping::updateTopologicalMappingTopDown()
 {
-    msg_warning() << "Method Hexa2TetraTopologicalMapping::updateTopologicalMappingTopDown() not yet implemented!";
-// TODO...
+    msg_warning() << "Method Hexa2TetraTopologicalMapping::updateTopologicalMappingTopDown() not "
+                     "yet implemented!";
+    // TODO...
 }
+
+Index Hexa2TetraTopologicalMapping::getFromIndex(Index /*ind*/) { return sofa::InvalidID; }
 
 
 } //namespace sofa::component::topology::mapping

--- a/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Hexa2TetraTopologicalMapping.h
+++ b/Sofa/Component/Topology/Mapping/src/sofa/component/topology/mapping/Hexa2TetraTopologicalMapping.h
@@ -53,11 +53,6 @@ protected:
     */
     Hexa2TetraTopologicalMapping();
 
-    /** \brief Destructor.
-    *
-    * Does nothing.
-    */
-    ~Hexa2TetraTopologicalMapping() override;
 public:
     /** \brief Initializes the target BaseTopology from the source BaseTopology.
     */

--- a/Sofa/Component/Topology/Mapping/tests/CMakeLists.txt
+++ b/Sofa/Component/Topology/Mapping/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(Sofa.Component.Topology.Mapping_test)
+
+set(SOURCE_FILES
+    Hexa2TetraTopologicalMapping_test.cpp
+)
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Component.Topology.Testing)
+target_link_libraries(${PROJECT_NAME} Sofa.Component.Topology.Mapping)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/Sofa/Component/Topology/Mapping/tests/Hexa2TetraTopologicalMapping_test.cpp
+++ b/Sofa/Component/Topology/Mapping/tests/Hexa2TetraTopologicalMapping_test.cpp
@@ -1,0 +1,284 @@
+#include <gtest/gtest.h>
+#include <sofa/component/topology/mapping/Hexa2TetraTopologicalMapping.h>
+#include <sofa/component/topology/container/grid/GridTopology.h>
+#include <sofa/component/topology/container/dynamic/TetrahedronSetTopologyContainer.h>
+
+// Test 1: Invalid input handling
+TEST(Hexa2TetraTopologicalMappingTest, InvalidInputHandling)
+{
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    // Test without setting input/output
+    EXPECT_NE(mapping->d_componentState.getValue(),
+              sofa::core::objectmodel::ComponentState::Valid);
+}
+
+// Test 2: Verify correct tetrahedron count
+TEST(Hexa2TetraTopologicalMappingTest, TetrahedronCountForVariousGridSizes)
+{
+    // Test different grid sizes
+    std::vector<std::pair<sofa::type::Vec3i, size_t>> gridSizes = {
+        {{2, 2, 2}, 6},      // 1 hexa -> 6 tetras
+        {{3, 2, 2}, 12},     // 2 hexas -> 12 tetras
+        {{3, 3, 2}, 24},     // 4 hexas -> 24 tetras
+        {{3, 3, 3}, 48}      // 8 hexas -> 48 tetras
+    };
+
+    for (const auto& [gridSize, expectedTetras] : gridSizes)
+    {
+        auto grid = sofa::core::objectmodel::New<
+            sofa::component::topology::container::grid::GridTopology>(gridSize);
+
+        auto tetraTopo = sofa::core::objectmodel::New<
+            sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+        auto mapping = sofa::core::objectmodel::New<
+            sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+        mapping->setTopologies(grid.get(), tetraTopo.get());
+        mapping->init();
+
+        EXPECT_EQ(tetraTopo->getNbTetrahedra(), expectedTetras)
+            << "Failed for grid size " << gridSize;
+    }
+}
+
+// Test 3: Verify vertex consistency
+TEST(Hexa2TetraTopologicalMappingTest, VertexConsistency)
+{
+    auto grid = sofa::core::objectmodel::New<
+        sofa::component::topology::container::grid::GridTopology>(3, 3, 3);
+
+    auto tetraTopo = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    mapping->setTopologies(grid.get(), tetraTopo.get());
+    mapping->init();
+
+    // Verify same number of points
+    ASSERT_EQ(tetraTopo->getNbPoints(), grid->getNbPoints());
+}
+
+// Test 4: Test with swapping enabled
+TEST(Hexa2TetraTopologicalMappingTest, SwappingParameter)
+{
+    auto grid = sofa::core::objectmodel::New<
+        sofa::component::topology::container::grid::GridTopology>(3, 3, 3);
+
+    // Test without swapping
+    auto tetraTopo1 = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping1 = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+    mapping1->d_swapping.setValue(false);
+    mapping1->setTopologies(grid.get(), tetraTopo1.get());
+    mapping1->init();
+
+    // Test with swapping
+    auto tetraTopo2 = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping2 = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+    mapping2->d_swapping.setValue(true);
+    mapping2->setTopologies(grid.get(), tetraTopo2.get());
+    mapping2->init();
+
+    // Both should have same number of tetrahedra
+    ASSERT_EQ(tetraTopo1->getNbTetrahedra(), tetraTopo2->getNbTetrahedra());
+}
+
+// Test 5: Verify tetrahedron validity (valid indices)
+TEST(Hexa2TetraTopologicalMappingTest, TetrahedronValidity)
+{
+    auto grid = sofa::core::objectmodel::New<
+        sofa::component::topology::container::grid::GridTopology>(3, 3, 3);
+
+    auto tetraTopo = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    mapping->setTopologies(grid.get(), tetraTopo.get());
+    mapping->init();
+
+    const sofa::Size nbPoints = tetraTopo->getNbPoints();
+
+    // Check all tetrahedra have valid vertex indices
+    for (size_t i = 0; i < tetraTopo->getNbTetrahedra(); ++i)
+    {
+        auto tetra = tetraTopo->getTetrahedron(i);
+        EXPECT_LT(tetra[0], nbPoints);
+        EXPECT_LT(tetra[1], nbPoints);
+        EXPECT_LT(tetra[2], nbPoints);
+        EXPECT_LT(tetra[3], nbPoints);
+    }
+}
+
+// Test 6: Local-to-global mapping consistency
+TEST(Hexa2TetraTopologicalMappingTest, LocalToGlobalMapping)
+{
+    auto grid = sofa::core::objectmodel::New<
+        sofa::component::topology::container::grid::GridTopology>(3, 3, 3);
+
+    auto tetraTopo = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    mapping->setTopologies(grid.get(), tetraTopo.get());
+    mapping->init();
+
+    // Verify mapping data structures
+    // Each hexahedron should map to 6 tetrahedra
+    const sofa::Size expectedSize = grid->getNbHexahedra() * 6;
+    EXPECT_EQ(mapping->Loc2GlobDataVec.getValue().size(), expectedSize);
+}
+
+// Test 7: Verify tetrahedra output for single hexahedron without swapping
+TEST(Hexa2TetraTopologicalMappingTest, SingleHexahedronOutputNoSwapping)
+{
+    // Create a 2x2x2 grid (1 hexahedron)
+    auto grid = sofa::core::objectmodel::New<
+        sofa::component::topology::container::grid::GridTopology>(2, 2, 2);
+
+    auto tetraTopo = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    mapping->d_swapping.setValue(false);
+    mapping->setTopologies(grid.get(), tetraTopo.get());
+    mapping->init();
+
+    // Get the hexahedron vertices (for a 2x2x2 grid, there's one hexahedron)
+    auto hexa = grid->getHexahedron(0);
+
+    // Verify we have exactly 6 tetrahedra
+    ASSERT_EQ(tetraTopo->getNbTetrahedra(), 6);
+
+    // Expected tetrahedra based on the decomposition pattern without swapping
+    // Pattern from Hexa2TetraTopologicalMapping.cpp:
+    const std::array expectedTetras = {
+        sofa::topology::Tetrahedron{hexa[0], hexa[5], hexa[1], hexa[6]},
+        sofa::topology::Tetrahedron{hexa[0], hexa[1], hexa[3], hexa[6]},
+        sofa::topology::Tetrahedron{hexa[1], hexa[3], hexa[6], hexa[2]},
+        sofa::topology::Tetrahedron{hexa[6], hexa[3], hexa[0], hexa[7]},
+        sofa::topology::Tetrahedron{hexa[6], hexa[7], hexa[0], hexa[5]},
+        sofa::topology::Tetrahedron{hexa[7], hexa[5], hexa[4], hexa[0]},
+    };
+
+    for (sofa::Size i = 0; i < tetraTopo->getNbTetrahedra(); ++i)
+    {
+        auto tetra = tetraTopo->getTetrahedron(i);
+        for (sofa::Index j = 0; j < 4; ++j)
+        {
+            EXPECT_EQ(tetra[j], expectedTetras[i][j]) << "Failed for tetra " << i << " at index " << j;
+        }
+    }
+}
+
+// Test 8: Verify tetrahedra output for single hexahedron with swapping
+TEST(Hexa2TetraTopologicalMappingTest, SingleHexahedronOutputWithSwapping)
+{
+    // Create a 2x2x2 grid (1 hexahedron)
+    auto grid = sofa::core::objectmodel::New<
+        sofa::component::topology::container::grid::GridTopology>(2, 2, 2);
+
+    auto tetraTopo = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    mapping->d_swapping.setValue(true);
+    mapping->setTopologies(grid.get(), tetraTopo.get());
+    mapping->init();
+
+    // Get the hexahedron vertices
+    auto hexa = grid->getHexahedron(0);
+
+    // Verify we have exactly 6 tetrahedra
+    ASSERT_EQ(tetraTopo->getNbTetrahedra(), 6);
+
+    // Expected tetrahedra based on the decomposition pattern with swapping
+    const std::array expectedTetras = {
+        sofa::topology::Tetrahedron{hexa[1], hexa[4], hexa[7], hexa[0]},
+        sofa::topology::Tetrahedron{hexa[1], hexa[0], hexa[7], hexa[2]},
+        sofa::topology::Tetrahedron{hexa[0], hexa[2], hexa[3], hexa[7]},
+        sofa::topology::Tetrahedron{hexa[7], hexa[2], hexa[6], hexa[1]},
+        sofa::topology::Tetrahedron{hexa[7], hexa[6], hexa[4], hexa[1]},
+        sofa::topology::Tetrahedron{hexa[6], hexa[4], hexa[1], hexa[5]},
+    };
+
+    for (sofa::Size i = 0; i < tetraTopo->getNbTetrahedra(); ++i)
+    {
+        auto tetra = tetraTopo->getTetrahedron(i);
+        for (sofa::Index j = 0; j < 4; ++j)
+        {
+            EXPECT_EQ(tetra[j], expectedTetras[i][j]) << "Failed for tetra " << i << " at index " << j;
+        }
+    }
+}
+
+// Test 9: Verify all tetrahedra vertices belong to source hexahedron
+TEST(Hexa2TetraTopologicalMappingTest, AllTetrahedraVerticesBelongToSourceHexa)
+{
+    // Create a 3x3x3 grid (8 hexahedra)
+    auto grid = sofa::core::objectmodel::New<sofa::component::topology::container::grid::GridTopology>(3, 3, 3);
+
+    auto tetraTopo = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    mapping->setTopologies(grid.get(), tetraTopo.get());
+    mapping->init();
+
+    // For each hexahedron, verify that its 6 tetrahedra use only vertices from that hexahedron
+    size_t nbHexas = grid->getNbHexahedra();
+    for (size_t hexaIdx = 0; hexaIdx < nbHexas; ++hexaIdx)
+    {
+        auto hexa = grid->getHexahedron(hexaIdx);
+        std::set<sofa::Index> hexaVertices(hexa.begin(), hexa.end());
+
+        // Check the 6 tetrahedra corresponding to this hexahedron
+        for (size_t localTetraIdx = 0; localTetraIdx < 6; ++localTetraIdx)
+        {
+            size_t globalTetraIdx = hexaIdx * 6 + localTetraIdx;
+            auto tetra = tetraTopo->getTetrahedron(globalTetraIdx);
+
+            // All 4 vertices of the tetrahedron must be in the hexahedron
+            for (int i = 0; i < 4; ++i)
+            {
+                EXPECT_TRUE(hexaVertices.find(tetra[i]) != hexaVertices.end())
+                    << "Tetrahedron " << globalTetraIdx << " vertex " << i
+                    << " (index " << tetra[i] << ") does not belong to hexahedron " << hexaIdx;
+            }
+        }
+    }
+}
+
+// Test 10: Verify tetrahedra have unique vertices (no degenerate tetrahedra)
+TEST(Hexa2TetraTopologicalMappingTest, NoDegenerateTetrahedra)
+{
+    auto grid = sofa::core::objectmodel::New<sofa::component::topology::container::grid::GridTopology>(3, 3, 3);
+
+    auto tetraTopo = sofa::core::objectmodel::New<
+        sofa::component::topology::container::dynamic::TetrahedronSetTopologyContainer>();
+    auto mapping = sofa::core::objectmodel::New<
+        sofa::component::topology::mapping::Hexa2TetraTopologicalMapping>();
+
+    mapping->setTopologies(grid.get(), tetraTopo.get());
+    mapping->init();
+
+    // Check that all tetrahedra have 4 unique vertices
+    for (size_t i = 0; i < tetraTopo->getNbTetrahedra(); ++i)
+    {
+        auto tetra = tetraTopo->getTetrahedron(i);
+        std::set<sofa::Index> uniqueVertices(tetra.begin(), tetra.end());
+
+        EXPECT_EQ(uniqueVertices.size(), 4)
+            << "Tetrahedron " << i << " has duplicate vertices";
+    }
+}

--- a/Sofa/framework/Geometry/src/sofa/geometry/Hexahedron.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Hexahedron.h
@@ -58,6 +58,36 @@ struct Hexahedron
     //  Z
 
     /**
+     * @brief Defines the edges of a hexahedron along the X-axis.
+     *
+     * This variable represents the edges of a hexahedron that are parallel to the X-axis according
+     * to the conventional node numbering. It consists of an array of 4 pairs, each pair containing
+     * the indices of the two nodes that form an edge along the X-axis.
+     */
+    static constexpr std::array<std::pair<sofa::Size, sofa::Size>, 4> xEdges{
+        {{0, 1}, {4, 5}, {3, 2}, {7, 6}}};
+
+    /**
+     * @brief Defines the edges of a hexahedron along the Y-axis.
+     *
+     * This variable represents the edges of a hexahedron that are parallel to the Y-axis according
+     * to the conventional node numbering. It consists of an array of 4 pairs, each pair containing
+     * the indices of the two nodes that form an edge along the Y-axis.
+     */
+    static constexpr std::array<std::pair<sofa::Size, sofa::Size>, 4> yEdges{
+        {{4, 7}, {5, 6}, {1, 2}, {0, 3}}};
+
+    /**
+     * @brief Defines the edges of a hexahedron along the Z-axis.
+     *
+     * This variable represents the edges of a hexahedron that are parallel to the Z-axis according
+     * to the conventional node numbering. It consists of an array of 4 pairs, each pair containing
+     * the indices of the two nodes that form an edge along the Z-axis.
+     */
+    static constexpr std::array<std::pair<sofa::Size, sofa::Size>, 4> zEdges{
+        {{4, 0}, {5, 1}, {6, 2}, {7, 3}}};
+
+    /**
     * @brief	Compute the center of a hexahedron
     * @remark	The order of nodes given as parameter is not necessary.
     * @tparam   Node iterable container, with operator[]


### PR DESCRIPTION
Based on https://github.com/sofa-framework/sofa/pull/5947

This PR refactors the `Hexa2TetraTopologicalMapping` to improve its readability and maintainability. It introduces static arrays for defining tetrahedron patterns and uses loops with these patterns for creating tetrahedra, replacing explicit individual calls. The commit also adds comprehensive unit tests to ensure the correct functionality of the mapping, including edge swapping logic and various grid configurations. These changes aim to make the code more robust and easier to understand.

Here's a list of the main changes:
- **Refactoring of :`Hexa2TetraTopologicalMapping.cpp`** The code has been cleaned up by replacing explicit vertex swapping for X, Y, and Z edges with loops iterating over `sofa::geometry::Hexahedron::xEdges`, `yEdges`, and `zEdges`. The direct addition of tetrahedra has also been refactored to use predefined patterns, improving readability.
- **Introduction of Test Cases:** New unit tests have been added in `Hexa2TetraTopologicalMapping_test.cpp` to cover various aspects of the mapping, including:
    - Handling of invalid inputs.
    - Verification of tetrahedron counts for different grid sizes.
    - Consistency of vertex counts between input hexahedra and output tetrahedra.
    - Testing the `swapping` parameter.
    - Ensuring tetrahedron vertex indices are valid.
    - Consistency of local-to-global mapping.
    - Specific output verification for single hexahedra with and without swapping.
    - Verification that all tetrahedron vertices belong to their source hexahedron.
    - Checking for degenerate tetrahedra.

- **Enhancements to :`Hexahedron.h`** Static constant arrays (`xEdges`, `yEdges`, `zEdges`) have been added to  `Hexahedron.h` to define the edges along each axis, which are then used in the mapping logic.

[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
