### PR TITLE
[Projective] Avoid template method specialization in AffineMovementProjectiveConstraint

### DIFF
--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.h
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.h
@@ -64,8 +64,8 @@ public:
     typedef Data<VecDeriv> DataVecDeriv;
     typedef type::vector<Index> SetIndexArray;
     typedef sofa::core::topology::TopologySubsetIndices SetIndex;
-    typedef type::Quat<SReal> Quat;
-    typedef type::Vec3 Vec3;
+    typedef type::Quat<Real> Quat;
+    typedef type::Vec<3,Real> Vec3;
 
     typedef typename DataTypes::MatrixDeriv MatrixDeriv;
     typedef core::objectmodel::Data<MatrixDeriv>    DataMatrixDeriv;

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.inl
@@ -239,36 +239,34 @@ void AffineMovementProjectiveConstraint<DataTypes>::initializeInitialPositions (
     }
 }
 
-
-template <>
-void AffineMovementProjectiveConstraint<defaulttype::Rigid3Types>::transform(const SetIndexArray & indices,
-                                                                   defaulttype::Rigid3Types::VecCoord& x0,
-                                                                   defaulttype::Rigid3Types::VecCoord& xf)
-{
-    // Get quaternion and translation values
-    RotationMatrix rotationMat(0);
-    const Quat quat =  d_quaternion.getValue();
-    quat.toMatrix(rotationMat);
-    const Vec3 translation = d_translation.getValue();
-
-    // Apply transformation
-    for (size_t i=0; i < indices.size() ; ++i)
-    {
-        // Translation
-        xf[indices[i]].getCenter() = rotationMat*(x0[indices[i]].getCenter()) + translation;
-        // Rotation
-        xf[indices[i]].getOrientation() = (quat)+x0[indices[i]].getOrientation();
-    }
-}
-
 template <class DataTypes>
 void AffineMovementProjectiveConstraint<DataTypes>::transform(const SetIndexArray & indices, VecCoord& x0, VecCoord& xf)
 {
-    Vec3 translation = d_translation.getValue();
-
-    for (size_t i=0; i < indices.size() ; ++i)
+    if constexpr (type::isRigidType<DataTypes>)
     {
-        DataTypes::setCPos(xf[indices[i]], (d_rotation.getValue()) * DataTypes::getCPos(x0[indices[i]]) + translation);
+        // Get quaternion and translation values
+        RotationMatrix rotationMat(0);
+        const Quat quat =  d_quaternion.getValue();
+        quat.toMatrix(rotationMat);
+        const Vec3 translation = d_translation.getValue();
+
+        // Apply transformation
+        for (size_t i=0; i < indices.size() ; ++i)
+        {
+            // Translation
+            xf[indices[i]].getCenter() = rotationMat*(x0[indices[i]].getCenter()) + translation;
+            // Rotation
+            xf[indices[i]].getOrientation() = (quat)+x0[indices[i]].getOrientation();
+        }
+    }
+    else
+    {
+        Vec3 translation = d_translation.getValue();
+
+        for (size_t i=0; i < indices.size() ; ++i)
+        {
+            DataTypes::setCPos(xf[indices[i]], (d_rotation.getValue()) * DataTypes::getCPos(x0[indices[i]]) + translation);
+        }
     }
 }
 

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.inl
@@ -246,9 +246,9 @@ void AffineMovementProjectiveConstraint<DataTypes>::transform(const SetIndexArra
     {
         // Get quaternion and translation values
         RotationMatrix rotationMat(0);
-        const Quat quat =  d_quaternion.getValue();
+        const Quat& quat =  d_quaternion.getValue();
         quat.toMatrix(rotationMat);
-        const Vec3 translation = d_translation.getValue();
+        const Vec3& translation = d_translation.getValue();
 
         // Apply transformation
         for (size_t i=0; i < indices.size() ; ++i)
@@ -261,11 +261,12 @@ void AffineMovementProjectiveConstraint<DataTypes>::transform(const SetIndexArra
     }
     else
     {
-        Vec3 translation = d_translation.getValue();
+        const Vec3& translation = d_translation.getValue();
+        const Vec3& rotation = d_rotation.getValue();
 
         for (size_t i=0; i < indices.size() ; ++i)
         {
-            DataTypes::setCPos(xf[indices[i]], (d_rotation.getValue()) * DataTypes::getCPos(x0[indices[i]]) + translation);
+            DataTypes::setCPos(xf[indices[i]], rotation * DataTypes::getCPos(x0[indices[i]]) + translation);
         }
     }
 }

--- a/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.inl
+++ b/Sofa/Component/Constraint/Projective/src/sofa/component/constraint/projective/AffineMovementProjectiveConstraint.inl
@@ -261,8 +261,8 @@ void AffineMovementProjectiveConstraint<DataTypes>::transform(const SetIndexArra
     }
     else
     {
-        const Vec3& translation = d_translation.getValue();
-        const Vec3& rotation = d_rotation.getValue();
+        const auto& translation = d_translation.getValue();
+        const auto& rotation = d_rotation.getValue();
 
         for (size_t i=0; i < indices.size() ; ++i)
         {


### PR DESCRIPTION
`AffineMovementProjectiveConstraint<DataTypes>::transform` is specialized for `Rigid3Types`. But not for `Rigid3fTypes`. To make it more generic, I removed the specialization to rely on the concept `isRigidType` instead.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
