### PR TITLE
[plugins] Change Cosserat plugin GIT_REF from master to main

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -46,7 +46,7 @@ sofa_add_external(plugin BeamAdapter GIT_REF master GIT_REPOSITORY https://www.g
 sofa_add_external(plugin STLIB GIT_REF master GIT_REPOSITORY https://www.github.com/SofaDefrost/STLIB.git)
 sofa_add_external(plugin SoftRobots GIT_REF master GIT_REPOSITORY https://www.github.com/SofaDefrost/SoftRobots.git)
 sofa_add_external(plugin SoftRobots.Inverse GIT_REF main GIT_REPOSITORY https://www.github.com/SofaDefrost/SoftRobots.Inverse.git)
-sofa_add_external(plugin Cosserat GIT_REF master GIT_REPOSITORY https://www.github.com/SofaDefrost/Cosserat.git) # Cosserat has an optional dependency on SoftRobots
+sofa_add_external(plugin Cosserat GIT_REF main GIT_REPOSITORY https://www.github.com/SofaDefrost/Cosserat.git) # Cosserat has an optional dependency on SoftRobots
 sofa_add_external(plugin SofaViscoElastic GIT_REF main GIT_REPOSITORY https://www.github.com/SofaDefrost/SofaViscoElastic.git)
 sofa_add_external(plugin CollisionAlgorithm GIT_REF master GIT_REPOSITORY https://forge.icube.unistra.fr/sofa/CollisionAlgorithm.git)
 sofa_add_external(plugin ConstraintGeometry GIT_REF master GIT_REPOSITORY https://forge.icube.unistra.fr/sofa/ConstraintGeometry.git)


### PR DESCRIPTION
Following a discussion with @adagolodjo, it appears that the new branch to follow is the *main* branch and no longer *master*.

The *main* branch is tested within the Cosserat plugin CI against SOFA master. This PR should therefore theoretically be harmless. An alternative was to PR main against master. This PR is the occasion to discuss it at the next SOFA dev meeting.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
