### PR TITLE
[SceneChecking] Mapping checks are no longer errors

### DIFF
--- a/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
+++ b/applications/projects/SceneChecking/src/SceneChecking/SceneCheckMapping.cpp
@@ -127,7 +127,7 @@ void SceneCheckMapping::doPrintSummary()
         std::stringstream ss;
         ss << "The following Node(s) contain a mapping but no state: " << msgendl;
         showNodes(ss, m_nodesWithMappingNoState);
-        msg_error(getName()) << ss.str();
+        msg_warning(getName()) << ss.str();
     }
 
     if (!m_nodesWithMappingWrongState.empty())
@@ -135,7 +135,7 @@ void SceneCheckMapping::doPrintSummary()
         std::stringstream ss;
         ss << "The following Node(s) contain a mapping and a state, and the state is not an output of the mapping: " << msgendl;
         showNodes(ss, m_nodesWithMappingWrongState);
-        msg_error(getName()) << ss.str();
+        msg_warning(getName()) << ss.str();
     }
 
     if (!m_nodesWithMappingWrongState.empty())
@@ -143,7 +143,7 @@ void SceneCheckMapping::doPrintSummary()
         std::stringstream ss;
         ss << "The following Node(s) contain a mapping, a mechanical state and a non-mechanical state. The non-mechanical state is an output of the mapping, but the presence of the mechanical state may interfere and lead to undefined behavior: " << msgendl;
         showNodes(ss, m_nodesWithMappingWrongState);
-        msg_error(getName()) << ss.str();
+        msg_warning(getName()) << ss.str();
     }
 }
 


### PR DESCRIPTION
Given recent dev on mapping graph. Those error are not always one, making them warnings. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
