### PR TITLE
[Core] Clarify how the visitor knows if a state is mapped or not

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
@@ -53,6 +53,22 @@ BaseMechanicalVisitor::BaseMechanicalVisitor(const sofa::core::ExecParams *param
     canAccessSleepingNode = false;
 }
 
+bool BaseMechanicalVisitor::isMechanicalStateMapped(simulation::Node* node) const
+{
+    /**
+     * WARNING!!!!!
+     *
+     * This condition is not valid for all cases, as it only checks for the presence of a mechanical
+     * mapping in the same Node. This condition does not ensure that the state is not an output of a
+     * mapping.
+     *
+     * Examples of situations where this condition is not appropritate:
+     * - No mapping in the Node but the mapping is defined in another Node.
+     * - There is a mapping in the Node, but the state is not an output of this mapping.
+     */
+    return node->mechanicalMapping != nullptr;
+}
+
 Visitor::Result BaseMechanicalVisitor::processNodeTopDown(simulation::Node *node, VisitorContext *ctx)
 {
     for (auto *solver : node->solver)
@@ -76,7 +92,7 @@ Visitor::Result BaseMechanicalVisitor::processNodeTopDown(simulation::Node *node
 
     if (node->mechanicalState != nullptr)
     {
-        if (node->mechanicalMapping != nullptr)
+        if (isMechanicalStateMapped(node))
         {
             res = runVisitorTask(this, ctx, &BaseMechanicalVisitor::fwdMappedMechanicalState, &*node->mechanicalState, fwdVisitorType);
         }
@@ -134,7 +150,7 @@ void BaseMechanicalVisitor::processNodeBottomUp(simulation::Node *node, VisitorC
 
     if (node->mechanicalState != nullptr)
     {
-        if (node->mechanicalMapping != nullptr)
+        if (isMechanicalStateMapped(node))
         {
             runVisitorTask(this, ctx, &BaseMechanicalVisitor::bwdMappedMechanicalState, &*node->mechanicalState, bwdVisitorType);
         }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.h
@@ -44,7 +44,7 @@ class SOFA_SIMULATION_CORE_API BaseMechanicalVisitor : public Visitor
 {
 
 protected:
-    simulation::Node* root; ///< root node from which the visitor was executed
+    simulation::Node* root { nullptr }; ///< root node from which the visitor was executed
 
     virtual Result processNodeTopDown(simulation::Node* node, VisitorContext* ctx);
     virtual void processNodeBottomUp(simulation::Node* node, VisitorContext* ctx);
@@ -55,6 +55,12 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override;
+
+    /**
+     * Returns true if the node has a mapped mechanical state. It is mapped if the state is not an
+     * output of a mapping.
+     */
+    virtual bool isMechanicalStateMapped(simulation::Node* node) const;
 
     /**@name Forward processing
     Methods called during the forward (top-down) traversal of the data structure.


### PR DESCRIPTION
Refactors the visitor logic by extracting the check for whether a mechanical state is mapped or not into a dedicated helper method, ` isMechanicalStateMapped`.

This change improves code clarity within BaseMechanicalVisitor, specifically updating how we determine if a node's mechanical state requires processing via [fwd|bwd]MappedMechanicalState or [fwd|bwd]MechanicalState during graph traversal.

**Impact**:

The logic for checking mapping status is now centralized in isMechanicalStateMapped.
The calling site is cleaner and relies on this new, descriptive function call.

**Note on Functionality**:
The internal implementation includes a warning about the scope of this check: it only validates the presence of a mapping on the node itself and does not guarantee global mapping status (e.g., if the state is mapped in an external node). This limitation is preserved and documented within the method's comments.

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
