### PR TITLE
[CMake] Fix TinyXML2 cmake module for windeppack

### DIFF
--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -27,10 +27,12 @@ else()
   endif()
 
   if(WIN32)
-    # possibly also add lib/{win32,win64} to path_suffixes for compat with the windeppack
+    # when using WinDepPack, dll are located alongside lib files (in lib/{win32,win64}),
+    # which have been set in CMAKE_LIBRARY_PATH
     find_file(TinyXML2_DLL
       NAMES tinyxml2.dll
       PATH_SUFFIXES bin
+      PATHS ${CMAKE_LIBRARY_PATH}
     )
   endif()
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -359,3 +359,4 @@ full-dev = { features = [
   "presets-defaultGUI",
   "qt-gui",
   "python-supported"]}
+ 


### PR DESCRIPTION
Since we add Pixi support for building Windows binary releases, the new CMake module for TinyXML2 is also looking for .dll file to correctly install it inside our binary package.
However, this was breaking classical usage with WinDepPack, as dll and lib files were stored alongside and the CMake module and not inside a bin/ directory.
Locally, the build did not fail on other dependencies of the WinDepPack on my side, but I'd like some feedback of other users to check if we need to fix other CMake modules.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
