### PR TITLE
[RigidContactMapper] Take radius into account for spheres

### DIFF
--- a/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/RigidContactMapper.h
+++ b/Sofa/Component/Collision/Response/Mapper/src/sofa/component/collision/response/mapper/RigidContactMapper.h
@@ -129,7 +129,7 @@ class ContactMapper<collision::geometry::RigidSphereModel,TVec3Types > : public 
             const typename TVec3Types::Coord & cP = P - rCenter.getCenter();
             const type::Quat<SReal> & ori = rCenter.getOrientation();
 
-            //r = e.r();
+            r = e.r();
 
             return RigidContactMapper<collision::geometry::RigidSphereModel,TVec3Types >::addPoint(ori.inverseRotate(cP),index,r);
         }


### PR DESCRIPTION
I don't know why but this was commented since 2013. Thus, the SphereCollisionModel was broken for rigids since then. 
This restores it. I suspect that many regression scene will fail, let's see... 

[with-all-tests]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
