### PR TITLE
[Mesh] Remove symbol export on template class BlenderExporter

### DIFF
--- a/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
+++ b/Sofa/Component/IO/Mesh/src/sofa/component/io/mesh/BlenderExporter.h
@@ -54,7 +54,7 @@ namespace _blenderexporter_
 // TODO: currently the export only support soft body and hair simulations, clothes, smoke and fluid simulation could be added.
 
 template<class T>
-class SOFA_COMPONENT_IO_MESH_API BlenderExporter: public sofa::simulation::BaseSimulationExporter
+class BlenderExporter: public sofa::simulation::BaseSimulationExporter
 {
 public:
     typedef sofa::simulation::BaseSimulationExporter Inherit;

--- a/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyBoundingTrasher.h
+++ b/Sofa/Component/Topology/Utility/src/sofa/component/topology/utility/TopologyBoundingTrasher.h
@@ -51,7 +51,7 @@ namespace sofa::component::topology::utility
  *
 */
 template <class DataTypes>
-class SOFA_COMPONENT_TOPOLOGY_UTILITY_API TopologyBoundingTrasher: public core::objectmodel::BaseComponent
+class TopologyBoundingTrasher: public core::objectmodel::BaseComponent
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(TopologyBoundingTrasher, DataTypes), core::objectmodel::BaseComponent);


### PR DESCRIPTION
It does not make any sense, and prevent the compilation of this class in different modules.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
