### PR TITLE
[SolidMechanics][FEM] Fix FastTetrahedralCorotationalForceField stiffness matrix assembly

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -556,7 +556,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::buildStiffnessMatrix(
     for(sofa::Size i=0; i < nbEdges; ++i )
     {
         const auto& edge = edges[i];
-        dfdx(3 * edge[0], 3 * edge[1]) += -edgeDfDx[i];
+        dfdx(3 * edge[0], 3 * edge[1]) += -edgeDfDx[i].transposed();
         dfdx(3 * edge[1], 3 * edge[0]) += -edgeDfDx[i];
     }
 }


### PR DESCRIPTION
A bit of an obscure bug. 

In `FastTetrahedralCorotationalForceField`, due to a missed transpose, the mechanics change if the edge indexing changes. This is observed in case the solver template triggers the `buildStiffnessMatrix` path. The other paths are ok.

This can happen in a scene such as the one below. In one case, the topology uses the edges computed by the mesh loader (unstable), in the other case, it re-computes them (stable). The two components register edge indices differently. This also raises another point: do we want to have components that create element arrays in different ways?

```
    root.addObject("ConstraintAttachButtonSetting")
    root.addObject("VisualStyle", displayFlags="showVisualModels")
    root.addObject("DefaultAnimationLoop")

    for i in range(2):
        with root.addChild("Liver"+str(i)) as liver:
            liver.addObject("EulerImplicitSolver")
            liver.addObject("EigenSimplicialLDLT", name="LinearSolver", template='CompressedRowSparseMatrixMat3x3d')
            liver.addObject("MeshGmshLoader", name="meshLoader", filename="mesh/liver.msh", scale3d=[0.08, 0.08, 0.08], translation=[0, -0.3, -0.2])

            # Explicitly copy position & tetrahedra VS sourcing the loader
            if(i==0):
                liver.addObject("TetrahedronSetTopologyContainer", name="TetraContainer", position="@meshLoader.position", tetrahedra="@meshLoader.tetrahedra")
            else:
                liver.addObject("TetrahedronSetTopologyContainer", name="TetraContainer", src="@meshLoader")

            liver.addObject("MechanicalObject", name="mstate_gel", template="Vec3d")
            liver.addObject("FastTetrahedralCorotationalForceField", name="FF", youngModulus=4e4, poissonRatio=0.3)
            liver.addObject("MeshMatrixMass", name="Mass",totalMass=0.01)
            liver.addObject("BoxROI", name="BoxROI", box=[-0.350, -0.280, -0.360, 0.130, 0.130, -0.200 ])
            liver.addObject("RestShapeSpringsForceField", stiffness=1e3, angularStiffness=1e3, points="@BoxROI.indices")

            with liver.addChild("Visual") as visual:
                color=[]
                if(i==0):
                    color=[0, 1, 0, 1]
                else:
                    color=[1, 0, 0, 1]
                visual.addObject("OglModel", color=color)
                visual.addObject("IdentityMapping")
```

https://github.com/user-attachments/assets/115c63fa-14d4-404a-bdcd-4ed85b4e37e8

[ci-build][with-all-tests]
