### PR TITLE
[SofaCUDA] Enable preprocessor conformance mode with MSVC

### DIFF
--- a/applications/plugins/SofaCUDA/Core/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/Core/CMakeLists.txt
@@ -16,6 +16,10 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     endif()
 endif()
 
+if(WIN32)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/Zc:preprocessor")
+endif()
+
 set(SOFACUDA_CORE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 set(HEADER_FILES


### PR DESCRIPTION
With CUDA 13.3 et Visual Studio 18.7.1, I have the following error:

```
Error C1189 fatal: #error:  MSVC/cl.exe with traditional preprocessor is used. This may lead to unexpected compilation errors. Please switch to the standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe. You can define CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
```

This is coming from `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\include\cccl\cuda\std\__cccl\preprocessor.h`:

```cpp
// Error when MSVC is used with the traditional preprocessor.
// We can't use `#pragma message` here because MSVC will encounter
// errors and exit before it processes pragma message directives.
#if defined(_MSC_VER) && !defined(__clang__)
#  if (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1) \
    && !defined(CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING)
#    error \
MSVC/cl.exe with traditional preprocessor is used. This may lead to unexpected compilation errors. Please \
switch to the standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe. You can define \
CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
#  endif // !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1
#endif // defined(_MSC_VER) && !defined(__clang__)
```

The solution has been found in the following PR: https://github.com/NVIDIA/cuda-samples/pull/412
See the doc: https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
