### PR TITLE
[CMake] Add path to the windeppack to help cmake find it

### DIFF
--- a/cmake/Modules/FindPNG.cmake
+++ b/cmake/Modules/FindPNG.cmake
@@ -135,7 +135,10 @@ if(ZLIB_FOUND)
     foreach(v IN LISTS PNG_NAMES)
       list(APPEND PNG_DLL_FILENAMES ${v}.dll)
     endforeach()
-    find_file(PNG_DLL NAMES ${PNG_DLL_FILENAMES} PATH_SUFFIXES bin)
+    find_file(PNG_DLL 
+        NAMES ${PNG_DLL_FILENAMES} 
+        PATH_SUFFIXES bin 
+        PATHS ${CMAKE_LIBRARY_PATH})
     mark_as_advanced(PNG_DLL)
  endif()
   unset(PNG_NAMES)

--- a/cmake/Modules/FindZLIB.cmake
+++ b/cmake/Modules/FindZLIB.cmake
@@ -181,6 +181,7 @@ if(NOT ZLIB_LIBRARY)
       find_file(ZLIB_DLL
         NAMES zlib.dll
         PATH_SUFFIXES bin
+        PATHS ${CMAKE_LIBRARY_PATH}
       )
     endif()
   endforeach()


### PR DESCRIPTION
We need to wait for windows scene tests



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
