### PR TITLE
[CMake] Activate the errors in scene checking in the dev configurations

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -328,6 +328,10 @@
         "APPLICATION_GETDEPRECATEDCOMPONENTS": {
           "type": "BOOL",
           "value": "ON"
+        },
+        "SOFA_SCENECHECKING_WARNINGS_ARE_ERRORS": {
+          "type": "BOOL",
+          "value": "ON"
         }
       }
     },


### PR DESCRIPTION
Activate the option to treat scene checking as errors on the CI.

[with-all-tests] 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
