### PR TITLE
[Core] Remove deprecated compatibility layer

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClassNameHelper.h
@@ -85,34 +85,6 @@ public:
     enum { value = sizeof(test<T>(0)) == sizeof(YesType) };
 };
 
-//TODO(dmarchal: 01/04/2020) This is for compatibility layer, remove it after 01/01/2021
-template<class T>
-class HasGetDefaultTemplateName
-{
-    typedef char YesType[1];
-    typedef char NoType[2];
-
-    template<typename C> static YesType& test( decltype (&C::GetDefaultTemplateName) );
-    template<typename C> static NoType& test(...);
-
-public:
-    enum { value = sizeof(test<T>(0)) == sizeof(YesType) };
-};
-
-//TODO(dmarchal: 01/04/2020) This is for compatibility layer, remove it after 01/01/2021
-template<class T>
-class HasDeprecatedTemplateName
-{
-    typedef char YesType[1];
-    typedef char NoType[2];
-
-    template<typename C> static YesType& test( decltype (&C::templateName) );
-    template<typename C> static NoType& test(...);
-
-public:
-    enum { value = sizeof(test<T>(0)) == sizeof(YesType) };
-};
-
 template<class T>
 class HasDeprecatedShortName
 {
@@ -120,20 +92,6 @@ class HasDeprecatedShortName
     typedef char NoType[2];
 
     template<typename C> static YesType& test(decltype(&C::template shortName<C>));
-    template<typename C> static NoType& test(...);
-
-public:
-    enum { value = sizeof(test<T>(0)) == sizeof(YesType) };
-};
-
-//TODO(dmarchal: 01/04/2020) This is for compatibility layer, remove it after 01/01/2021
-template<class T>
-class HasDeprecatedClassName
-{
-    typedef char YesType[1];
-    typedef char NoType[2];
-
-    template<typename C> static YesType& test( decltype (&C::className) );
     template<typename C> static NoType& test(...);
 
 public:
@@ -208,7 +166,10 @@ private:
             const std::string n = T::template shortName<T>(ptr);
             return n;
         }
-        return sofa::helper::NameDecoder::shortName(getOverridableClassName<T>());
+        else
+        {
+            return sofa::helper::NameDecoder::shortName(getOverridableClassName<T>());
+        }
     }
 
     template<class T>
@@ -216,19 +177,14 @@ private:
     {
         /// If there is a Get CustomClassName method in T we use it to return the name
         if constexpr (HasGetCustomClassName<T>::value)
-                return T::GetCustomClassName();
-
-        //TODO(dmarchal 01/04/2020): compatibility layer, remove after 01/01/2020
-        // use the className method.
-        if constexpr (HasDeprecatedClassName<T>::value)
         {
-            T* ptr {nullptr};
-            const std::string& n = T::className(ptr);
-            return n;
+            return T::GetCustomClassName();
         }
-
-        /// If nothing works we decode the class name from the typeid.
-        return sofa::helper::NameDecoder::decodeClassName(typeid(T));
+        else
+        {
+            /// If nothing works we decode the class name from the typeid.
+            return sofa::helper::NameDecoder::decodeClassName(typeid(T));
+        }
     }
 
     template<class T>
@@ -237,24 +193,14 @@ private:
         /// If the T object implement a GetCustomTemplateName static method... then we
         /// use that to return the name.
         if constexpr (HasGetCustomTemplateName<T>::value)
-                return T::GetCustomTemplateName();
-
-        //TODO(dmarchal 01/04/2020): compatibility layer, remove after 01/01/2020
-        // use the templateName method.
-        if constexpr (HasDeprecatedTemplateName<T>::value)
         {
-            T* ptr {nullptr};
-            const std::string n = T::templateName(ptr);
-            return n;
+            return T::GetCustomTemplateName();
         }
-
-        /// A GetDefaultTemplateName method is added by the SOFA_CLASS macro, if the object is
-        /// has not better option it will use this one.
-        if constexpr (HasGetDefaultTemplateName<T>::value)
-                return T::GetDefaultTemplateName();
-
-        /// Finally if nothing matches, decode the template name from the typeid
-        return sofa::helper::NameDecoder::decodeTemplateName(typeid(T));
+        else
+        {
+            /// Finally if nothing matches, decode the template name from the typeid
+            return sofa::helper::NameDecoder::decodeTemplateName(typeid(T));
+        }
     }
 };
 
@@ -262,9 +208,9 @@ template<typename T>
 std::string GetSofaTypeTemplateName(const std::string prefix)
 {
     if constexpr (HasName<T>::value )
-            return prefix + T::Name();
+        return prefix + T::Name();
     else if constexpr (HasDataTypeInfo<T>::value )
-            return prefix + sofa::defaulttype::DataTypeInfo<T, void>::name();
+        return prefix + sofa::defaulttype::DataTypeInfo<T, void>::name();
     else
         return prefix + sofa::helper::NameDecoder::decodeTypeName(typeid(T));
 }


### PR DESCRIPTION
As the comment suggested.

This PR also adds a `else` statement to the `if constexpr` branches to remove the spamming warnings (`Warning C4702 : unreachable code`).



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
