### PR TITLE
[defaulttype] Fix VecN type when compiling with float

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -153,13 +153,13 @@ public:
 
     static Deriv coordDifference(const Coord& c1, const Coord& c2)
     {
-        type::Vec3 vCenter = c1.getCenter() - c2.getCenter();
+        const Vec3 vCenter = c1.getCenter() - c2.getCenter();
         const type::Quat<real> quat2(c2.getOrientation());
         const type::Quat<real> quat1(c1.getOrientation());
         // Transformation between c2 and c1 frames
         type::Quat<real> quat = quat1 * quat2.inverse();
         quat.normalize();
-        type::Vec3 axis(type::NOINIT);
+        Vec3 axis(type::NOINIT);
         real angle{};
         quat.quatToAxis(axis, angle);
         axis *= angle;
@@ -361,7 +361,7 @@ public:
 
     static Deriv coordDifference(const Coord& c1, const Coord& c2)
     {
-        const type::Vec2 vCenter = c1.getCenter() - c2.getCenter();
+        const Vec2 vCenter = c1.getCenter() - c2.getCenter();
         real angle = c1.getOrientation() - c2.getOrientation(); // Difference in orientation (angle between frames)
         angle = std::fmod(angle + M_PI, 2 * M_PI) - M_PI; // Normalize angle to [-π, π]
 


### PR DESCRIPTION
`type::Vec3` uses `SReal`. But when you compile `StdRigidTypes` with something different from `SReal`, compilation fails because types are not compatible.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
