### PR TITLE
[Geometry] Prism: remove warning about multiline comment

### DIFF
--- a/Sofa/framework/Geometry/src/sofa/geometry/Prism.h
+++ b/Sofa/framework/Geometry/src/sofa/geometry/Prism.h
@@ -34,18 +34,18 @@ struct Prism
 
     Prism() = delete;
 
-    // CONVENTION : indices ordering for the nodes of a prism :
-    //
-    //     5
-    //   / |  \
-    //  /  |   \
-    // 3---+----4
-    // |   |    |
-    // |   2    |
-    // | /   \  |
-    // |/      \|
-    // 0--------1
-    //
+    /* CONVENTION : indices ordering for the nodes of a prism :
+     *
+     *      5
+     *    / |  \
+     *   /  |   \
+     *  3---+----4
+     *  |   |    |
+     *  |   2    |
+     *  | /   \  |
+     *  |/      \|
+     *  0--------1
+     */
 };
 
 using Pentahedron SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v26.06", "Pentahedron is renamed to Prism") = Prism;


### PR DESCRIPTION
The ASCII drawing of a prism is triggering a multiline-comment warning (in gcc), due to the `\` being at the end of the line.
The triggered warning is quite verbose 🥴:
e.g for CenterOfMassMultiMapping.cpp:
```
In file included from /workspace/sofa/Sofa/framework/Topology/src/sofa/topology/Prism.h:24,
                 from /workspace/sofa/Sofa/framework/Topology/src/sofa/topology/Topology.h:28,
                 from /workspace/sofa/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Topology.h:25,
                 from /workspace/sofa/Sofa/framework/DefaultType/src/sofa/defaulttype/DataTypeInfo.h:48,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/objectmodel/BaseData.h:25,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/objectmodel/Data.h:25,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/objectmodel/Base.h:25,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/objectmodel/BaseContext.h:25,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/objectmodel/BaseComponent.h:24,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/BaseState.h:23,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/behavior/BaseMechanicalState.h:25,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/behavior/MechanicalState.h:24,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/BaseMapping.h:23,
                 from /workspace/sofa/Sofa/framework/Core/src/sofa/core/Mapping.h:24,
                 from /workspace/sofa/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/LinearMapping.h:23,
                 from /workspace/sofa/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/CenterOfMassMultiMapping.h:25,
                 from /workspace/sofa/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/CenterOfMassMultiMapping.inl:24,
                 from /workspace/sofa/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/CenterOfMassMultiMapping.cpp:24:
/workspace/sofa/Sofa/framework/Geometry/src/sofa/geometry/Prism.h:40:5: warning: multi-line comment [-Wcomment]
```
and it is spammed by everything including Base/Data, so by every component...

So this PR change the commenting with // by /*
The alternatives are: changing how it is drawn, or adding a character after the ending `\`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
