### PR TITLE
[CI] Fix scene tests by ignoring Cuda scenes from benchmarks

### DIFF
--- a/examples/.scene-tests
+++ b/examples/.scene-tests
@@ -42,3 +42,11 @@ ignore "Benchmark/TopologicalChanges/FixedPlaneConstraint_RemovingMeshTest.scn"
 ignore "Component/Constraint/Lagrangian/Contact_ImprovedJacobi.scn"
 
 timeout "Component/AnimationLoop/FreeMotionAnimationLoop.scn" "180"
+
+
+#SofaCuda not available
+ignore "Benchmark/Performance/Bar16-fem-implicit-CudaVec3d.py"
+ignore "Benchmark/Performance/Bar16-fem-implicit-CudaVec3f.py"
+ignore "Benchmark/Performance/Bar16-spring-rk4-CudaVec3d.py"
+ignore "Benchmark/Performance/Bar16-spring-rk4-CudaVec3f.py"
+

--- a/examples/Benchmark/Performance/Bar16-fem-implicit-CudaVec3d.py
+++ b/examples/Benchmark/Performance/Bar16-fem-implicit-CudaVec3d.py
@@ -3,4 +3,4 @@ bar16_fem_implicit = importlib.import_module("Bar16-fem-implicit")
 
 def createScene(root_node):
     root_node.addObject('RequiredPlugin', name='SofaCUDA')
-    bar16_fem_implicit.createScene(root_node, "CudaVec3d")
+    bar16_fem_implicit.internalCreateScene(root_node, "CudaVec3d")

--- a/examples/Benchmark/Performance/Bar16-fem-implicit-CudaVec3f.py
+++ b/examples/Benchmark/Performance/Bar16-fem-implicit-CudaVec3f.py
@@ -3,4 +3,4 @@ bar16_fem_implicit = importlib.import_module("Bar16-fem-implicit")
 
 def createScene(root_node):
     root_node.addObject('RequiredPlugin', name='SofaCUDA')
-    bar16_fem_implicit.createScene(root_node, "CudaVec3f")
+    bar16_fem_implicit.internalCreateScene(root_node, "CudaVec3f")

--- a/examples/Benchmark/Performance/Bar16-fem-implicit-Vec3d.py
+++ b/examples/Benchmark/Performance/Bar16-fem-implicit-Vec3d.py
@@ -2,4 +2,4 @@ import importlib
 bar16_fem_implicit = importlib.import_module("Bar16-fem-implicit")
 
 def createScene(root_node):
-    bar16_fem_implicit.createScene(root_node, "Vec3d")
+    bar16_fem_implicit.internalCreateScene(root_node, "Vec3d")

--- a/examples/Benchmark/Performance/Bar16-fem-implicit-Vec3f.py
+++ b/examples/Benchmark/Performance/Bar16-fem-implicit-Vec3f.py
@@ -2,4 +2,4 @@ import importlib
 bar16_fem_implicit = importlib.import_module("Bar16-fem-implicit")
 
 def createScene(root_node):
-    bar16_fem_implicit.createScene(root_node, "Vec3f")
+    bar16_fem_implicit.internalCreateScene(root_node, "Vec3f")

--- a/examples/Benchmark/Performance/Bar16-fem-implicit.py
+++ b/examples/Benchmark/Performance/Bar16-fem-implicit.py
@@ -4,7 +4,7 @@ import os
 
 g_size = 10;
 
-def createScene(root_node, template):
+def internalCreateScene(root_node, template):
 
     size = int(os.getenv('s', g_size)) # read the value for size from the env, fallback to g_size if the env.var not set
 

--- a/examples/Benchmark/Performance/Bar16-spring-rk4-CudaVec3d.py
+++ b/examples/Benchmark/Performance/Bar16-spring-rk4-CudaVec3d.py
@@ -3,4 +3,4 @@ Bar16_spring_rk4 = importlib.import_module("Bar16-spring-rk4")
 
 def createScene(root_node):
     root_node.addObject('RequiredPlugin', name='SofaCUDA')
-    Bar16_spring_rk4.createScene(root_node, "CudaVec3d")
+    Bar16_spring_rk4.internalCreateScene(root_node, "CudaVec3d")

--- a/examples/Benchmark/Performance/Bar16-spring-rk4-CudaVec3f.py
+++ b/examples/Benchmark/Performance/Bar16-spring-rk4-CudaVec3f.py
@@ -3,4 +3,4 @@ Bar16_spring_rk4 = importlib.import_module("Bar16-spring-rk4")
 
 def createScene(root_node):
     root_node.addObject('RequiredPlugin', name='SofaCUDA')
-    Bar16_spring_rk4.createScene(root_node, "CudaVec3f")
+    Bar16_spring_rk4.internalCreateScene(root_node, "CudaVec3f")

--- a/examples/Benchmark/Performance/Bar16-spring-rk4-Vec3d.py
+++ b/examples/Benchmark/Performance/Bar16-spring-rk4-Vec3d.py
@@ -2,4 +2,4 @@ import importlib
 Bar16_spring_rk4 = importlib.import_module("Bar16-spring-rk4")
 
 def createScene(root_node):
-    Bar16_spring_rk4.createScene(root_node, "Vec3d")
+    Bar16_spring_rk4.internalCreateScene(root_node, "Vec3d")

--- a/examples/Benchmark/Performance/Bar16-spring-rk4-Vec3f.py
+++ b/examples/Benchmark/Performance/Bar16-spring-rk4-Vec3f.py
@@ -2,4 +2,4 @@ import importlib
 Bar16_spring_rk4 = importlib.import_module("Bar16-spring-rk4")
 
 def createScene(root_node):
-    Bar16_spring_rk4.createScene(root_node, "Vec3f")
+    Bar16_spring_rk4.internalCreateScene(root_node, "Vec3f")

--- a/examples/Benchmark/Performance/Bar16-spring-rk4.py
+++ b/examples/Benchmark/Performance/Bar16-spring-rk4.py
@@ -4,7 +4,7 @@ import os
 
 g_size = 10;
 
-def createScene(root_node, template):
+def internalCreateScene(root_node, template):
 
     size = int(os.getenv('s', g_size)) # read the value for size from the env, fallback to g_size if the env.var not set
 


### PR DESCRIPTION
Ignore cuda based scene tests and rename the generic function to create scene. The CI will launch any scene that contains a method called 'createScene', no matter the number of argument. This would also be the case while using runSofa. For me, calling a method 'createScene' means it is usable by runSofa, this is not the case, so I renamed them.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
