### PR TITLE
[FEM.Elastic] introduce virtual method called before force derivatives

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FEMForceField.h
@@ -106,6 +106,8 @@ protected:
         sofa::type::vector<ElementForce>& df,
         const sofa::VecDeriv_t<DataTypes>& dx);
 
+    virtual void beforeElementForceDeriv(const sofa::core::MechanicalParams* mparams) {}
+
     virtual void computeElementsForcesDeriv(
         const sofa::simulation::Range<std::size_t>& range,
         const sofa::core::MechanicalParams* mparams,

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FEMForceField.inl
@@ -164,6 +164,8 @@ void FEMForceField<DataTypes, ElementType>::computeElementsForcesDeriv(
 {
     SCOPED_TIMER("ElementForcesDeriv");
 
+    this->beforeElementForceDeriv(mparams);
+
     const auto& elements = trait::FiniteElement::getElementSequence(*this->l_topology);
 
     sofa::simulation::forEachRange(getExecutionPolicy(d_computeForceDerivStrategy), *this->m_taskScheduler,


### PR DESCRIPTION
Not used right now, but it will be used in the hyperelasticity force field to re-compute the Hessian.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
