### PR TITLE
[FileSystem] Use generic_string to enfore forward slash in path

### DIFF
--- a/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
+++ b/Sofa/framework/Helper/src/sofa/helper/system/FileSystem.cpp
@@ -377,7 +377,7 @@ int FileSystem::findFiles(const std::string& directoryPath,
             msg_error("FileSystem::findFiles()") << directoryPath << ": " << ec.message();
             return -1;
         }
-        const std::string filepath = it->path().string();
+        const std::string filepath = it->path().generic_string();
 
         if (it->is_directory(ec) && it->path().filename().string()[0] != '.' && depth > 0)
         {


### PR DESCRIPTION
In BeamAdapter plugin, there are two  regression reference files : under examples and under examples/python. the second one is found by the exe by using FileSytem::findFile.  

I don't get why bu on the cloudstack VM this resulted in a proper path aka `examples/python/State[...]` but not on github VMs where the resulting path was `examples/python\State[...]` which broke the call to all other methods of the API given that the forward slash is expected everywhere. So the directory path becomes `examples` and the filename `python\State[...]`, breaking the regression tests on the github VM. 

This should fix this issue given that `generic_string` always uses the forward slash as separator.

--> this is needed for the release. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
