### PR TITLE
[Spring] Enable dynamic update of spring stiffness

### DIFF
--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
@@ -106,9 +106,10 @@ void SpringForceField<DataTypes>::init()
         updateSpringsFromTopologyIndices();
 
 
-    this->addUpdateCallback("TopoCallBack",{ &d_springsIndices[0], &d_springsIndices[1], &d_lengths},
+    this->addUpdateCallback("TopoCallBack",{ &d_springsIndices[0], &d_springsIndices[1], &d_lengths, &d_ks, &d_kd},
                       [this](const sofa::core::DataTracker& ) -> sofa::core::objectmodel::ComponentState
                       {
+                          std::cout << "coucou\n";
                           updateSpringsFromTopologyIndices();
                           return sofa::core::objectmodel::ComponentState::Valid;
                       },
@@ -235,55 +236,62 @@ void SpringForceField<DataTypes>::updateSpringsFromTopologyIndices()
     if (indices1.empty())
         return;
 
-    auto lengths = sofa::helper::getWriteAccessor(d_lengths);
-    if (lengths.empty())
     {
-        lengths.push_back({0.0});
+        auto lengths = sofa::helper::getWriteAccessor(d_lengths);
+        if (lengths.empty())
+        {
+            lengths.push_back({0.0});
+        }
+
+        if (lengths.size() != indices1.size())
+        {
+            msg_warning() << "Lengths list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
+            lengths->resize(indices1.size(), lengths->back());
+        }
+
+        auto kds = sofa::helper::getWriteAccessor(d_kd);
+        if (kds.size() != indices1.size())
+        {
+            msg_warning() << "Kd list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
+            kds->resize(indices1.size(), kds->back());
+        }
+
+        auto kss = sofa::helper::getWriteAccessor(d_ks);
+        if (kss.size() != indices1.size())
+        {
+            msg_warning() << "Ks list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
+            kss->resize(indices1.size(), kss->back());
+        }
+
+        auto elongationOnly = sofa::helper::getWriteAccessor(d_elongationOnly);
+        if (elongationOnly.size() != indices1.size())
+        {
+            msg_warning() << "elongationOnly list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
+            elongationOnly->resize(indices1.size(), elongationOnly->back());
+        }
+
+
+        auto enabled = sofa::helper::getWriteAccessor(d_enabled);
+        if (enabled.size() != indices1.size())
+        {
+            msg_warning() << "enabled list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
+            enabled->resize(indices1.size(), enabled->back());
+        }
+
+        msg_info() << "Inputs have changed, recompute  Springs From Data Inputs";
+
+        type::vector<Spring>& _springs = *this->d_springs.beginEdit();
+        _springs.clear();
+
+        for (sofa::Index i = 0; i<indices1.size(); ++i)
+            _springs.push_back(Spring(indices1[i], indices2[i], kss[i], kds[i], lengths[i],elongationOnly[i],enabled[i]));
+
     }
 
-    if (lengths.size() != indices1.size())
-    {
-        msg_warning() << "Lengths list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
-        lengths->resize(indices1.size(), lengths->back());
-    }
+    d_lengths.cleanDirty();
+    d_ks.cleanDirty();
+    d_kd.cleanDirty();
 
-    auto kds = sofa::helper::getWriteAccessor(d_kd);
-    if (kds.size() != indices1.size())
-    {
-        msg_warning() << "Kd list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
-        kds->resize(indices1.size(), kds->back());
-    }
-
-    auto kss = sofa::helper::getWriteAccessor(d_ks);
-    if (kss.size() != indices1.size())
-    {
-        msg_warning() << "Ks list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
-        kss->resize(indices1.size(), kss->back());
-    }
-
-    auto elongationOnly = sofa::helper::getWriteAccessor(d_elongationOnly);
-    if (elongationOnly.size() != indices1.size())
-    {
-        msg_warning() << "elongationOnly list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
-        elongationOnly->resize(indices1.size(), elongationOnly->back());
-    }
-
-
-    auto enabled = sofa::helper::getWriteAccessor(d_enabled);
-    if (enabled.size() != indices1.size())
-    {
-        msg_warning() << "enabled list has a different size than indices1. The list will be resized to " << indices1.size() << " elements.";
-        enabled->resize(indices1.size(), enabled->back());
-    }
-
-    msg_info() << "Inputs have changed, recompute  Springs From Data Inputs";
-
-    type::vector<Spring>& _springs = *this->d_springs.beginEdit();
-    _springs.clear();
-
-    for (sofa::Index i = 0; i<indices1.size(); ++i)
-        _springs.push_back(Spring(indices1[i], indices2[i], kss[i], kds[i], lengths[i],elongationOnly[i],enabled[i]));
-    
     areSpringIndicesDirty = false;
 }
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/SpringForceField.inl
@@ -109,7 +109,6 @@ void SpringForceField<DataTypes>::init()
     this->addUpdateCallback("TopoCallBack",{ &d_springsIndices[0], &d_springsIndices[1], &d_lengths, &d_ks, &d_kd},
                       [this](const sofa::core::DataTracker& ) -> sofa::core::objectmodel::ComponentState
                       {
-                          std::cout << "coucou\n";
                           updateSpringsFromTopologyIndices();
                           return sofa::core::objectmodel::ComponentState::Valid;
                       },


### PR DESCRIPTION
For SOFA.Diff, I need to update the spring stiffness. To do so, I need to add the spring stiffness to the callback, which resulted in constant dirtiness. To fix that, I force the dirtiness to false at the end of the callback.
I also did the same for the damping (which was not updated before), and the lengths (which was broken before).


[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
