### PR TITLE
[LinearSystem] ConstantSparsityPatternSystem: change key type to support bigger meshes

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.h
@@ -69,7 +69,7 @@ public:
     void resizeSystem(sofa::Size n) override;
     void clearSystem() override;
 
-    using ConstantCRSMapping = std::unordered_map<std::int64_t, std::size_t>;
+    using ConstantCRSMapping = std::unordered_map<std::uint64_t, std::size_t>;
 
     bool isConstantSparsityPatternUsedYet() const;
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.h
@@ -69,7 +69,7 @@ public:
     void resizeSystem(sofa::Size n) override;
     void clearSystem() override;
 
-    using ConstantCRSMapping = std::unordered_map<sofa::SignedIndex, std::size_t>;
+    using ConstantCRSMapping = std::unordered_map<std::int64_t, std::size_t>;
 
     bool isConstantSparsityPatternUsedYet() const;
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/ConstantSparsityPatternSystem.inl
@@ -132,7 +132,7 @@ void ConstantSparsityPatternSystem<TMatrix, TVector>::replaceLocalMatrixMapped(c
                     mat->compressedInsertionOrderList.reserve(insertionOrderList.size());
                     for (const auto& [row, col] : insertionOrderList)
                     {
-                        mat->compressedInsertionOrderList.push_back(mapping.at(row + col * sharedMatrix->rows()));
+                        mat->compressedInsertionOrderList.push_back(mapping.at(static_cast<std::int64_t>(row) + static_cast<std::int64_t>(col) * sharedMatrix->rows()));
                     }
                 }
                 else
@@ -209,7 +209,7 @@ void ConstantSparsityPatternSystem<TMatrix, TVector>::replaceLocalMatrixNonMappe
         // row and col are in global coordinates but the local coordinates will be checked
         pairInsertionOrderList.push_back({row - posInGlobalMatrix[0], col - posInGlobalMatrix[1]});
 
-        const auto flatIndex = row + col * this->getSystemMatrix()->rows();
+        const auto flatIndex = static_cast<std::int64_t>(row) + static_cast<std::int64_t>(col) * this->getSystemMatrix()->rows();
         const auto it = m_constantCRSMapping->find(flatIndex);
         if (it != m_constantCRSMapping->end())
         {
@@ -327,7 +327,7 @@ void ConstantSparsityPatternSystem<TMatrix, TVector>::buildHashTable(linearalgeb
         for(auto xj = rowRange.begin() ; xj < rowRange.end() ; ++xj )  // for each non-null block
         {
             const auto col = M.colsIndex[xj];
-            mapping.emplace(row + col * M.rows(), xj);
+            mapping.emplace(static_cast<std::int64_t>(row) + static_cast<std::int64_t>(col) * M.rows(), xj);
         }
     }
 }


### PR DESCRIPTION
Tried to increase the size of the beam in `examples/Validation/cantilever_beam` but came accross this error while running with 20x20x100 grid:
`[ERROR]   [ConstantSparsityPatternSystem(A)] Could not find index -446175222 (row 32074, col 32073) in the hash table`
which smelled a lot like an overflow somewhere...

Culprit (thanks Claude) being the key type in the map of ConstantSparsityPatternSystem, which was a sofa::SignedIndex aka int32_t.
The flat index computation row + col * rows() overflows.

So the fix is to change this type to handle bigger values, with a int64_t


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
