### PR TITLE
[FEM] TetrahedralCorotationalFEMForceField fix stream functions

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.h
@@ -113,14 +113,32 @@ public:
         }
 
         /// Output stream
-        inline friend std::ostream& operator<< ( std::ostream& os, const TetrahedronInformation& /*tri*/ )
+        inline friend std::ostream& operator<< ( std::ostream& os, const TetrahedronInformation& tri )
         {
+            os << tri.materialMatrix << " ";
+            os << tri.strainDisplacementTransposedMatrix << " ";
+
+            for (int i = 0; i < 4; ++i)
+                os << tri.rotatedInitialElements[i] << " ";
+
+            os << tri.elemShapeFun << " ";
+            os << tri.rotation << " ";
+            os << tri.initialTransformation << " ";
             return os;
         }
 
         /// Input stream
-        inline friend std::istream& operator>> ( std::istream& in, TetrahedronInformation& /*tri*/ )
+        inline friend std::istream& operator>> ( std::istream& in, TetrahedronInformation& tri )
         {
+            in >> tri.materialMatrix;
+            in >> tri.strainDisplacementTransposedMatrix;
+
+            for (int i = 0; i < 4; ++i)
+                in >> tri.rotatedInitialElements[i];
+
+            in >> tri.elemShapeFun;
+            in >> tri.rotation;
+            in >> tri.initialTransformation;
             return in;
         }
     };

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedralCorotationalFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/TetrahedralCorotationalFEMForceField_test.cpp
@@ -85,4 +85,61 @@ TEST_F(TetrahedralCorotationalFEMForceField_test, emptyTology)
     this->checkEmptyTopology();
 }
 
+TEST_F(TetrahedralCorotationalFEMForceField_test, TetrahedronInformationStreamOperators)
+{
+    TetraCorotationalFEM::TetrahedronInformation initialInfo;
+
+    for (int i = 0; i < 6; ++i)
+        for (int j = 0; j < 6; ++j)
+            initialInfo.materialMatrix[i][j] = 1;
+
+    for (int i = 0; i < 12; ++i)
+        for (int j = 0; j < 6; ++j)
+            initialInfo.strainDisplacementTransposedMatrix[i][j] = 1;
+
+    for (int i = 0; i < 4; ++i)
+        initialInfo.rotatedInitialElements[i] = Coord(1, 2, 3);
+
+    for (int i = 0; i < 4; ++i)
+        for (int j = 0; j < 4; ++j)
+            initialInfo.elemShapeFun[i][j] = 1;
+
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+            initialInfo.rotation[i][j] = 1;
+
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+            initialInfo.initialTransformation[i][j] = 1;
+
+    std::stringstream buffer;
+    buffer << initialInfo;
+
+    TetraCorotationalFEM::TetrahedronInformation loadedInfo;
+    buffer >> loadedInfo;
+
+    for (int i = 0; i < 6; ++i)
+        for (int j = 0; j < 6; ++j)
+            EXPECT_EQ(initialInfo.materialMatrix[i][j], loadedInfo.materialMatrix[i][j]);
+
+    for (int i = 0; i < 12; ++i)
+        for (int j = 0; j < 6; ++j)
+            EXPECT_EQ(initialInfo.strainDisplacementTransposedMatrix[i][j],
+                     loadedInfo.strainDisplacementTransposedMatrix[i][j]);
+
+    for (int i = 0; i < 4; ++i)
+        EXPECT_EQ(initialInfo.rotatedInitialElements[i], loadedInfo.rotatedInitialElements[i]);
+
+    for (int i = 0; i < 4; ++i)
+        for (int j = 0; j < 4; ++j)
+            EXPECT_EQ(initialInfo.elemShapeFun[i][j], loadedInfo.elemShapeFun[i][j]);
+
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+        {
+            EXPECT_EQ(initialInfo.rotation[i][j], loadedInfo.rotation[i][j]);
+            EXPECT_EQ(initialInfo.initialTransformation[i][j], loadedInfo.initialTransformation[i][j]);
+        }
+}
+
 }


### PR DESCRIPTION
Hello !

For my project, I want to save and load data from components. In TetrahedralCorotationalFEMForceField, I had a problem with the data " tetrahedronInfo" : this data contained no value, but this is necessary to load correctly.

So, in this PR, I fix the Output stream and Input stream functions from TetrahedralCorotationalFEMForceField.

For example,
Without this PR :
<img width="1495" height="90" alt="Screenshot from 2026-05-27 14-41-27" src="https://github.com/user-attachments/assets/7108dc26-8610-48b2-ac49-f0e4de741a01" />

With this PR : 
<img width="1495" height="90" alt="Screenshot from 2026-05-27 14-41-20" src="https://github.com/user-attachments/assets/270e08bc-de08-4973-83f5-b8b12956791f" />

Now, I can save and load the component TetrahedralCorotationalFEMForceField.

Thank you !

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
