### PR TITLE
[SofaCarving] Clean the handleEvent method to have less conditions and also remove some Data

### DIFF
--- a/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.cpp
@@ -188,6 +188,7 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
 
     if (sofa::core::objectmodel::KeypressedEvent::checkEventType(event))
     {
+        sofa::core::objectmodel::KeypressedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeypressedEvent*>(event);
         dmsg_info() << "GET KEY "<<ev->getKey();
         if (ev->getKey() == d_keyEvent.getValue())
         {
@@ -200,6 +201,7 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
     }
     else if (sofa::core::objectmodel::KeyreleasedEvent::checkEventType(event))
     {
+        sofa::core::objectmodel::KeyreleasedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeyreleasedEvent*>(event);
         if (ev->getKey() == d_keyEvent.getValue())
         {
             d_active.setValue(false);
@@ -207,7 +209,8 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
     }
     else if (sofa::simulation::AnimateEndEvent::checkEventType(event))
     {
-        if (d_active.getValue()) {
+        if (d_active.getValue()) 
+        {
             doCarve();
         }
     }

--- a/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.cpp
@@ -186,7 +186,7 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
     if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
-    if (sofa::core::objectmodel::KeypressedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeypressedEvent*>(event))
+    if (sofa::core::objectmodel::KeypressedEvent::checkEventType(event))
     {
         dmsg_info() << "GET KEY "<<ev->getKey();
         if (ev->getKey() == d_keyEvent.getValue())
@@ -198,7 +198,7 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
             d_active.setValue(!d_active.getValue());
         }
     }
-    else if (sofa::core::objectmodel::KeyreleasedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeyreleasedEvent*>(event))
+    else if (sofa::core::objectmodel::KeyreleasedEvent::checkEventType(event))
     {
         if (ev->getKey() == d_keyEvent.getValue())
         {

--- a/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.cpp
@@ -36,6 +36,7 @@
 
 namespace sofacarving
 {
+    
 
 void registerCarvingManager(sofa::core::ObjectFactory* factory)
 {
@@ -51,9 +52,6 @@ CarvingManager::CarvingManager()
     , d_active( initData(&d_active, false, "active", "Activate this object.\nNote that this can be dynamically controlled by using a key") )
     , d_keyEvent( initData(&d_keyEvent, '1', "key", "key to press to activate this object until the key is released") )
     , d_keySwitchEvent( initData(&d_keySwitchEvent, '4', "keySwitch", "key to activate this object until the key is pressed again") )
-    , d_mouseEvent( initData(&d_mouseEvent, true, "mouseEvent", "Activate carving with middle mouse button") )
-    , d_omniEvent( initData(&d_omniEvent, true, "omniEvent", "Activate carving with omni button") )
-    , d_activatorName(initData(&d_activatorName, "button1", "activatorName", "Name to active the script event parsing. Will look for 'pressed' or 'release' keyword. For example: 'button1_pressed'"))
 {
     this->f_listening.setValue(true);
 }
@@ -188,9 +186,8 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
     if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
-    if (sofa::core::objectmodel::KeypressedEvent::checkEventType(event))
+    if (sofa::core::objectmodel::KeypressedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeypressedEvent*>(event))
     {
-        sofa::core::objectmodel::KeypressedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeypressedEvent*>(event);
         dmsg_info() << "GET KEY "<<ev->getKey();
         if (ev->getKey() == d_keyEvent.getValue())
         {
@@ -201,59 +198,21 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
             d_active.setValue(!d_active.getValue());
         }
     }
-    else if(sofa::core::objectmodel::KeyreleasedEvent::checkEventType(event))
+    else if (sofa::core::objectmodel::KeyreleasedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeyreleasedEvent*>(event))
     {
-        sofa::core::objectmodel::KeyreleasedEvent* ev = dynamic_cast<sofa::core::objectmodel::KeyreleasedEvent*>(event);
         if (ev->getKey() == d_keyEvent.getValue())
-        {
-            d_active.setValue(false);
-        }
-    }
-    else if(sofa::core::objectmodel::MouseEvent::checkEventType(event))
-    {
-        sofa::core::objectmodel::MouseEvent * ev = dynamic_cast<sofa::core::objectmodel::MouseEvent*>(event);
-        if ((ev->getState() == sofa::core::objectmodel::MouseEvent::MiddlePressed) && (d_mouseEvent.getValue()))
-        {
-            d_active.setValue(true);
-        }
-        else if ((ev->getState() == sofa::core::objectmodel::MouseEvent::MiddleReleased) && (d_mouseEvent.getValue()))
-        {
-            d_active.setValue(false);
-        }
-    }
-    else if(sofa::core::objectmodel::HapticDeviceEvent::checkEventType(event))
-    {
-        sofa::core::objectmodel::HapticDeviceEvent * ev = dynamic_cast<sofa::core::objectmodel::HapticDeviceEvent *>(event);
-        if (ev->getButtonState() == 1)
-        {
-            d_active.setValue(true);
-        }
-        else if (ev->getButtonState() == 0)
-        {
-            d_active.setValue(false);
-        }
-    }
-    else if(sofa::core::objectmodel::ScriptEvent::checkEventType(event))
-    {
-        sofa::core::objectmodel::ScriptEvent *ev = dynamic_cast<sofa::core::objectmodel::ScriptEvent *>(event);
-        const std::string& eventS = ev->getEventName();
-        if (eventS.find(d_activatorName.getValue()) != std::string::npos && eventS.find("pressed") != std::string::npos)
-        {
-            d_active.setValue(true);
-        }
-
-        if (eventS.find(d_activatorName.getValue()) != std::string::npos && eventS.find("released") != std::string::npos)
         {
             d_active.setValue(false);
         }
     }
     else if (sofa::simulation::AnimateEndEvent::checkEventType(event))
     {
-        if (d_active.getValue())
-        {
+        if (d_active.getValue()) {
             doCarve();
         }
     }
+
+
 }
 
 } // namespace sofacarving

--- a/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.h
+++ b/applications/plugins/SofaCarving/src/SofaCarving/CarvingManager.h
@@ -87,12 +87,6 @@ public:
     Data < char > d_keyEvent;
     ///< key to activate this object until the key is pressed again
     Data < char > d_keySwitchEvent;
-    ///< Activate carving with middle mouse button
-    Data < bool > d_mouseEvent;
-    ///< Activate carving with omni button
-    Data < bool > d_omniEvent;
-    ///< Activate carving with string Event, the activator name has to be inside the script event. Will look for 'pressed' or 'release' keyword. For example: 'button1_pressed'
-    Data < std::string > d_activatorName;
     
 protected:
     // Pointer to the target object collision model


### PR DESCRIPTION
All those different events to activate the carving do not make sense, as the Data can be changed directly from python controller or code or linking it to other Data.

The middle mouse event was hidden and was randomly activating/deactivating the carving when you were zooming in the 3D view leading to buggy situation.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
