### PR TITLE
[Helper] DrawTool: rename confusing `direction` term

### DIFF
--- a/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
+++ b/Sofa/GL/src/sofa/gl/DrawToolGL.cpp
@@ -111,23 +111,23 @@ void DrawToolGL::drawLine(const Vec3 &p1, const Vec3 &p2, const type::RGBAColor&
     glEnd();
 }
 
-void DrawToolGL::drawInfiniteLine(const Vec3 &point, const Vec3 &direction, const type::RGBAColor& color, const bool& vanishing)
+void DrawToolGL::drawInfiniteLine(const Vec3& start, const Vec3& end, const type::RGBAColor& color, const bool& vanishing)
 {
     glBegin(GL_LINES);
 
     glColor4f(color[0], color[1], color[2], color[3]);
-    glVertex4d(point[0], point[1], point[2], 1.0);
+    glVertex4d(start[0], start[1], start[2], 1.0);
     if(vanishing)
         glColor4f(color[0], color[1], color[2], 0.0f);
-    glVertex4d(direction[0], direction[1], direction[2], 0.0);
+    glVertex4d(end[0], end[1], end[2], 0.0);
 
     glEnd();
 }
 
-void DrawToolGL::drawInfiniteLine(const Vec3 &point, const Vec3 &direction, const float& size, const type::RGBAColor& color, const bool &vanishing)
+void DrawToolGL::drawInfiniteLine(const Vec3& start, const Vec3& end, const float& size, const type::RGBAColor& color, const bool& vanishing)
 {
     glLineWidth(size);
-    drawInfiniteLine(point, direction, color, vanishing);
+    drawInfiniteLine(start, end, color, vanishing);
     glLineWidth(1);
 }
 

--- a/Sofa/GL/src/sofa/gl/DrawToolGL.h
+++ b/Sofa/GL/src/sofa/gl/DrawToolGL.h
@@ -47,8 +47,8 @@ public:
     virtual void drawPoints(const std::vector<type::Vec3> &points, float size, const std::vector<type::RGBAColor>& color) override;
 
     void drawLine(const type::Vec3 &p1, const type::Vec3 &p2, const type::RGBAColor& color) override;
-    void drawInfiniteLine(const type::Vec3 &point, const type::Vec3 &direction, const type::RGBAColor& color, const bool& vanishing=false) override;
-    void drawInfiniteLine(const Vec3 &point, const Vec3 &direction, const float& size, const type::RGBAColor& color, const bool& vanishing=false) override;
+    void drawInfiniteLine(const type::Vec3& start, const type::Vec3& end, const type::RGBAColor& color, const bool& vanishing = false) override;
+    void drawInfiniteLine(const Vec3& start, const Vec3& end, const float& size, const type::RGBAColor& color, const bool& vanishing = false) override;
 
     virtual void drawLines(const std::vector<type::Vec3> &points, float size, const type::RGBAColor& color) override;
     virtual void drawLines(const std::vector<type::Vec3> &points, float size, const std::vector<type::RGBAColor>& colors) override;

--- a/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.h
+++ b/Sofa/framework/Helper/src/sofa/helper/visual/DrawTool.h
@@ -61,8 +61,8 @@ public:
     virtual void drawPoints(const std::vector<Vec3> &points, float size, const std::vector<RGBAColor>& color) = 0;
 
     virtual void drawLine(const Vec3 &p1, const Vec3 &p2, const RGBAColor& color) =  0;
-    virtual void drawInfiniteLine(const Vec3 &point, const Vec3 &direction, const RGBAColor& color, const bool& vanishing=false) = 0;
-    virtual void drawInfiniteLine(const Vec3 &point, const Vec3 &direction, const float& size, const RGBAColor& color, const bool& vanishing=false) = 0;
+    virtual void drawInfiniteLine(const Vec3& start, const Vec3& end, const RGBAColor& color, const bool& vanishing = false) = 0;
+    virtual void drawInfiniteLine(const Vec3& start, const Vec3& end, const float& size, const RGBAColor& color, const bool& vanishing = false) = 0;
     virtual void drawLines(const std::vector<Vec3> &points, float size, const RGBAColor& color) = 0 ;
     virtual void drawLines(const std::vector<Vec3> &points, float size, const std::vector<RGBAColor>& colors) = 0 ;
     virtual void drawLines(const std::vector<Vec3> &points, const std::vector< Vec2i > &index , float size, const RGBAColor& color) = 0 ;


### PR DESCRIPTION
According to the implementation, the argument `direction` is not really a direction, but rather the end point of the line segment.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
