### PR TITLE
[Core, Simulation.Core] MSVC: fix inconsistent linkages

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/fwd.h
+++ b/Sofa/framework/Core/src/sofa/core/fwd.h
@@ -235,10 +235,13 @@ const sofa::core::objectmodel::BaseClass* GetClass(){return B::GetClass(); }
 ///
 /// Once declare it is mandatory to also define the same functions.
 /// For that you must use SOFA_DEFINE_OPAQUE_FUNCTION_BETWEEN_BASE_AND
+#define SOFA_DECLARE_WITH_API_MACRO_OPAQUE_FUNCTION_BETWEEN_BASE_AND(TYPENAME, API_MACRO) \
+    template<> API_MACRO TYPENAME* castTo(sofa::core::objectmodel::Base* base); \
+    API_MACRO sofa::core::objectmodel::Base* castToBase(TYPENAME* b); \
+    namespace objectmodel::base { template<> API_MACRO const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>(); }
+
 #define SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(TYPENAME) \
-    template<> SOFA_CORE_API TYPENAME* castTo(sofa::core::objectmodel::Base* base); \
-    SOFA_CORE_API sofa::core::objectmodel::Base* castToBase(TYPENAME* b); \
-    namespace objectmodel::base { template<> SOFA_CORE_API const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>(); }
+    SOFA_DECLARE_WITH_API_MACRO_OPAQUE_FUNCTION_BETWEEN_BASE_AND(TYPENAME, SOFA_CORE_API)
 
 /// Define the opaque function signature for a type that in-herit from Base.
 ///

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/fwd.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/fwd.h
@@ -55,7 +55,7 @@ SOFA_SIMULATION_CORE_API Node* getNodeFrom(sofa::core::objectmodel::BaseContext*
 
 namespace sofa::core
 {
-SOFA_DECLARE_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::simulation::Node);
+SOFA_DECLARE_WITH_API_MACRO_OPAQUE_FUNCTION_BETWEEN_BASE_AND(sofa::simulation::Node, SOFA_SIMULATION_CORE_API);
 }
 
 namespace sofa::simulation::common


### PR DESCRIPTION
MSVC throws these compilation and linkage warnings:

```
J:\0\src\Sofa\framework\Simulation\Core\src\sofa\simulation\fwd.cpp(29): warning C4273: 'sofa::core::castTo': inconsistent dll linkage
J:\0\src\Sofa\framework\Simulation\Core\src\sofa/simulation/fwd.h(58): note: see previous definition of 'castTo'
J:\0\src\Sofa\framework\Simulation\Core\src\sofa\simulation\fwd.cpp(29): warning C4273: 'sofa::core::castToBase': inconsistent dll linkage
J:\0\src\Sofa\framework\Simulation\Core\src\sofa/simulation/fwd.h(58): note: see previous definition of 'castToBase'
J:\0\src\Sofa\framework\Simulation\Core\src\sofa\simulation\fwd.cpp(29): warning C4273: 'sofa::core::objectmodel::base::GetClass': inconsistent dll linkage
J:\0\src\Sofa\framework\Simulation\Core\src\sofa/simulation/fwd.h(58): note: see previous definition of 'GetClass'
```
```
symbol '??$castTo@PEAVNode@simulation@sofa@@@core@sofa@@YAPEAVNode@simulation@1@PEAVBase@objectmodel@01@@Z (class sofa::simulation::Node * __cdecl sofa::core::castTo<class sofa::simulation::Node *>(class sofa::core::objectmodel::Base *))' defined in 'fwd.obj' is imported by 'Node.obj'
symbol '??$GetClass@VNode@simulation@sofa@@@base@objectmodel@core@sofa@@YAPEBVBaseClass@123@XZ (class sofa::core::objectmodel::BaseClass const * __cdecl sofa::core::objectmodel::base::GetClass<class sofa::simulation::Node>(void))' defined in 'fwd.obj' is imported by 'DefaultVisualManagerLoop.obj' in function '"public: static bool __cdecl sofa::core::PathResolver::FindLinkDest<class sofa::simulation::Node>(class sofa::core::objectmodel::Base *,class sofa::simulation::Node * &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class sofa::core::objectmodel::BaseLink const *)" (??$FindLinkDest@VNode@simulation@sofa@@@PathResolver@core@sofa@@SA_NPEAVBase@objectmodel@12@AEAPEAVNode@simulation@2@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBVBaseLink@412@@Z)'
symbol '?castToBase@core@sofa@@YAPEAVBase@objectmodel@12@PEAVNode@simulation@2@@Z (class sofa::core::objectmodel::Base * __cdecl sofa::core::castToBase(class sofa::simulation::Node *))' defined in 'fwd.obj' is imported by 'DefaultVisualManagerLoop.obj' in function '"protected: virtual class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl sofa::core::objectmodel::TLink<class sofa::simulation::DefaultVisualManagerLoop,class sofa::simulation::Node,32>::_doGetLinkedPath_(unsigned __int64)const " (?_doGetLinkedPath_@?$TLink@VDefaultVisualManagerLoop@simulation@sofa@@VNode@23@$0CA@@objectmodel@core@sofa@@MEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@_K@Z)'
symbol '??$castTo@PEAVNode@simulation@sofa@@@core@sofa@@YAPEAVNode@simulation@1@PEAVBase@objectmodel@01@@Z (class sofa::simulation::Node * __cdecl sofa::core::castTo<class sofa::simulation::Node *>(class sofa::core::objectmodel::Base *))' defined in 'fwd.obj' is imported by 'DefaultVisualManagerLoop.obj' in function '"public: static bool __cdecl sofa::core::PathResolver::FindLinkDest<class sofa::simulation::Node>(class sofa::core::objectmodel::Base *,class sofa::simulation::Node * &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class sofa::core::objectmodel::BaseLink const *)" (??$FindLinkDest@VNode@simulation@sofa@@@PathResolver@core@sofa@@SA_NPEAVBase@objectmodel@12@AEAPEAVNode@simulation@2@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBVBaseLink@412@@Z)'
```

because the macro is called from Sofa.Simulation.Core, but the macro integrates the SOFA_CORE_API so it leads to inconsistency for import/export keywords.

The solution in the PR is a bit ad-hoc so maybe a better one could be implemented instead

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
