### PR TITLE
[FEM.Elastic] FEMForcefield: getExecutionPolicy did not use the provided data

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FEMForceField.inl
@@ -208,7 +208,7 @@ template <class DataTypes, class ElementType>
 sofa::simulation::ForEachExecutionPolicy FEMForceField<DataTypes, ElementType>::getExecutionPolicy(
     const sofa::Data<ComputeStrategy>& strategy) const
 {
-    auto computeForceStrategyAccessor = sofa::helper::getReadAccessor(d_computeForceStrategy);
+    auto computeForceStrategyAccessor = sofa::helper::getReadAccessor(strategy);
     const auto& computeForceStrategy = computeForceStrategyAccessor->key();
 
     return (computeForceStrategy == parallelComputeStrategy)


### PR DESCRIPTION
Title.

The consequence was that  `computeElementsForcesDeriv` was using `d_computeForceStrategy` value, not `d_computeForceDerivStrategy`

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
