### PR TITLE
[SofaCUDA] CMake: Remove old options

### DIFF
--- a/applications/plugins/SofaCUDA/Core/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/Core/CMakeLists.txt
@@ -67,7 +67,7 @@ sofa_find_package(Sofa.Component.Mass REQUIRED) # because of CudaMassType -> nee
 
 option(SOFACUDA_CORE_VERBOSE_PTXAS "???" OFF)
 
-option(SOFACUDA_DOUBLE "Activate double-precision support in CUDA." OFF)
+option(SOFACUDA_DOUBLE "Activate double-precision support in CUDA." ON)
 if(SOFACUDA_DOUBLE)
     set(SOFA_GPU_CUDA_DOUBLE 1)       # #cmakedefine
 endif()

--- a/applications/plugins/SofaCUDA/Core/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/Core/CMakeLists.txt
@@ -67,6 +67,12 @@ sofa_find_package(Sofa.Component.Mass REQUIRED) # because of CudaMassType -> nee
 
 option(SOFACUDA_CORE_VERBOSE_PTXAS "???" OFF)
 
+option(SOFACUDA_DOUBLE "Activate double-precision support in CUDA." OFF)
+if(SOFACUDA_DOUBLE)
+    set(SOFA_GPU_CUDA_DOUBLE 1)       # #cmakedefine
+endif()
+
+
 # Note: with SOFA_GPU_CUDA_PRECISE and SOFA_GPU_CUDA_DOUBLE you get IEEE
 # 754-compliant floating point operations for addition and multiplication only.
 option(SOFACUDA_PRECISE "Use IEEE 754-compliant floating point operations." OFF)

--- a/applications/plugins/SofaCUDA/Core/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/Core/CMakeLists.txt
@@ -67,20 +67,7 @@ sofa_find_package(Sofa.Component.Mass REQUIRED) # because of CudaMassType -> nee
 
 option(SOFACUDA_CORE_VERBOSE_PTXAS "???" OFF)
 
-option(SOFACUDA_CUBLAS "Activate cublas support in CUDA (requires SOFACUDA_DOUBLE)." OFF)
-if(SOFACUDA_CUBLAS)
-    set(SOFA_GPU_CUBLAS 1)       # #cmakedefine
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
-    find_package(CUDASparse REQUIRED)
-endif()
-
-# Note: THRUST is included in CUDA SDK 4.0+, it is recommended to use it if available
-option(SOFACUDA_THRUST "Activate THRUST (for RadixSort)." ON)
-if(SOFACUDA_THRUST)
-    set(SOFA_GPU_THRUST 1)       # #cmakedefine
-endif()
-
-option(SOFACUDA_DOUBLE "Activate double-precision support in CUDA (requires GT200+ GPU and -arch sm_13 flag." OFF)
+option(SOFACUDA_DOUBLE "Activate double-precision support in CUDA." OFF)
 if(SOFACUDA_DOUBLE)
     set(SOFA_GPU_CUDA_DOUBLE 1)       # #cmakedefine
 endif()
@@ -126,10 +113,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Mass)
 target_link_libraries(${PROJECT_NAME} PUBLIC CUDA::cudart)
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17 cuda_std_17)
-
-if(SOFACUDA_CUBLAS)
-    target_link_libraries(${PROJECT_NAME} ${CUDA_cusparse_LIBRARY} CUDA::cublas)
-endif()
+target_link_libraries(${PROJECT_NAME} PUBLIC ${CUDA_cusparse_LIBRARY} CUDA::cublas)
 
 # see (I guess) https://github.com/sofa-framework/sofa/blob/314b95cbfba411bf8431486ea75b7c67c0bbcc76/Sofa/framework/Config/cmake/SofaMacrosInstall.cmake#L695
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>/include/${PROJECT_NAME}/${PROJECT_NAME}")

--- a/applications/plugins/SofaCUDA/Core/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/Core/CMakeLists.txt
@@ -67,12 +67,6 @@ sofa_find_package(Sofa.Component.Mass REQUIRED) # because of CudaMassType -> nee
 
 option(SOFACUDA_CORE_VERBOSE_PTXAS "???" OFF)
 
-option(SOFACUDA_DOUBLE "Activate double-precision support in CUDA." OFF)
-if(SOFACUDA_DOUBLE)
-    set(SOFA_GPU_CUDA_DOUBLE 1)       # #cmakedefine
-endif()
-
-
 # Note: with SOFA_GPU_CUDA_PRECISE and SOFA_GPU_CUDA_DOUBLE you get IEEE
 # 754-compliant floating point operations for addition and multiplication only.
 option(SOFACUDA_PRECISE "Use IEEE 754-compliant floating point operations." OFF)

--- a/applications/plugins/SofaCUDA/Core/src/SofaCUDA/core/config.h.in
+++ b/applications/plugins/SofaCUDA/Core/src/SofaCUDA/core/config.h.in
@@ -24,12 +24,13 @@
 #include <sofa/config.h>
 #include <sofa/config/sharedlibrary_defines.h>
 
-#cmakedefine SOFA_GPU_THRUST
 #cmakedefine SOFA_GPU_CUDA_DOUBLE
 #cmakedefine SOFA_GPU_CUDA_PRECISE
 #cmakedefine SOFA_GPU_CUDA_DOUBLE_PRECISE
-#cmakedefine SOFA_GPU_CUBLAS
 #cmakedefine01 SOFACUDA_CORE_HAVE_SOFA_GL
+
+#define SOFA_GPU_THRUST
+#define SOFA_GPU_CUBLAS
 
 #ifdef SOFA_BUILD_SOFACUDA_CORE
 #  define SOFACUDA_CORE_API SOFA_EXPORT_DYNAMIC_LIBRARY

--- a/applications/plugins/SofaCUDA/Core/src/SofaCUDA/core/config.h.in
+++ b/applications/plugins/SofaCUDA/Core/src/SofaCUDA/core/config.h.in
@@ -24,14 +24,13 @@
 #include <sofa/config.h>
 #include <sofa/config/sharedlibrary_defines.h>
 
-#define SOFA_GPU_CUDA_DOUBLE
-#define SOFA_GPU_THRUST
-#define SOFA_GPU_CUBLAS
+#cmakedefine SOFA_GPU_CUDA_DOUBLE
 #cmakedefine SOFA_GPU_CUDA_PRECISE
 #cmakedefine SOFA_GPU_CUDA_DOUBLE_PRECISE
-
 #cmakedefine01 SOFACUDA_CORE_HAVE_SOFA_GL
 
+#define SOFA_GPU_THRUST
+#define SOFA_GPU_CUBLAS
 
 #ifdef SOFA_BUILD_SOFACUDA_CORE
 #  define SOFACUDA_CORE_API SOFA_EXPORT_DYNAMIC_LIBRARY

--- a/applications/plugins/SofaCUDA/Core/src/SofaCUDA/core/config.h.in
+++ b/applications/plugins/SofaCUDA/Core/src/SofaCUDA/core/config.h.in
@@ -24,13 +24,14 @@
 #include <sofa/config.h>
 #include <sofa/config/sharedlibrary_defines.h>
 
-#cmakedefine SOFA_GPU_CUDA_DOUBLE
-#cmakedefine SOFA_GPU_CUDA_PRECISE
-#cmakedefine SOFA_GPU_CUDA_DOUBLE_PRECISE
-#cmakedefine01 SOFACUDA_CORE_HAVE_SOFA_GL
-
+#define SOFA_GPU_CUDA_DOUBLE
 #define SOFA_GPU_THRUST
 #define SOFA_GPU_CUBLAS
+#cmakedefine SOFA_GPU_CUDA_PRECISE
+#cmakedefine SOFA_GPU_CUDA_DOUBLE_PRECISE
+
+#cmakedefine01 SOFACUDA_CORE_HAVE_SOFA_GL
+
 
 #ifdef SOFA_BUILD_SOFACUDA_CORE
 #  define SOFACUDA_CORE_API SOFA_EXPORT_DYNAMIC_LIBRARY


### PR DESCRIPTION
First intention was to fix the cmake configure process with cuBLAS activated (it was missing the `PUBLIC` keyword)

But then cuBLAS and THRUST are fully integrated into CudaToolkit, which is a requirement for SofaCUDA ; and I guess it came from the time it was not supported by all the GPUs
So IMO it should always be enabled.

Same for double, but I am not 100% sure about it, as one may not want the double version maybe.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
