### PR TITLE
[LinearSystem] Replace deprecated header

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/BaseMatrixProjectionMethod.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/BaseMatrixProjectionMethod.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <sofa/component/linearsystem/config.h>
-#include <sofa/component/linearsystem/MappingGraph.h>
+#include <sofa/simulation/MappingGraph.h>
 #include <sofa/core/behavior/StateAccessor.h>
 #include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/BaseMatrixProjectionMethod.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/BaseMatrixProjectionMethod.h
@@ -62,7 +62,7 @@ public:
      * \param globalMatrix The product is added into this matrix
      */
     virtual void projectMatrixToGlobalMatrix(const core::MechanicalParams* mparams,
-                                             const MappingGraph& mappingGraph,
+                                             const simulation::MappingGraph& mappingGraph,
                                              TMatrix* matrixToProject,
                                              linearalgebra::BaseMatrix* globalMatrix) = 0;
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
@@ -80,7 +80,7 @@ public:
     using Contribution = core::matrixaccumulator::Contribution;
     using PairMechanicalStates = sofa::type::fixed_array<core::behavior::BaseMechanicalState*, 2>;
 
-    [[nodiscard]] const MappingGraph& getMappingGraph() const;
+    [[nodiscard]] const simulation::MappingGraph& getMappingGraph() const;
 
     Data< bool > d_assembleStiffness; ///< If true, the stiffness is added to the global matrix
     Data< bool > d_assembleMass; ///< If true, the mass is added to the global matrix

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.h
@@ -26,7 +26,7 @@
 #include <sofa/core/behavior/BaseLocalForceFieldMatrix.h>
 #include <sofa/core/behavior/BaseLocalMassMatrix.h>
 #include <sofa/core/BaseLocalMappingMatrix.h>
-#include <sofa/component/linearsystem/MappingGraph.h>
+#include <sofa/simulation/MappingGraph.h>
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
 #include <sofa/component/linearsystem/matrixaccumulators/AssemblingMappedMatrixAccumulator.h>
 #include <sofa/component/linearsystem/CreateMatrixDispatcher.h>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
@@ -760,7 +760,7 @@ TMatrix, TVector>::getContributors() const
 }
 
 template <class TMatrix, class TVector>
-const MappingGraph& MatrixLinearSystem<TMatrix, TVector>::getMappingGraph() const
+const simulation::MappingGraph& MatrixLinearSystem<TMatrix, TVector>::getMappingGraph() const
 {
     return m_mappingGraph;
 }

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.h
@@ -42,7 +42,7 @@ public:
     ~MatrixProjectionMethod() override;
 
     void computeMatrixJacobians(const core::MechanicalParams* mparams,
-                                const MappingGraph& mappingGraph,
+                                const simulation::MappingGraph& mappingGraph,
                                 TMatrix* matrixToProject);
 
 protected:
@@ -51,12 +51,12 @@ protected:
 
     void reinit() override;
 
-    virtual void computeMatrixProduct(const MappingGraph& mappingGraph,
+    virtual void computeMatrixProduct(const simulation::MappingGraph& mappingGraph,
                           TMatrix* matrixToProject,
                           linearalgebra::BaseMatrix* globalMatrix);
 
     virtual void projectMatrixToGlobalMatrix(const core::MechanicalParams* mparams,
-                                     const MappingGraph& mappingGraph,
+                                     const simulation::MappingGraph& mappingGraph,
                                      TMatrix* matrixToProject,
                                      linearalgebra::BaseMatrix* globalMatrix) override;
 
@@ -67,7 +67,7 @@ protected:
      * Build the jacobian matrices of mappings from a mapped state to its top most parents (in the
      * sense of mappings)
      */
-    simulation::MappingJacobians<TMatrix> computeJacobiansFrom(core::behavior::BaseMechanicalState* mstate, const core::MechanicalParams* mparams, const MappingGraph& mappingGraph, TMatrix* crs);
+    simulation::MappingJacobians<TMatrix> computeJacobiansFrom(core::behavior::BaseMechanicalState* mstate, const core::MechanicalParams* mparams, const simulation::MappingGraph& mappingGraph, TMatrix* crs);
 
     core::objectmodel::BaseContext* getSolveContext();
 
@@ -88,7 +88,7 @@ protected:
         sofa::type::fixed_array<core::behavior::BaseMechanicalState*, 2> mstatePair,
         TMatrix* mappedMatrix,
         sofa::type::fixed_array<simulation::MappingJacobians<TMatrix>, 2> jacobians,
-        const MappingGraph& mappingGraph,
+        const simulation::MappingGraph& mappingGraph,
         linearalgebra::BaseMatrix* globalMatrix);
 
     Eigen::Map<Eigen::SparseMatrix<Block, Eigen::RowMajor> > makeEigenMap(const TMatrix& matrix);

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.inl
@@ -72,7 +72,7 @@ void MatrixProjectionMethod<TMatrix>::addMappedMatrixToGlobalMatrixEigen(
     sofa::type::fixed_array<core::behavior::BaseMechanicalState*, 2> mstatePair,
     TMatrix* mappedMatrix,
     sofa::type::fixed_array<simulation::MappingJacobians<TMatrix>, 2> jacobians,
-    const MappingGraph& mappingGraph, linearalgebra::BaseMatrix* globalMatrix)
+    const simulation::MappingGraph& mappingGraph, linearalgebra::BaseMatrix* globalMatrix)
 {
     if (!mappedMatrix)
     {
@@ -203,7 +203,7 @@ void addToGlobalMatrix(linearalgebra::BaseMatrix* globalMatrix, Eigen::SparseMat
 }
 
 template <class TMatrix>
-void MatrixProjectionMethod<TMatrix>::computeMatrixJacobians(const core::MechanicalParams* mparams, const MappingGraph& mappingGraph, TMatrix* matrixToProject)
+void MatrixProjectionMethod<TMatrix>::computeMatrixJacobians(const core::MechanicalParams* mparams, const simulation::MappingGraph& mappingGraph, TMatrix* matrixToProject)
 {
     if (!m_mappingJacobians.has_value() || !d_areJacobiansConstant.getValue())
     {
@@ -219,7 +219,8 @@ void MatrixProjectionMethod<TMatrix>::computeMatrixJacobians(const core::Mechani
 }
 
 template <class TMatrix>
-void MatrixProjectionMethod<TMatrix>::computeMatrixProduct(const MappingGraph& mappingGraph, TMatrix* matrixToProject, linearalgebra::BaseMatrix* globalMatrix)
+void MatrixProjectionMethod<TMatrix>::computeMatrixProduct(
+    const simulation::MappingGraph& mappingGraph, TMatrix* matrixToProject, linearalgebra::BaseMatrix* globalMatrix)
 {
     this->addMappedMatrixToGlobalMatrixEigen(
         {this->l_mechanicalStates[0], this->l_mechanicalStates[1]},
@@ -229,7 +230,7 @@ void MatrixProjectionMethod<TMatrix>::computeMatrixProduct(const MappingGraph& m
 
 template <class TMatrix>
 void MatrixProjectionMethod<TMatrix>::projectMatrixToGlobalMatrix(const core::MechanicalParams* mparams,
-    const MappingGraph& mappingGraph,
+    const simulation::MappingGraph& mappingGraph,
     TMatrix* matrixToProject, linearalgebra::BaseMatrix* globalMatrix)
 {
     computeMatrixJacobians(mparams, mappingGraph, matrixToProject);
@@ -265,7 +266,7 @@ std::vector<unsigned> MatrixProjectionMethod<TMatrix>::identifyAffectedDoFs(
 template <class TMatrix>
 simulation::MappingJacobians<TMatrix> MatrixProjectionMethod<TMatrix>::computeJacobiansFrom(
     core::behavior::BaseMechanicalState* mstate, const core::MechanicalParams* mparams,
-    const MappingGraph& mappingGraph, TMatrix* crs)
+    const simulation::MappingGraph& mappingGraph, TMatrix* crs)
 {
     core::ConstraintParams cparams(*mparams);
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
@@ -106,7 +106,7 @@ protected:
     LinearSystemData<TMatrix, TVector> m_linearSystem;
 
     /// Relationships between the mechanical states and their associated components
-    MappingGraph m_mappingGraph;
+    ::sofa::simulation::MappingGraph m_mappingGraph;
 
     /// The list of force fields contributing to the matrix assembly
     sofa::type::vector<sofa::core::behavior::BaseForceField*> m_forceFields;

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/TypedMatrixLinearSystem.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/behavior/BaseMatrixLinearSystem.h>
 #include <sofa/core/MultiVecId.h>
-#include <sofa/component/linearsystem/MappingGraph.h>
+#include <sofa/simulation/MappingGraph.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/component/linearsystem/LinearSystemData.h>
 #include <sofa/core/MatrixAccumulator.h>

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.cpp
@@ -26,7 +26,7 @@ namespace sofa::component::linearsystem
 {
 
 AssembleGlobalVectorFromLocalVectorVisitor::AssembleGlobalVectorFromLocalVectorVisitor(const core::ExecParams* params,
-    const MappingGraph& mappingGraph, sofa::core::ConstMultiVecId src, linearalgebra::BaseVector* globalVector)
+    const simulation::MappingGraph& mappingGraph, sofa::core::ConstMultiVecId src, linearalgebra::BaseVector* globalVector)
     : BaseMechanicalVisitor(params)
     , m_src(src)
     , m_globalVector(globalVector)

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.h
@@ -38,7 +38,7 @@ public:
 
     AssembleGlobalVectorFromLocalVectorVisitor(
         const core::ExecParams* params,
-        const MappingGraph& mappingGraph,
+        const simulation::MappingGraph& mappingGraph,
         sofa::core::ConstMultiVecId src,
         linearalgebra::BaseVector * globalVector);
 
@@ -57,7 +57,7 @@ protected:
     sofa::linearalgebra::BaseVector *m_globalVector { nullptr};
 
     /// Structure used to identify where in the global vector the local vectors will be copied into
-    const MappingGraph& m_mappingGraph;
+    const simulation::MappingGraph& m_mappingGraph;
 };
 
 } // namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.h
@@ -23,7 +23,7 @@
 
 #include <sofa/component/linearsystem/config.h>
 #include <sofa/simulation/BaseMechanicalVisitor.h>
-#include <sofa/component/linearsystem/MappingGraph.h>
+#include <sofa/simulation/MappingGraph.h>
 
 namespace sofa::component::linearsystem
 {

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.cpp
@@ -26,7 +26,7 @@ namespace sofa::component::linearsystem
 {
 
 DispatchFromGlobalVectorToLocalVectorVisitor::DispatchFromGlobalVectorToLocalVectorVisitor(const core::ExecParams* params,
-    const MappingGraph& mappingGraph, sofa::core::MultiVecId dst, linearalgebra::BaseVector* globalVector)
+    const simulation::MappingGraph& mappingGraph, sofa::core::MultiVecId dst, linearalgebra::BaseVector* globalVector)
     : BaseMechanicalVisitor(params)
     , m_dst(dst)
     , m_globalVector(globalVector)

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.h
@@ -38,7 +38,7 @@ public:
 
     DispatchFromGlobalVectorToLocalVectorVisitor(
         const core::ExecParams* params,
-        const MappingGraph& mappingGraph,
+        const simulation::MappingGraph& mappingGraph,
         sofa::core::MultiVecId dst,
         linearalgebra::BaseVector * globalVector);
 
@@ -57,7 +57,7 @@ protected:
     sofa::linearalgebra::BaseVector *m_globalVector { nullptr};
 
     /// Structure used to identify where in the global vector the local vectors will be copied from
-    const MappingGraph& m_mappingGraph;
+    const simulation::MappingGraph& m_mappingGraph;
 };
 
 } // namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.h
@@ -23,7 +23,7 @@
 
 #include <sofa/component/linearsystem/config.h>
 #include <sofa/simulation/BaseMechanicalVisitor.h>
-#include <sofa/component/linearsystem/MappingGraph.h>
+#include <sofa/simulation/MappingGraph.h>
 
 namespace sofa::component::linearsystem
 {


### PR DESCRIPTION
`sofa/component/linearsystem/MappingGraph.h` is deprecated due to a move in https://github.com/sofa-framework/sofa/pull/5991



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
