### PR TITLE
[Type] vector: Fix warning(error) about implicit cast of long into int

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/vector_Integral.cpp
+++ b/Sofa/framework/Type/src/sofa/type/vector_Integral.cpp
@@ -37,12 +37,12 @@ SOFA_TYPE_API int getInteger(const std::string& s, std::stringstream& msg, unsig
 {
     const char* attrstr = s.c_str();
     char* end = nullptr;
-    const int retval = strtol(attrstr, &end, 10);
+    const long retval = strtol(attrstr, &end, 10);
 
     /// It is important to check that the string was totally parsed to report
     /// message to users because a silent error is the worse thing that can happen in UX.
     if (end == attrstr + strlen(attrstr))
-        return retval;
+        return static_cast<int>(retval);
 
     if (numErrors < 5)
         msg << "    - problem while parsing '" << s << "' as Integer'. Replaced by 0 instead." << "\n";


### PR DESCRIPTION
Due to the fact that warning becomes error in Sofa.Type, the implicit cast was throwing an error on Xcode 26 (appleclang 17)
I guess it was set a warning in an newer version of the appleclang compiler than the CI


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
