### PR TITLE
[CMake] Add missing install compat headers for Sofa.Component.LinearSystem

### DIFF
--- a/Sofa/Component/LinearSystem/CMakeLists.txt
+++ b/Sofa/Component/LinearSystem/CMakeLists.txt
@@ -76,6 +76,8 @@ sofa_create_package_with_targets(
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
 )
 
+install(DIRECTORY compat/ DESTINATION include/${PROJECT_NAME}_compat COMPONENT headers)
+
 cmake_dependent_option(SOFA_COMPONENT_LINEARSYSTEM_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
 if(SOFA_COMPONENT_LINEARSYSTEM_BUILD_TESTS)
     add_subdirectory(tests)


### PR DESCRIPTION
Similar to #5994 to fix invalid install introduced in #5991.
See broken CI i here: https://github.com/sofa-framework/conda-ci/actions/runs/23180448548/job/67361814043#step:11:423


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
