### PR TITLE
[CI] Clean old results folder if it exists

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -206,6 +206,12 @@ jobs:
               done
           fi
 
+          ## Cleaning old tests results of they exists
+          if [ -d "${{ env.BUILD_DIR }}/tests_results/" ]; then 
+              echo "Cleaning old test results folder."
+              rm -rf "${{ env.BUILD_DIR }}/tests_results/"
+          fi
+
       - name: Build
         id: build-step
         shell: bash


### PR DESCRIPTION
If you launch twice the CI in the same day, without force full building it, the build folder will not be cleaned. Same for tests results. If you fix all of you tests in this new PR, the reports will not bee overridden so you'll still see those errors even if you have fixed them. 

This cleans the test results directory if it exists. 


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
