### PR TITLE
[FEM] Add support of pyramids elements

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.cpp
+++ b/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.cpp
@@ -38,6 +38,7 @@ template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sof
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
+template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 
 void registerFEMMass(sofa::core::ObjectFactory* factory)
 {
@@ -52,6 +53,7 @@ void registerFEMMass(sofa::core::ObjectFactory* factory)
         .add< FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron> >()
         .add< FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron> >()
         .add< FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Prism> >()
+        .add< FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid> >()
     );
 }
 

--- a/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.h
@@ -260,7 +260,7 @@ template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sof
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
-template class SOFA_COMPONENT_MASS_API ElementFEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
+template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 #endif
 
 }  // namespace sofa::component::mass

--- a/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.h
@@ -260,6 +260,7 @@ template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sof
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 template class SOFA_COMPONENT_MASS_API FEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
+template class SOFA_COMPONENT_MASS_API ElementFEMMass<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 #endif
 
 }  // namespace sofa::component::mass

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.cpp
@@ -42,6 +42,7 @@ void registerCorotationalFEMForceField(sofa::core::ObjectFactory* factory)
         .add< CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron> >()
         .add< CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron> >()
         .add< CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism> >()
+        .add< CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid> >()
     );
 }
 
@@ -55,5 +56,6 @@ template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForc
 template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
+template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 
 }

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
@@ -185,7 +185,7 @@ extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API Corotational
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
-extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API ElementCorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
+extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 #endif
 
 }  // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
@@ -185,6 +185,7 @@ extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API Corotational
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API CorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
+extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API ElementCorotationalFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 #endif
 
 }  // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.cpp
@@ -42,6 +42,7 @@ void registerLinearSmallStrainFEMForceField(sofa::core::ObjectFactory* factory)
         .add< LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron> >()
         .add< LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron> >()
         .add< LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism> >()
+        .add< LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid> >()
     );
 }
 
@@ -55,5 +56,6 @@ template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFE
 template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
+template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 
 }

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
@@ -92,7 +92,7 @@ extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallS
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
-extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API ElementLinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
+extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 #endif
 
 }  // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
@@ -92,6 +92,7 @@ extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallS
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
 extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API LinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Prism>;
+extern template class SOFA_COMPONENT_SOLIDMECHANICS_FEM_ELASTIC_API ElementLinearSmallStrainFEMForceField<sofa::defaulttype::Vec3Types, sofa::geometry::Pyramid>;
 #endif
 
 }  // namespace sofa::component::solidmechanics::fem::elastic

--- a/Sofa/framework/Core/src/sofa/core/visual/DrawMesh.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/DrawMesh.h
@@ -454,6 +454,85 @@ private:
 };
 
 template<>
+struct SOFA_CORE_API DrawElementMesh<sofa::geometry::Pyramid>
+    : public BaseDrawMesh<DrawElementMesh<sofa::geometry::Pyramid>, 5>
+{
+    using ElementType = sofa::geometry::Pyramid;
+    friend BaseDrawMesh;
+
+    static constexpr ColorContainer defaultColors {
+        sofa::type::RGBAColor::green(),
+        sofa::type::RGBAColor::teal(),
+        sofa::type::RGBAColor::navy(),
+        sofa::type::RGBAColor::gold(),
+        sofa::type::RGBAColor::purple()
+    };
+
+private:
+    template<class PositionContainer, class IndicesContainer>
+    void doDraw(
+        sofa::helper::visual::DrawTool* drawTool,
+        const PositionContainer& position,
+        sofa::core::topology::BaseMeshTopology* topology,
+        const IndicesContainer& elementIndices,
+        const ColorContainer& colors)
+    {
+        if (!topology)
+            return;
+
+        const auto& elements = topology->getPyramids();
+
+        // Allocate space for rendering points
+        // 1 Quad + 4 Triangles
+        renderedPoints[0].resize(elementIndices.size() * sofa::geometry::Quad::NumberOfNodes);
+        renderedPoints[1].resize(elementIndices.size() * sofa::geometry::Triangle::NumberOfNodes);
+        renderedPoints[2].resize(elementIndices.size() * sofa::geometry::Triangle::NumberOfNodes);
+        renderedPoints[3].resize(elementIndices.size() * sofa::geometry::Triangle::NumberOfNodes);
+        renderedPoints[4].resize(elementIndices.size() * sofa::geometry::Triangle::NumberOfNodes);
+
+        std::array<std::size_t, NumberColors> renderedPointId {};
+
+        for (auto i : elementIndices)
+        {
+            const auto& pyramid = elements[i];
+            const auto center = this->elementCenter(position, pyramid);
+
+            const auto drawQuad = [&](sofa::Index bufferId, sofa::Index v0, sofa::Index v1, sofa::Index v2, sofa::Index v3)
+            {
+                const std::array vertexIndices { pyramid[v0], pyramid[v1], pyramid[v2], pyramid[v3] };
+                for (std::size_t k = 0; k < sofa::geometry::Quad::NumberOfNodes; ++k)
+                {
+                    const auto p = this->applyElementSpace(position[vertexIndices[k]], center);
+                    renderedPoints[bufferId][renderedPointId[bufferId]++] = sofa::type::toVec3(p);
+                }
+            };
+
+            const auto drawTriangle = [&](sofa::Index bufferId, sofa::Index v0, sofa::Index v1, sofa::Index v2)
+            {
+                const std::array vertexIndices { pyramid[v0], pyramid[v1], pyramid[v2] };
+                for (std::size_t k = 0; k < sofa::geometry::Triangle::NumberOfNodes; ++k)
+                {
+                    const auto p = this->applyElementSpace(position[vertexIndices[k]], center);
+                    renderedPoints[bufferId][renderedPointId[bufferId]++] = sofa::type::toVec3(p);
+                }
+            };
+
+            drawQuad(0, 0, 3, 2, 1);
+            drawTriangle(1, 0, 1, 4);
+            drawTriangle(2, 1, 2, 4);
+            drawTriangle(3, 3, 4, 2);
+            drawTriangle(4, 0, 4, 3);
+        }
+
+        drawTool->drawQuads(renderedPoints[0], colors[0]);
+        drawTool->drawTriangles(renderedPoints[1], colors[1]);
+        drawTool->drawTriangles(renderedPoints[2], colors[2]);
+        drawTool->drawTriangles(renderedPoints[3], colors[3]);
+        drawTool->drawTriangles(renderedPoints[4], colors[4]);
+    }
+};
+
+template<>
 struct SOFA_CORE_API DrawElementMesh<sofa::geometry::Hexahedron>
     : public BaseDrawMesh<DrawElementMesh<sofa::geometry::Hexahedron>, 6>
 {
@@ -564,6 +643,7 @@ public:
         drawElements<sofa::geometry::Tetrahedron>(drawTool, position, topology);
         drawElements<sofa::geometry::Hexahedron>(drawTool, position, topology);
         drawElements<sofa::geometry::Prism>(drawTool, position, topology);
+        drawElements<sofa::geometry::Pyramid>(drawTool, position, topology);
     }
 
     template<class PositionContainer>
@@ -582,8 +662,9 @@ public:
         const auto hasTetra = !topology->getTetrahedra().empty();
         const auto hasHexa = !topology->getHexahedra().empty();
         const auto hasPrism = !topology->getPrisms().empty();
+        const auto hasPyramid = !topology->getPyramids().empty();
 
-        const bool hasVolumeElements = hasTetra || hasHexa || hasPrism;
+        const bool hasVolumeElements = hasTetra || hasHexa || hasPrism || hasPyramid;
 
         if (!hasSurfaceElements && !hasVolumeElements)
         {
@@ -609,7 +690,8 @@ private:
         DrawElementMesh<sofa::geometry::Quad>,
         DrawElementMesh<sofa::geometry::Tetrahedron>,
         DrawElementMesh<sofa::geometry::Hexahedron>,
-        DrawElementMesh<sofa::geometry::Prism>
+        DrawElementMesh<sofa::geometry::Prism>,
+        DrawElementMesh<sofa::geometry::Pyramid>
     > m_meshes;
 };
 

--- a/Sofa/framework/FEM/CMakeLists.txt
+++ b/Sofa/framework/FEM/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HEADER_FILES
     ${SOFAFEMSRC_ROOT}/FiniteElement[Edge].h
     ${SOFAFEMSRC_ROOT}/FiniteElement[Hexahedron].h
     ${SOFAFEMSRC_ROOT}/FiniteElement[Prism].h
+    ${SOFAFEMSRC_ROOT}/FiniteElement[Pyramid].h
     ${SOFAFEMSRC_ROOT}/FiniteElement[Quad].h
     ${SOFAFEMSRC_ROOT}/FiniteElement[Tetrahedron].h
     ${SOFAFEMSRC_ROOT}/FiniteElement[Triangle].h
@@ -23,6 +24,7 @@ set(SOURCE_FILES
     ${SOFAFEMSRC_ROOT}/FiniteElement[Edge].cpp
     ${SOFAFEMSRC_ROOT}/FiniteElement[Hexahedron].cpp
     ${SOFAFEMSRC_ROOT}/FiniteElement[Prism].cpp
+    ${SOFAFEMSRC_ROOT}/FiniteElement[Pyramid].cpp
     ${SOFAFEMSRC_ROOT}/FiniteElement[Quad].cpp
     ${SOFAFEMSRC_ROOT}/FiniteElement[Tetrahedron].cpp
     ${SOFAFEMSRC_ROOT}/FiniteElement[Triangle].cpp

--- a/Sofa/framework/FEM/src/sofa/fem/FiniteElement[Pyramid].cpp
+++ b/Sofa/framework/FEM/src/sofa/fem/FiniteElement[Pyramid].cpp
@@ -19,12 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
-
-#include <sofa/fem/FiniteElement[Edge].h>
-#include <sofa/fem/FiniteElement[Hexahedron].h>
-#include <sofa/fem/FiniteElement[Prism].h>
+#define SOFA_FEM_FINITE_ELEMENT_PYRAMID_CPP
 #include <sofa/fem/FiniteElement[Pyramid].h>
-#include <sofa/fem/FiniteElement[Quad].h>
-#include <sofa/fem/FiniteElement[Tetrahedron].h>
-#include <sofa/fem/FiniteElement[Triangle].h>
+#include <sofa/defaulttype/VecTypes.h>
+
+namespace sofa::fem
+{
+
+template struct SOFA_FEM_API FiniteElement<sofa::geometry::Pyramid, sofa::defaulttype::Vec3Types>;
+
+}

--- a/Sofa/framework/FEM/src/sofa/fem/FiniteElement[Pyramid].h
+++ b/Sofa/framework/FEM/src/sofa/fem/FiniteElement[Pyramid].h
@@ -1,0 +1,97 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/fem/FiniteElement.h>
+#include <sofa/geometry/Pyramid.h>
+
+#if !defined(SOFA_FEM_FINITE_ELEMENT_PYRAMID_CPP)
+#include <sofa/defaulttype/VecTypes.h>
+#endif
+
+namespace sofa::fem
+{
+
+template <class DataTypes>
+struct FiniteElement<sofa::geometry::Pyramid, DataTypes>
+{
+    FINITEELEMENT_HEADER(sofa::geometry::Pyramid, DataTypes, 3);
+    static_assert(spatial_dimensions == 3, "Pyramids are only defined in 3D");
+
+    constexpr static std::array<ReferenceCoord, NumberOfNodesInElement> referenceElementNodes {{
+        {-1, -1, -1},
+        { 1, -1, -1},
+        { 1,  1, -1},
+        {-1,  1, -1},
+        { 0,  0,  1},
+    }};
+
+    static const sofa::type::vector<TopologyElement>& getElementSequence(sofa::core::topology::BaseMeshTopology& topology)
+    {
+        return topology.getPyramids();
+    }
+
+    static constexpr sofa::type::Vec<NumberOfNodesInElement, Real> shapeFunctions(const sofa::type::Vec<TopologicalDimension, Real>& q)
+    {
+        return {
+            static_cast<Real>(0.125) * (1 - q[0]) * (1 - q[1]) * (1 - q[2]),
+            static_cast<Real>(0.125) * (1 + q[0]) * (1 - q[1]) * (1 - q[2]),
+            static_cast<Real>(0.125) * (1 + q[0]) * (1 + q[1]) * (1 - q[2]),
+            static_cast<Real>(0.125) * (1 - q[0]) * (1 + q[1]) * (1 - q[2]),
+            static_cast<Real>(0.5)   * (1 + q[2])
+        };
+    }
+
+    static constexpr sofa::type::Mat<NumberOfNodesInElement, TopologicalDimension, Real> gradientShapeFunctions(const sofa::type::Vec<TopologicalDimension, Real>& q)
+    {
+        return {
+            {-static_cast<Real>(0.125) * (1 - q[1]) * (1 - q[2]), -static_cast<Real>(0.125) * (1 - q[0]) * (1 - q[2]), -static_cast<Real>(0.125) * (1 - q[0]) * (1 - q[1])},
+            { static_cast<Real>(0.125) * (1 - q[1]) * (1 - q[2]), -static_cast<Real>(0.125) * (1 + q[0]) * (1 - q[2]), -static_cast<Real>(0.125) * (1 + q[0]) * (1 - q[1])},
+            { static_cast<Real>(0.125) * (1 + q[1]) * (1 - q[2]),  static_cast<Real>(0.125) * (1 + q[0]) * (1 - q[2]), -static_cast<Real>(0.125) * (1 + q[0]) * (1 + q[1])},
+            {-static_cast<Real>(0.125) * (1 + q[1]) * (1 - q[2]),  static_cast<Real>(0.125) * (1 - q[0]) * (1 - q[2]), -static_cast<Real>(0.125) * (1 - q[0]) * (1 + q[1])},
+            { 0,                                                 0,                                                 static_cast<Real>(0.5)}
+        };
+    }
+
+    static constexpr auto quadraturePoints()
+    {
+        constexpr Real sqrt3_1 = static_cast<Real>(1) / static_cast<Real>(1.73205080757);
+        constexpr Real one = static_cast<Real>(1);
+
+        // We use the 8 Gauss points of the hexahedron, which exactly integrate the (1-z)^2 Jacobian of the pyramid.
+        return std::array {
+            std::pair{ReferenceCoord{-sqrt3_1, -sqrt3_1, -sqrt3_1}, one},
+            std::pair{ReferenceCoord{ sqrt3_1, -sqrt3_1, -sqrt3_1}, one},
+            std::pair{ReferenceCoord{ sqrt3_1,  sqrt3_1, -sqrt3_1}, one},
+            std::pair{ReferenceCoord{-sqrt3_1,  sqrt3_1, -sqrt3_1}, one},
+            std::pair{ReferenceCoord{-sqrt3_1, -sqrt3_1,  sqrt3_1}, one},
+            std::pair{ReferenceCoord{ sqrt3_1, -sqrt3_1,  sqrt3_1}, one},
+            std::pair{ReferenceCoord{ sqrt3_1,  sqrt3_1,  sqrt3_1}, one},
+            std::pair{ReferenceCoord{-sqrt3_1,  sqrt3_1,  sqrt3_1}, one},
+        };
+    }
+};
+
+#if !defined(SOFA_FEM_FINITE_ELEMENT_PYRAMID_CPP)
+extern template struct SOFA_FEM_API FiniteElement<sofa::geometry::Pyramid, sofa::defaulttype::Vec3Types>;
+#endif
+
+}

--- a/Sofa/framework/FEM/test/FiniteElement_test.cpp
+++ b/Sofa/framework/FEM/test/FiniteElement_test.cpp
@@ -88,6 +88,11 @@ TEST(FiniteElement, prism3dWeights)
     testSumWeights<sofa::geometry::Prism, sofa::defaulttype::Vec3Types>(1 / 2.);
 }
 
+TEST(FiniteElement, pyramid3dWeights)
+{
+    testSumWeights<sofa::geometry::Pyramid, sofa::defaulttype::Vec3Types>(8);
+}
+
 /**
  * Checks that the sum of the gradients of shape functions is zero at the evaluation point.
  */
@@ -167,6 +172,12 @@ TEST(FiniteElement, prism3dGradientShapeFunctions)
 {
     testGradientShapeFunctions<sofa::geometry::Prism, sofa::defaulttype::Vec3Types>(sofa::type::Vec3(0., 0., 0.));
     testGradientShapeFunctions<sofa::geometry::Prism, sofa::defaulttype::Vec3Types>(sofa::type::Vec3(1., 1., 1.));
+}
+
+TEST(FiniteElement, pyramid3dGradientShapeFunctions)
+{
+    testGradientShapeFunctions<sofa::geometry::Pyramid, sofa::defaulttype::Vec3Types>(sofa::type::Vec3(0., 0., 0.));
+    testGradientShapeFunctions<sofa::geometry::Pyramid, sofa::defaulttype::Vec3Types>(sofa::type::Vec3(0.5, 0.5, 0.5));
 }
 
 }

--- a/examples/Component/SolidMechanics/FEM/PyramidCorotationalFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/PyramidCorotationalFEMForceField.scn
@@ -2,9 +2,9 @@
     <Node name="plugins">
         <RequiredPlugin pluginName="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
         <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
-        <RequiredPlugin pluginName="Sofa.Component.Mass"/> <!-- Needed to use components [NodalMassDensity,PyramidFEMMass] -->
+        <RequiredPlugin pluginName="Sofa.Component.Mass"/> <!-- Needed to use components [NodalMassDensity,FEMMass] -->
         <RequiredPlugin pluginName="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [BDFOdeSolver,NewtonRaphsonSolver] -->
-        <RequiredPlugin pluginName="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [PyramidCorotationalFEMForceField] -->
+        <RequiredPlugin pluginName="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [CorotationalFEMForceField] -->
         <RequiredPlugin pluginName="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
         <RequiredPlugin pluginName="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
         <RequiredPlugin pluginName="Sofa.Component.Visual"/> <!-- Needed to use components [VisualMesh] -->

--- a/examples/Component/SolidMechanics/FEM/PyramidCorotationalFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/PyramidCorotationalFEMForceField.scn
@@ -1,0 +1,52 @@
+<Node name="root" dt="0.01" gravity="0 -9.81 0">
+    <Node name="plugins">
+        <RequiredPlugin pluginName="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
+        <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
+        <RequiredPlugin pluginName="Sofa.Component.Mass"/> <!-- Needed to use components [NodalMassDensity,PyramidFEMMass] -->
+        <RequiredPlugin pluginName="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [BDFOdeSolver,NewtonRaphsonSolver] -->
+        <RequiredPlugin pluginName="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [PyramidCorotationalFEMForceField] -->
+        <RequiredPlugin pluginName="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin pluginName="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [MeshTopology] -->
+        <RequiredPlugin pluginName="Sofa.Component.Visual"/> <!-- Needed to use components [VisualMesh] -->
+    </Node>
+
+    <DefaultAnimationLoop/>
+    <Node name="physics">
+        <BDFOdeSolver order="2" printLog="false" rayleighMass="0.01" rayleighStiffness="0.01"/>
+        <NewtonRaphsonSolver name="newton" printLog="false"
+                             maxNbIterationsNewton="10" absoluteResidualStoppingThreshold="1e-5"
+                             maxNbIterationsLineSearch="5" lineSearchCoefficient="0.5"
+                             relativeInitialStoppingThreshold="1e-3"
+                             absoluteEstimateDifferenceThreshold="1e-5"
+                             relativeEstimateDifferenceThreshold="1e-5"/>
+        <SparseLDLSolver name="linear_solver" template="CompressedRowSparseMatrix"/>
+
+        <!-- A cube made of 6 pyramids -->
+        <MeshTopology name="mesh" pyramids="
+            0 1 5 4 8
+            1 5 6 2 8
+            2 3 7 6 8
+            0 3 7 4 8
+            3 2 1 0 8
+            6 7 4 5 8
+        "
+        position="
+            -1 -1 -1
+            1 -1 -1
+            1 1 -1
+            -1 1 -1
+            -1 -1 1
+            1 -1 1
+            1 1 1
+            -1 1 1
+            0 0 0
+        "/>
+        <MechanicalObject template="Vec3" name="state" />
+        <NodalMassDensity property="10"/>
+        <PyramidFEMMass/>
+        <PyramidCorotationalFEMForceField name="FEM" poissonRatio="0.45" youngModulus="500"/>
+        <FixedProjectiveConstraint indices="2 3 7 6"/>
+
+        <VisualMesh position="@state.position" topology="@mesh"/>
+    </Node>
+</Node>

--- a/examples/Component/SolidMechanics/FEM/PyramidCorotationalFEMForceField.scn
+++ b/examples/Component/SolidMechanics/FEM/PyramidCorotationalFEMForceField.scn
@@ -43,8 +43,8 @@
         "/>
         <MechanicalObject template="Vec3" name="state" />
         <NodalMassDensity property="10"/>
-        <PyramidFEMMass/>
-        <PyramidCorotationalFEMForceField name="FEM" poissonRatio="0.45" youngModulus="500"/>
+        <FEMMass template="Vec3,Pyramid"/>
+        <CorotationalFEMForceField template="Vec3,Pyramid" name="FEM" poissonRatio="0.45" youngModulus="500"/>
         <FixedProjectiveConstraint indices="2 3 7 6"/>
 
         <VisualMesh position="@state.position" topology="@mesh"/>


### PR DESCRIPTION
The following components now support pyramid elements:
- Corotational force field
- Linear small strain force field
- Mass
- VisualMesh

An example is added:

https://github.com/user-attachments/assets/0a19ebf9-46fd-4b51-afbd-fc72557426f7


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
