### PR TITLE
fix: deprecate unused SimpleTimer header

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/SimpleTimer.h
+++ b/Sofa/framework/Helper/src/sofa/helper/SimpleTimer.h
@@ -19,6 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#pragma once
+
+#include <sofa/helper/config.h>
+
+SOFA_HEADER_DEPRECATED("v26.06", "v27.06", "This header is unused and will be removed.")
+
 #ifndef SOFA_HELPER_SIMPLETIMER_H
 #define SOFA_HELPER_SIMPLETIMER_H
 


### PR DESCRIPTION
## Summary

Marks `Sofa/framework/Helper/src/sofa/helper/SimpleTimer.h` as deprecated using `SOFA_HEADER_DEPRECATED`. The header has no usages anywhere in the codebase and can be safely deprecated for later removal.

## Changes

`Sofa/framework/Helper/src/sofa/helper/SimpleTimer.h`: Added `SOFA_HEADER_DEPRECATED("v26.06", "v27.06", "This header is unused and will be removed.")` and included `sofa/helper/config.h` for the macro definition.

Verified with `grep -rn "SimpleTimer"` across the entire codebase - no includes or references outside the header file itself.

Fixes #5214

This contribution was developed with AI assistance (Claude Code).