### PR TITLE
[LinearSystem] Fix CompositeLinearSystem not invalidating its matrix

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/CompositeLinearSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/CompositeLinearSystem.inl
@@ -81,6 +81,11 @@ void CompositeLinearSystem<TMatrix, TVector>::init()
             }
         }
     }
+
+    if (!this->isComponentStateInvalid())
+    {
+        this->d_matrixChanged.setParent(&l_solverLinearSystem->d_matrixChanged);
+    }
 }
 
 template <class TMatrix, class TVector>

--- a/examples/Component/LinearSystem/CompositeLinearSystem.scn
+++ b/examples/Component/LinearSystem/CompositeLinearSystem.scn
@@ -21,8 +21,6 @@
     <DefaultAnimationLoop/>
     <DefaultVisualManagerLoop/>
 
-    <DefaultVisualManagerLoop/>
-
     <Node name="node">
         <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
 

--- a/examples/Component/LinearSystem/CompositeLinearSystem.scn
+++ b/examples/Component/LinearSystem/CompositeLinearSystem.scn
@@ -13,7 +13,8 @@
     <RequiredPlugin pluginName="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
     <RequiredPlugin pluginName="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin pluginName="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
-    <RequiredPlugin pluginName="SofaMatrix.Qt"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
+    <RequiredPlugin pluginName="SofaMatrix"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
+    <RequiredPlugin pluginName="SofaMatrix.imgui"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
 
     <VisualStyle displayFlags="showBehaviorModels showWireframe" />
 

--- a/examples/Component/LinearSystem/CompositeLinearSystem.scn
+++ b/examples/Component/LinearSystem/CompositeLinearSystem.scn
@@ -14,7 +14,7 @@
     <RequiredPlugin pluginName="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin pluginName="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <RequiredPlugin pluginName="SofaMatrix"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
-    <RequiredPlugin pluginName="SofaMatrix.imgui"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
+<!--    <RequiredPlugin pluginName="SofaMatrix.imgui"/> &lt;!&ndash; Needed to use components [GlobalSystemMatrixImage] &ndash;&gt;-->
 
     <VisualStyle displayFlags="showBehaviorModels showWireframe" />
 

--- a/examples/Component/LinearSystem/CompositeLinearSystem.scn
+++ b/examples/Component/LinearSystem/CompositeLinearSystem.scn
@@ -14,7 +14,6 @@
     <RequiredPlugin pluginName="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->
     <RequiredPlugin pluginName="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
     <RequiredPlugin pluginName="SofaMatrix"/> <!-- Needed to use components [GlobalSystemMatrixImage] -->
-<!--    <RequiredPlugin pluginName="SofaMatrix.imgui"/> &lt;!&ndash; Needed to use components [GlobalSystemMatrixImage] &ndash;&gt;-->
 
     <VisualStyle displayFlags="showBehaviorModels showWireframe" />
 

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -62,6 +62,7 @@ Component/LinearSolver/Preconditioner/FEMBAR_PCG_NoPreconditioner.scn 100 1e-8 0
 Component/LinearSolver/Preconditioner/FEMBAR_PCG_PrecomputedWarpPreconditioner.scn 100 1e-8 0 1
 Component/LinearSolver/Preconditioner/FEMBAR_PCG_SSORPreconditioner.scn 100 1e-8 0 1
 Component/LinearSolver/Preconditioner/FEMBAR_PCG_WarpPreconditioner.scn 100 1e-8 0 1
+Component/LinearSystem/CompositeLinearSystem.scn 100 1e-8 0 1
 Component/Mapping/NonLinear/DistanceMapping.scn 100 1e-8 0 1
 Component/Mapping/NonLinear/DistanceMultiMapping.scn 100 1e-8 0 1
 Component/Mapping/NonLinear/SquareDistanceMapping.scn 100 1e-8 0 1


### PR DESCRIPTION
`CompositeLinearSystem` never invalidates its matrix, hence it is never inverted. In this PR, the invalidation of the matrix is linked to the invalidation of the matrix used by the linear solver.

Probably broken since https://github.com/sofa-framework/sofa/commit/60d44cf467f116a629e6c1fab322632b1d7bb1f4 indicating a lack of tests.

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
