### PR TITLE
[type] Add missing TypeTrait.h in CMakeList

### DIFF
--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -38,6 +38,7 @@ set(HEADER_FILES
     ${SOFATYPESRC_ROOT}/stable_vector.h
     ${SOFATYPESRC_ROOT}/StrongType.h
     ${SOFATYPESRC_ROOT}/trait/Rebind.h
+    ${SOFATYPESRC_ROOT}/trait/TypeTrait.h
     ${SOFATYPESRC_ROOT}/trait/is_container.h
     ${SOFATYPESRC_ROOT}/trait/is_fixed_array.h
     ${SOFATYPESRC_ROOT}/trait/is_specialization_of.h


### PR DESCRIPTION
Missed from https://github.com/sofa-framework/sofa/pull/6121