### PR TITLE
[All] Factorize primitive numeric types reflection

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Bool.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Bool.h
@@ -22,15 +22,13 @@
 #pragma once
 
 #include <sofa/defaulttype/typeinfo/models/BoolTypeInfo.h>
+#include <sofa/type/trait/TypeTrait.h>
 namespace sofa::defaulttype
 {
 
 template<>
-struct DataTypeInfo<bool> : public BoolTypeInfo
-{
-    static const std::string name() { return "bool"; }
-    static const std::string GetTypeName() { return "bool"; }
-};
+struct DataTypeInfo<bool> : public BoolTypeInfo, public sofa::type::TypeTrait<bool>
+{};
 
 
 } /// namespace sofa::defaulttype

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Integer.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Integer.h
@@ -23,48 +23,13 @@
 
 #include <sofa/defaulttype/typeinfo/models/IntegerTypeInfo.h>
 #include <sofa/type/trait/TypeTrait.h>
+#include <concepts>
 
 namespace sofa::defaulttype
 {
 
-template<>
-struct DataTypeInfo<char> : public IntegerTypeInfo<char>, public type::TypeTrait<char>
-{};
-
-template<>
-struct DataTypeInfo<unsigned char> : public IntegerTypeInfo<unsigned char>, public sofa::type::TypeTrait<unsigned char>
-{};
-
-template<>
-struct DataTypeInfo<short> : public IntegerTypeInfo<short>, public sofa::type::TypeTrait<short>
-{};
-
-template<>
-struct DataTypeInfo<unsigned short> : public IntegerTypeInfo<unsigned short>, public sofa::type::TypeTrait<unsigned short>
-{};
-
-template<>
-struct DataTypeInfo<int> : public IntegerTypeInfo<int>, public sofa::type::TypeTrait<int>
-{};
-
-template<>
-struct DataTypeInfo<unsigned int> : public IntegerTypeInfo<unsigned int>, public sofa::type::TypeTrait<unsigned int>
-{};
-
-template<>
-struct DataTypeInfo<long> : public IntegerTypeInfo<long>, public sofa::type::TypeTrait<long>
-{};
-
-template<>
-struct DataTypeInfo<unsigned long> : public IntegerTypeInfo<unsigned long>, public sofa::type::TypeTrait<unsigned long>
-{};
-
-template<>
-struct DataTypeInfo<long long> : public IntegerTypeInfo<long long>, public sofa::type::TypeTrait<long long>
-{};
-
-template<>
-struct DataTypeInfo<unsigned long long> : public IntegerTypeInfo<unsigned long long>, public sofa::type::TypeTrait<unsigned long long>
+template<std::integral T>
+struct DataTypeInfo<T> : public IntegerTypeInfo<T>, public type::TypeTrait<T>
 {};
 
 } /// typeNamespace sofa::defaulttype

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Integer.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Integer.h
@@ -22,80 +22,50 @@
 #pragma once
 
 #include <sofa/defaulttype/typeinfo/models/IntegerTypeInfo.h>
+#include <sofa/type/trait/TypeTrait.h>
 
 namespace sofa::defaulttype
 {
 
 template<>
-struct DataTypeInfo<char> : public IntegerTypeInfo<char>
-{
-    static const std::string GetTypeName() { return "char"; }
-    static const std::string name() { return "b"; }
-};
+struct DataTypeInfo<char> : public IntegerTypeInfo<char>, public type::TypeTrait<char>
+{};
 
 template<>
-struct DataTypeInfo<unsigned char> : public IntegerTypeInfo<unsigned char>
-{
-    static const std::string GetTypeName() { return "unsigned char"; }
-    static const std::string name() { return "B"; }
-};
+struct DataTypeInfo<unsigned char> : public IntegerTypeInfo<unsigned char>, public sofa::type::TypeTrait<unsigned char>
+{};
 
 template<>
-struct DataTypeInfo<short> : public IntegerTypeInfo<short>
-{
-    static const std::string GetTypeName() { return "short"; }
-    static const std::string name() { return "h"; }
-};
+struct DataTypeInfo<short> : public IntegerTypeInfo<short>, public sofa::type::TypeTrait<short>
+{};
 
 template<>
-struct DataTypeInfo<unsigned short> : public IntegerTypeInfo<unsigned short>
-{
-    static const std::string GetTypeName() { return "unsigned short"; }
-    static const std::string name() { return "H"; }
-};
+struct DataTypeInfo<unsigned short> : public IntegerTypeInfo<unsigned short>, public sofa::type::TypeTrait<unsigned short>
+{};
 
 template<>
-struct DataTypeInfo<int> : public IntegerTypeInfo<int>
-{
-    static const std::string GetTypeName() { return "int"; }
-    static const std::string name() { return "i"; }
-};
+struct DataTypeInfo<int> : public IntegerTypeInfo<int>, public sofa::type::TypeTrait<int>
+{};
 
 template<>
-struct DataTypeInfo<unsigned int> : public IntegerTypeInfo<unsigned int>
-{
-    static const std::string GetTypeName() { return "unsigned int"; }
-    static const std::string name() { return "I"; }
-};
+struct DataTypeInfo<unsigned int> : public IntegerTypeInfo<unsigned int>, public sofa::type::TypeTrait<unsigned int>
+{};
 
 template<>
-struct DataTypeInfo<long> : public IntegerTypeInfo<long>
-{
-    static const std::string GetTypeName() { return "long"; }
-    static const std::string name() { return "l"; }
-};
+struct DataTypeInfo<long> : public IntegerTypeInfo<long>, public sofa::type::TypeTrait<long>
+{};
 
 template<>
-struct DataTypeInfo<unsigned long> : public IntegerTypeInfo<unsigned long>
-{
-    static const std::string GetTypeName() { return "unsigned long"; }
-    static const std::string name() { return "L"; }
-};
+struct DataTypeInfo<unsigned long> : public IntegerTypeInfo<unsigned long>, public sofa::type::TypeTrait<unsigned long>
+{};
 
 template<>
-struct DataTypeInfo<long long> : public IntegerTypeInfo<long long>
-{
-    static const std::string GetTypeName() { return "long long"; }
-    static const std::string name() { return "q"; }
-};
+struct DataTypeInfo<long long> : public IntegerTypeInfo<long long>, public sofa::type::TypeTrait<long long>
+{};
 
 template<>
-struct DataTypeInfo<unsigned long long> : public IntegerTypeInfo<unsigned long long>
-{
-    static const std::string GetTypeName() { return "unsigned long long"; }
-    static const std::string name() { return "Q"; }
-};
-
+struct DataTypeInfo<unsigned long long> : public IntegerTypeInfo<unsigned long long>, public sofa::type::TypeTrait<unsigned long long>
+{};
 
 } /// typeNamespace sofa::defaulttype
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Scalar.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Scalar.h
@@ -23,6 +23,7 @@
 
 #include <sofa/defaulttype/typeinfo/models/ScalarTypeInfo.h>
 #include <sofa/defaulttype/TypeInfoRegistry.h>
+#include <sofa/type/trait/TypeTrait.h>
 
 namespace sofa::defaulttype
 {

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Scalar.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Scalar.h
@@ -28,19 +28,16 @@ namespace sofa::defaulttype
 {
 
 template<>
-struct DataTypeInfo<float> : public ScalarTypeInfo<float>
-{
-    static const std::string GetTypeName() { return "float"; }
-    static const std::string name(){ return "f"; }
-};
-
+struct DataTypeInfo<float> : public ScalarTypeInfo<float>, public sofa::type::TypeTrait<float>
+{};
 
 template<>
-struct DataTypeInfo<double> : public ScalarTypeInfo<double>
-{
-    static const std::string GetTypeName() { return "double"; }
-    static const std::string name(){ return "d"; }
-};
+struct DataTypeInfo<double> : public ScalarTypeInfo<double>, public sofa::type::TypeTrait<double>
+{};
+
+template<>
+struct DataTypeInfo<long double> : public ScalarTypeInfo<long double>, public sofa::type::TypeTrait<long double>
+{};
 
 } /// namespace sofa::defaulttype
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Scalar.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Scalar.h
@@ -24,20 +24,13 @@
 #include <sofa/defaulttype/typeinfo/models/ScalarTypeInfo.h>
 #include <sofa/defaulttype/TypeInfoRegistry.h>
 #include <sofa/type/trait/TypeTrait.h>
+#include <concepts>
 
 namespace sofa::defaulttype
 {
 
-template<>
-struct DataTypeInfo<float> : public ScalarTypeInfo<float>, public sofa::type::TypeTrait<float>
-{};
-
-template<>
-struct DataTypeInfo<double> : public ScalarTypeInfo<double>, public sofa::type::TypeTrait<double>
-{};
-
-template<>
-struct DataTypeInfo<long double> : public ScalarTypeInfo<long double>, public sofa::type::TypeTrait<long double>
+template<std::floating_point T>
+struct DataTypeInfo<T> : public ScalarTypeInfo<T>, public sofa::type::TypeTrait<T>
 {};
 
 } /// namespace sofa::defaulttype

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenSparseMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenSparseMatrix.h
@@ -455,16 +455,9 @@ public:
         std::ostringstream o;
         o << "EigenMatrix";
 
-        if constexpr (std::is_scalar<Real>::value)
+        if constexpr (std::is_scalar_v<Real>)
         {
-            if constexpr (std::is_same<float, Real>::value)
-            {
-                o << "f";
-            }
-            if constexpr (std::is_same<double, Real>::value)
-            {
-                o << "d";
-            }
+            o << sofa::type::TypeTrait<Real>::suffix;
         }
 
         return o.str();

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenVector.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenVector.h
@@ -24,6 +24,7 @@
 
 #include <sofa/linearalgebra/BaseVector.h>
 #include <sofa/type/Vec.h>
+#include <sofa/type/trait/TypeTrait.h>
 #include <Eigen/Dense>
 
 namespace sofa::linearalgebra

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenVector.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/EigenVector.h
@@ -163,16 +163,9 @@ public:
         std::ostringstream o;
         o << "EigenVector";
 
-        if constexpr (std::is_scalar<TReal>::value)
+        if constexpr (std::is_scalar_v<TReal>)
         {
-            if constexpr (std::is_same<float, TReal>::value)
-            {
-                o << "f";
-            }
-            if constexpr (std::is_same<double, TReal>::value)
-            {
-                o << "d";
-            }
+            o << sofa::type::TypeTrait<TReal>::suffix;
         }
 
         return o.str();

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
@@ -20,11 +20,11 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <sofa/linearalgebra/config.h>
-
-#include <sofa/type/Vec.h>
-#include <sofa/type/Mat.h>
 #include <sofa/linearalgebra/BaseMatrix.h>
+#include <sofa/linearalgebra/config.h>
+#include <sofa/type/Mat.h>
+#include <sofa/type/Vec.h>
+#include <sofa/type/trait/TypeTrait.h>
 
 namespace sofa::linearalgebra
 {
@@ -146,20 +146,7 @@ public:
     static const std::string Name()
     {
         std::ostringstream o;
-        o << "Mat" << L << "x" << C;
-        if constexpr (std::is_same_v<float, real>)
-        {
-            o << "f";
-        }
-        if constexpr (std::is_same_v<double, real>)
-        {
-            o << "d";
-        }
-        if constexpr (std::is_same_v<int, real>)
-        {
-            o << "i";
-        }
-
+        o << "Mat" << L << "x" << C << sofa::type::TypeTrait<Real>::suffix;
         return o.str();
     }
 };
@@ -202,57 +189,10 @@ public:
     static const std::string Name()
     {
         std::ostringstream o;
-        o << "V" << N;
-        if constexpr (std::is_same_v<float, Real>)
-        {
-            o << "f";
-        }
-        if constexpr (std::is_same_v<double, Real>)
-        {
-            o << "d";
-        }
-        if constexpr (std::is_same_v<int, Real>)
-        {
-            o << "i";
-        }
-
+        o << "V" << N << sofa::type::TypeTrait<Real>::suffix;
         return o.str();
     }
 };
-
-//template<> inline const char* matrix_bloc_traits<type::Mat<1,1,float >, sofa::SignedIndex >::Name() { return "1f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<1,1,double>, sofa::SignedIndex  >::Name() { return "1d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<2,2,float >, sofa::SignedIndex >::Name() { return "2f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<2,2,double>, sofa::SignedIndex >::Name() { return "2d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<3,3,float >, sofa::SignedIndex >::Name() { return "3f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<3,3,double>, sofa::SignedIndex >::Name() { return "3d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<4,4,float >, sofa::SignedIndex >::Name() { return "4f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<4,4,double>, sofa::SignedIndex >::Name() { return "4d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<6,6,float >, sofa::SignedIndex >::Name() { return "6f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<6,6,double>, sofa::SignedIndex >::Name() { return "6d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<8,8,float >, sofa::SignedIndex >::Name() { return "8f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<8,8,double>, sofa::SignedIndex >::Name() { return "8d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<9,9,float >, sofa::SignedIndex >::Name() { return "9f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<9,9,double>, sofa::SignedIndex >::Name() { return "9d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<12,12,float >, sofa::SignedIndex >::Name() { return "12f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<12,12,double>, sofa::SignedIndex >::Name() { return "12d"; }
-
-//template<> inline const char* matrix_bloc_traits<type::Mat<1,1,float >, Size >::Name() { return "1f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<1,1,double>, Size >::Name() { return "1d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<2,2,float >, Size >::Name() { return "2f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<2,2,double>, Size >::Name() { return "2d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<3,3,float >, Size >::Name() { return "3f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<3,3,double>, Size >::Name() { return "3d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<4,4,float >, Size >::Name() { return "4f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<4,4,double>, Size >::Name() { return "4d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<6,6,float >, Size >::Name() { return "6f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<6,6,double>, Size >::Name() { return "6d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<8,8,float >, Size >::Name() { return "8f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<8,8,double>, Size >::Name() { return "8d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<9,9,float >, Size >::Name() { return "9f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<9,9,double>, Size >::Name() { return "9d"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<12,12,float >, Size >::Name() { return "12f"; }
-//template<> inline const char* matrix_bloc_traits<type::Mat<12,12,double>, Size >::Name() { return "12d"; }
 
 template <typename IndexType>
 class matrix_bloc_traits < float, IndexType >
@@ -284,7 +224,7 @@ public:
         subBlock = v(b, row, col);
     }
 
-    static const std::string Name() { return "f"; }
+    static const std::string Name() { return sofa::type::TypeTrait<Real>::GetTypeName(); }
     static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return sofa::linearalgebra::BaseMatrix::ELEMENT_FLOAT; }
     static IndexType getElementSize() { return sizeof(Real); }
 };
@@ -320,7 +260,7 @@ public:
     static void split_col_index(IndexType& index, IndexType& modulo) { bloc_index_func<NC, IndexType>::split(index, modulo); }
 
     static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return sofa::linearalgebra::BaseMatrix::ELEMENT_FLOAT; }
-    static const std::string Name() { return "d"; }
+    static const std::string Name() { return sofa::type::TypeTrait<Real>::GetTypeName(); }
 };
 
 template <typename IndexType>
@@ -354,7 +294,7 @@ public:
     static void split_col_index(int& index, int& modulo) { bloc_index_func<NC, IndexType>::split(index, modulo); }
 
     static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return sofa::linearalgebra::BaseMatrix::ELEMENT_INT; }
-    static const std::string Name() { return "f"; }
+    static const std::string Name() { return sofa::type::TypeTrait<Real>::GetTypeName(); }
 };
 
 

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
@@ -224,7 +224,7 @@ public:
         subBlock = v(b, row, col);
     }
 
-    static const std::string Name() { return sofa::type::TypeTrait<Real>::GetTypeName(); }
+    static const std::string Name() { return sofa::type::TypeTrait<Real>::name(); }
     static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return sofa::linearalgebra::BaseMatrix::ELEMENT_FLOAT; }
     static IndexType getElementSize() { return sizeof(Real); }
 };
@@ -260,7 +260,7 @@ public:
     static void split_col_index(IndexType& index, IndexType& modulo) { bloc_index_func<NC, IndexType>::split(index, modulo); }
 
     static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return sofa::linearalgebra::BaseMatrix::ELEMENT_FLOAT; }
-    static const std::string Name() { return sofa::type::TypeTrait<Real>::GetTypeName(); }
+    static const std::string Name() { return sofa::type::TypeTrait<Real>::name(); }
 };
 
 template <typename IndexType>
@@ -294,7 +294,7 @@ public:
     static void split_col_index(int& index, int& modulo) { bloc_index_func<NC, IndexType>::split(index, modulo); }
 
     static sofa::linearalgebra::BaseMatrix::ElementType getElementType() { return sofa::linearalgebra::BaseMatrix::ELEMENT_INT; }
-    static const std::string Name() { return sofa::type::TypeTrait<Real>::GetTypeName(); }
+    static const std::string Name() { return sofa::type::TypeTrait<Real>::name(); }
 };
 
 

--- a/Sofa/framework/Type/src/sofa/type/trait/TypeTrait.h
+++ b/Sofa/framework/Type/src/sofa/type/trait/TypeTrait.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string_view>
+
+namespace sofa::type
+{
+
+template<class T> struct TypeTrait{};
+
+#define MAKE_TYPE_TRAIT(type, suffix_string) \
+    template<> struct TypeTrait<type> \
+    { \
+        static constexpr std::string_view typeName = #type; \
+        static constexpr std::string_view suffix = suffix_string; \
+        static const std::string name() { return std::string(typeName); } \
+        static const std::string GetTypeName() { return std::string(suffix); } \
+    }
+
+MAKE_TYPE_TRAIT(bool, "bool");
+
+MAKE_TYPE_TRAIT(float, "f");
+MAKE_TYPE_TRAIT(double, "d");
+MAKE_TYPE_TRAIT(long double, "e");
+
+MAKE_TYPE_TRAIT(int, "i");
+MAKE_TYPE_TRAIT(unsigned int, "I");
+
+MAKE_TYPE_TRAIT(short, "h");
+MAKE_TYPE_TRAIT(unsigned short, "H");
+
+MAKE_TYPE_TRAIT(char, "b");
+MAKE_TYPE_TRAIT(unsigned char, "B");
+
+MAKE_TYPE_TRAIT(long, "l");
+MAKE_TYPE_TRAIT(unsigned long, "L");
+
+MAKE_TYPE_TRAIT(long long, "q");
+MAKE_TYPE_TRAIT(unsigned long long, "Q");
+
+#undef MAKE_TYPE_TRAIT
+
+}

--- a/Sofa/framework/Type/src/sofa/type/trait/TypeTrait.h
+++ b/Sofa/framework/Type/src/sofa/type/trait/TypeTrait.h
@@ -33,8 +33,8 @@ template<class T> struct TypeTrait{};
     { \
         static constexpr std::string_view typeName = #type; \
         static constexpr std::string_view suffix = suffix_string; \
-        static const std::string name() { return std::string(typeName); } \
-        static const std::string GetTypeName() { return std::string(suffix); } \
+        static const std::string name() { return std::string(suffix); } \
+        static const std::string GetTypeName() { return std::string(typeName); } \
     }
 
 MAKE_TYPE_TRAIT(bool, "bool");

--- a/Sofa/framework/Type/src/sofa/type/trait/TypeTrait.h
+++ b/Sofa/framework/Type/src/sofa/type/trait/TypeTrait.h
@@ -1,3 +1,24 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
 #pragma once
 
 #include <string_view>


### PR DESCRIPTION
This is to factorize all places where we need a mapping type->suffix or type->name, mainly for primitive numeric types. `long double` has been added.


[with-all-tests]


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
