### PR TITLE
[Core] DrawMesh<Hexahedron>: add quick test for quads when drawing hexa

### DIFF
--- a/Sofa/framework/Core/src/sofa/core/visual/DrawMesh.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/DrawMesh.h
@@ -328,6 +328,17 @@ private:
         const auto& elements = topology->getTetrahedra();
         const auto& facets = topology->getTriangles();
 
+        if(facets.empty())
+        {
+            static bool firstTime = true;
+            if (firstTime)
+            {
+                msg_error("DrawElementMesh<Tetrahedron>") << "Drawing tetrahedra needs the associated triangles in the topology.";
+                firstTime = false;
+            }
+            return;
+        }
+
         for ( auto& p : renderedPoints)
         {
             p.resize(elementIndices.size() * sofa::geometry::Triangle::NumberOfNodes);

--- a/Sofa/framework/Core/src/sofa/core/visual/DrawMesh.h
+++ b/Sofa/framework/Core/src/sofa/core/visual/DrawMesh.h
@@ -474,6 +474,17 @@ private:
         const auto& elements = topology->getHexahedra();
         const auto& facets = topology->getQuads();
 
+        if(facets.empty())
+        {
+            static bool firstTime = true;
+            if (firstTime)
+            {
+                msg_error("DrawElementMesh<Hexahedron>") << "Drawing hexahedra needs the associated quads in the topology.";
+                firstTime = false;
+            }
+            return;
+        }
+
         for ( auto& p : renderedPoints)
         {
             p.resize(elementIndices.size() * sofa::geometry::Quad::NumberOfNodes);


### PR DESCRIPTION
More a hotfix than a real fix:
-> #6151 

as I think sparsegrid and hexahedronFEMForceField are quite used here and there.

The real fix(es) should be:
- sparsegrid should also generate quads ?
- DrawMesh (all the primitives) should check the consistency of the topology ?
- even better, DrawMesh should just generates its own facets but slower of course

and maybe, doing the same for triangles and Tetrahedron ?

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
