### PR TITLE
[Core] Use `toBaseComponent()` instead of `toBaseObject()`

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
@@ -209,8 +209,8 @@ std::string BaseLink::CreateString(const std::string& path, const std::string& d
 std::string BaseLink::CreateStringPath(Base* dest, Base* from)
 {
     if (!dest || dest == from) return std::string("[]");
-    BaseObject* o = dest->toBaseObject();
-    BaseObject* f = from->toBaseObject();
+    BaseObject* o = dest->toBaseComponent()();
+    BaseObject* f = from->toBaseComponent()();
     const BaseContext* ctx = from->toBaseContext();
     if (!ctx && f) ctx = f->getContext();
     if (o)

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
@@ -209,8 +209,8 @@ std::string BaseLink::CreateString(const std::string& path, const std::string& d
 std::string BaseLink::CreateStringPath(Base* dest, Base* from)
 {
     if (!dest || dest == from) return std::string("[]");
-    BaseObject* o = dest->toBaseComponent()();
-    BaseObject* f = from->toBaseComponent()();
+    BaseObject* o = dest->toBaseComponent();
+    BaseObject* f = from->toBaseComponent();
     const BaseContext* ctx = from->toBaseContext();
     if (!ctx && f) ctx = f->getContext();
     if (o)

--- a/applications/projects/Modeler/lib/GraphHistoryManager.cpp
+++ b/applications/projects/Modeler/lib/GraphHistoryManager.cpp
@@ -91,7 +91,7 @@ void GraphHistoryManager::undoOperation(Operation &o)
     switch(o.ID)
     {
     case Operation::DELETE_OBJECT:
-        o.parent->addObject(o.sofaComponent->toBaseObject());
+        o.parent->addObject(o.sofaComponent->toBaseComponent()());
         graph->moveItem(graph->graphListener->items[o.sofaComponent.get()],graph->graphListener->items[o.above.get()]);
         o.ID = Operation::ADD_OBJECT;
         message=std::string("Undo Delete NODE ") + " (" + o.sofaComponent->getClassName() + ") " + o.sofaComponent->getName();
@@ -109,7 +109,7 @@ void GraphHistoryManager::undoOperation(Operation &o)
     case Operation::ADD_OBJECT:
         o.parent=graph->getNode(graph->graphListener->items[o.sofaComponent.get()]);
         o.above=graph->getComponentAbove(graph->graphListener->items[o.sofaComponent.get()]);
-        o.parent->removeObject(o.sofaComponent->toBaseObject());
+        o.parent->removeObject(o.sofaComponent->toBaseComponent()());
         o.ID = Operation::DELETE_OBJECT;
 
         message=std::string("Undo Delete OBJECT ") +" (" + o.sofaComponent->getClassName() + ") " + o.sofaComponent->getName();


### PR DESCRIPTION
Following https://github.com/sofa-framework/sofa/pull/5934

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
