### PR TITLE
[CI] Only launch pixi action in sofa-framework

### DIFF
--- a/.github/workflows/CI_macos_linux_windows_pixi.yml
+++ b/.github/workflows/CI_macos_linux_windows_pixi.yml
@@ -17,6 +17,7 @@ jobs:
   sofa-pixi:
     name: ${{ matrix.os }} - Env ${{ matrix.environment }} ${{ matrix.build_type }} ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
+    if: ${{ github.repository_owner == 'sofa-framework' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Sorry @epernod for this ci load. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
