### PR TITLE
[Core] Move SceneCheckerVisitor out of the SceneChecking project into the core

### DIFF
--- a/Sofa/framework/Simulation/Core/CMakeLists.txt
+++ b/Sofa/framework/Simulation/Core/CMakeLists.txt
@@ -68,6 +68,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/SceneCheckMainRegistry.h
     ${SRC_ROOT}/MappingGraph.h
     ${SRC_ROOT}/MappingGraphMechanicalOperations.h
+    ${SRC_ROOT}/SceneCheckerVisitor.h
 
     ${SRC_ROOT}/events/BuildConstraintSystemEndEvent.h
     ${SRC_ROOT}/events/SimulationInitDoneEvent.h
@@ -215,6 +216,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/init.cpp
     ${SRC_ROOT}/fwd.cpp
     ${SRC_ROOT}/BaseSimulationExporter.cpp
+    ${SRC_ROOT}/SceneCheckerVisitor.cpp
 
     ${SRC_ROOT}/events/BuildConstraintSystemEndEvent.cpp
     ${SRC_ROOT}/events/SimulationInitDoneEvent.cpp

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckerVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckerVisitor.cpp
@@ -52,7 +52,7 @@ void SceneCheckerVisitor::removeCheck(sofa::simulation::SceneCheck::SPtr check)
     m_checkset.erase( std::remove( m_checkset.begin(), m_checkset.end(), check ), m_checkset.end() );
 }
 
-void SceneCheckerVisitor::  validate(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader)
+void SceneCheckerVisitor::validate(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader)
 {
     std::stringstream tmp;
     bool first = true;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckerVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckerVisitor.cpp
@@ -19,12 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "SceneCheckerVisitor.h"
+#include <sofa/simulation/SceneCheckerVisitor.h>
 
-#include <algorithm>
 #include <sofa/simulation/Node.h>
 
-namespace sofa::_scenechecking_
+#include <algorithm>
+
+namespace sofa::simulation
 {
 using sofa::core::ExecParams ;
 
@@ -51,7 +52,7 @@ void SceneCheckerVisitor::removeCheck(sofa::simulation::SceneCheck::SPtr check)
     m_checkset.erase( std::remove( m_checkset.begin(), m_checkset.end(), check ), m_checkset.end() );
 }
 
-void SceneCheckerVisitor::validate(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader)
+void SceneCheckerVisitor::  validate(sofa::simulation::Node* node, simulation::SceneLoader* sceneLoader)
 {
     std::stringstream tmp;
     bool first = true;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckerVisitor.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/SceneCheckerVisitor.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-#include <SceneChecking/config.h>
+#include <sofa/simulation/config.h>
 #include <sofa/simulation/SceneCheck.h>
 #include <sofa/core/ExecParams.h>
 #include <sofa/simulation/SceneLoaderFactory.h>
@@ -31,10 +31,10 @@
 
 #include <sofa/simulation/Visitor.h>
 
-namespace sofa::_scenechecking_
+namespace sofa::simulation
 {
 
-class SOFA_SCENECHECKING_API SceneCheckerVisitor : public sofa::simulation::Visitor
+class SOFA_SIMULATION_CORE_API SceneCheckerVisitor : public sofa::simulation::Visitor
 {
 public:
     SceneCheckerVisitor(const sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance()) ;
@@ -50,9 +50,4 @@ private:
     std::vector<sofa::simulation::SceneCheck::SPtr> m_checkset ;
 };
 
-} // namespace sofa::_scenechecking_
-
-namespace sofa::scenechecking
-{
-    using _scenechecking_::SceneCheckerVisitor;
-} // namespace sofa::scenechecking
+} // namespace sofa::simulation

--- a/applications/projects/SceneChecking/CMakeLists.txt
+++ b/applications/projects/SceneChecking/CMakeLists.txt
@@ -24,7 +24,6 @@ set(HEADER_FILES
     ${SCENECHECK_SRC_DIR}/SceneCheckSpecialCharacters.h
     ${SCENECHECK_SRC_DIR}/SceneCheckUsingAlias.h
     ${SCENECHECK_SRC_DIR}/SceneCheckerListener.h
-    ${SCENECHECK_SRC_DIR}/SceneCheckerVisitor.h
 )
 
 set(SOURCE_FILES
@@ -40,7 +39,6 @@ set(SOURCE_FILES
     ${SCENECHECK_SRC_DIR}/SceneCheckSpecialCharacters.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckUsingAlias.cpp
     ${SCENECHECK_SRC_DIR}/SceneCheckerListener.cpp
-    ${SCENECHECK_SRC_DIR}/SceneCheckerVisitor.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})

--- a/applications/projects/SceneChecking/CMakeLists.txt
+++ b/applications/projects/SceneChecking/CMakeLists.txt
@@ -10,6 +10,11 @@ sofa_find_package(Sofa.Component.Collision.Response.Contact REQUIRED)
 
 set(SCENECHECK_SRC_DIR src/SceneChecking)
 
+set(DEPRECATED_DIR "compat/SceneChecking")
+set(DEPRECATED_HEADER_FILES
+    ${DEPRECATED_DIR}/SceneCheckerVisitor.h
+)
+
 set(HEADER_FILES
     ${SCENECHECK_SRC_DIR}/config.h.in
     ${SCENECHECK_SRC_DIR}/init.h
@@ -41,9 +46,16 @@ set(SOURCE_FILES
     ${SCENECHECK_SRC_DIR}/SceneCheckerListener.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${DEPRECATED_HEADER_FILES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Core Sofa.Component.SceneUtility Sofa.Component.Collision.Response.Contact)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/compat>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}_compat>
+)
+
+install(DIRECTORY compat/ DESTINATION include/${PROJECT_NAME}_compat COMPONENT headers)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/applications/projects/SceneChecking/compat/SceneChecking/SceneCheckerVisitor.h
+++ b/applications/projects/SceneChecking/compat/SceneChecking/SceneCheckerVisitor.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <sofa/simulation/SceneCheckerVisitor.h>
+SOFA_HEADER_DEPRECATED("v26.06", "v27.06", "sofa/simulation/SceneCheckerVisitor.h")
+
+namespace sofa::scenechecking
+{
+using SceneCheckerVisitor SOFA_ATTRIBUTE_DEPRECATED("v26.06", "v27.06",
+    "sofa::scenechecking::SceneCheckerVisitor has been moved to sofa::simulation::SceneCheckerVisitor")
+    = sofa::simulation::SceneCheckerVisitor;
+} // namespace sofa::scenechecking

--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckerListener.cpp
@@ -21,9 +21,9 @@
 ******************************************************************************/
 #include "SceneCheckerListener.h"
 
+#include <sofa/simulation/SceneCheckerVisitor.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/SceneCheckMainRegistry.h>
-#include <SceneChecking/SceneCheckerVisitor.h>
 
 namespace sofa::_scenechecking_
 {
@@ -38,7 +38,7 @@ void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr n
 {
     if(node.get())
     {
-        sofa::scenechecking::SceneCheckerVisitor sceneCheckerVisitor;
+        sofa::simulation::SceneCheckerVisitor sceneCheckerVisitor;
 
         for (const auto& sceneCheck : sofa::simulation::SceneCheckMainRegistry::getRegisteredSceneChecks())
         {

--- a/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
+++ b/applications/projects/SceneChecking/tests/SceneChecker_test.cpp
@@ -24,8 +24,8 @@ using sofa::testing::BaseSimulationTest;
 
 #include <sofa/simulation/Node.h>
 
-#include <SceneChecking/SceneCheckerVisitor.h>
-using sofa::scenechecking::SceneCheckerVisitor;
+#include <sofa/simulation/SceneCheckerVisitor.h>
+using sofa::simulation::SceneCheckerVisitor;
 
 #include <sofa/simulation/SceneCheck.h>
 using sofa::simulation::SceneCheck;


### PR DESCRIPTION
Moves the SceneCheck visitor into the core. This is required for the SofaPython3 PR enabling scene checking when launching a scene using python. 

[with-all-tests]
[force-full-build]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
