### PR TITLE
[XML] Error handling when parsing

### DIFF
--- a/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/ObjectElement.cpp
+++ b/Sofa/framework/Simulation/Common/src/sofa/simulation/common/xml/ObjectElement.cpp
@@ -56,7 +56,26 @@ bool ObjectElement::init()
 
 bool ObjectElement::initNode()
 {
-    core::objectmodel::BaseContext* ctx = getParent()->getObject()->toBaseContext();
+    core::objectmodel::BaseContext* ctx { nullptr };
+    if (auto* parent = getParent())
+    {
+        if (auto* parentObj = parent->getObject())
+        {
+            ctx = parentObj->toBaseContext();
+        }
+        else
+        {
+            msg_error("XML parser") << "Cannot access to a valid component from parent element \'"
+                << parent->getName() << "\' (type:\'" << parent->getAttribute("type")
+                << "\') for the object element \'" << this->getName() << "\'";
+        }
+    }
+    else
+    {
+        msg_error("XML parser") << "Cannot find a parent for the object element \'" << this->getName() << "\'";
+    }
+    if (!ctx)
+        return false;
 
     for (AttributeMap::iterator it = attributes.begin(), itend = attributes.end(); it != itend; ++it)
     {


### PR DESCRIPTION
This PR fixes a crash in some bad formatted XML.

Example:

```xml
<dNode>
    <MechanicalObject name="state"/>
</Node>
```
Note the typo in `dNode`.

[with-all-tests]


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
