### PR TITLE
[Framework] Fix more warnings (clang, macos)

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObjectDescription.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseObjectDescription.cpp
@@ -141,7 +141,7 @@ int BaseObjectDescription::getAttributeAsInt(const std::string& attr, const int 
 
     const char* attrstr=it->second.c_str();
     char* end=nullptr;
-    const int retval = strtol(attrstr, &end, 10);
+    const int retval = static_cast<int>(strtol(attrstr, &end, 10));
 
     /// It is important to check that the attribute was totally parsed to report
     /// message to users because a silent error is the worse thing that can happen in UX.

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetData.inl
@@ -117,8 +117,8 @@ void TopologySubsetData <ElementType, VecT>::add(sofa::Size nbElements,
     helper::WriteOnlyAccessor<Data<container_type> > data = this;
 
     // first resize the subsetData. value will be applied in the loop using callbacks
-    const Size size = data.size();
-    data.resize(size + nbElements);
+    const Size size = static_cast<Size>(data.size());
+    data.resize(size + static_cast<Size>(nbElements));
     
 
     if (this->p_onCreationCallback)
@@ -129,7 +129,7 @@ void TopologySubsetData <ElementType, VecT>::add(sofa::Size nbElements,
             value_type& t = data[id];
             
             // update map if needed
-            addPostProcess(LastDataId + i + 1);
+            addPostProcess(LastDataId + static_cast<sofa::Index>(i) + 1);
 
             this->p_onCreationCallback(id, t, elems[i], 
                 (ancestors.empty() || coefs.empty()) ? s_empty_ancestors : ancestors[i],
@@ -154,7 +154,7 @@ void TopologySubsetData <ElementType, VecT>::add(const sofa::type::vector<Index>
 {
     SOFA_UNUSED(ancestorElems);
 
-    const sofa::Size nbElements = index.size();
+    const sofa::Size nbElements = static_cast<sofa::Size>(index.size());
     this->add(nbElements, elems, ancestors, coefs);
 }
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/TypeInfoRegistry.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/TypeInfoRegistry.cpp
@@ -90,7 +90,7 @@ int TypeInfoRegistry::AllocateNewTypeId(const std::type_info& nfo)
     const std::string name = sofa::helper::NameDecoder::decodeTypeName(nfo);
     const std::string typeName = sofa::helper::NameDecoder::decodeTypeName(nfo);
     typeinfos.push_back(new NameOnlyTypeInfo(name, typeName));
-    return typeinfos.size()-1;
+    return static_cast<int>(typeinfos.size()-1);
 }
 
 

--- a/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
@@ -1087,7 +1087,7 @@ std::string getTime(ctime_t t, int niter=1)
 double strToDouble(std::string const &stringToConvert, std::size_t const precision)
 {
     std::stringstream convertingStream;
-    convertingStream << std::setprecision(precision) << std::fixed << stringToConvert << std::endl;
+    convertingStream << std::setprecision(static_cast<int>(precision)) << std::fixed << stringToConvert << std::endl;
 
     double answer;
     convertingStream >> answer;

--- a/Sofa/framework/Helper/src/sofa/helper/MarchingCubeUtility.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/MarchingCubeUtility.cpp
@@ -852,14 +852,14 @@ namespace sofa::helper
     void MarchingCubeUtility::updateTriangleInRegularGridVector ( type::vector< type::vector<unsigned int /*regular grid space index*/> >& triangleIndexInRegularGrid, const type::Vec3i& coord, const GridCell& cell, unsigned int nbTriangles ) const
     {
         vector<unsigned int> voxels;
-        if ( cell.val[0] ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
-        if ( cell.val[1] ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
-        if ( cell.val[3] ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
-        if ( cell.val[2] ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
-        if ( cell.val[4] ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
-        if ( cell.val[5] ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
-        if ( cell.val[7] ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
-        if ( cell.val[6] ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[0] != 0 ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[1] != 0 ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[3] != 0 ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[2] != 0 ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+0 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[4] != 0 ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[5] != 0 ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+0 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[7] != 0 ) voxels.push_back ( ( coord[0]+0 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
+        if ( cell.val[6] != 0 ) voxels.push_back ( ( coord[0]+1 ) + ( coord[1]+1 ) *m_dataResolution[0] + ( coord[2]+1 ) *m_dataResolution[0]*m_dataResolution[1] ); //les voxels occupes ds ce cube
 
         for ( size_t i = 0; i < nbTriangles; i++ )
         {

--- a/Sofa/framework/Helper/src/sofa/helper/TriangleOctree.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/TriangleOctree.cpp
@@ -840,7 +840,7 @@ void TriangleOctreeRoot::buildOctree()
     // for each triangle add it to the octree
     for (size_t i = 0; i < octreeTriangles->size(); i++)
     {
-        fillOctree (i);
+        fillOctree (static_cast<int>(i));
     }
 }
 

--- a/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/Utils.cpp
@@ -109,7 +109,7 @@ static std::string computeExecutablePath()
 #elif defined(__APPLE__)
     std::vector<char> buffer(PATH_MAX);
     std::vector<char> real_path(PATH_MAX);
-    uint32_t size = buffer.size();
+    uint32_t size = static_cast<uint32_t>(buffer.size());
     if (_NSGetExecutablePath(&buffer[0], &size) != 0) {
         msg_error("Utils::computeExecutablePath()") << "_NSGetExecutablePath() failed";
     }

--- a/Sofa/framework/Helper/src/sofa/helper/io/MeshGmsh.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/io/MeshGmsh.cpp
@@ -63,7 +63,7 @@ void MeshGmsh::init (std::string filename)
         std::getline(file, version); // Getting the version line (e.g. 4.1 0 8)
         try
         {
-            gmshFormat = std::stoul(version.substr( 0, version.find(" ")) ); // Retrieving the mesh format, keeping only the integer part
+            gmshFormat = static_cast<unsigned int>(std::stoul(version.substr( 0, version.find(" ")) )); // Retrieving the mesh format, keeping only the integer part
         }
         catch (const std::exception&)
         {

--- a/Sofa/framework/Helper/src/sofa/helper/system/FileMonitor_macosx.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileMonitor_macosx.cpp
@@ -95,7 +95,7 @@ These steps are explained in more detail in the sections that follow.
                                           0.2, // CFTimeInterval latency
                                           kFSEventStreamCreateFlagFileEvents // FSEventStreamCreateFlags flags
                                           );
-        FSEventStreamScheduleWithRunLoop(m_eventStream,CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        FSEventStreamSetDispatchQueue(m_eventStream, dispatch_get_main_queue());
         FSEventStreamStart(m_eventStream);
     }
 

--- a/Sofa/framework/Helper/src/sofa/helper/system/PipeProcess.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/PipeProcess.cpp
@@ -306,7 +306,7 @@ bool PipeProcess::executeProcess(const std::string &command,  const std::vector<
                 {
                     int n = BUFSIZE-nfill[i];
                     if (n> STEPSIZE) n = STEPSIZE;
-                    n = ::read(fds[i][0], buf[i]+nfill[i], n);
+                    n = static_cast<int>(::read(fds[i][0], buf[i]+nfill[i], n));
 
                     if (n == 0)
                     {

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BlockDiagonalMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BlockDiagonalMatrix.h
@@ -78,12 +78,12 @@ public:
 
     Index rowBSize(void) const
     {
-        return data.size();
+        return static_cast<Index>(data.size());
     }
 
     Index colBSize(void) const
     {
-        return data.size();
+        return static_cast<Index>(data.size());
     }
 
     const Block& bloc(Index i) const

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixConstraint.h
@@ -549,7 +549,7 @@ public:
     RowConstIterator readLine(Index lIndex) const
     {
         if constexpr (Policy::AutoCompress) const_cast<Matrix*>(this)->compress();  /// \warning this violates the const-ness of the method !
-        Index rowId = (this->nBlockRow == 0) ? 0 : lIndex * this->rowIndex.size() / this->nBlockRow;
+        Index rowId = (this->nBlockRow == 0) ? 0 : static_cast<Index>(lIndex * this->rowIndex.size() / this->nBlockRow);
         if (this->sortedFind(this->rowIndex, lIndex, rowId))
         {
             return RowConstIterator(this, rowId);

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/SparseMatrixProduct.inl
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/SparseMatrixProduct.inl
@@ -291,8 +291,8 @@ void SparseMatrixProduct<Lhs, Rhs, ResultType>::computeProductFromIntersection()
     auto* rhs_ptr = m_rhs->valuePtr();
     auto* product_ptr = m_productResult.valuePtr();
 
-    [[maybe_unused]] const auto lhsNonZeros = m_lhs->nonZeros();
-    [[maybe_unused]] const auto rhsNonZeros = m_rhs->nonZeros();
+    [[maybe_unused]] const Eigen::Index lhsNonZeros = m_lhs->nonZeros();
+    [[maybe_unused]] const Eigen::Index rhsNonZeros = m_rhs->nonZeros();
 
     for (const auto& pairs : m_intersectionAB.intersection)
     {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Colors.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Colors.cpp
@@ -104,7 +104,7 @@ const char* getColor(const sofa::Index id)
 sofa::Index registerColor(const std::string& hexColor)
 {
     DEFAULTCOLORS.emplace_back(hexColor);
-    return DEFAULTCOLORS.size()-1;
+    return static_cast<sofa::Index>(DEFAULTCOLORS.size()-1);
 }
 
 sofa::Index registerColor(const std::string& className, const std::string& hexColor)

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelSparseMatrixProduct.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/ParallelSparseMatrixProduct.h
@@ -38,7 +38,7 @@ public:
 
     void computeProductFromIntersection() override
     {
-        assert(this->m_intersectionAB.intersection.size() == this->m_productResult.nonZeros());
+        assert(static_cast<Eigen::Index>(this->m_intersectionAB.intersection.size()) == this->m_productResult.nonZeros());
         assert(taskScheduler);
 
         auto* lhs_ptr = this->m_lhs->valuePtr();

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalAddMBKdxVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalAddMBKdxVisitor.cpp
@@ -49,7 +49,7 @@ void MechanicalAddMBKdxVisitor::bwdMechanicalMapping(simulation::Node* /*node*/,
     if (accumulate)
     {
         map->applyJT(mparams, res, res);
-        if( mparams->kFactor() ) map->applyDJT(mparams, res, res);
+        if( mparams->kFactor() != 0 ) map->applyDJT(mparams, res, res);
     }
 }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeDfVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalComputeDfVisitor.cpp
@@ -49,7 +49,7 @@ void MechanicalComputeDfVisitor::bwdMechanicalMapping(simulation::Node* /*node*/
     if (accumulate)
     {
         map->applyJT(mparams, res, res);  // apply material stiffness: variation of force below the mapping
-        if( mparams->kFactor() ) map->applyDJT(mparams, res, res); // apply geometric stiffness: variation due to a change of mapping, with a constant force below the mapping
+        if(mparams->kFactor() != 0) map->applyDJT(mparams, res, res); // apply geometric stiffness: variation due to a change of mapping, with a constant force below the mapping
     }
 }
 

--- a/Sofa/framework/Type/src/sofa/type/DualQuat.inl
+++ b/Sofa/framework/Type/src/sofa/type/DualQuat.inl
@@ -170,7 +170,7 @@ void  DualQuatCoord3<real>::normalize_getdJ( type::Mat<4,4,real>& dJ0, type::Mat
 
     real q0dqe = (real) ( qn.orientation[0]*dq.dual[0] + qn.orientation[1]*dq.dual[1] + qn.orientation[2]*dq.dual[2] + qn.orientation[3]*dq.dual[3]);
 
-    if(dq.orientation[0] || dq.orientation[1] || dq.orientation[2] || dq.orientation[3])
+    if(dq.orientation[0] != 0 || dq.orientation[1] != 0 || dq.orientation[2] != 0 || dq.orientation[3] != 0)
     {
         real q0dq0 = (real) ( qn.orientation[0]*dq.orientation[0] + qn.orientation[1]*dq.orientation[1] + qn.orientation[2]*dq.orientation[2] + qn.orientation[3]*dq.orientation[3]);
         real qedq0 = (real) ( qn.dual[0]*dq.orientation[0] + qn.dual[1]*dq.orientation[1] + qn.dual[2]*dq.orientation[2] + qn.dual[3]*dq.orientation[3]);

--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -167,7 +167,9 @@ public:
     template<typename real2>
     constexpr Mat(const Mat<L,C,real2>& m) noexcept
     {
-        std::copy(m.begin(), m.begin()+L, this->begin());
+        for( Size i=0; i<L; i++ )
+            for( Size j=0; j<C; j++ )
+                (*this)(i,j) = static_cast<real>(m(i,j));
     }
 
     /// Constructor from another matrix with different size (with null default entries and ignoring outside entries)

--- a/Sofa/framework/Type/src/sofa/type/Vec.h
+++ b/Sofa/framework/Type/src/sofa/type/Vec.h
@@ -517,7 +517,7 @@ public:
         {
             ValueType n=0;
             for( Size i=0; i<N; i++ )
-                if( this->elems[i] ) n+=1;
+                if( this->elems[i] != static_cast<ValueType>(0) ) n+=1;
             return n;
         }
         else // generic implementation


### PR DESCRIPTION
Mostly warning about implicit conversions (real to bool, signed/unsigned, to a smaller type)

The not-trivial one is Sofa/framework/Type/src/sofa/type/Mat.h
```
  template<typename real2>
    constexpr Mat(const Mat<L,C,real2>& m) noexcept
    {
        std::copy(m.begin(), m.begin()+L, this->begin());
    }
```
used with CRS templated on blocks (i.e Vec), it can lead conversion (copy) from Vec3f to Vec3d, thus triggering the deprecations set in #5675 


NOTE: the AI was a local-deployed one (Qwen3.5)

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
