### PR TITLE
[Framework] Fix last warnings

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionForceField.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/MixedInteractionForceField.h
@@ -153,8 +153,8 @@ public:
         return name;
     }
 
-    using Inherit2::getMechModel1;
-    using Inherit2::getMechModel2;
+    BaseMechanicalState* getMechModel1() override { return Inherit2::getMechModel1(); }
+    BaseMechanicalState* getMechModel2() override { return Inherit2::getMechModel2(); }
 };
 
 #if !defined(SOFA_CORE_BEHAVIOR_MIXEDINTERACTIONFORCEFIELD_CPP)

--- a/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionConstraint.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionConstraint.h
@@ -152,8 +152,8 @@ public:
         return obj;
     }
 
-    using Inherit2::getMechModel1;
-    using Inherit2::getMechModel2;
+    BaseMechanicalState* getMechModel1() override { return Inherit2::getMechModel1(); }
+    BaseMechanicalState* getMechModel2() override { return Inherit2::getMechModel2(); }
 
 protected:
 

--- a/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
@@ -169,8 +169,8 @@ public:
         return obj;
     }
 
-    using Inherit2::getMechModel1;
-    using Inherit2::getMechModel2;
+    BaseMechanicalState* getMechModel1() override { return Inherit2::getMechModel1(); }
+    BaseMechanicalState* getMechModel2() override { return Inherit2::getMechModel2(); }
 };
 
 #if !defined(SOFA_CORE_BEHAVIOR_PAIRINTERACTIONPROJECTIVECONSTRAINTSET_CPP)

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/FixedArrayTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/FixedArrayTypeInfo.h
@@ -94,13 +94,17 @@ struct FixedArrayTypeInfo
     template <typename T>
     static void getValue(const DataType &data, sofa::Size index, T& value)
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::getValue(data[(sofa::Size)index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::getValue(data[(sofa::Size)(index/BaseTypeInfo::size())], (sofa::Size)(index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::getValue(data[(sofa::Size)index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::getValue(data[(sofa::Size)(index / BaseTypeInfo::size())],
+                                       (sofa::Size)(index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {
@@ -121,13 +125,17 @@ struct FixedArrayTypeInfo
     template<typename T>
     static void setValue(DataType &data, sofa::Size index, const T& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::setValue(data[(sofa::Size)index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::setValue(data[(sofa::Size)(index/BaseTypeInfo::size())], (sofa::Size)(index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::setValue(data[(sofa::Size)index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::setValue(data[(sofa::Size)(index / BaseTypeInfo::size())],
+                                       (sofa::Size)(index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {
@@ -147,13 +155,16 @@ struct FixedArrayTypeInfo
 
     static void getValueString(const DataType &data, sofa::Size index, std::string& value)
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::getValueString(data[(sofa::Size)index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::getValueString(data[(sofa::Size)(index/BaseTypeInfo::size())], (sofa::Size)(index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::getValueString(data[(sofa::Size)index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::getValueString(data[(sofa::Size)(index/BaseTypeInfo::size())], (sofa::Size)(index%BaseTypeInfo::size()), value);
+            }
         }
         else
         {
@@ -173,13 +184,17 @@ struct FixedArrayTypeInfo
 
     static void setValueString(DataType &data, sofa::Size index, const std::string& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::setValueString(data[(sofa::Size)index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::setValueString(data[(sofa::Size)(index/BaseTypeInfo::size())], (sofa::Size)(index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::setValueString(data[(sofa::Size)index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::setValueString(data[(sofa::Size)(index / BaseTypeInfo::size())],
+                                             (sofa::Size)(index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
@@ -105,15 +105,24 @@ struct SetTypeInfo
     template<typename T>
     static void setValue(DataType &data, sofa::Size /*index*/, const T& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseType t;
-            BaseTypeInfo::setValue(t, 0, value);
-            data.insert(t);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseType t;
+                BaseTypeInfo::setValue(t, 0, value);
+                data.insert(t);
+            }
+            else
+            {
+                msg_error("SetTypeInfo")
+                    << "setValueString not implemented for set with composite values.";
+            }
         }
         else
         {
-            msg_error("SetTypeInfo") << "setValue not implemented for set with composite values.";
+            msg_error("SetTypeInfo") << "setValueString not implemented for set with dymamic size.";
         }
     }
 
@@ -143,15 +152,22 @@ struct SetTypeInfo
 
     static void setValueString(DataType &data, sofa::Size /*index*/, const std::string& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseType t;
-            BaseTypeInfo::setValueString(t, 0, value);
-            data.insert(t);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseType t;
+                BaseTypeInfo::setValueString(t, 0, value);
+                data.insert(t);
+            }
+            else
+            {
+                msg_error("SetTypeInfo") << "setValueString not implemented for set with composite values.";
+            }
         }
         else
         {
-            msg_error("SetTypeInfo") << "setValueString not implemented for set with composite values.";
+            msg_error("SetTypeInfo") << "setValueString not implemented for set with dymamic size.";
         }
     }
 

--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
@@ -91,13 +91,17 @@ struct VectorTypeInfo
     template <typename T>
     static void getValue(const DataType &data, sofa::Size index, T& value)
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::getValue(data[index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::getValue(data[(index/BaseTypeInfo::size())], (index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::getValue(data[index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::getValue(data[(index / BaseTypeInfo::size())],
+                                       (index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {
@@ -118,13 +122,17 @@ struct VectorTypeInfo
     template<typename T>
     static void setValue(DataType &data, sofa::Size index, const T& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::setValue(data[index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::setValue(data[(index/BaseTypeInfo::size())], (index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::setValue(data[index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::setValue(data[(index / BaseTypeInfo::size())],
+                                       (index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {
@@ -144,13 +152,17 @@ struct VectorTypeInfo
 
     static void getValueString(const DataType &data, sofa::Size index, std::string& value)
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::getValueString(data[index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::getValueString(data[(index/BaseTypeInfo::size())], (index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::getValueString(data[index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::getValueString(data[(index / BaseTypeInfo::size())],
+                                             (index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {
@@ -170,13 +182,17 @@ struct VectorTypeInfo
 
     static void setValueString(DataType &data, sofa::Size index, const std::string& value )
     {
-        if (BaseTypeInfo::FixedSize && BaseTypeInfo::size() == 1)
+        if constexpr (BaseTypeInfo::FixedSize)
         {
-            BaseTypeInfo::setValueString(data[index], 0, value);
-        }
-        else if constexpr (BaseTypeInfo::FixedSize)
-        {
-            BaseTypeInfo::setValueString(data[(index/BaseTypeInfo::size())], (index%BaseTypeInfo::size()), value);
+            if (BaseTypeInfo::size() == 1)
+            {
+                BaseTypeInfo::setValueString(data[index], 0, value);
+            }
+            else
+            {
+                BaseTypeInfo::setValueString(data[(index / BaseTypeInfo::size())],
+                                             (index % BaseTypeInfo::size()), value);
+            }
         }
         else
         {

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/BaseMatrix.cpp
@@ -733,7 +733,7 @@ public:
     {
         switch(NC)
         {
-        case 1: if (NL==1) opDynamicReal1<Real, M1, M2 >(m1, m2, fact, category);
+        case 1: if constexpr (NL==1) opDynamicReal1<Real, M1, M2 >(m1, m2, fact, category);
             else opDynamicRealNLNC<Real, NL, 1, M1, M2 >(m1, m2, fact, category);
             break;
         case 2: opDynamicRealNLNC<Real, NL, 2, M1, M2 >(m1, m2, fact, category); break;

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrixMechanical.h
@@ -487,21 +487,25 @@ public:
     }
     static bool upper(Index   i  , Index   j  , Block& val, const Real /*ref*/)
     {
-        if (NL>1 && i*NL == j*NC)
+        if constexpr (NL > 1)
         {
-            for (Index bi = 1; bi < (Index)NL; ++bi)
-                for (Index bj = 0; bj < bi; ++bj)
-                    traits::vset(val, bi, bj, 0);
+            if (i * NL == j * NC)
+            {
+                for (Index bi = 1; bi < (Index)NL; ++bi)
+                    for (Index bj = 0; bj < bi; ++bj) traits::vset(val, bi, bj, 0);
+            }
         }
         return i*NL <= j*NC;
     }
-    static bool lower(Index   i  , Index   j  , Block& val, const Real /*ref*/)
+    static bool lower(Index i, Index j, Block& val, const Real /*ref*/)
     {
-        if (NL>1 && i*NL == j*NC)
+        if constexpr (NL > 1)
         {
-            for (Index bi = 0; bi < (Index)NL-1; ++bi)
-                for (Index bj = bi+1; bj < (Index)NC; ++bj)
-                    traits::vset(val, bi, bj, 0);
+            if (i * NL == j * NC)
+            {
+                for (Index bi = 0; bi < (Index)NL - 1; ++bi)
+                    for (Index bj = bi + 1; bj < (Index)NC; ++bj) traits::vset(val, bi, bj, 0);
+            }
         }
         return i*NL >= j*NC;
     }

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/FullMatrix.inl
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/FullMatrix.inl
@@ -79,9 +79,12 @@ typename FullMatrix<Real>::LineConstIterator FullMatrix<Real>::end()   const { r
 template<class Real>
 void FullMatrix<Real>::resize(Index nbRow, Index nbCol)
 {
-    if ( FULLMATRIX_VERBOSE && (nbRow != rowSize() || nbCol != colSize()) )
+    if constexpr ( FULLMATRIX_VERBOSE )
     {
-        msg_info() << /*this->Name() << */": resize(" << nbRow << "," << nbCol << ")";
+        if (nbRow != rowSize() || nbCol != colSize())
+        {
+            msg_info() << /*this->Name() << */ ": resize(" << nbRow << "," << nbCol << ")";
+        }
     }
     if (type::hardening::checkOverflow(nbRow,nbCol))
     {
@@ -119,10 +122,15 @@ void FullMatrix<Real>::resize(Index nbRow, Index nbCol)
 template<class Real>
 SReal FullMatrix<Real>::element(Index i, Index j) const
 {
-    if ( FULLMATRIX_CHECK &&  (i >= rowSize() || j >= colSize()) )
+    if constexpr (FULLMATRIX_CHECK)
     {
-        msg_error() << "Invalid read access to element (" << i << "," << j << ") in " <</*this->Name() << */" of size (" << rowSize() << "," << colSize() << ")";
-        return 0.0;
+        if (i >= rowSize() || j >= colSize())
+        {
+            msg_error() << "Invalid read access to element (" << i << "," << j << ") in "
+                        << /*this->Name() << */ " of size (" << rowSize() << "," << colSize()
+                        << ")";
+            return 0.0;
+        }
     }
     return (SReal)data[i*pitch+j];
 }
@@ -131,10 +139,15 @@ template<class Real>
 void FullMatrix<Real>::set(Index i, Index j, double v)
 {
     msg_info_when(FULLMATRIX_VERBOSE) << /*this->Name() <<*/ "(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") = " << v;
-    if ( FULLMATRIX_CHECK &&  (i >= rowSize() || j >= colSize()) )
+    if constexpr (FULLMATRIX_CHECK)
     {
-        msg_error() << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name() << */" of size (" << rowSize() << "," << colSize() << ")";
-        return;
+        if (i >= rowSize() || j >= colSize())
+        {
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in "
+                        << /*this->Name() << */ " of size (" << rowSize() << "," << colSize()
+                        << ")";
+            return;
+        }
     }
     data[i*pitch+j] = (Real)v;
 }
@@ -143,10 +156,15 @@ template<class Real>
 void FullMatrix<Real>::add(Index i, Index j, double v)
 {
     msg_info_when(FULLMATRIX_VERBOSE) << /*this->Name() << */"(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") += " << v;
-    if ( FULLMATRIX_CHECK &&  (i >= rowSize() || j >= colSize()) )
+    if constexpr (FULLMATRIX_CHECK)
     {
-        msg_error() << "Invalid write access to element (" << i << "," << j << ") in "/* << this->Name()*/ << " of size (" << rowSize() << "," << colSize() << ")";
-        return;
+        if (i >= rowSize() || j >= colSize())
+        {
+            msg_error() << "Invalid write access to element (" << i << "," << j
+                        << ") in " /* << this->Name()*/ << " of size (" << rowSize() << ","
+                        << colSize() << ")";
+            return;
+        }
     }
     data[i*pitch+j] += (Real)v;
 }
@@ -155,10 +173,15 @@ template<class Real>
 void FullMatrix<Real>::clear(Index i, Index j)
 {
     msg_info_when(FULLMATRIX_VERBOSE) << /*this->Name() <<*/ "(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") = 0";
-    if ( FULLMATRIX_CHECK &&  (i >= rowSize() || j >= colSize()) )
+    if (FULLMATRIX_CHECK)
     {
-        msg_error() << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name() << */" of size (" << rowSize() << "," << colSize() << ")";
-        return;
+        if (i >= rowSize() || j >= colSize())
+        {
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in "
+                        << /*this->Name() << */ " of size (" << rowSize() << "," << colSize()
+                        << ")";
+            return;
+        }
     }
     data[i*pitch+j] = (Real)0;
 }
@@ -167,10 +190,15 @@ template<class Real>
 void FullMatrix<Real>::clearRow(Index i)
 {
     msg_info_when(FULLMATRIX_VERBOSE) << /*this->Name() <<*/ "(" << rowSize() << "," << colSize() << "): row(" << i << ") = 0";
-    if ( FULLMATRIX_CHECK &&  (i >= rowSize()) )
+    if constexpr (FULLMATRIX_CHECK)
     {
-        msg_error() << "Invalid write access to row " << i << " in " <</*this->Name() << */" of size (" << rowSize() << "," << colSize() << ")";
-        return;
+        if (i >= rowSize())
+        {
+            msg_error() << "Invalid write access to row " << i << " in "
+                        << /*this->Name() << */ " of size (" << rowSize() << "," << colSize()
+                        << ")";
+            return;
+        }
     }
     for (Index j=0; j<nCol; ++j)
         data[i*pitch+j] = (Real)0;
@@ -180,10 +208,15 @@ template<class Real>
 void FullMatrix<Real>::clearCol(Index j)
 {
     msg_info_when(FULLMATRIX_VERBOSE) <</* this->Name() << */"(" << rowSize() << "," << colSize() << "): col(" << j << ") = 0";
-    if ( FULLMATRIX_CHECK &&  (j >= colSize()) )
+    if constexpr (FULLMATRIX_CHECK)
     {
-        msg_error() << "Invalid write access to column " << j << " in " <</*this->Name() << */" of size (" << rowSize() << "," << colSize() << ")";
-        return;
+        if (j >= colSize())
+        {
+            msg_error() << "Invalid write access to column " << j << " in "
+                        << /*this->Name() << */ " of size (" << rowSize() << "," << colSize()
+                        << ")";
+            return;
+        }
     }
     for (Index i=0; i<nRow; ++i)
         data[i*pitch+j] = (Real)0;
@@ -193,10 +226,15 @@ template<class Real>
 void FullMatrix<Real>::clearRowCol(Index i)
 {
     msg_info_when(FULLMATRIX_VERBOSE) << /*this->Name() << */"(" << rowSize() << "," << colSize() << "): row(" << i << ") = 0 and col(" << i << ") = 0";
-    if ( FULLMATRIX_CHECK &&  (i >= rowSize() || i >= colSize()) )
+    if constexpr (FULLMATRIX_CHECK)
     {
-        msg_error() << "Invalid write access to row and column " << i << " in " <</*this->Name() << */" of size (" << rowSize() << "," << colSize() << ")";
-        return;
+        if (i >= rowSize() || i >= colSize())
+        {
+            msg_error() << "Invalid write access to row and column " << i << " in "
+                        << /*this->Name() << */ " of size (" << rowSize() << "," << colSize()
+                        << ")";
+            return;
+        }
     }
     clearRow(i);
     clearCol(i);

--- a/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/SparseMatrix.h
+++ b/Sofa/framework/LinearAlgebra/src/sofa/linearalgebra/SparseMatrix.h
@@ -101,9 +101,12 @@ public:
 
     void resize(Index nbRow, Index nbCol) override
     {
-        if ( SPARSEMATRIX_VERBOSE && (nbRow != rowSize() || nbCol != colSize()) )
+        if constexpr (SPARSEMATRIX_VERBOSE)
         {
-            msg_info() << ": resize(" << nbRow << "," << nbCol << ")" ;
+            if (nbRow != rowSize() || nbCol != colSize())
+            {
+                msg_info() << ": resize(" << nbRow << "," << nbCol << ")";
+            }
         }
         data.clear();
         nRow = nbRow;
@@ -122,10 +125,15 @@ public:
 
     SReal element(Index i, Index j) const override
     {
-        if ( SPARSEMATRIX_CHECK && (i >= rowSize() || j >= colSize()) )
+        if constexpr (SPARSEMATRIX_CHECK)
         {
-            dmsg_error() << "ERROR: invalid read access to element (" << i << "," << j << ") in " << /* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")" ;
-            return 0.0;
+            if (i >= rowSize() || j >= colSize())
+            {
+                dmsg_error() << "ERROR: invalid read access to element (" << i << "," << j
+                             << ") in " << /* this->Name() <<*/ " of size (" << rowSize() << ","
+                             << colSize() << ")";
+                return 0.0;
+            }
         }
         LineConstIterator it = data.find(i);
         if (it==data.end())
@@ -139,10 +147,15 @@ public:
     void set(Index i, Index j, double v) override
     {
         msg_info_when(SPARSEMATRIX_VERBOSE) << "(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") = " ;
-        if ( SPARSEMATRIX_CHECK && (i >= rowSize() || j >= colSize()) )
+        if constexpr (SPARSEMATRIX_CHECK)
         {
-            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " << /* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")" ;
-            return;
+            if (i >= rowSize() || j >= colSize())
+            {
+                msg_error() << "Invalid write access to element (" << i << "," << j << ") in "
+                            << /* this->Name() <<*/ " of size (" << rowSize() << "," << colSize()
+                            << ")";
+                return;
+            }
         }
         data[i][j] = (Real)v;
     }
@@ -151,10 +164,15 @@ public:
     void add(Index i, Index j, double v) override
     {
         msg_info_when(SPARSEMATRIX_VERBOSE) << "(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") += " << v ;
-        if ( SPARSEMATRIX_CHECK && (i >= rowSize() || j >= colSize()) )
+        if constexpr (SPARSEMATRIX_CHECK)
         {
-            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " << /* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")" ;
-            return;
+            if (i >= rowSize() || j >= colSize())
+            {
+                msg_error() << "Invalid write access to element (" << i << "," << j << ") in "
+                            << /* this->Name() <<*/ " of size (" << rowSize() << ","
+                            << colSize() << ")";
+                return;
+            }
         }
         data[i][j] += (Real)v;
     }
@@ -162,10 +180,15 @@ public:
     void clear(Index i, Index j) override
     {
         msg_info_when(SPARSEMATRIX_VERBOSE) << "(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") = 0" ;
-        if ( SPARSEMATRIX_CHECK && (i >= rowSize() || j >= colSize()) )
+        if constexpr (SPARSEMATRIX_CHECK)
         {
-            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " << /* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
-            return;
+            if (i >= rowSize() || j >= colSize())
+            {
+                msg_error() << "Invalid write access to element (" << i << "," << j << ") in "
+                            << /* this->Name() <<*/ " of size (" << rowSize() << ","
+                            << colSize() << ")";
+                return;
+            }
         }
         LineIterator it = data.find(i);
         if (it==data.end())
@@ -181,10 +204,15 @@ public:
     void clearRow(Index i) override
     {
         msg_info_when(SPARSEMATRIX_VERBOSE) << "(" << rowSize() << "," << colSize() << "): row(" << i << ") = 0" ;
-        if ( SPARSEMATRIX_CHECK && (i >= rowSize()) )
+        if constexpr (SPARSEMATRIX_CHECK)
         {
-            msg_error() << "Invalid write access to row " << i << " in " << /* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")" ;
-            return;
+            if (i >= rowSize())
+            {
+                msg_error() << "Invalid write access to row " << i << " in "
+                            << /* this->Name() <<*/ " of size (" << rowSize() << "," << colSize()
+                            << ")";
+                return;
+            }
         }
 
         LineIterator it = data.find(i);
@@ -196,10 +224,15 @@ public:
     void clearCol(Index j) override
     {
         msg_info_when(SPARSEMATRIX_VERBOSE) << "(" << rowSize() << "," << colSize() << "): col(" << j << ") = 0" ;
-        if ( SPARSEMATRIX_CHECK && (j >= colSize()) )
+        if constexpr (SPARSEMATRIX_CHECK)
         {
-            msg_error() << "Invalid write access to column " << j << " in " << /* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")" ;
-            return;
+            if (j >= colSize())
+            {
+                msg_error() << "Invalid write access to column " << j << " in "
+                            << /* this->Name() <<*/ " of size (" << rowSize() << ","
+                            << colSize() << ")";
+                return;
+            }
         }
         for(LineIterator it=data.begin(),itend=data.end(); it!=itend; ++it)
         {
@@ -212,10 +245,15 @@ public:
     void clearRowCol(Index i) override
     {
         msg_info_when(SPARSEMATRIX_VERBOSE) << "(" << rowSize() << "," << colSize() << "): row(" << i << ") = 0 and col(" << i << ") = 0" ;
-        if ( SPARSEMATRIX_CHECK && (i >= rowSize() || i >= colSize()) )
+        if (SPARSEMATRIX_CHECK)
         {
-            msg_error() << "Invalid write access to row and column " << i << " in " << /* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
-            return;
+            if (i >= rowSize() || i >= colSize())
+            {
+                msg_error() << "Invalid write access to row and column " << i << " in "
+                            << /* this->Name() <<*/ " of size (" << rowSize() << ","
+                            << colSize() << ")";
+                return;
+            }
         }
         clearRow(i);
         clearCol(i);

--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/NodeElement.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/NodeElement.cpp
@@ -53,12 +53,15 @@ bool NodeElement::initNode()
     if (obj != nullptr)
     {
         setObject(obj);
-        core::objectmodel::BaseNode* baseNode;
-        if (getTypedObject()!=nullptr && getParentElement()!=nullptr && (baseNode = getParentElement()->getObject()->toBaseNode()))
+        if (getTypedObject() != nullptr && getParentElement() != nullptr)
         {
-            getTypedObject()->setInstanciationSourceFilePos(getSrcLine());
-            getTypedObject()->setInstanciationSourceFileName(getSrcFile());
-            baseNode->addChild(getTypedObject());
+            core::objectmodel::BaseNode* baseNode = getParentElement()->getObject()->toBaseNode();
+            if (baseNode != nullptr)
+            {
+                getTypedObject()->setInstanciationSourceFilePos(getSrcLine());
+                getTypedObject()->setInstanciationSourceFileName(getSrcFile());
+                baseNode->addChild(getTypedObject());
+            }
         }
         return true;
     }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/BaseMechanicalVisitor.cpp
@@ -253,20 +253,20 @@ void BaseMechanicalVisitor::printReadVectors(simulation::Node* node, core::objec
     {
         core::behavior::BaseMechanicalState *dof1, *dof2;
 
-        if (BaseInteractionForceField* interact = dynamic_cast< BaseInteractionForceField* > (obj))
+        if (BaseInteractionForceField* interact1 = dynamic_cast< BaseInteractionForceField* > (obj))
         {
-            dof1 = interact->getMechModel1();
-            dof2 = interact->getMechModel2();
+            dof1 = interact1->getMechModel1();
+            dof2 = interact1->getMechModel2();
         }
-        else if (BaseInteractionProjectiveConstraintSet* interact = dynamic_cast< BaseInteractionProjectiveConstraintSet* > (obj))
+        else if (BaseInteractionProjectiveConstraintSet* interact2 = dynamic_cast< BaseInteractionProjectiveConstraintSet* > (obj))
         {
-            dof1 = interact->getMechModel1();
-            dof2 = interact->getMechModel2();
+            dof1 = interact2->getMechModel1();
+            dof2 = interact2->getMechModel2();
         }
-        else if (BaseInteractionConstraint* interact = dynamic_cast< BaseInteractionConstraint* > (obj))
+        else if (BaseInteractionConstraint* interact3 = dynamic_cast< BaseInteractionConstraint* > (obj))
         {
-            dof1 = interact->getMechModel1();
-            dof2 = interact->getMechModel2();
+            dof1 = interact3->getMechModel1();
+            dof2 = interact3->getMechModel2();
         }else
         {
             printReadVectors(node->mechanicalState);
@@ -301,20 +301,20 @@ void BaseMechanicalVisitor::printWriteVectors(simulation::Node* node, core::obje
     {
         BaseMechanicalState *dof1, *dof2;
 
-        if (BaseInteractionForceField* interact = dynamic_cast< BaseInteractionForceField* > (obj))
+        if (BaseInteractionForceField* interact1 = dynamic_cast< BaseInteractionForceField* > (obj))
         {
-            dof1 = interact->getMechModel1();
-            dof2 = interact->getMechModel2();
+            dof1 = interact1->getMechModel1();
+            dof2 = interact1->getMechModel2();
         }
-        else if (BaseInteractionProjectiveConstraintSet* interact = dynamic_cast< BaseInteractionProjectiveConstraintSet* > (obj))
+        else if (BaseInteractionProjectiveConstraintSet* interact2 = dynamic_cast< BaseInteractionProjectiveConstraintSet* > (obj))
         {
-            dof1 = interact->getMechModel1();
-            dof2 = interact->getMechModel2();
+            dof1 = interact2->getMechModel1();
+            dof2 = interact2->getMechModel2();
         }
-        else if (BaseInteractionConstraint* interact = dynamic_cast< BaseInteractionConstraint* > (obj))
+        else if (BaseInteractionConstraint* interact3 = dynamic_cast< BaseInteractionConstraint* > (obj))
         {
-            dof1 = interact->getMechModel1();
-            dof2 = interact->getMechModel2();
+            dof1 = interact3->getMechModel1();
+            dof2 = interact3->getMechModel2();
         }else
         {
             BaseMechanicalState* dof = node->mechanicalState;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/MappingGraphAlgorithms.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/MappingGraphAlgorithms.cpp
@@ -209,7 +209,7 @@ void MappingGraphAlgorithms::traverseComponentGroups(MappingGraphVisitor& visito
 
         sofa::simulation::parallelForEach(*taskScheduler,
             parallelNodes.begin(), parallelNodes.end(),
-            [&visitor, &scope](const auto& node)
+            [&visitor](const auto& node)
             {
                 for (auto& child : node->m_children)
                 {

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/task/WorkerThread.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/task/WorkerThread.cpp
@@ -245,15 +245,15 @@ bool WorkerThread::addTask(Task *task)
 
 bool WorkerThread::stealTask(Task **task)
 {
-    for (const auto it : m_taskScheduler->_threads)
+    for (const auto& [id, otherThread] : m_taskScheduler->_threads)
     {
         // if this is the main thread continue
-        if (std::this_thread::get_id() == it.first)
+        if (std::this_thread::get_id() == id)
         {
             continue;
         }
 
-        WorkerThread *otherThread = it.second;
+        //WorkerThread *otherThread = it.second;
         {
             simulation::ScopedLock lock(otherThread->m_taskMutex);
             if (!otherThread->m_tasks.empty())


### PR DESCRIPTION
- triggered by clang/macos: unused lambda capture
- triggered by gcc: `overloaded-virtual` warnings, apparently thrown because getMechModelX() defined as virtual in Inherit1 (aka BaseInteractionProjectiveConstraintSet, BaseInteractionForceField) and non-virtual in Inherit2 (aka PairStateAccessor) ; and the `using` keyword is overloading, not overriding. So the solution is to explicitly override (with the keyword override)
- triggered by msvc2022 (and not 2026....): `consider using 'if constexpr' statement instead`


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
