### PR TITLE
[Core] Fix: avoid extra ';' in macro causing massive warnings

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -234,6 +234,7 @@ public:
 
 // Do not use this macro directly, use SOFA_ABSTRACT_CLASS instead
 #define SOFA_ABSTRACT_CLASS_DECL                                        \
+    using BaseObject SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v29.06", "BaseObject has been renamed to BaseComponent") = sofa::core::objectmodel::BaseComponent; /*this alias allows the transition from BaseObject to BaseComponent.*/ \
     typedef MyType* Ptr;                                                \
     friend class sofa::core::objectmodel::BaseClassNameHelper;          \
     static std::string GetDefaultTemplateName(){ return sofa::core::objectmodel::BaseClassNameHelper::DefaultTypeTemplateName<MyType>::Get(); } \
@@ -248,7 +249,6 @@ public:
     return ::sofa::core::objectmodel::BaseLink::InitLink<MyType>    \
     (this, n, help);                                             \
 }\
-    using BaseObject SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v29.06", "BaseObject has been renamed to BaseComponent") = sofa::core::objectmodel::BaseComponent; // this alias allows the transition from BaseObject to BaseComponent.
 
 // Do not use this macro directly, use SOFA_CLASS instead
 #define SOFA_CLASS_DECL                                        \

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseClass.h
@@ -248,7 +248,7 @@ public:
 {                                                                   \
     return ::sofa::core::objectmodel::BaseLink::InitLink<MyType>    \
     (this, n, help);                                             \
-}\
+}
 
 // Do not use this macro directly, use SOFA_CLASS instead
 #define SOFA_CLASS_DECL                                        \


### PR DESCRIPTION
Move deprecated BaseObject alias inside SOFA_ABSTRACT_CLASS_DECL to avoid emitting an extra semicolon, which was triggering thousands of compiler warnings.

No behavior change, only warning cleanup.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
