### PR TITLE
[Core] Improve UX when defining template of a Component

### DIFF
--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSolver.h
@@ -226,6 +226,11 @@ public:
         return ThreadManager::Name()+Matrix::Name();
     }
 
+    static std::vector<std::string> GetTemplateNameAttributeList()
+    {
+        return {"matrixType"};
+    }
+
     bool isAsyncSolver() override
     {
         return ThreadManager::isAsyncSolver();

--- a/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
+++ b/Sofa/Component/StateContainer/src/sofa/component/statecontainer/MechanicalObject.h
@@ -71,6 +71,11 @@ public:
     typedef typename DataTypes::MatrixDeriv::RowIterator		MatrixDerivRowIterator;
     typedef typename core::behavior::BaseMechanicalState::ConstraintBlock ConstraintBlock;
 
+    static std::vector<std::string> GetTemplateNameAttributeList()
+    {
+        return {"dofType"};
+    }
+
 protected:
     MechanicalObject();
 public:

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.cpp
@@ -138,6 +138,69 @@ void findTemplatedCreator(
     }
 }
 
+std::vector<std::string> replaceDeprecatedTemplates(std::vector<std::string>& templateNames)
+{
+    std::vector<std::string> deprecatedTemplates;
+    for(auto& name : templateNames)
+    {
+        const sofa::defaulttype::TemplateAlias* alias = sofa::defaulttype::TemplateAliases::getTemplateAlias(name);
+        if( alias != nullptr )
+        {
+            assert(alias != nullptr);
+            /// This alias results in "undefined" behavior.
+            if( alias->second )
+            {
+                deprecatedTemplates.push_back("The deprecated template '"+name+"' has been replaced by "+alias->first+".");
+            }
+
+            name = alias->first;
+        }
+    }
+    return deprecatedTemplates;
+}
+
+
+std::optional<std::string> buildTemplateNamesFromAttributes(const ObjectFactory::ClassEntry& entry, objectmodel::BaseObjectDescription* arg)
+{
+    assert(arg);
+    if (entry.templateNameAttributes.has_value())
+    {
+        const auto& attributeList = entry.templateNameAttributes.value();
+        if (attributeList.empty())
+            return {};
+
+        std::vector<std::string> attributeValues;
+
+        std::vector<std::string> foundAttributes;
+        std::vector<std::string> missingAttributes;
+
+        for (const auto& attributeName : attributeList)
+        {
+            if (auto* attr = arg->getAttribute(attributeName, nullptr))
+            {
+                foundAttributes.push_back(attributeName);
+                attributeValues.emplace_back(attr);
+            }
+            else
+            {
+                missingAttributes.push_back(attributeName);
+            }
+        }
+
+        if (!attributeValues.empty() && !missingAttributes.empty())
+        {
+            arg->logError("Found attributes '" + sofa::helper::join(missingAttributes, ", ") +
+                          "', but not '" + sofa::helper::join(foundAttributes, ", ") +
+                          "', preventing to deduce a template list");
+        }
+
+        replaceDeprecatedTemplates(attributeValues);
+        return sofa::helper::join(attributeValues, ",");
+    }
+
+    return {};
+}
+
 objectmodel::BaseComponent::SPtr ObjectFactory::createObject(objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg)
 {
     objectmodel::BaseComponent::SPtr object = nullptr;
@@ -157,22 +220,8 @@ objectmodel::BaseComponent::SPtr ObjectFactory::createObject(objectmodel::BaseCo
     ///      type precision into a different one.
     ///  (4) rebuild the template string by joining them all with ','.
     std::vector<std::string> usertemplatenames = sofa::helper::split(usertemplatename, ',');
-    std::vector<std::string> deprecatedTemplates;
-    for(auto& name : usertemplatenames)
-    {
-        const sofa::defaulttype::TemplateAlias* alias;
-        if( (alias=sofa::defaulttype::TemplateAliases::getTemplateAlias(name)) != nullptr )
-        {
-            assert(alias != nullptr);
-            /// This alias results in "undefined" behavior.
-            if( alias->second )
-            {
-                deprecatedTemplates.push_back("The deprecated template '"+name+"' has been replaced by "+alias->first+".");
-            }
+    std::vector<std::string> deprecatedTemplates = replaceDeprecatedTemplates(usertemplatenames);
 
-            name = alias->first;
-        }
-    }
     std::string templatename = sofa::helper::join(usertemplatenames, ",");
     std::string userresolved = templatename; // Copy in case we change for the default one
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -194,11 +243,24 @@ objectmodel::BaseComponent::SPtr ObjectFactory::createObject(objectmodel::BaseCo
     const auto previous_errors = arg->getErrors();
     arg->clearErrors();
 
-    // For every classes in the registry
     ClassEntryMap::iterator it = registry.find(classname);
     if (it != registry.end()) // Found the classname
     {
         entry = it->second;
+
+        if (templatename.empty())
+        {
+            const auto templateNameFromAttributes = buildTemplateNamesFromAttributes(*entry, arg);
+            if (templateNameFromAttributes.has_value())
+            {
+                const auto& templateNameFromAttributesValue = templateNameFromAttributes.value();
+                if (entry->creatorMap.contains(templateNameFromAttributesValue))
+                {
+                    templatename = templateNameFromAttributesValue;
+                }
+            }
+        }
+
         // If no template has been given or if the template does not exist, first try with the default one
         if(templatename.empty() || !entry->creatorMap.contains(templatename))
             templatename = entry->defaultTemplate;
@@ -714,6 +776,7 @@ bool ObjectRegistrationData::commitTo(sofa::core::ObjectFactory* objectFactory) 
         reg.authors += entry.authors;
         reg.license += entry.license;
         reg.documentationURL += entry.documentationURL;
+        reg.templateNameAttributes = entry.templateNameAttributes;
         if (!entry.defaultTemplate.empty())
         {
             if (!reg.defaultTemplate.empty())

--- a/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
+++ b/Sofa/framework/Core/src/sofa/core/ObjectFactory.h
@@ -28,6 +28,7 @@
 #include <numeric>
 #include <sofa/helper/Utils.h>
 #include <sofa/url.h>
+#include <optional>
 
 
 namespace sofa::helper::system
@@ -110,7 +111,10 @@ public:
         std::string documentationURL;
         std::string defaultTemplate;
         ObjectTemplateCreatorMap creatorMap; // to create instances of the class for different templates
-        std::map<std::string, std::vector<std::string>> m_dataAlias ;
+        std::map<std::string, std::vector<std::string>> m_dataAlias;
+
+        // list of keys.
+        std::optional<std::vector<std::string>> templateNameAttributes;
     };
 
     using ClassName = std::string;
@@ -363,6 +367,11 @@ public:
         const std::string classname = sofa::core::objectmodel::BaseClassNameHelper::getClassName<RealObject>();
         const std::string templatename = sofa::core::objectmodel::BaseClassNameHelper::getTemplateName<RealObject>();
 
+        if constexpr (requires {RealObject::GetTemplateNameAttributeList(); })
+        {
+            entry.templateNameAttributes = RealObject::GetTemplateNameAttributeList();
+        }
+
         if (defaultTemplate)
             entry.defaultTemplate = templatename;
 
@@ -386,6 +395,11 @@ public:
                 << RealObject::GetClass()->className << "<" << RealObject::GetClass()->templateName << "> into the object factory";
         }
         return addCreator(classname, templatename, objectCreator);
+    }
+
+    void addTemplateNameAttributeList(const std::initializer_list<std::string>& list)
+    {
+        entry.templateNameAttributes = list;
     }
 
     /// This is the final operation that will actually commit the additions to the ObjectFactory.


### PR DESCRIPTION
To get rid of the `template` keyword when defining a Component. Example:

```xml
<Node name="root">
    <RequiredPlugin pluginName="Sofa.Component.StateContainer"/>
    <RequiredPlugin pluginName='Sofa.Component.LinearSolver.Direct'/>

    <MechanicalObject dofType="Vec2d"/>
    <SparseLDLSolver matrixType="CompressedRowSparseMatrixMat3x3d"/>
</Node>
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
