### PR TITLE
[Simulation.Core] Add warning if RequiredPlugin uses its name to load a plugin

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
@@ -110,7 +110,18 @@ bool RequiredPlugin::loadPlugin()
     /// In case the pluginName is not set we copy the provided name into the set to load.
     if(!d_pluginName.isSet() && name.isSet())
     {
-        pluginsToLoad.push_back(this->getName());
+        const auto componentName = this->getName();
+        {
+            const auto considerNameAsPluginName = FileSystem::cleanPath(componentName);
+            if (FileSystem::isFile(considerNameAsPluginName) || !pluginManager.findPlugin(considerNameAsPluginName).empty())
+            {
+                msg_deprecated() << "The name of the plugin to load (" << componentName
+                    << ") must be defined in the Data '" << d_pluginName.getName()
+                    << "', not in the the Data '" << this->name.getName() << "'. The plugin '"
+                    << componentName << "' may be loaded, but this may change in the future.";
+            }
+        }
+        pluginsToLoad.push_back(componentName);
     }
 
     type::vector< std::string > failed;


### PR DESCRIPTION
[with-all-tests]






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
