### PR TITLE
[Framework] Fix more warnings (msvc)

### DIFF
--- a/Sofa/framework/Config/CMakeLists.txt
+++ b/Sofa/framework/Config/CMakeLists.txt
@@ -181,6 +181,9 @@ endif()
 ## Windows-specific
 if(WIN32)
     list(APPEND SOFACONFIG_COMPILE_OPTIONS "/W4")
+    # MSVC warning suppressions
+    list(APPEND SOFACONFIG_COMPILE_OPTIONS "/wd4589") # Constructor of abstract class ignores initializer for virtual base class
+
     list(APPEND SOFACONFIG_COMPILE_OPTIONS "-D_USE_MATH_DEFINES")
     list(APPEND SOFACONFIG_COMPILE_OPTIONS "-D_CRT_SECURE_NO_WARNINGS")
     list(APPEND SOFACONFIG_COMPILE_OPTIONS "-D_CRT_NONSTDC_NO_DEPRECATE")

--- a/Sofa/framework/Core/src/sofa/core/CollisionElement.h
+++ b/Sofa/framework/Core/src/sofa/core/CollisionElement.h
@@ -59,7 +59,7 @@ public:
     /// Constructor.
     /// This constructor should be used in case a vector of indices is used.
     BaseCollisionElementIterator(VIterator vit, VIterator vitend)
-        : index(-1), it(vit), itend(vitend)
+        : index(static_cast<Index>(-1)), it(vit), itend(vitend)
     {
         if (it != itend) index = *it;
     }

--- a/Sofa/framework/Core/src/sofa/core/ComponentLibrary.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ComponentLibrary.cpp
@@ -29,7 +29,7 @@ namespace sofa::core
 std::string caseInsensitive(const std::string &text)
 {
     std::string result; result.resize(text.size());
-    for (unsigned int i=0; i<text.size(); ++i) result[i] = toupper(text[i]);
+    for (unsigned int i=0; i<text.size(); ++i) result[i] = static_cast<char>(toupper(text[i]));
     return result;
 }
 

--- a/Sofa/framework/Core/src/sofa/core/DataTracker.cpp
+++ b/Sofa/framework/Core/src/sofa/core/DataTracker.cpp
@@ -87,8 +87,8 @@ void DataTrackerDDGNode::cleanDirty(const core::ExecParams*)
 
 void DataTrackerDDGNode::updateAllInputsIfDirty()
 {
-    const DDGLinkContainer& inputs = DDGNode::getInputs();
-    for(const auto input : inputs)
+    const DDGLinkContainer& ddgInputs = DDGNode::getInputs();
+    for(const auto input : ddgInputs)
     {
         static_cast<core::objectmodel::BaseData*>(input)->updateIfDirty();
     }

--- a/Sofa/framework/Core/src/sofa/core/Mapping.cpp
+++ b/Sofa/framework/Core/src/sofa/core/Mapping.cpp
@@ -28,7 +28,6 @@ namespace sofa::core
 {
 
 using namespace sofa::defaulttype;
-using namespace core;
 
 template class SOFA_CORE_API Mapping< sofa::defaulttype::Vec1Types, sofa::defaulttype::Vec1Types >;
 template class SOFA_CORE_API Mapping< sofa::defaulttype::Vec1Types, sofa::defaulttype::Vec2Types >;

--- a/Sofa/framework/Core/src/sofa/core/Mapping.inl
+++ b/Sofa/framework/Core/src/sofa/core/Mapping.inl
@@ -135,12 +135,12 @@ sofa::linearalgebra::BaseMatrix* Mapping<In,Out>::createMappedMatrix(const behav
 template <class In, class Out>
 void Mapping<In,Out>::apply(const MechanicalParams* mparams, MultiVecCoordId outPos, ConstMultiVecCoordId inPos)
 {
-    State<In>* fromModel = this->fromModel.get();
-    State<Out>*  toModel = this->toModel.get();
-    if(fromModel && toModel)
+    State<In>* from = this->fromModel.get();
+    State<Out>*  to = this->toModel.get();
+    if(from && to)
     {
-        OutDataVecCoord* out = outPos[toModel].write();
-        const InDataVecCoord* in = inPos[fromModel].read();
+        OutDataVecCoord* out = outPos[to].write();
+        const InDataVecCoord* in = inPos[from].read();
         if(out && in)
         {
             this->apply(mparams, *out, *in);
@@ -151,12 +151,12 @@ void Mapping<In,Out>::apply(const MechanicalParams* mparams, MultiVecCoordId out
 template <class In, class Out>
 void Mapping<In,Out>::applyJ(const MechanicalParams* mparams, MultiVecDerivId outVel, ConstMultiVecDerivId inVel)
 {
-    State<In>* fromModel = this->fromModel.get();
-    State<Out>*  toModel = this->toModel.get();
-    if(fromModel && toModel)
+    State<In>* from = this->fromModel.get();
+    State<Out>*  to = this->toModel.get();
+    if(from && to)
     {
-        OutDataVecDeriv* out = outVel[toModel].write();
-        const InDataVecDeriv* in = inVel[fromModel].read();
+        OutDataVecDeriv* out = outVel[to].write();
+        const InDataVecDeriv* in = inVel[from].read();
         if(out && in)
         {
                 this->applyJ(mparams, *out, *in);
@@ -167,12 +167,12 @@ void Mapping<In,Out>::applyJ(const MechanicalParams* mparams, MultiVecDerivId ou
 template <class In, class Out>
 void Mapping<In,Out>::applyJT(const MechanicalParams *mparams, MultiVecDerivId inForce, ConstMultiVecDerivId outForce)
 {
-    State<In>* fromModel = this->fromModel.get();
-    State<Out>*  toModel = this->toModel.get();
-    if(fromModel && toModel)
+    State<In>* from = this->fromModel.get();
+    State<Out>*  to = this->toModel.get();
+    if(from && to)
     {
-        InDataVecDeriv* out = inForce[fromModel].write();
-        const OutDataVecDeriv* in = outForce[toModel].read();
+        InDataVecDeriv* out = inForce[from].write();
+        const OutDataVecDeriv* in = outForce[to].read();
         if(out && in)
         {
             this->applyJT(mparams, *out, *in);
@@ -184,12 +184,12 @@ void Mapping<In,Out>::applyJT(const MechanicalParams *mparams, MultiVecDerivId i
 template <class In, class Out>
 void Mapping<In,Out>::applyJT(const ConstraintParams* cparams, MultiMatrixDerivId inConst, ConstMultiMatrixDerivId outConst )
 {
-    State<In>* fromModel = this->fromModel.get();
-    State<Out>*  toModel = this->toModel.get();
-    if(fromModel && toModel)
+    State<In>* from = this->fromModel.get();
+    State<Out>*  to = this->toModel.get();
+    if(from && to)
     {
-        InDataMatrixDeriv* out = inConst[fromModel].write();
-        const OutDataMatrixDeriv* in = outConst[toModel].read();
+        InDataMatrixDeriv* out = inConst[from].write();
+        const OutDataMatrixDeriv* in = outConst[to].read();
         if(out && in)
         {
             this->applyJT(cparams, *out, *in);
@@ -208,13 +208,13 @@ void Mapping<In,Out>::applyDJT(const MechanicalParams* /*mparams */ , MultiVecDe
 template <class In, class Out>
 void Mapping<In,Out>::computeAccFromMapping(const MechanicalParams* mparams, MultiVecDerivId outAcc, ConstMultiVecDerivId inVel, ConstMultiVecDerivId inAcc )
 {
-    State<In>* fromModel = this->fromModel.get();
-    State<Out>*  toModel = this->toModel.get();
-    if(fromModel && toModel)
+    State<In>* from = this->fromModel.get();
+    State<Out>*  to = this->toModel.get();
+    if(from && to)
     {
-        OutDataVecDeriv* out = outAcc[toModel].write();
-        const InDataVecDeriv* inV = inVel[fromModel].read();
-        const InDataVecDeriv* inA = inAcc[fromModel].read();
+        OutDataVecDeriv* out = outAcc[to].write();
+        const InDataVecDeriv* inV = inVel[from].read();
+        const InDataVecDeriv* inA = inAcc[from].read();
         if(out && inV && inA)
             this->computeAccFromMapping(mparams, *out, *inV, *inA);
     }

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -529,7 +529,7 @@ void ObjectFactory::dump(std::ostream& out)
         if (!entry->aliases.empty())
         {
             out << "  aliases :";
-            for (std::set<std::string>::iterator myit = entry->aliases.begin(), itend = entry->aliases.end(); myit != itend; ++myit)
+            for (std::set<std::string>::iterator myit = entry->aliases.begin(), aliasesEnd = entry->aliases.end(); myit != aliasesEnd; ++myit)
                 out << " " << *myit;
             out << "\n";
         }
@@ -573,7 +573,7 @@ void ObjectFactory::dumpXML(std::ostream& out)
         const ClassEntry::SPtr entry = it->second;
         if (entry->className != it->first) continue;
         out << "<class name=\"" << xmlencode(entry->className) <<"\">\n";
-        for (std::set<std::string>::iterator myit = entry->aliases.begin(), itend = entry->aliases.end(); myit != itend; ++myit)
+        for (std::set<std::string>::iterator myit = entry->aliases.begin(), aliasesEnd = entry->aliases.end(); myit != aliasesEnd; ++myit)
             out << "<alias>" << xmlencode(*myit) << "</alias>\n";
         if (!entry->description.empty())
             out << "<description>"<<entry->description<<"</description>\n";
@@ -607,7 +607,7 @@ void ObjectFactory::dumpHTML(std::ostream& out)
         if (!entry->aliases.empty())
         {
             out << "<li>Aliases:<i>";
-            for (std::set<std::string>::iterator myit = entry->aliases.begin(), itend = entry->aliases.end(); myit != itend; ++myit)
+            for (std::set<std::string>::iterator myit = entry->aliases.begin(), aliasesEnd = entry->aliases.end(); myit != aliasesEnd; ++myit)
                 out << " " << xmlencode(*myit);
             out << "</i></li>\n";
         }

--- a/Sofa/framework/Core/src/sofa/core/SofaLibrary.cpp
+++ b/Sofa/framework/Core/src/sofa/core/SofaLibrary.cpp
@@ -48,9 +48,9 @@ void SofaLibrary::build( const std::vector< std::string >& examples)
         if (creatorEntry != entries[i]->creatorMap.end())
         {
             const objectmodel::BaseClass* baseClass = creatorEntry->second->getClass();
-            std::vector<std::string> categories;
-            CategoryLibrary::getCategories(baseClass, categories);
-            for (std::vector<std::string>::iterator it = categories.begin(); it != categories.end(); ++it)
+            std::vector<std::string> categoriesVec;
+            CategoryLibrary::getCategories(baseClass, categoriesVec);
+            for (std::vector<std::string>::iterator it = categoriesVec.begin(); it != categoriesVec.end(); ++it)
             {
                 mainCategories.insert((*it));
                 inventory.insert(std::make_pair((*it), entries[i]));

--- a/Sofa/framework/Core/src/sofa/core/behavior/DefaultMultiMatrixAccessor.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/DefaultMultiMatrixAccessor.cpp
@@ -52,7 +52,7 @@ void DefaultMultiMatrixAccessor::clear()
 {
     globalDim = 0;
     for (auto it = realStateOffsets.begin(), itend = realStateOffsets.end(); it != itend; ++it)
-        it->second = -1;
+        it->second = static_cast<decltype(it->second)>(-1);
 
     for (std::map< const sofa::core::behavior::BaseMechanicalState*, linearalgebra::BaseMatrix* >::iterator it = mappedMatrices.begin(), itend = mappedMatrices.end(); it != itend; ++it)
         if (it->second != nullptr) delete it->second;

--- a/Sofa/framework/Core/src/sofa/core/collision/Intersection.cpp
+++ b/Sofa/framework/Core/src/sofa/core/collision/Intersection.cpp
@@ -42,11 +42,11 @@ helper::TypeInfo IntersectorMap::getType(core::CollisionModel* model)
     if (it == castMap.end())
     {
         helper::TypeInfo t2 = t;
-        for (std::set<const objectmodel::ClassInfo* >::iterator it = classes.begin(); it != classes.end(); ++it)
+        for (std::set<const objectmodel::ClassInfo* >::iterator ci = classes.begin(); ci != classes.end(); ++ci)
         {
-            if ((*it)->isInstance(model))
+            if ((*ci)->isInstance(model))
             {
-                t2 = (*it)->type();
+                t2 = (*ci)->type();
                 break;
             }
         }
@@ -76,14 +76,14 @@ ElementIntersector* IntersectorMap::get(core::CollisionModel* model1, core::Coll
 
 
     std::stringstream tmp;
-    for(InternalMap::const_iterator it = intersectorsMap.begin(), itEnd = intersectorsMap.end(); it != itEnd; ++it)
+    for(InternalMap::const_iterator it2 = intersectorsMap.begin(), itEnd = intersectorsMap.end(); it2 != itEnd; ++it2)
     {
-        helper::TypeInfo t1 = it->first.first;
-        helper::TypeInfo t2 = it->first.second;
+        helper::TypeInfo t1_tmp = it2->first.first;
+        helper::TypeInfo t2_tmp = it2->first.second;
         tmp << "  "
-                << gettypename(t1) << "-"
-                << gettypename(t2);
-        const ElementIntersector* i = it->second;
+                << gettypename(t1_tmp) << "-"
+                << gettypename(t2_tmp);
+        const ElementIntersector* i = it2->second;
         if (!i)
             tmp << "  nullptr";
         else

--- a/Sofa/framework/Core/src/sofa/core/loader/VoxelLoader.cpp
+++ b/Sofa/framework/Core/src/sofa/core/loader/VoxelLoader.cpp
@@ -35,7 +35,6 @@ namespace sofa::core::loader
 {
 
 using namespace sofa::defaulttype;
-using namespace sofa::core::loader;
 
 VoxelLoader::VoxelLoader()
     :BaseLoader()

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseComponent.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseComponent.cpp
@@ -209,11 +209,11 @@ const BaseComponent::VecSlaves& BaseComponent::getSlaves() const
     return l_slaves.getValue();
 }
 
-BaseComponent* BaseComponent::getSlave(const std::string& name) const
+BaseComponent* BaseComponent::getSlave(const std::string& slaveName) const
 {
     for (auto slave : l_slaves)
     {
-        if (slave.get() && slave->getName() == name)
+        if (slave.get() && slave->getName() == slaveName)
             return slave.get();
     }
     return nullptr;

--- a/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/Sofa/framework/Core/src/sofa/core/objectmodel/BaseLink.cpp
@@ -316,9 +316,9 @@ bool BaseLink::read( const std::string& str )
 
     /// Add the detected objects that are not already present to the container of this Link
     clear();
-    for (const auto& [base, path] : entries)
+    for (const auto& [base, linkPath] : entries)
     {
-        ok = add(base, path) && ok;
+        ok = add(base, linkPath) && ok;
     }
     return ok;
 }

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NameOnlyTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NameOnlyTypeInfo.h
@@ -78,16 +78,16 @@ public:
     /// and those six elements are conceptually numbered from 0 to 5.  This is
     /// relevant only if FixedSize() is true. I FixedSize() is false,
     /// the return value will be equivalent to the one of byteSize()
-    sofa::Size size() const override {return -1;}
+    sofa::Size size() const override {return static_cast<sofa::Size>(-1);}
     /// The size in bytes of the ValueType
     /// For example, the size of a fixed_array<fixed_array<int, 2>, 3>` is 4 on most systems,
     /// as it is the byte size of the smallest dimension in the array (int -> 32bit)
-    sofa::Size byteSize() const override {return -1;}
+    sofa::Size byteSize() const override {return static_cast<sofa::Size>(-1);}
 
     /// The size of \a data, in number of iterable elements
     /// (For containers, that'll be the number of elements in the 1st dimension).
     /// For example, with type == `
-    sofa::Size size(const void* /*data*/) const override {return -1;}
+    sofa::Size size(const void* /*data*/) const override {return static_cast<sofa::Size>(-1);}
     /// Resize \a data to \a size elements, if relevant.
 
     /// But resizing is not always relevant, for example:

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
@@ -74,16 +74,16 @@ public:
     /// and those six elements are conceptually numbered from 0 to 5.  This is
     /// relevant only if FixedSize() is true. I FixedSize() is false,
     /// the return value will be equivalent to the one of byteSize()
-    sofa::Size size() const override {return -1;}
+    sofa::Size size() const override {return static_cast<sofa::Size>(-1);}
     /// The size in bytes of the ValueType
     /// For example, the size of a fixed_array<fixed_array<int, 2>, 3>` is 4 on most systems,
     /// as it is the byte size of the smallest dimension in the array (int -> 32bit)
-    sofa::Size byteSize() const override {return -1;}
+    sofa::Size byteSize() const override {return static_cast<sofa::Size>(-1);}
 
     /// The size of \a data, in number of iterable elements
     /// (For containers, that'll be the number of elements in the 1st dimension).
     /// For example, with type == `
-    sofa::Size size(const void* /*data*/) const override {return -1;}
+    sofa::Size size(const void* /*data*/) const override {return static_cast<sofa::Size>(-1);}
     /// Resize \a data to \a size elements, if relevant.
 
     /// But resizing is not always relevant, for example:

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/FixedArrayTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/FixedArrayTypeInfo.h
@@ -80,7 +80,7 @@ struct FixedArrayTypeInfo
     {
         if constexpr (!FixedSize)
         {
-            size /= data.size();
+            size /= static_cast<sofa::Size>(data.size());
             for (sofa::Size i = 0; i < data.size(); ++i)
             {
                 if (!BaseTypeInfo::setSize(data[(sofa::Size)i], size)) 

--- a/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/AdvancedTimer.cpp
@@ -934,7 +934,7 @@ void TimerData::print()
 AdvancedTimer::outputType AdvancedTimer::convertOutputType(std::string type)
 {
 	std::for_each(type.begin(), type.end(),  [](char& c) {
-		c = std::tolower(static_cast<unsigned char>(c)); } );
+		c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); } );
 
 	if(type.compare("json") == 0)
 		return JSON;

--- a/Sofa/framework/Helper/src/sofa/helper/DiffLib.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/DiffLib.cpp
@@ -36,10 +36,10 @@ std::vector<std::tuple<std::string, SReal>> SOFA_HELPER_API getClosestMatch(cons
     class Tuple
     {
     public:
-        Tuple(float ratio_, std::string value_)
+        Tuple(SReal ratio_, std::string value_)
             : ratio(ratio_), value(std::move(value_)) {}
 
-        float ratio;
+        SReal ratio;
         std::string value;
     };
     auto cmp = [](const Tuple& left, Tuple& right) { return left.ratio < right.ratio; };

--- a/Sofa/framework/Helper/src/sofa/helper/LCPcalc.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/LCPcalc.cpp
@@ -113,7 +113,7 @@ void LCP::setLCP(unsigned int input_dim, SReal *input_dfree, SReal **input_W, SR
 void LCP::solveNLCP(bool convergenceTest, std::vector<SReal>* residuals, std::vector<SReal>* violations)
 {
     //SReal error;
-    SReal f_1[3],dn, ds, dt;
+    SReal f_1_local[3],dn, ds, dt;
     const int numContacts = dim/3;
     const bool computeError = (convergenceTest || residuals);
     for (it=0; it<numItMax; it++)
@@ -121,7 +121,7 @@ void LCP::solveNLCP(bool convergenceTest, std::vector<SReal>* residuals, std::ve
         error = 0;
         for (int c=0;  c<numContacts ; c++)
         {
-            f_1[0] = f[3*c]; f_1[1] = f[3*c+1]; f_1[2] = f[3*c+2];
+            f_1_local[0] = f[3*c]; f_1_local[1] = f[3*c+1]; f_1_local[2] = f[3*c+2];
             dn =dfree[3*c];  dt=dfree[3*c+1]; ds =dfree[3*c+2];
             for (int i=0; i<dim; i++)
             {
@@ -140,14 +140,14 @@ void LCP::solveNLCP(bool convergenceTest, std::vector<SReal>* residuals, std::ve
             if (f[3*c]<0)
             {
 
-                if (f_1[0]>0 && computeError)  // the point was in contact and is no more in contact..
+                if (f_1_local[0]>0 && computeError)  // the point was in contact and is no more in contact..
                 {
 
                     for (int j=0; j<3; j++ )
                     {
-                        Ddn -= W[3*c  ][3*c+j]*f_1[j];
-                        Ddt -= W[3*c+1][3*c+j]*f_1[j];
-                        Dds -= W[3*c+2][3*c+j]*f_1[j];
+                        Ddn -= W[3*c  ][3*c+j]*f_1_local[j];
+                        Ddt -= W[3*c+1][3*c+j]*f_1_local[j];
+                        Dds -= W[3*c+2][3*c+j]*f_1_local[j];
                     }
                     error += sqrt(Ddn*Ddn + Ddt*Ddt + Dds*Dds);
                 }
@@ -161,8 +161,8 @@ void LCP::solveNLCP(bool convergenceTest, std::vector<SReal>* residuals, std::ve
             ////// FRICTION
 
             // evaluation of the current tangent positions (motion du to force change along normal)
-            dt +=  W[3*c+1][3*c]*(f[3*c]-f_1[0]);
-            ds +=  W[3*c+2][3*c]*(f[3*c]-f_1[0]);
+            dt +=  W[3*c+1][3*c]*(f[3*c]-f_1_local[0]);
+            ds +=  W[3*c+2][3*c]*(f[3*c]-f_1_local[0]);
 
             // envaluation of the new fricton forces
 

--- a/Sofa/framework/Helper/src/sofa/helper/TriangleOctree.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/TriangleOctree.cpp
@@ -840,7 +840,7 @@ void TriangleOctreeRoot::buildOctree()
     // for each triangle add it to the octree
     for (size_t i = 0; i < octreeTriangles->size(); i++)
     {
-        fillOctree (static_cast<int>(i));
+        fillOctree(static_cast<Index>(i));
     }
 }
 

--- a/Sofa/framework/Helper/src/sofa/helper/io/ImageDDS.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/io/ImageDDS.cpp
@@ -204,11 +204,13 @@ bool ImageDDS::load(std::string filename)
         //case DDS_FORMAT_BGR32F:  type = Image::FLOAT;  channels = Image::BGR;        break;
         //case DDS_FORMAT_BGRA32F: type = Image::FLOAT;  channels = Image::BGRA;       break;
 
-    default:
-    {
-        bool error = false;
+        default:
+        {
+            bool error = false;
+            type = Image::UNORM8;  // Initialize with a default value
+            channels = Image::L;   // Initialize with a default value
 
-        switch (header.ddpfPixelFormat.dwRGBBitCount)
+            switch (header.ddpfPixelFormat.dwRGBBitCount)
         {
             // 8bit formats (R8, L8)
         case 8:

--- a/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/DynamicLibrary.cpp
@@ -177,9 +177,13 @@ void DynamicLibrary::fetchLastError()
     m_lastError = std::string(pMsgBuf);
 # else
     std::wstring s(pMsgBuf);
-    // This is terrible, it will truncate wchar_t to char_t,
-    // but it should work for characters 0 to 127.
-    m_lastError = std::string(s.begin(), s.end());
+    // Convert wide string to narrow string properly
+    int size = WideCharToMultiByte(CP_UTF8, 0, s.c_str(), -1, nullptr, 0, NULL, FALSE);
+    if (size > 0)
+    {
+        m_lastError.resize(size - 1);
+        WideCharToMultiByte(CP_UTF8, 0, s.c_str(), -1, &m_lastError[0], size, NULL, FALSE);
+    }
 # endif
     LocalFree(pMsgBuf);
 #else

--- a/Sofa/framework/Helper/src/sofa/helper/system/SetDirectory.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/SetDirectory.cpp
@@ -174,7 +174,13 @@ std::string SetDirectory::GetProcessFullPath(const char* filename)
         GetModuleFileName(nullptr,tpath,1024);
         std::wstring wprocessPath = tpath;
         std::string processPath;
-        processPath.assign(wprocessPath.begin(), wprocessPath.end() );
+        // Convert wide string to narrow string properly
+        int size = WideCharToMultiByte(CP_UTF8, 0, wprocessPath.c_str(), -1, nullptr, 0, NULL, FALSE);
+        if (size > 0)
+        {
+            processPath.resize(size - 1);
+            WideCharToMultiByte(CP_UTF8, 0, wprocessPath.c_str(), -1, &processPath[0], size, NULL, FALSE);
+        }
         return processPath;
     }
     /// \TODO use GetCommandLineW and/or CommandLineToArgvW. This is however not strictly necessary, as argv[0] already contains the full path in most cases.

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
@@ -452,7 +452,7 @@ protected:
 
             for (std::size_t r = std::size_t(rowId); r < rowBegin.size()-1; ++r)
             {
-                rowBegin[r+1] -= nnzRow;
+                rowBegin[r+1] -= static_cast<decltype(rowBegin)::value_type>(nnzRow);
             }
             rowBegin.erase(rowBegin.begin()+rowId);
             rowIndex.erase(rowIndex.begin()+rowId);

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixGeneric.h
@@ -452,7 +452,7 @@ protected:
 
             for (std::size_t r = std::size_t(rowId); r < rowBegin.size()-1; ++r)
             {
-                rowBegin[r+1] -= static_cast<decltype(rowBegin)::value_type>(nnzRow);
+                rowBegin[r+1] -= static_cast<typename decltype(rowBegin)::value_type>(nnzRow);
             }
             rowBegin.erase(rowBegin.begin()+rowId);
             rowIndex.erase(rowIndex.begin()+rowId);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
@@ -128,27 +128,27 @@ bool RequiredPlugin::loadPlugin()
     std::ostringstream errmsg;
     for (const auto& pluginName : pluginsToLoad)
     {
-        const std::string name = FileSystem::cleanPath( pluginName ); // name is not necessarily a path
+        const std::string pluginFilePath = FileSystem::cleanPath( pluginName ); // pluginFilePath is not necessarily a path
         bool isNameLoaded = false;
         for (const auto& suffix : suffixVec)
         {
-            bool isPluginLoaded = pluginManager.pluginIsLoaded(name);
+            bool isPluginLoaded = pluginManager.pluginIsLoaded(pluginFilePath);
             if (!isPluginLoaded)
             {
-                const auto status = pluginManager.loadPlugin(name, suffix, true, true, &errmsg);
+                const auto status = pluginManager.loadPlugin(pluginFilePath, suffix, true, true, &errmsg);
                 isPluginLoaded = (status == PluginManager::PluginLoadStatus::SUCCESS || status == PluginManager::PluginLoadStatus::ALREADY_LOADED);
             }
             if (isPluginLoaded)
             {
-                loadedPlugins.push_back(name);
+                loadedPlugins.push_back(pluginFilePath);
                 isNameLoaded = true;
 
                 // Register Objects explicitly
-                objectFactory->registerObjectsFromPlugin(name);
+                objectFactory->registerObjectsFromPlugin(pluginFilePath);
 
                 // fail-safe to check if potential components have been registered (implicitly or explicitly)
                 std::vector<sofa::core::ObjectFactory::ClassEntry::SPtr> entries;
-                objectFactory->getEntriesFromTarget(entries, name);
+                objectFactory->getEntriesFromTarget(entries, pluginFilePath);
 
                 if (entries.empty())
                 {
@@ -164,7 +164,7 @@ bool RequiredPlugin::loadPlugin()
         }
         if (!isNameLoaded)
         {
-            failed.push_back(name);
+            failed.push_back(pluginFilePath);
         }
         else if (d_stopAfterFirstNameFound.getValue())
         {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/VectorOperations.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/VectorOperations.cpp
@@ -186,9 +186,9 @@ void VectorOperations::print(sofa::core::ConstMultiVecId v, std::ostream &out, s
 
 size_t VectorOperations::v_size(core::MultiVecId v)
 {
-    size_t result = 0;
-    executeVisitor( MechanicalVSizeVisitor(params,&result,v) );
-    return result;
+    size_t vecSize = 0;
+    executeVisitor( MechanicalVSizeVisitor(params,&vecSize,v) );
+    return vecSize;
 }
 
 SReal VectorOperations::finish()

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/WorkerThread.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/WorkerThread.cpp
@@ -75,7 +75,7 @@ void WorkerThread::run(void)
 {
 #ifdef WIN32
     const std::wstring widestr = std::wstring(m_name.begin(), m_name.end());
-    HRESULT r = SetThreadDescription(
+    (void)SetThreadDescription(
         GetCurrentThread(),
         widestr.c_str()
         );


### PR DESCRIPTION
Based on 
- #6083 

I let you search the codes for the warnings referenced by the commits...

and one warning is explicitly ignored (flag set in the cmake file) 
because it is considered as a false positive (lots of projects are purposely ignoring it)

On my msvc 2026 setup, there is no more warning while compiling Sofa.Framework


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
