### PR TITLE
[All] Replace `BaseObject::canCreate` by `BaseComponent::canCreate`

### DIFF
--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/LineCollisionModel.h
@@ -151,7 +151,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     sofa::core::topology::BaseMeshTopology* getCollisionTopology() override

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/PointCollisionModel.h
@@ -116,7 +116,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/SphereCollisionModel.h
@@ -134,7 +134,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     template<class T>

--- a/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
+++ b/Sofa/Component/Collision/Geometry/src/sofa/component/collision/geometry/TriangleCollisionModel.h
@@ -207,7 +207,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;

--- a/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactListener.h
+++ b/Sofa/Component/Collision/Response/Contact/src/sofa/component/collision/response/contact/ContactListener.h
@@ -104,7 +104,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     template<class T>

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PairBoxRoi.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PairBoxRoi.h
@@ -84,7 +84,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/PlaneROI.h
@@ -88,7 +88,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ProximityROI.h
@@ -82,7 +82,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 public:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/SubsetTopology.h
@@ -89,7 +89,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.h
+++ b/Sofa/Component/Engine/Select/src/sofa/component/engine/select/ValuesFromPositions.h
@@ -86,7 +86,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.h
+++ b/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.h
@@ -104,7 +104,7 @@ public:
             return false;
         }
 
-        return core::objectmodel::BaseObject::canCreate(obj, context, arg);
+        return core::objectmodel::sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Override method to lock or unlock the force feedback computation. According to parameter, value == true (resp. false) will lock (resp. unlock) mutex @sa lockForce

--- a/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.h
+++ b/Sofa/Component/Haptics/src/sofa/component/haptics/LCPForceFeedback.h
@@ -104,7 +104,7 @@ public:
             return false;
         }
 
-        return core::objectmodel::sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Override method to lock or unlock the force feedback computation. According to parameter, value == true (resp. false) will lock (resp. unlock) mutex @sa lockForce

--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
@@ -105,7 +105,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 };
 

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
@@ -141,7 +141,7 @@ public:
             arg->logError(std::string("No mechanical state with the datatype '") + TDataTypes::Name() + "' found in the context node.");
             return false;
         }
-        return sofa::core::objectmodel::sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected :

--- a/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
+++ b/Sofa/Component/LinearSolver/Preconditioner/src/sofa/component/linearsolver/preconditioner/PrecomputedWarpPreconditioner.h
@@ -141,7 +141,7 @@ public:
             arg->logError(std::string("No mechanical state with the datatype '") + TDataTypes::Name() + "' found in the context node.");
             return false;
         }
-        return sofa::core::objectmodel::BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected :

--- a/Sofa/Component/Playback/src/sofa/component/playback/CompareState.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/CompareState.h
@@ -57,7 +57,7 @@ public:
             arg->logError("No mechanical state found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Return the total errors (position and velocity)

--- a/Sofa/Component/Playback/src/sofa/component/playback/CompareTopology.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/CompareTopology.h
@@ -57,7 +57,7 @@ public:
             arg->logError("Cannot find a mesh topology in the current context");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Return the total number of errors

--- a/Sofa/Component/Playback/src/sofa/component/playback/ReadState.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/ReadState.h
@@ -91,7 +91,7 @@ public:
             arg->logError("No mechanical state found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 

--- a/Sofa/Component/Playback/src/sofa/component/playback/ReadTopology.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/ReadTopology.h
@@ -90,7 +90,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 

--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteState.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteState.h
@@ -103,7 +103,7 @@ public:
             arg->logError("No mechanical state found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 };

--- a/Sofa/Component/Playback/src/sofa/component/playback/WriteTopology.h
+++ b/Sofa/Component/Playback/src/sofa/component/playback/WriteTopology.h
@@ -93,7 +93,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 };

--- a/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.h
+++ b/Sofa/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetGeometryAlgorithms.h
@@ -101,7 +101,7 @@ public:
                           "' found in the context node.");
             return false;
         }
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /** \brief Called by the state change callback to initialize added

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologicalChangeProcessor.h
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologicalChangeProcessor.h
@@ -127,7 +127,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     void draw(const core::visual::VisualParams* vparams) override;

--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.h
@@ -150,7 +150,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     void setMState(MechanicalState<DataTypes> *_mstate)

--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.h
@@ -215,7 +215,7 @@ public:
                 }
             }
 
-            return BaseObject::canCreate(obj, context, arg);
+            return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
         }
         return false;
     }

--- a/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.h
@@ -115,7 +115,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     virtual type::vector<std::string> getBaseConstraintIdentifiers() override final

--- a/Sofa/framework/Core/src/sofa/core/behavior/ProjectiveConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ProjectiveConstraintSet.h
@@ -153,7 +153,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 };
 

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologicalMapping.h
@@ -152,7 +152,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /// Construction method called by ObjectFactory.

--- a/applications/plugins/BulletCollisionDetection/src/BulletCollisionDetection/BulletConvexHullModel.h
+++ b/applications/plugins/BulletCollisionDetection/src/BulletCollisionDetection/BulletConvexHullModel.h
@@ -111,7 +111,7 @@ public:
     {
         if (dynamic_cast<core::behavior::MechanicalState<DataTypes>*>(context->getMechanicalState()) == NULL)
             return false;
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     // -- Bullet interface

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.h
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/CapsuleModel.h
@@ -165,7 +165,7 @@ public:
             }
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     sofa::core::topology::BaseMeshTopology* getCollisionTopology() override

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/OBBModel.h
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/OBBModel.h
@@ -175,7 +175,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     /**

--- a/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/RigidCapsuleModel.h
+++ b/applications/plugins/CollisionOBBCapsule/src/CollisionOBBCapsule/geometry/RigidCapsuleModel.h
@@ -163,7 +163,7 @@ public:
             return false;
         }
 
-        return BaseObject::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
     Data<VecReal > & writeRadii();

--- a/applications/plugins/VolumetricRendering/extensions/CUDA/src/VolumetricRendering/CUDA/CudaTetrahedralVisualModel.h
+++ b/applications/plugins/VolumetricRendering/extensions/CUDA/src/VolumetricRendering/CUDA/CudaTetrahedralVisualModel.h
@@ -79,7 +79,7 @@ public:
     {
         if (dynamic_cast<core::behavior::MechanicalState<DataTypes>*>(context->getMechanicalState()) == NULL)
             return false;
-        return core::objectmodel::BaseObject::canCreate(obj, context, arg);
+        return core::objectmodel::sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:

--- a/applications/plugins/VolumetricRendering/extensions/CUDA/src/VolumetricRendering/CUDA/CudaTetrahedralVisualModel.h
+++ b/applications/plugins/VolumetricRendering/extensions/CUDA/src/VolumetricRendering/CUDA/CudaTetrahedralVisualModel.h
@@ -79,7 +79,7 @@ public:
     {
         if (dynamic_cast<core::behavior::MechanicalState<DataTypes>*>(context->getMechanicalState()) == NULL)
             return false;
-        return core::objectmodel::sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
+        return sofa::core::objectmodel::BaseComponent::canCreate(obj, context, arg);
     }
 
 protected:


### PR DESCRIPTION
Following https://github.com/sofa-framework/sofa/pull/5934

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
