### PR TITLE
[Mapping] SkinningMapping: compute weights from position

### DIFF
--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SkinningMapping.h
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SkinningMapping.h
@@ -85,6 +85,7 @@ protected:
     // data for dual quat blending
     Data< type::vector<unsigned int> > d_nbRef; ///< Number of primitives influencing each point.
     Data< type::vector<sofa::type::SVector<unsigned int> > > d_index; ///< parent indices for each child.
+    Data< bool > d_computeWeightsFromPosition;
     Data< type::vector<sofa::type::SVector<InReal> > > d_weight; ///< influence weights of the Dofs.
     void updateWeights();
 

--- a/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SkinningMapping.inl
+++ b/Sofa/Component/Mapping/Linear/src/sofa/component/mapping/linear/SkinningMapping.inl
@@ -42,6 +42,7 @@ SkinningMapping<TIn, TOut>::SkinningMapping ()
     , d_index (initData (&d_index, "indices", "parent indices for each child." ) )
     , d_weight (initData (&d_weight, "weight", "influence weights of the Dofs." ) )
     , d_showFromIndex (initData (&d_showFromIndex, ( unsigned int ) 0, "showFromIndex", "Displayed From Index." ) )
+    , d_computeWeightsFromPosition (initData (&d_computeWeightsFromPosition, false, "computeWeightsFromPosition", "By default, the weights are computed w.r.t the rest positions of the input model. Set to true to compute them from the position instead." ) )
     , d_showWeights (initData (&d_showWeights, false, "showWeights", "Show influence." ) )
 {
     type::vector<unsigned int> defaultNbRef;
@@ -86,7 +87,7 @@ void SkinningMapping<TIn, TOut>::reinit()
 
     sofa::helper::ReadAccessor<Data<OutVecCoord> > out (*this->toModel->read(core::vec_id::read_access::position));
     sofa::helper::ReadAccessor<Data<OutVecCoord> > xto (this->d_initPos);
-    sofa::helper::ReadAccessor<Data<InVecCoord> > xfrom = *this->fromModel->read(core::vec_id::read_access::restPosition);
+    sofa::helper::ReadAccessor<Data<InVecCoord> > xfrom = *this->fromModel->read(d_computeWeightsFromPosition.getValue()? core::vec_id::read_access::position : core::vec_id::read_access::restPosition);
     sofa::helper::WriteAccessor<Data<type::vector<sofa::type::SVector<InReal> > > > m_weights  (d_weight );
     const sofa::helper::ReadAccessor<Data<type::vector<sofa::type::SVector<unsigned int> > > > index ( this->d_index );
 
@@ -133,7 +134,8 @@ void SkinningMapping<TIn, TOut>::updateWeights ()
     msg_info() << "UPDATE WEIGHTS";
 
     sofa::helper::ReadAccessor<Data<OutVecCoord> > xto (this->d_initPos);
-    sofa::helper::ReadAccessor<Data<InVecCoord> > xfrom = *this->fromModel->read(core::vec_id::read_access::restPosition);
+    sofa::helper::ReadAccessor<Data<InVecCoord> > xfrom = *this->fromModel->read(d_computeWeightsFromPosition.getValue()? core::vec_id::read_access::position : core::vec_id::read_access::restPosition);
+
     sofa::helper::WriteAccessor<Data<type::vector<sofa::type::SVector<InReal> > > > m_weights  (d_weight );
     sofa::helper::WriteAccessor<Data<type::vector<sofa::type::SVector<unsigned int> > > > index (d_index );
 


### PR DESCRIPTION
By default, the weights of the `SkinningMapping` are computed w.r.t the rest position of the input model. 
This PR adds an option to compute them from the position instead.

For exemple, I'm using this with pre-bent concentric tubes: the rest position is curved, while the visual model and position at start are straight. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
