### PR TITLE
[Mass] NodalMassDensity: add explicit  registrations to float and double instead of SReal

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/NodalMassDensity.cpp
+++ b/Sofa/Component/Mass/src/sofa/component/mass/NodalMassDensity.cpp
@@ -25,12 +25,14 @@
 namespace sofa::component::mass
 {
 
-template class SOFA_COMPONENT_MASS_API NodalMassDensity<SReal>;
+template class SOFA_COMPONENT_MASS_API NodalMassDensity<double>;
+template class SOFA_COMPONENT_MASS_API NodalMassDensity<float>;
 
 void registerNodalMassDensity(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(core::ObjectRegistrationData("Definition of a nodal mass density (one value per dof).")
-        .add< NodalMassDensity<SReal> >()
+        .add< NodalMassDensity<double> >()
+        .add< NodalMassDensity<float> >()
     );
 }
 


### PR DESCRIPTION
Necessary for CudaVec3f FEMMass





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
