### PR TITLE
[Tracy] Fix compilation when enabling Tracy

### DIFF
--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/SubCollisionPipeline.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/SubCollisionPipeline.cpp
@@ -171,7 +171,8 @@ void SubCollisionPipeline::computeCollisionReset()
 void SubCollisionPipeline::computeCollisionDetection()
 {
     const std::string timerPrefix = formatComponentName(this->getName()) + " ";
-    SCOPED_TIMER_VARNAME(docollisiontimer, timerPrefix + std::string("doCollisionDetection"));
+    const std::string globalTimerName = timerPrefix + std::string("doCollisionDetection");
+    SCOPED_TIMER_VARNAME(docollisiontimer, globalTimerName.c_str());
 
     if (!this->isComponentStateValid())
         return;
@@ -182,7 +183,8 @@ void SubCollisionPipeline::computeCollisionDetection()
     // These hierarchical structures enable efficient spatial queries
     type::vector<CollisionModel*> vectBoundingVolume;
     {
-        SCOPED_TIMER_VARNAME(bboxtimer, timerPrefix + std::string("ComputeBoundingTree"));
+        const std::string localTimerName = timerPrefix + std::string("ComputeBoundingTree");
+        SCOPED_TIMER_VARNAME(bboxtimer, timerPrefix + localTimerName.c_str());
 
         // Check if continuous collision detection (CCD) is enabled
         const bool continuous = l_intersectionMethod->useContinuous();
@@ -234,7 +236,8 @@ void SubCollisionPipeline::computeCollisionDetection()
     msg_info()  << "doCollisionDetection, BroadPhaseDetection "<<l_broadPhaseDetection->getName();
 
     {
-        SCOPED_TIMER_VARNAME(broadphase, timerPrefix + std::string("BroadPhase"));
+        const std::string localTimerName = timerPrefix + std::string("BroadPhase");
+        SCOPED_TIMER_VARNAME(broadphase, localTimerName.c_str() );
         l_intersectionMethod->beginBroadPhase();
         l_broadPhaseDetection->beginBroadPhase();
         l_broadPhaseDetection->addCollisionModels(vectBoundingVolume);  // Actual detection happens here
@@ -247,7 +250,8 @@ void SubCollisionPipeline::computeCollisionDetection()
     msg_info() << "doCollisionDetection, NarrowPhaseDetection "<< l_narrowPhaseDetection->getName();
 
     {
-        SCOPED_TIMER_VARNAME(narrowphase, timerPrefix + std::string("NarrowPhase"));
+        const std::string localTimerName = timerPrefix + std::string("NarrowPhase");
+        SCOPED_TIMER_VARNAME(narrowphase,  localTimerName.c_str());
         l_intersectionMethod->beginNarrowPhase();
         l_narrowPhaseDetection->beginNarrowPhase();
 

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/SubCollisionPipeline.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/SubCollisionPipeline.cpp
@@ -171,8 +171,8 @@ void SubCollisionPipeline::computeCollisionReset()
 void SubCollisionPipeline::computeCollisionDetection()
 {
     const std::string timerPrefix = formatComponentName(this->getName()) + " ";
-    const std::string globalTimerName = timerPrefix + std::string("doCollisionDetection");
-    SCOPED_TIMER_VARNAME(docollisiontimer, globalTimerName.c_str());
+    const std::string globalTimerName = timerPrefix + "doCollisionDetection";
+    SCOPED_TIMER_VARNAME_DYN(docollisiontimer, globalTimerName.c_str());
 
     if (!this->isComponentStateValid())
         return;
@@ -183,8 +183,8 @@ void SubCollisionPipeline::computeCollisionDetection()
     // These hierarchical structures enable efficient spatial queries
     type::vector<CollisionModel*> vectBoundingVolume;
     {
-        const std::string localTimerName = timerPrefix + std::string("ComputeBoundingTree");
-        SCOPED_TIMER_VARNAME(bboxtimer, timerPrefix + localTimerName.c_str());
+        const std::string localTimerName = timerPrefix + "ComputeBoundingTree";
+        SCOPED_TIMER_VARNAME_DYN(bboxtimer, localTimerName.c_str());
 
         // Check if continuous collision detection (CCD) is enabled
         const bool continuous = l_intersectionMethod->useContinuous();
@@ -210,15 +210,15 @@ void SubCollisionPipeline::computeCollisionDetection()
             if (continuous)
             {
                 // CCD: Compute swept bounding volumes that cover the motion trajectory
-                const std::string msg = timerPrefix + std::string("Compute Continuous BoundingTree: ") + (*it)->getName();
-                SCOPED_TIMER(msg.c_str());
+                const std::string msg = timerPrefix + "Compute Continuous BoundingTree: " + (*it)->getName();
+                SCOPED_TIMER_DYN(msg.c_str());
                 (*it)->computeContinuousBoundingTree(dt, continuousIntersectionType, used_depth);
             }
             else
             {
                 // Discrete: Compute bounding volumes at current positions
-                std::string msg = timerPrefix + std::string("Compute BoundingTree: ") + (*it)->getName();
-                SCOPED_TIMER(msg.c_str());
+                std::string msg = timerPrefix + "Compute BoundingTree: " + (*it)->getName();
+                SCOPED_TIMER_DYN(msg.c_str());
                 (*it)->computeBoundingTree(used_depth);
             }
 
@@ -236,8 +236,8 @@ void SubCollisionPipeline::computeCollisionDetection()
     msg_info()  << "doCollisionDetection, BroadPhaseDetection "<<l_broadPhaseDetection->getName();
 
     {
-        const std::string localTimerName = timerPrefix + std::string("BroadPhase");
-        SCOPED_TIMER_VARNAME(broadphase, localTimerName.c_str() );
+        const std::string localTimerName = timerPrefix + "BroadPhase";
+        SCOPED_TIMER_VARNAME_DYN(broadphase, localTimerName.c_str());
         l_intersectionMethod->beginBroadPhase();
         l_broadPhaseDetection->beginBroadPhase();
         l_broadPhaseDetection->addCollisionModels(vectBoundingVolume);  // Actual detection happens here
@@ -250,8 +250,8 @@ void SubCollisionPipeline::computeCollisionDetection()
     msg_info() << "doCollisionDetection, NarrowPhaseDetection "<< l_narrowPhaseDetection->getName();
 
     {
-        const std::string localTimerName = timerPrefix + std::string("NarrowPhase");
-        SCOPED_TIMER_VARNAME(narrowphase,  localTimerName.c_str());
+        const std::string localTimerName = timerPrefix + "NarrowPhase";
+        SCOPED_TIMER_VARNAME_DYN(narrowphase, localTimerName.c_str());
         l_intersectionMethod->beginNarrowPhase();
         l_narrowPhaseDetection->beginNarrowPhase();
 

--- a/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/SubCollisionPipeline.cpp
+++ b/Sofa/Component/Collision/Detection/Algorithm/src/sofa/component/collision/detection/algorithm/SubCollisionPipeline.cpp
@@ -171,7 +171,7 @@ void SubCollisionPipeline::computeCollisionReset()
 void SubCollisionPipeline::computeCollisionDetection()
 {
     const std::string timerPrefix = formatComponentName(this->getName()) + " ";
-    SCOPED_TIMER_VARNAME(docollisiontimer, timerPrefix + "doCollisionDetection");
+    SCOPED_TIMER_VARNAME(docollisiontimer, timerPrefix + std::string("doCollisionDetection"));
 
     if (!this->isComponentStateValid())
         return;
@@ -182,7 +182,7 @@ void SubCollisionPipeline::computeCollisionDetection()
     // These hierarchical structures enable efficient spatial queries
     type::vector<CollisionModel*> vectBoundingVolume;
     {
-        SCOPED_TIMER_VARNAME(bboxtimer, timerPrefix + "ComputeBoundingTree");
+        SCOPED_TIMER_VARNAME(bboxtimer, timerPrefix + std::string("ComputeBoundingTree"));
 
         // Check if continuous collision detection (CCD) is enabled
         const bool continuous = l_intersectionMethod->useContinuous();
@@ -208,14 +208,14 @@ void SubCollisionPipeline::computeCollisionDetection()
             if (continuous)
             {
                 // CCD: Compute swept bounding volumes that cover the motion trajectory
-                const std::string msg = timerPrefix + "Compute Continuous BoundingTree: " + (*it)->getName();
+                const std::string msg = timerPrefix + std::string("Compute Continuous BoundingTree: ") + (*it)->getName();
                 SCOPED_TIMER(msg.c_str());
                 (*it)->computeContinuousBoundingTree(dt, continuousIntersectionType, used_depth);
             }
             else
             {
                 // Discrete: Compute bounding volumes at current positions
-                std::string msg = timerPrefix + "Compute BoundingTree: " + (*it)->getName();
+                std::string msg = timerPrefix + std::string("Compute BoundingTree: ") + (*it)->getName();
                 SCOPED_TIMER(msg.c_str());
                 (*it)->computeBoundingTree(used_depth);
             }
@@ -234,7 +234,7 @@ void SubCollisionPipeline::computeCollisionDetection()
     msg_info()  << "doCollisionDetection, BroadPhaseDetection "<<l_broadPhaseDetection->getName();
 
     {
-        SCOPED_TIMER_VARNAME(broadphase, timerPrefix + "BroadPhase");
+        SCOPED_TIMER_VARNAME(broadphase, timerPrefix + std::string("BroadPhase"));
         l_intersectionMethod->beginBroadPhase();
         l_broadPhaseDetection->beginBroadPhase();
         l_broadPhaseDetection->addCollisionModels(vectBoundingVolume);  // Actual detection happens here
@@ -247,7 +247,7 @@ void SubCollisionPipeline::computeCollisionDetection()
     msg_info() << "doCollisionDetection, NarrowPhaseDetection "<< l_narrowPhaseDetection->getName();
 
     {
-        SCOPED_TIMER_VARNAME(narrowphase, timerPrefix + "NarrowPhase");
+        SCOPED_TIMER_VARNAME(narrowphase, timerPrefix + std::string("NarrowPhase"));
         l_intersectionMethod->beginNarrowPhase();
         l_narrowPhaseDetection->beginNarrowPhase();
 

--- a/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -66,7 +66,9 @@ ScopedAdvancedTimer::ScopedAdvancedTimer(const char* message, T* obj)
 #ifdef TRACY_ENABLE
     #include <tracy/Tracy.hpp>
     #define SCOPED_TIMER_TR(name) ZoneScopedN(name)
+    #define SCOPED_TIMER_DYN_TR(name) ZoneTransientN( ___tracy_scoped_zone,name, true)
     #define SCOPED_TIMER_VARNAME_TR(varname, name) ZoneNamedN(varname##_tr, name, true)
+    #define SCOPED_TIMER_VARNAME_DYN_TR(varname, name) ZoneTransientN(varname##_tr, name, true)
 #else
     #define SCOPED_TIMER_TR(name)
     #define SCOPED_TIMER_VARNAME_TR(varname, name)
@@ -81,4 +83,6 @@ ScopedAdvancedTimer::ScopedAdvancedTimer(const char* message, T* obj)
 #endif
 
 #define SCOPED_TIMER(name) SCOPED_TIMER_TR(name); SCOPED_TIMER_AD(name)
+#define SCOPED_TIMER_DYN(name) SCOPED_TIMER_DYN_TR(name); SCOPED_TIMER_AD(name)
 #define SCOPED_TIMER_VARNAME(varname, name) SCOPED_TIMER_VARNAME_TR(varname, name); SCOPED_TIMER_VARNAME_AD(varname, name)
+#define SCOPED_TIMER_VARNAME_DYN(varname, name) SCOPED_TIMER_VARNAME_DYN_TR(varname, name); SCOPED_TIMER_VARNAME_AD(varname, name)

--- a/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -71,7 +71,9 @@ ScopedAdvancedTimer::ScopedAdvancedTimer(const char* message, T* obj)
     #define SCOPED_TIMER_VARNAME_DYN_TR(varname, name) ZoneTransientN(varname##_tr, name, true)
 #else
     #define SCOPED_TIMER_TR(name)
+    #define SCOPED_TIMER_DYN_TR(name)
     #define SCOPED_TIMER_VARNAME_TR(varname, name)
+    #define SCOPED_TIMER_VARNAME_DYN_TR(varname, name)
 #endif
 
 #ifdef SOFA_ENABLE_SCOPED_ADVANCED_TIMER


### PR DESCRIPTION
Compilation was broken from #6019 because it is not tested on the CI. It was broken because the way tracy's timers are used in SOFA, they require only constexpr names to be used. A dynamic equivalent exists but at the cost of having some overhead in execution time. 

My solution is to add two new time macro for dynamic names. They do the same when Tracy is off, but will use the 'transient' version of Tracy.

I saw it actually because the performance tests are broken since this commit, and the reason is that they are using Tracy... I tested this Pr on the builder and it fixes this CI. 

Here is the resource that helped me https://github.com/wolfpld/tracy/issues/103  



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
