### PR TITLE
[Type] Standardize extern template instantiations for vector

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/vector_Integral.cpp
+++ b/Sofa/framework/Type/src/sofa/type/vector_Integral.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_HELPER_VECTOR_INTEGRAL_DEFINITION
+#define SOFA_TYPE_VECTOR_INTEGRAL_CPP
 
 #include <sofa/type/vector_Integral.h>
 #include <sofa/type/vector_T.inl>

--- a/Sofa/framework/Type/src/sofa/type/vector_Integral.h
+++ b/Sofa/framework/Type/src/sofa/type/vector_Integral.h
@@ -30,3 +30,14 @@ template<> SOFA_TYPE_API std::istream& sofa::type::vector<unsigned int>::read( s
 template<> SOFA_TYPE_API std::ostream& sofa::type::vector<unsigned char>::write(std::ostream& os) const;
 template<> SOFA_TYPE_API std::istream& sofa::type::vector<unsigned char>::read(std::istream& in);
 
+#if !defined(SOFA_TYPE_VECTOR_INTEGRAL_CPP)
+extern template class SOFA_TYPE_API sofa::type::vector<bool>;
+extern template class SOFA_TYPE_API sofa::type::vector<char>;
+extern template class SOFA_TYPE_API sofa::type::vector<unsigned char>;
+extern template class SOFA_TYPE_API sofa::type::vector<int>;
+extern template class SOFA_TYPE_API sofa::type::vector<unsigned int>;
+extern template class SOFA_TYPE_API sofa::type::vector<long>;
+extern template class SOFA_TYPE_API sofa::type::vector<unsigned long>;
+extern template class SOFA_TYPE_API sofa::type::vector<long long>;
+extern template class SOFA_TYPE_API sofa::type::vector<unsigned long long>;
+#endif

--- a/Sofa/framework/Type/src/sofa/type/vector_Real.cpp
+++ b/Sofa/framework/Type/src/sofa/type/vector_Real.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_TYPE_VECTOR_REAL_CPP
 #include <sofa/type/vector_Real.h>
 #include <sofa/type/vector_T.inl>
 

--- a/Sofa/framework/Type/src/sofa/type/vector_Real.h
+++ b/Sofa/framework/Type/src/sofa/type/vector_Real.h
@@ -22,3 +22,7 @@
 #pragma once
 #include <sofa/type/vector_T.h>
 
+#if !defined(SOFA_TYPE_VECTOR_REAL_CPP)
+extern template class SOFA_TYPE_API sofa::type::vector<float>;
+extern template class SOFA_TYPE_API sofa::type::vector<double>;
+#endif

--- a/Sofa/framework/Type/src/sofa/type/vector_String.cpp
+++ b/Sofa/framework/Type/src/sofa/type/vector_String.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_HELPER_VECTOR_STRING_DEFINITION
+#define SOFA_TYPE_VECTOR_STRING_CPP
 #include <sofa/type/vector_String.h>
 #include <sofa/type/vector_T.inl>
 

--- a/Sofa/framework/Type/src/sofa/type/vector_String.h
+++ b/Sofa/framework/Type/src/sofa/type/vector_String.h
@@ -24,3 +24,6 @@
 
 template<> SOFA_TYPE_API std::ostream& sofa::type::vector<std::string>::write(std::ostream& os) const;
 
+#if !defined(SOFA_TYPE_VECTOR_STRING_CPP)
+extern template class SOFA_TYPE_API sofa::type::vector<std::string>;
+#endif


### PR DESCRIPTION
This PR ensures that the template class `vector` is generated only once by the compiler for fundamental types such as `int`, `float`, `std::string` etc.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
