### PR TITLE
[Framework] Fix warnings from modern gcc/clang

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ConstraintCorrection.h
@@ -57,7 +57,7 @@ public:
 protected:
     /// Default Constructor
     explicit ConstraintCorrection(MechanicalState< DataTypes > *ms = nullptr)
-        : Inherit1(), Inherit2(ms)
+        : Inherit2(ms), Inherit1()
         , l_constraintsolvers(initLink("constraintSolvers", "Constraint solvers using this constraint correction"))
     {}
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/ForceField.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ForceField.inl
@@ -33,7 +33,7 @@ namespace sofa::core::behavior
 
 template<class DataTypes>
 ForceField<DataTypes>::ForceField(MechanicalState<DataTypes> *mm)
-    : BaseForceField(), SingleStateAccessor<DataTypes>(mm)
+    : SingleStateAccessor<DataTypes>(mm), BaseForceField()
 {
 }
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_CORE_BEHAVIOR_CONSTRAINT_CPP
-#include <sofa/core/behavior/Constraint.inl>
+#include <sofa/core/behavior/LagrangianConstraint.inl>
 
 namespace sofa::core::behavior
 {

--- a/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/LagrangianConstraint.inl
@@ -29,7 +29,7 @@ namespace sofa::core::behavior
 
 template<class DataTypes>
 LagrangianConstraint<DataTypes>::LagrangianConstraint(MechanicalState<DataTypes> *mm)
-    : Inherit1(), Inherit2(mm)
+    : Inherit2(mm), Inherit1()
     , endTime( initData(&endTime,(Real)-1,"endTime","The constraint stops acting after the given value.\nUse a negative value for infinite constraints") )
 {
 }

--- a/Sofa/framework/Core/src/sofa/core/behavior/ProjectiveConstraintSet.inl
+++ b/Sofa/framework/Core/src/sofa/core/behavior/ProjectiveConstraintSet.inl
@@ -30,7 +30,7 @@ namespace sofa::core::behavior
 
 template<class DataTypes>
 ProjectiveConstraintSet<DataTypes>::ProjectiveConstraintSet(MechanicalState<DataTypes> *mm)
-    : Inherit1(), Inherit2(mm)
+    : Inherit2(mm), Inherit1()
     , endTime( initData(&endTime,(Real)-1,"endTime","The constraint stops acting after the given value.\nUse a negative value for infinite constraints") )
 {
 }

--- a/Sofa/framework/Core/src/sofa/core/loader/MeshLoader.h
+++ b/Sofa/framework/Core/src/sofa/core/loader/MeshLoader.h
@@ -162,7 +162,10 @@ public:
     Data< type::vector< Tetrahedron > > d_tetrahedra; ///< Tetrahedra of the mesh loaded
     Data< type::vector< Hexahedron > > d_hexahedra; ///< Hexahedra of the mesh loaded
     Data< type::vector< Prism > > d_prisms;
+
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED("v25.12", "v26.06", "Pentahedron is renamed to Prism")
+#endif
     objectmodel::lifecycle::RenamedData<type::vector< Prism >> d_pentahedra; ///< Pentahedra of the mesh loaded
     Data< type::vector< HighOrderTetrahedronPosition > > d_highOrderTetrahedronPositions; ///< High order tetrahedron points of the mesh loaded
     Data< type::vector< HighOrderHexahedronPosition > > d_highOrderHexahedronPositions; ///< High order hexahedron points of the mesh loaded

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseNode.cpp
@@ -64,13 +64,13 @@ core::visual::VisualLoop* BaseNode::getVisualLoop() const
 }
 
 /// Set the context of an object to this
-void BaseNode::setObjectContext(BaseObject::SPtr obj)
+void BaseNode::setObjectContext(BaseComponent::SPtr obj)
 {
     obj->l_context.set(this->getContext());
 }
 
 /// Reset the context of an object
-void BaseNode::clearObjectContext(BaseObject::SPtr obj)
+void BaseNode::clearObjectContext(BaseComponent::SPtr obj)
 {
     if (obj != nullptr)
     {

--- a/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/Sofa/framework/Core/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -355,12 +355,12 @@ void BaseMeshTopology::addHexa(Index, Index, Index, Index, Index, Index, Index, 
     msg_error() << "addHexa() not supported.";
 }
 
-void BaseMeshTopology::addPrism(Index a, Index b, Index c, Index d, Index e, Index f)
+void BaseMeshTopology::addPrism(Index, Index, Index, Index, Index, Index)
 {
     msg_error() << "addPrism() not supported.";
 }
 
-void BaseMeshTopology::addPyramid(Index a, Index b, Index c, Index d, Index e)
+void BaseMeshTopology::addPyramid(Index, Index, Index, Index, Index)
 {
     msg_error() << "addPyramid() not supported.";
 }

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
@@ -82,7 +82,10 @@ struct VectorTypeInfo
             data.resize(size/BaseTypeInfo::size());
             return true;
         }
-        return false;
+        else
+        {
+            return false;
+        }
     }
 
     template <typename T>

--- a/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -85,7 +85,7 @@ ScopedAdvancedTimer::ScopedAdvancedTimer(const char* message, T* obj)
 #endif
 
 consteval const char* ensure_name_must_be_a_compile_time_string_literal(const char* s) { return s; }
-#define ENSURE_SCOPED_ADVANCED_TIMER_ARG_IS_CONSTEXPR(s) ensure_name_must_be_a_compile_time_string_literal(s)
+#define ENSURE_SCOPED_ADVANCED_TIMER_ARG_IS_CONSTEXPR(s) (void)ensure_name_must_be_a_compile_time_string_literal(s)
 
 #define SCOPED_TIMER(name) ENSURE_SCOPED_ADVANCED_TIMER_ARG_IS_CONSTEXPR(name) ; SCOPED_TIMER_TR(name); SCOPED_TIMER_AD(name)
 #define SCOPED_TIMER_DYN(name) SCOPED_TIMER_DYN_TR(name); SCOPED_TIMER_AD(name)

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
@@ -250,7 +250,7 @@ bool FileRepository::findFileIn(std::string& filename, const std::string& path)
     if (filename.empty()) return false; // no filename
     const std::string newfname = SetDirectory::GetRelativeFromDir(filename.c_str(), path.c_str());
 
-    const auto p = fs::path(newfname);
+    const auto p = fs::path(std::u8string(newfname.begin(), newfname.end()));
     if (fs::exists(p))
     {
         // File found

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileRepository.cpp
@@ -250,7 +250,7 @@ bool FileRepository::findFileIn(std::string& filename, const std::string& path)
     if (filename.empty()) return false; // no filename
     const std::string newfname = SetDirectory::GetRelativeFromDir(filename.c_str(), path.c_str());
 
-    const fs::path p = fs::u8path(newfname);
+    const auto p = fs::path(newfname);
     if (fs::exists(p))
     {
         // File found

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
@@ -40,19 +40,19 @@ public:
             ; // nothing
             return;
         }
-        if constexpr (N == 2)
+        else if constexpr (N == 2)
         {
             modulo = index & 1;
             index = index >> 1;
             return;
         }
-        if constexpr (N == 4)
+        else if constexpr (N == 4)
         {
             modulo = index & 3;
             index = index >> 2;
             return;
         }
-        if constexpr (N == 8)
+        else if constexpr (N == 8)
         {
             modulo = index & 7;
             index = index >> 3;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/AnimateVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/AnimateVisitor.h
@@ -22,7 +22,10 @@
 #pragma once
 
 #include <sofa/config.h>
+
+#ifndef SOFA_BUILD_SOFA_SIMULATION_CORE
 SOFA_HEADER_DEPRECATED_NOT_REPLACED("v25.12", "v26.06")
+#endif
 
 #include <sofa/simulation/config.h>
 #include <sofa/simulation/fwd.h>

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/TaskSchedulerSettings.h
@@ -20,7 +20,7 @@ public:
 
     TaskSchedulerSettings() = default;
 
-    void init()
+    void init() override
     {
         initTaskScheduler(true);
     }

--- a/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.h
+++ b/Sofa/framework/Simulation/Graph/src/sofa/simulation/graph/DAGNode.h
@@ -23,8 +23,9 @@
 #include <sofa/simulation/graph/config.h>
 #include <sofa/simulation/Node.h>
 
-//header moved in the plugin SofaValidation
+#ifndef SOFA_BUILD_SOFA_SIMULATION_GRAPH
 SOFA_HEADER_DEPRECATED("v25.12", "v26.06", "'sofa/simulation/Node.h' instead of 'sofa/simulation/graph/DAGNode.h' and replace uses of DAGNode with Node")
+#endif
 
 namespace sofa::simulation::graph
 {


### PR DESCRIPTION
MSVC still reports ~160 warnings 🫢


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
