### PR TITLE
[Simulation.Core] Fix BoundingBox initialization and updates

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.cpp
@@ -37,14 +37,15 @@ Visitor::Result InitVisitor::processNodeTopDown(simulation::Node* node)
     node->initialize();
 
     sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
-    if(!node->f_bbox.isSet())
+    if(!node->m_bboxIsFixed)
         nodeBBox->invalidate();
 
     for(unsigned int i=0; i<node->object.size(); ++i)
     {
         node->object[i]->init();
         node->object[i]->computeBBox(params, true);
-        nodeBBox->include(node->object[i]->f_bbox.getValue());
+        if(!node->m_bboxIsFixed)
+            nodeBBox->include(node->object[i]->f_bbox.getValue());
     }
     node->f_bbox.endEdit();
     return RESULT_CONTINUE;
@@ -60,7 +61,8 @@ void InitVisitor::processNodeBottomUp(simulation::Node* node)
     for(std::size_t i=node->object.size(); i>0; --i)
     {
         node->object[i-1]->bwdInit();
-        nodeBBox->include(node->object[i-1]->f_bbox.getValue());
+        if(!node->m_bboxIsFixed)
+            nodeBBox->include(node->object[i-1]->f_bbox.getValue());
     }
 
     node->f_bbox.endEdit();

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/InitVisitor.cpp
@@ -37,14 +37,14 @@ Visitor::Result InitVisitor::processNodeTopDown(simulation::Node* node)
     node->initialize();
 
     sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
-    if(!node->m_bboxIsFixed)
+    if(!node->bboxIsFixed())
         nodeBBox->invalidate();
 
     for(unsigned int i=0; i<node->object.size(); ++i)
     {
         node->object[i]->init();
         node->object[i]->computeBBox(params, true);
-        if(!node->m_bboxIsFixed)
+        if(!node->bboxIsFixed())
             nodeBBox->include(node->object[i]->f_bbox.getValue());
     }
     node->f_bbox.endEdit();
@@ -61,7 +61,7 @@ void InitVisitor::processNodeBottomUp(simulation::Node* node)
     for(std::size_t i=node->object.size(); i>0; --i)
     {
         node->object[i-1]->bwdInit();
-        if(!node->m_bboxIsFixed)
+        if(!node->bboxIsFixed())
             nodeBBox->include(node->object[i-1]->f_bbox.getValue());
     }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -191,6 +191,13 @@ void Node::parse( sofa::core::objectmodel::BaseObjectDescription* arg )
         objDesc.setAttribute("displayFlags", oldFlags);
         sofa::core::objectmodel::BaseComponent::SPtr obj = sofa::core::ObjectFactory::CreateObject(this, &objDesc);
     }
+    
+    // BoundingBox state management
+    const char* bboxAttrStr = arg->getAttribute("bbox", nullptr);
+    if(bboxAttrStr != nullptr)
+    {
+        this->m_bboxIsFixed = true;
+    }
 }
 
 /// Initialize the components of this node and all the nodes which depend on it.

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -556,10 +556,11 @@ public:
     /// return the smallest common parent between this and node2 (returns nullptr if separated sub-graphes)
     Node* findCommonParent( simulation::Node* node2 );
     
-    bool m_bboxIsFixed{false};
+    bool bboxIsFixed() const { return m_bboxIsFixed; }
 protected:
     bool debug_;
     bool initialized;
+    bool m_bboxIsFixed{false};
 
     virtual bool doAddObject(sofa::core::objectmodel::BaseComponent::SPtr obj,  sofa::core::objectmodel::TypeOfInsertion insertionLocation= sofa::core::objectmodel::TypeOfInsertion::AtEnd);
     virtual bool doRemoveObject(sofa::core::objectmodel::BaseComponent::SPtr obj);

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.h
@@ -555,7 +555,8 @@ public:
 
     /// return the smallest common parent between this and node2 (returns nullptr if separated sub-graphes)
     Node* findCommonParent( simulation::Node* node2 );
-
+    
+    bool m_bboxIsFixed{false};
 protected:
     bool debug_;
     bool initialized;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -41,7 +41,7 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
     type::vector<BaseObject*>::iterator object;
     node->get<BaseObject>(&objectList,BaseContext::Local);
     sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
-    if(!node->f_bbox.isSet()) // bmarques: Without invalidating the bbox, the node's bbox will only be sized up, and never down with this visitor, to my understanding..
+    if(!node->m_bboxIsFixed) // bmarques: Without invalidating the bbox, the node's bbox will only be sized up, and never down with this visitor, to my understanding..
         nodeBBox->invalidate();
     for ( object = objectList.begin(); object != objectList.end(); ++object)
     {
@@ -53,8 +53,9 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
         // if some objects does not participate to the bounding box where they should,
         // you should overload their computeBBox function to correct that
         (*object)->computeBBox(params, true);
-
-        nodeBBox->include((*object)->f_bbox.getValue());
+        
+        if(!node->m_bboxIsFixed)
+            nodeBBox->include((*object)->f_bbox.getValue());
     }
     node->f_bbox.endEdit();
     return RESULT_CONTINUE;
@@ -62,13 +63,21 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
 
 void UpdateBoundingBoxVisitor::processNodeBottomUp(simulation::Node* node)
 {
-    sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
-    Node::ChildIterator childNode;
-    for( childNode = node->child.begin(); childNode!=node->child.end(); ++childNode)
+    if(!node->m_bboxIsFixed)
     {
-        nodeBBox->include((*childNode)->f_bbox.getValue());
+        sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
+        Node::ChildIterator childNode;
+        for( childNode = node->child.begin(); childNode!=node->child.end(); ++childNode)
+        {
+            nodeBBox->include((*childNode)->f_bbox.getValue());
+        }
+        node->f_bbox.endEdit();
     }
-    node->f_bbox.endEdit();
+    else
+    {
+        // the node bounding box is supposed to be fixed
+    }
+        
 }
 
 }

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -41,7 +41,7 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
     type::vector<BaseObject*>::iterator object;
     node->get<BaseObject>(&objectList,BaseContext::Local);
     sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
-    if(!node->m_bboxIsFixed) // bmarques: Without invalidating the bbox, the node's bbox will only be sized up, and never down with this visitor, to my understanding..
+    if(!node->bboxIsFixed()) // bmarques: Without invalidating the bbox, the node's bbox will only be sized up, and never down with this visitor, to my understanding..
         nodeBBox->invalidate();
     for ( object = objectList.begin(); object != objectList.end(); ++object)
     {
@@ -54,7 +54,7 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
         // you should overload their computeBBox function to correct that
         (*object)->computeBBox(params, true);
         
-        if(!node->m_bboxIsFixed)
+        if(!node->bboxIsFixed())
             nodeBBox->include((*object)->f_bbox.getValue());
     }
     node->f_bbox.endEdit();
@@ -63,7 +63,7 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
 
 void UpdateBoundingBoxVisitor::processNodeBottomUp(simulation::Node* node)
 {
-    if(!node->m_bboxIsFixed)
+    if(!node->bboxIsFixed())
     {
         sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
         Node::ChildIterator childNode;


### PR DESCRIPTION
BoundingBox's handling in SOFA is a recurring issue for time immemorial.

This PR is supposed to fix the fact that the bounding box cannot shrink during the simulation, only increase, which poses quite a problem for the scenes with long wire.

Admittedly This comes from the bug
```
    sofa::type::BoundingBox* nodeBBox = node->f_bbox.beginEdit();
    if(!node->f_bbox.isSet())
    ....
 ```
I guess the isSet was understood like "if in the xml, it is written bbox=XXXX" but isSet is set to true as soon as beginEdit() is called... so the condition will be always true.
 Before, as the condition was always true, the bbox was always kept from the previous step. Moreover, bbox's API  only allow the bbox to be increased.
Now if the BBox is `not set before init` then it will invalided and then recomputed from zero. 

A better solution would be (maybe) to have a better tracking of the value in the Data API but I did not want to touch anything in Data/Base....

Note that the BBoxes of the component inside the Node are still computed.

---
before (never reduced)
<img width="758" height="360" alt="bbox_norefit" src="https://github.com/user-attachments/assets/c6c1cb8d-56dc-4057-9f33-fcfde345cd99" />
after (can shrink)
<img width="758" height="360" alt="bbox_refit" src="https://github.com/user-attachments/assets/c0e3e5a2-7f88-4596-93d7-b1fab9bae5b3" />

---

This fixes also an other bug when computeBBox=false for the animation loop, when the bbox is computed only during init() but does not take into account mappings.
My use case, a BeamAdapter scene, the bounding box is huge because of the rest position of the catheter (due to the quirks on how to build a wire), the bbox is computed once after init(), and then never resized:
<img width="325" height="150"  src="https://github.com/user-attachments/assets/901ff9ef-7bdf-4d59-b877-e36bafb057e4" />

with this PR:
<img width="325" height="150"  src="https://github.com/user-attachments/assets/87c64c73-67f5-47aa-9ab7-68473387fce6" />

--

NB: I set experimental because I know someone, somewhere will have a problem due to this PR, so I would like extensive tests from users 🥸

[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
