### PR TITLE
[Defaulttype] TypeInfoRegistry: Fix crash at exit in TypeInfoRegistry deleter

### DIFF
--- a/Sofa/framework/DefaultType/src/sofa/defaulttype/TypeInfoRegistry.cpp
+++ b/Sofa/framework/DefaultType/src/sofa/defaulttype/TypeInfoRegistry.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <typeindex>
 #include <map>
+#include <memory>
 #include <iostream>
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/defaulttype/AbstractTypeInfo.h>
@@ -38,21 +39,24 @@
 namespace sofa::defaulttype
 {
 
+/// Non-owning list of registered type infos, indexed by TypeInfoId.
+/// Most entries are borrowed pointers to function-local static singletons
+/// (e.g. NoTypeInfo::Get() or DataTypeInfoDynamicWrapper<...>::get()) that
+/// must never be deleted here. The few objects actually allocated by this
+/// registry are owned by getOwnedStorage() instead.
 static std::vector<const AbstractTypeInfo*>& getStorage()
 {
-    static auto deleter = [](const std::vector<const AbstractTypeInfo*>* v)
-    {
-        for (const auto* info : *v)
-        {
-            if (info != NoTypeInfo::Get())
-            {
-                delete info;
-            }
-        }
-    };
-    static std::unique_ptr<std::vector<const AbstractTypeInfo*>, decltype(deleter)> type_infos(
-        new std::vector<const AbstractTypeInfo*>{NoTypeInfo::Get()}, deleter);
-    return *type_infos;
+    static std::vector<const AbstractTypeInfo*> type_infos{NoTypeInfo::Get()};
+    return type_infos;
+}
+
+/// Owns the type infos allocated by this registry itself (see AllocateNewTypeId).
+/// The raw pointers stored in getStorage() alias these objects, so ownership is
+/// kept here to release them at exit without deleting borrowed singletons.
+static std::vector<std::unique_ptr<const AbstractTypeInfo>>& getOwnedStorage()
+{
+    static std::vector<std::unique_ptr<const AbstractTypeInfo>> owned_type_infos;
+    return owned_type_infos;
 }
 
 std::vector<const AbstractTypeInfo*> TypeInfoRegistry::GetRegisteredTypes(const std::string& target)
@@ -89,7 +93,8 @@ int TypeInfoRegistry::AllocateNewTypeId(const std::type_info& nfo)
     auto& typeinfos = getStorage();
     const std::string name = sofa::helper::NameDecoder::decodeTypeName(nfo);
     const std::string typeName = sofa::helper::NameDecoder::decodeTypeName(nfo);
-    typeinfos.push_back(new NameOnlyTypeInfo(name, typeName));
+    auto& owned = getOwnedStorage().emplace_back(std::make_unique<NameOnlyTypeInfo>(name, typeName));
+    typeinfos.push_back(owned.get());
     return static_cast<int>(typeinfos.size()-1);
 }
 


### PR DESCRIPTION
Fix Issue #6182 

By Claude:

The root cause is the storage deleter in `TypeInfoRegistry::getStorage()`, which calls `delete info` on **every** stored pointer except `NoTypeInfo::Get()`. However the registry holds two kinds of pointers:
 - `NameOnlyTypeInfo` objects it allocates itself with `new` (in   `AllocateNewTypeId`) ‚ genuinely heap-owned.
- Pointers registered via `Set()`, e.g. `DataTypeInfoDynamicWrapper<...>::get()`  (and `VirtualTypeInfo<T>::get()` used by `Data::getValueTypeInfo()`), which  return **function-local statics**.

Deleting those static-storage singletons is undefined behavior (invalid`delete` + double destruction, since the statics also self-destruct via their own `atexit` handlers), which triggers the trap. The deleter already special-cased `NoTypeInfo::Get()` as a singleton but missed that every info registered via `Set()` is a singleton too.

Fix: Only free what the registry actually allocates:

- `getStorage()` now holds **non-owning** borrowed pointers (no delete-all deleter).
- A separate `getOwnedStorage()` (`vector<unique_ptr<const AbstractTypeInfo>>`)
  owns the `NameOnlyTypeInfo` objects created in `AllocateNewTypeId`.

This preserves the leak-free intent of the original deleter (#4838) while never deleting the borrowed static singletons registered through `Set()`.

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
