### PR TITLE
[Mapping.Linear] Add applyJT for matrices for IdentityMultiMapping

### DIFF
--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/IdentityMultiMapping.cpp
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/IdentityMultiMapping.cpp
@@ -34,10 +34,14 @@ namespace sofa::component::mapping::linear
 void registerIdentityMultiMapping(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(core::ObjectRegistrationData("Concatenate several mechanical states together.")
+        .add< IdentityMultiMapping< Vec1Types, Vec1Types > >()
+        .add< IdentityMultiMapping< Vec2Types, Vec2Types > >()
         .add< IdentityMultiMapping< Vec3Types, Vec3Types > >()
         .add< IdentityMultiMapping< Rigid3Types, Rigid3Types > >());
 }
 
+template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< Vec1Types, Vec1Types >;
+template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< Vec2Types, Vec2Types >;
 template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< Vec3Types, Vec3Types >;
 template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< Rigid3Types, Rigid3Types >;
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/IdentityMultiMapping.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/IdentityMultiMapping.h
@@ -89,6 +89,8 @@ protected :
 
 
 #if !defined(SOFA_COMPONENT_MAPPING_IDENTITYMULTIMAPPING_CPP)
+extern template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< defaulttype::Vec1Types, defaulttype::Vec1Types >;
+extern template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< defaulttype::Vec2Types, defaulttype::Vec2Types >;
 extern template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< defaulttype::Vec3Types, defaulttype::Vec3Types >;
 extern template class SOFA_COMPONENT_MAPPING_LINEAR_API IdentityMultiMapping< defaulttype::Rigid3Types, defaulttype::Rigid3Types >;
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/IdentityMultiMapping.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/IdentityMultiMapping.inl
@@ -141,19 +141,18 @@ void IdentityMultiMapping<TIn, TOut>::applyJT(const core::MechanicalParams* mpar
 {
     SOFA_UNUSED(mparams);
 
+    assert(dataVecInForce.size() == 1);
     const OutVecDeriv& in = dataVecInForce[0]->getValue();
 
     unsigned offset = 0;
-    for(unsigned i=0; i<dataVecOutForce.size(); i++ )
+    for (InDataVecDeriv* const dataOut : dataVecOutForce)
     {
-        InVecDeriv& out = *dataVecOutForce[i]->beginEdit();
+        auto out = sofa::helper::getWriteAccessor(*dataOut);
 
-        for(unsigned int j=0; j<out.size(); j++)
+        for (unsigned int j = 0; j < out.size(); j++)
         {
-            core::peq( out[j], in[offset+j]);
+            core::peq(out[j], in[offset + j]);
         }
-
-        dataVecOutForce[i]->endEdit();
 
         offset += out.size();
     }
@@ -162,9 +161,70 @@ void IdentityMultiMapping<TIn, TOut>::applyJT(const core::MechanicalParams* mpar
 }
 
 template <class TIn, class TOut>
-void IdentityMultiMapping<TIn, TOut>::applyJT( const core::ConstraintParams* /*cparams*/, const type::vector< InDataMatrixDeriv* >& /*dOut*/, const type::vector< const OutDataMatrixDeriv* >& /*dIn*/)
+void IdentityMultiMapping<TIn, TOut>::applyJT( const core::ConstraintParams* cparams, const type::vector< InDataMatrixDeriv* >& dOut, const type::vector< const OutDataMatrixDeriv* >& dIn)
 {
+    SOFA_UNUSED(cparams);
 
+    //only one output in the mapping
+    assert(dIn.size() == 1);
+
+    sofa::type::vector<sofa::helper::WriteAccessor<InDataMatrixDeriv> > outAccessors;
+    outAccessors.reserve(dOut.size());
+    for (auto* out : dOut)
+    {
+        outAccessors.emplace_back(out);
+    }
+
+    //compute the position of each mapping input in the provided matrix
+    sofa::type::vector<std::size_t> offsets(this->fromModels.size() + 1, 0);
+    for (std::size_t i = 0; i < this->fromModels.size(); ++i)
+    {
+        offsets[i + 1] = offsets[i] + this->fromModels[i]->getSize() * Out::deriv_total_size;
+    }
+
+    const auto findInputId = [this, &offsets](auto scalarIndex) -> std::size_t
+    {
+        auto it = std::upper_bound(offsets.begin(), offsets.end(), scalarIndex);
+        return std::distance(offsets.begin(), it) - 1;
+    };
+
+    const typename Out::MatrixDeriv& in = dIn[0]->getValue();
+    for (auto rowIt = in.begin(); rowIt != in.end(); ++rowIt)
+    {
+        // Convert the row block index into scalar index
+        const auto rowId = rowIt.index() * OutMatrixDeriv::NL;
+
+        // find which mapping input is affected by this row
+        const auto outId_row = findInputId(rowId);
+
+        for (auto colIt = rowIt.begin(); colIt != rowIt.end(); ++colIt)
+        {
+            // Convert the column block index into scalar index
+            const auto colId = colIt.index() * OutMatrixDeriv::NC;
+
+            // find which mapping input is affected by this column
+            const auto outId_col = findInputId(colId);
+
+            // coupled terms are not supported
+            if (outId_col != outId_row)
+            {
+                continue;
+            }
+
+            if (outId_col < outAccessors.size())
+            {
+                auto lineIt = outAccessors[outId_col]->writeLine(rowId / InMatrixDeriv::NL);
+
+                Deriv_t<In> value;
+                core::eq( value, colIt.val() );
+
+                const auto blockColIndex = colId - offsets[outId_col];
+                const auto localColIndex = In::deriv_total_size * (blockColIndex / Out::deriv_total_size) + blockColIndex % Out::deriv_total_size;
+
+                lineIt.addCol(localColIndex / InMatrixDeriv::NC, value);
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
Based on https://github.com/sofa-framework/sofa/pull/6032

The goal was to verify that the two following scenes produce the same behaviour:

1. Two objects in the same solver. No mapping involved

```xml
<Node name="root" gravity="0 -9.81 0">

    <Node name="meshes">
        <StringMeshCreator name="string_1" resolution="10"/>
        <StringMeshCreator name="string_2" resolution="8"/>
    </Node>

    <EulerImplicitSolver/>
    <SparseLDLSolver template="CompressedRowSparseMatrixMat3x3d"/>
    <GlobalSystemMatrixImage/>

    <Node name="string_1">
        <MechanicalObject name="state" src="@/meshes/string_1" translation="0 0 0.5" />
        <MeshTopology src="@/meshes/string_1" />
        <MeshSpringForceField name="spring" drawMode="1" linesStiffness="1000"/>
        <FixedProjectiveConstraint indices="0"/>
        <UniformMass vertexMass="2"/>
    </Node>

    <Node name="string_2">
        <MechanicalObject name="state" src="@/meshes/string_2" translation="0 0 -0.5" />
        <MeshTopology src="@/meshes/string_2" />
        <MeshSpringForceField name="spring" drawMode="1" linesStiffness="1000"/>
        <FixedProjectiveConstraint indices="0"/>
        <UniformMass vertexMass="2"/>
    </Node>
</Node>
```

2. Two objects. The mass is mapped, applied on the concatenation of both objects.

```xml
<Node name="root" gravity="0 -9.81 0">

    <Node name="meshes">
        <StringMeshCreator name="string_1" resolution="10"/>
        <StringMeshCreator name="string_2" resolution="8"/>
    </Node>

    <EulerImplicitSolver/>
    <SparseLDLSolver template="CompressedRowSparseMatrixMat3x3d"/>

    <Node name="string_1">
        <MechanicalObject name="state" src="@/meshes/string_1" translation="0 0 0.5" />
        <MeshTopology src="@/meshes/string_1" />
        <MeshSpringForceField name="spring" drawMode="1" linesStiffness="1000"/>
        <FixedProjectiveConstraint indices="0"/>
    </Node>

    <Node name="string_2">
        <MechanicalObject name="state" src="@/meshes/string_2" translation="0 0 -0.5" />
        <MeshTopology src="@/meshes/string_2" />
        <MeshSpringForceField name="spring" drawMode="1" linesStiffness="1000"/>
        <FixedProjectiveConstraint indices="0"/>
    </Node>

    <Node name="mass">
        <MechanicalObject name="state"/>
        <IdentityMultiMapping input="@../string_1/state @../string_2/state" output="@state"/>
        <UniformMass vertexMass="2"/>
    </Node>
</Node>
```

Both scene should produce the same result. Except that the scene with the mapping has a problem. See the system matrix:

![missingMass](https://github.com/user-attachments/assets/0331b703-04d3-46a9-b7ce-3ae2e771239b)


The mass matrix is missing. It's because `IdentityMultiMapping` does not implement `applyJT` for matrices.

With this PR, the system matrices is now:
![afterPR](https://github.com/user-attachments/assets/d26293f4-a5a2-4b2a-9575-62677ffdb749)



Note:
`IdentityMultiMapping` is not available in `<Vec3,Vec2>`, but I made sure that the current implementation is compatible with such templates. For example, I tried the following scene:

```xml
<Node name="root" gravity="0 -9.81 0">

    <Node name="meshes">
        <StringMeshCreator name="string_1" resolution="10"/>
        <StringMeshCreator name="string_2" resolution="8"/>
    </Node>

    <EulerImplicitSolver/>
    <SparseLDLSolver template="CompressedRowSparseMatrixMat3x3d"/>

    <Node name="string_1">
        <MechanicalObject name="state" src="@/meshes/string_1" translation="0 0 0.5" />
        <MeshTopology src="@/meshes/string_1" />
        <MeshSpringForceField name="spring" drawMode="1" linesStiffness="1000"/>
        <FixedProjectiveConstraint indices="0"/>
    </Node>

    <Node name="string_2">
        <MechanicalObject name="state" src="@/meshes/string_2" translation="0 0 -0.5" />
        <MeshTopology src="@/meshes/string_2" />
        <MeshSpringForceField name="spring" drawMode="1" linesStiffness="1000"/>
        <FixedProjectiveConstraint indices="0"/>
    </Node>

    <Node name="mass">
        <MechanicalObject name="state" template="Vec2"/>   <!-- Note here the 2d -->
        <IdentityMultiMapping input="@../string_1/state @../string_2/state" output="@state"/> <!-- not available, but I compiled it for the experiment -->
        <UniformMass vertexMass="2"/>
    </Node>
</Node>
```
The system matrix is:
![afterPR_2d](https://github.com/user-attachments/assets/be82686a-f916-4182-9486-a758b6e41b3e)

It is rank-deficient, but it is expected (the mass is computed in 2d, not in 3d. One component is missing). So it works as expected.

[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
