### PR TITLE
[Visual] Fix crash when texturename is not leading to a valid texture file

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -130,7 +130,7 @@ VisualModelImpl::VisualModelImpl() //const std::string &name, std::string filena
     , d_vertPosIdx      (initData   (&d_vertPosIdx, "vertPosIdx", "If vertices have multiple normals/texcoords stores vertices position indices"))
     , d_vertNormIdx     (initData   (&d_vertNormIdx, "vertNormIdx", "If vertices have multiple normals/texcoords stores vertices normal indices"))
     , d_fileMesh          (initData   (&d_fileMesh, "filename", " Path to an ogl model"))
-    , d_texturename       (initData   (&d_texturename, "texturename", "Name of the Texture"))
+    , d_texturename       (initData   (&d_texturename, "texturename", "Full path of the texture file"))
     , d_translation     (initData   (&d_translation, Vec3Real(), "translation", "Initial Translation of the object"))
     , d_rotation        (initData   (&d_rotation, Vec3Real(), "rotation", "Initial Rotation of the object"))
     , d_scale           (initData   (&d_scale, Vec3Real(1.0, 1.0, 1.0), "scale3d", "Initial Scale of the object"))
@@ -224,7 +224,11 @@ void VisualModelImpl::doDrawVisual(const core::visual::VisualParams* vparams)
         if (m_textureChanged)
         {
             deleteTextures();
-            loadTexture(d_texturename.getFullPath());
+            std::string textureFilename = d_texturename.getFullPath();
+            if (sofa::helper::system::DataRepository.findFile(textureFilename))
+            {
+                loadTexture(d_texturename.getFullPath());
+            }
             m_textureChanged = false;
         }
         initVisual(vparams);
@@ -491,7 +495,7 @@ bool VisualModelImpl::load(const std::string& filename, const std::string& loade
             const bool textureLoaded = loadTexture(textureName);
             if(!textureLoaded)
             {
-                msg_error()<<"Texture "<<textureName<<" cannot be loaded";
+                msg_error() << "Texture " << textureName << " cannot be loaded";
             }
         }
         else

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -229,6 +229,10 @@ void VisualModelImpl::doDrawVisual(const core::visual::VisualParams* vparams)
             {
                 loadTexture(d_texturename.getFullPath());
             }
+            else
+            {
+                msg_error() << "Texture " << textureFilename << " cannot be loaded";
+            }
             m_textureChanged = false;
         }
         initVisual(vparams);

--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -29,6 +29,7 @@
 #include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/helper/io/Mesh.h>
 #include <sofa/helper/system/FileRepository.h>
+#include <sofa/helper/system/FileSystem.h>
 #include <sofa/core/topology/TopologyData.inl>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
@@ -225,9 +226,9 @@ void VisualModelImpl::doDrawVisual(const core::visual::VisualParams* vparams)
         {
             deleteTextures();
             std::string textureFilename = d_texturename.getFullPath();
-            if (sofa::helper::system::DataRepository.findFile(textureFilename))
+            if (sofa::helper::system::FileSystem::exists(textureFilename))
             {
-                loadTexture(d_texturename.getFullPath());
+                loadTexture(textureFilename);
             }
             else
             {

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -59,7 +59,6 @@ OglModel::OglModel()
     , blendEquation( initData(&blendEquation, "blendEquation", "if alpha blending is enabled this specifies how source and destination colors are combined") )
     , sourceFactor( initData(&sourceFactor, "sfactor", "if alpha blending is enabled this specifies how the red, green, blue, and alpha source blending factors are computed") )
     , destFactor( initData(&destFactor, "dfactor", "if alpha blending is enabled this specifies how the red, green, blue, and alpha destination blending factors are computed") )
-    , m_tex(nullptr)
     , vbo(0), iboEdges(0), iboTriangles(0), iboQuads(0)
     , VBOGenDone(false), initDone(false), useEdges(false), useTriangles(false), useQuads(false), canUsePatches(false)
     , oldVerticesSize(0), oldNormalsSize(0), oldTexCoordsSize(0), oldTangentsSize(0), oldBitangentsSize(0), oldEdgesSize(0), oldTrianglesSize(0), oldQuadsSize(0)
@@ -90,8 +89,7 @@ void OglModel::deleteTextures()
 {
     if (m_tex != nullptr) 
     {
-        delete m_tex;
-        m_tex = nullptr;
+        m_tex.reset(nullptr);
     }
 
     for (unsigned int i = 0 ; i < textures.size() ; i++)
@@ -595,7 +593,8 @@ bool OglModel::loadTexture(const std::string& filename)
     helper::io::Image *img = helper::io::Image::Create(filename);
     if (!img)
         return false;
-    m_tex = new sofa::gl::Texture(img, true, true, false, d_srgbTexturing.getValue());
+
+    m_tex = std::make_unique<sofa::gl::Texture>(img, true, true, false, d_srgbTexturing.getValue());
     return true;
 }
 

--- a/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
+++ b/Sofa/GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.h
@@ -71,7 +71,7 @@ protected:
     Data<sofa::helper::OptionsGroup> destFactor; ///< if alpha blending is enabled this specifies how the red, green, blue, and alpha destination blending factors are computed
     GLenum blendEq, sfactor, dfactor;
 
-    sofa::gl::Texture *m_tex; //this texture is used only if a texture name is specified in the scn
+    std::unique_ptr<sofa::gl::Texture> m_tex; //this texture is used only if a texture name is specified in the scn
     GLuint vbo, iboEdges, iboTriangles, iboQuads;
     bool VBOGenDone, initDone, useEdges, useTriangles, useQuads, canUsePatches;
     size_t oldVerticesSize, oldNormalsSize, oldTexCoordsSize, oldTangentsSize, oldBitangentsSize, oldEdgesSize, oldTrianglesSize, oldQuadsSize;
@@ -123,7 +123,7 @@ public:
     bool isUseTriangles()	{ return useTriangles; }
     bool isUseQuads()	{ return useQuads; }
 
-    sofa::gl::Texture* getTex() const	{ return m_tex; }
+    sofa::gl::Texture* getTex() const	{ return m_tex.get(); }
     GLuint getVbo()	{ return vbo;	}
     GLuint getIboEdges() { return iboEdges; }
     GLuint getIboTriangles() { return iboTriangles; }


### PR DESCRIPTION
everything is in the title, if d_texturename is not empty but the file doesn't exists there is some crash even if ImageIO is also doing the check...

[with-all-tests]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
