### PR TITLE
[Type] Introduce clamped scalar ensuring value not outside bounds

### DIFF
--- a/Sofa/Component/Visual/src/sofa/component/visual/VisualMesh.cpp
+++ b/Sofa/Component/Visual/src/sofa/component/visual/VisualMesh.cpp
@@ -35,7 +35,7 @@ void registerVisualMesh(sofa::core::ObjectFactory* factory)
 
 VisualMesh::VisualMesh()
     : d_position(initData(&d_position, "position", "The position of the vertices of mesh"))
-    , d_elementSpace(initData(&d_elementSpace, 0.15_sreal, "elementSpace",
+    , d_elementSpace(initData(&d_elementSpace, {0.15_sreal, {0_sreal, 1_sreal}}, "elementSpace",
                               "The space between element (scalar between 0 and 1)"))
     , d_lighting(initData(&d_lighting, true, "lighting", "If true, light is simulated on the mesh. Otherwise, no lighting effect."))
     , d_vertexValues(initData(&d_vertexValues, "vertexValues", "Optional list of values associated to the vertices of the mesh. If provided, the values are converted to colors."))

--- a/Sofa/framework/Type/CMakeLists.txt
+++ b/Sofa/framework/Type/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADER_FILES
     ${SOFATYPESRC_ROOT}/config.h.in
     ${SOFATYPESRC_ROOT}/init.h
     ${SOFATYPESRC_ROOT}/BoundingBox.h
+    ${SOFATYPESRC_ROOT}/ClampedScalar.h
     ${SOFATYPESRC_ROOT}/DualQuat.h
     ${SOFATYPESRC_ROOT}/DualQuat.inl
     ${SOFATYPESRC_ROOT}/Frame.h
@@ -58,6 +59,7 @@ set(HEADER_FILES
 set(SOURCE_FILES
     ${SOFATYPESRC_ROOT}/init.cpp
     ${SOFATYPESRC_ROOT}/BoundingBox.cpp
+    ${SOFATYPESRC_ROOT}/ClampedScalar.cpp
     ${SOFATYPESRC_ROOT}/DualQuat.cpp
     ${SOFATYPESRC_ROOT}/Frame.cpp
     ${SOFATYPESRC_ROOT}/Mat.cpp

--- a/Sofa/framework/Type/src/sofa/type/ClampedScalar.cpp
+++ b/Sofa/framework/Type/src/sofa/type/ClampedScalar.cpp
@@ -19,48 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
-#include <sofa/component/visual/config.h>
-#include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/core/visual/DrawColoredMesh.h>
-#include <sofa/core/visual/DrawMesh.h>
-#include <sofa/core/visual/VisualModel.h>
-#include <sofa/helper/ColorMap.h>
+#define SOFA_TYPE_CLAMPEDSCALAR_CPP
 #include <sofa/type/ClampedScalar.h>
 
-namespace sofa::component::visual
+namespace sofa::type
 {
 
-class VisualMesh : public core::visual::VisualModel
-{
-public:
-    SOFA_CLASS(VisualMesh, core::visual::VisualModel);
-
-    Data<type::vector<type::Vec3>> d_position;
-    Data<type::ClampedScalar<SReal>> d_elementSpace;
-    Data<bool> d_lighting;
-
-
-    Data<type::vector<SReal>> d_vertexValues;
-    Data<sofa::helper::ColorMap> d_colorMap;
-
-    /// The topology will give access to the elements
-    sofa::SingleLink<VisualMesh, sofa::core::topology::BaseMeshTopology,
-        sofa::BaseLink::FLAG_STOREPATH | sofa::BaseLink::FLAG_STRONGLINK> l_topology;
-
-    void init() override;
-    void computeBBox(const core::ExecParams*, bool onlyVisible) override;
-
-protected:
-
-    VisualMesh();
-
-    void doDrawVisual(const core::visual::VisualParams* vparams) override;
-
-    core::visual::DrawMesh m_drawMesh;
-    core::visual::DrawColoredMesh m_drawColoredMesh;
-
-    void validateTopology();
-};
+template class SOFA_TYPE_API ClampedScalar<double>;
+template class SOFA_TYPE_API ClampedScalar<float>;
 
 }

--- a/Sofa/framework/Type/src/sofa/type/ClampedScalar.h
+++ b/Sofa/framework/Type/src/sofa/type/ClampedScalar.h
@@ -1,0 +1,169 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/type/config.h>
+
+#include <iostream>
+#include <algorithm>
+
+namespace sofa::type
+{
+
+/**
+ * @class ClampedScalar
+ * @brief A templated class that ensures a stored scalar value never falls outside
+ *        a defined minimum and maximum range [minBound, maxBound].
+ *
+ * The bounds are set during construction and cannot be changed afterward.
+ *
+ * @tparam T The underlying numeric type (e.g., float, double).
+ */
+template <typename T>
+class ClampedScalar
+{
+private:
+    T m_value;        // The current stored value, guaranteed to be within bounds.
+    T m_minBound;     // The absolute minimum allowed value (immutable after construction).
+    T m_maxBound;     // The absolute maximum allowed value (immutable after construction).
+
+public:
+    /**
+     * @brief Constructor initializes the scalar with defined bounds and an initial value.
+     *
+     * Note: The constructor automatically clamps the provided initial value against
+     *       the given bounds.
+     *
+     * @param initialValue The starting value (will be clamped if out of range).
+     * @param bounds A pair defining {{min_val, max_val}}. The actual min/max are derived from this pair.
+     */
+    constexpr ClampedScalar(T initialValue = {}, const std::pair<T,T> bounds = {{}, static_cast<T>(1)})
+        : m_minBound(std::min(bounds.first, bounds.second)), m_maxBound(std::max(bounds.first, bounds.second))
+    {
+        // Use the internal setter to ensure the initial value is correctly clamped
+        setValue(initialValue);
+    }
+
+    constexpr T getMinBound() const
+    {
+        return m_minBound;
+    }
+
+    constexpr T getMaxBound() const
+    {
+        return m_maxBound;
+    }
+
+    /**
+     * @brief Sets the internal value after clamping it against the established bounds [minBound, maxBound].
+     *
+     * This method is used internally by constructors and setters.
+     *
+     * @param rawValue The raw input value (may be outside bounds).
+     */
+    constexpr void setValue(T rawValue)
+    {
+        m_value = std::clamp(rawValue, m_minBound, m_maxBound);
+    }
+
+    /**
+     * @brief Returns the current clamped value.
+     * @return The stored value, guaranteed to be within [min_bound_, max_bound_].
+     */
+    constexpr T getValue() const
+    {
+        return m_value;
+    }
+
+    /**
+     * @brief Calculates what the clamped result of a given input would be
+     *        without modifying the object's state. Useful for prediction/calculation.
+     * @param rawValue The unconstrained input value.
+     * @return The clamped version of rawValue.
+     */
+    constexpr T calculateClamped(T rawValue) const
+    {
+        return std::clamp(rawValue, m_minBound, m_maxBound);
+    }
+
+    /**
+     * @brief Conversion operator allows the ClampedScalar to be implicitly treated as its underlying type T.
+     * @return The stored, clamped value (T).
+     */
+    constexpr operator T() const
+    {
+        return m_value;
+    }
+
+    /**
+     * @brief Overloads assignment with a raw scalar value for concise state updates.
+     *
+     * This operation clamps the new value against the existing bounds and updates the internal state.
+     *
+     * @param newValue The raw input value to assign.
+     * @return Reference to this object.
+     */
+    constexpr ClampedScalar<T>& operator=(T newValue)
+    {
+        setValue(newValue);
+        return *this;
+    }
+};
+
+/**
+ * @brief Overload stream insertion operator (<<).
+ * Writes only the clamped value to the stream. Bounds are ignored.
+ * @param o The output stream reference.
+ * @param s The ClampedScalar object.
+ * @return Reference to the output stream.
+ */
+template <typename T>
+std::ostream& operator<<(std::ostream& o, const sofa::type::ClampedScalar<T>& s)
+{
+    return o << s.getValue();
+}
+
+/**
+ * @brief Overload stream extraction operator (>>).
+ * Reads a raw value from the stream and clamps it against the stored bounds before updating the object's state.
+ * Bounds are not read or written during this operation.
+ * @param i The input stream reference.
+ * @param s The ClampedScalar object to be updated.
+ * @return Reference to the input stream.
+ */
+template <typename T>
+std::istream& operator>>(std::istream& i, sofa::type::ClampedScalar<T>& s)
+{
+    T rawValue{};
+    i >> rawValue;
+    s.setValue(rawValue);
+    return i;
+}
+
+#if !defined(SOFA_TYPE_CLAMPEDSCALAR_CPP)
+extern template class SOFA_TYPE_API ClampedScalar<double>;
+extern template class SOFA_TYPE_API ClampedScalar<float>;
+#endif
+
+}
+
+

--- a/Sofa/framework/Type/test/CMakeLists.txt
+++ b/Sofa/framework/Type/test/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Sofa.Type_test)
 
 set(SOURCE_FILES
     BoundingBox_test.cpp
+    ClampedScalar_test.cpp
     MatSym_test.cpp
     MatTypes_test.cpp
     Material_test.cpp

--- a/Sofa/framework/Type/test/ClampedScalar_test.cpp
+++ b/Sofa/framework/Type/test/ClampedScalar_test.cpp
@@ -1,0 +1,189 @@
+/******************************************************************************
+ *                 SOFA, Simulation Open-Framework Architecture                *
+ *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+ *                                                                             *
+ * This program is free software; you can redistribute it and/or modify it     *
+ * under the terms of the GNU Lesser General Public License as published by    *
+ * the Free Software Foundation; either version 2.1 of the License, or (at     *
+ * your option) any later version.                                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful, but WITHOUT *
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+ * for more details.                                                           *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+ *******************************************************************************
+ * Authors: The SOFA Team and external contributors (see Authors.txt)          *
+ *                                                                             *
+ * Contact information: contact@sofa-framework.org                             *
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/type/ClampedScalar.h>
+
+namespace sofa
+{
+
+using namespace sofa::type;
+
+TEST(ClampedScalarTestDouble, ConstructionWithinBounds)
+{
+    constexpr double MIN_VAL = -10.0;
+    constexpr double MAX_VAL = 20.0;
+    constexpr double INIT_VAL = 5.0;
+
+    // Initialize using bounds and a valid value
+    ClampedScalar<double> s(INIT_VAL, {MIN_VAL, MAX_VAL});
+
+    EXPECT_DOUBLE_EQ(s.getMinBound(), MIN_VAL);
+    EXPECT_DOUBLE_EQ(s.getMaxBound(), MAX_VAL);
+    EXPECT_DOUBLE_EQ(s.getValue(), INIT_VAL);
+}
+
+TEST(ClampedScalarTestDouble, ConstructionClampsValueTooHigh)
+{
+    constexpr double MIN_VAL = 0.0;
+    constexpr double MAX_VAL = 10.0;
+    constexpr double OVERFLOW_VAL = 99.0;
+
+    // Initialize with a value higher than max bound
+    ClampedScalar<double> s(OVERFLOW_VAL, {MIN_VAL, MAX_VAL});
+
+    EXPECT_DOUBLE_EQ(s.getMinBound(), MIN_VAL);
+    EXPECT_DOUBLE_EQ(s.getMaxBound(), MAX_VAL);
+    // The value should be clamped to the maximum bound (10.0)
+    EXPECT_DOUBLE_EQ(s.getValue(), 10.0);
+}
+
+TEST(ClampedScalarTestDouble, ConstructionClampsValueTooLow)
+{
+    constexpr double MIN_VAL = -5.0;
+    constexpr double MAX_VAL = 5.0;
+    constexpr double UNDERFLOW_VAL = -50.0;
+
+    // Initialize with a value lower than min bound
+    ClampedScalar<double> s(UNDERFLOW_VAL, {MIN_VAL, MAX_VAL});
+
+    EXPECT_DOUBLE_EQ(s.getMinBound(), MIN_VAL);
+    EXPECT_DOUBLE_EQ(s.getMaxBound(), MAX_VAL);
+    // The value should be clamped to the minimum bound (-5.0)
+    EXPECT_DOUBLE_EQ(s.getValue(), -5.0);
+}
+
+TEST(ClampedScalarTestDouble, ConstructionHandlesReversedBounds)
+{
+    constexpr double MIN_VAL = 10.0;
+    constexpr double MAX_VAL = 0.0;  // Input bounds reversed (10 > 0)
+    constexpr double INIT_VAL = 5.0;
+
+    // Check if the constructor correctly determines min/max regardless of input order
+    ClampedScalar<double> s(INIT_VAL, {MAX_VAL, MIN_VAL});
+
+    EXPECT_DOUBLE_EQ(s.getMinBound(), 0.0);   // Should use std::min
+    EXPECT_DOUBLE_EQ(s.getMaxBound(), 10.0);  // Should use std::max
+}
+
+TEST(ClampedScalarTestDouble, SetterClampsValueTooHigh)
+{
+    constexpr double MIN_VAL = -5.0;
+    constexpr double MAX_VAL = 15.0;
+
+    // Start with a valid initial value
+    ClampedScalar<double> s(5.0, {MIN_VAL, MAX_VAL});
+
+    // Set a value higher than max bound (20.0 -> should become 15.0)
+    s = 20.0;
+    EXPECT_DOUBLE_EQ(s.getValue(), 15.0);
+
+    // Test setting exactly to the maximum bound
+    s = 15.0;
+    EXPECT_DOUBLE_EQ(s.getValue(), 15.0);
+}
+
+TEST(ClampedScalarTestDouble, SetterClampsValueTooLow)
+{
+    constexpr double MIN_VAL = -15.0;
+    constexpr double MAX_VAL = 15.0;
+
+    // Start with a valid initial value
+    ClampedScalar<double> s(5.0, {MIN_VAL, MAX_VAL});
+
+    // Set a value lower than min bound (-20.0 -> should become -15.0)
+    s = -20.0;
+    EXPECT_DOUBLE_EQ(s.getValue(), -15.0);
+}
+
+TEST(ClampedScalarTestDouble, CalculateClampedPredictionHigh)
+{
+    constexpr double MIN_VAL = 0.0;
+    constexpr double MAX_VAL = 10.0;
+    // Start state doesn't matter for prediction
+    ClampedScalar<double> s(5.0, {MIN_VAL, MAX_VAL});
+
+    // Predict value far above max bound (99.0 -> should be 10.0)
+    EXPECT_DOUBLE_EQ(s.calculateClamped(99.0), 10.0);
+
+    // Predict value slightly above max bound (10.1 -> should be 10.0)
+    EXPECT_DOUBLE_EQ(s.calculateClamped(10.1), 10.0);
+}
+
+TEST(ClampedScalarTestDouble, CalculateClampedPredictionLow)
+{
+    constexpr double MIN_VAL = -10.0;
+    constexpr double MAX_VAL = 10.0;
+    ClampedScalar<double> s(5.0, {MIN_VAL, MAX_VAL});
+
+    // Predict value far below min bound (-99.0 -> should be -10.0)
+    EXPECT_DOUBLE_EQ(s.calculateClamped(-99.0), -10.0);
+
+    // Predict value slightly below min bound (-10.1 -> should be -10.0)
+    EXPECT_DOUBLE_EQ(s.calculateClamped(-10.1), -10.0);
+}
+
+TEST(ClampedScalarTestDouble, StreamOperatorOverloadOutput)
+{
+    constexpr double MIN_VAL = -10.0;
+    constexpr double MAX_VAL = 10.0;
+    // Use a string stream to capture output
+    std::stringstream ss;
+
+    // Clamping doesn't affect the printed value, only getValue() matters here.
+    ClampedScalar<double> s(5.0, {MIN_VAL, MAX_VAL});
+
+    ss << s;  // Should print 5.0
+    EXPECT_EQ(ss.str(), "5");
+
+    // Test stream output after setting a clamped value (15.0 -> becomes 10.0)
+    s = 15.0;  // Clamps to 10.0
+    std::stringstream ss2;
+    ss2 << s;
+    EXPECT_EQ(ss2.str(), "10");
+}
+
+TEST(ClampedScalarTestDouble, StreamOperatorOverloadInput)
+{
+    constexpr double MIN_VAL = -5.0;
+    constexpr double MAX_VAL = 5.0;
+    // Use a string stream to simulate input data
+    std::stringstream ss("2");  // Input value is 2.0
+
+    ClampedScalar<double> s(0.0, {MIN_VAL, MAX_VAL});
+
+    ss >> s;  // Reads 2.0 (within bounds)
+    EXPECT_DOUBLE_EQ(s.getValue(), 2.0);
+
+    // Test reading a value that is too high (15.0 -> clamps to 5.0)
+    std::stringstream ss_high("15");
+    ClampedScalar<double> s_high(0.0, {MIN_VAL, MAX_VAL});
+    ss_high >> s_high;
+    EXPECT_DOUBLE_EQ(s_high.getValue(), 5.0);
+
+    // Test reading a value that is too low (-20.0 -> clamps to -5.0)
+    std::stringstream ss_low("-20");
+    ClampedScalar<double> s_low(0.0, {MIN_VAL, MAX_VAL});
+    ss_low >> s_low;
+    EXPECT_DOUBLE_EQ(s_low.getValue(), -5.0);
+}
+
+}  // namespace sofa


### PR DESCRIPTION
This pull request introduces a new foundational type, sofa::type::ClampedScalar<T>. This class template wraps a standard scalar value and guarantees that the stored value cannot fall outside predefined minimum and maximum bounds (min/max).

### Key Changes & Implementation Details

1.  **New Type (`ClampedScalar`):**
    *   A templated class that encapsulates a scalar value and two immutable bounds ($\text{minBound}, \text{maxBound}$).
    *   The class implements clamping logic in several key areas:
        *   **Construction:** Initial values are automatically clamped upon object creation.
        *   **Assignment/Setting (`operator=`):** Any attempt to set the value uses clamping, ensuring state integrity.
        *   **Input/Output Operators:** Stream extraction (`>>`) reads a raw value and clamps it before updating the internal state. Stream insertion (`<<`) only outputs the valid, clamped value.
        *   **Prediction:** A `calculateClamped(T rawValue)` method allows users to predict what the bound-constrained result would be without modifying the object's actual state.

2.  **Integration into `VisualMesh` Component:**
    *   The `d_elementSpace` data member in `sofa::component::visual::VisualMesh` has been updated from `Data<SReal>` to **`Data<type::ClampedScalar<SReal>>`**.
    *   This change ensures that the element space parameter (which must logically be between 0 and 1) is enforced and clamped correctly, making the mesh visualization component more robust.

3.  **Framework Updates:**
    *   Added `ClampedScalar.h`, `ClampedScalar.cpp`, and corresponding test files (`ClampedScalar_test.cpp`) to `Sofa/framework/Type`.
    *   Updated CMake files across the framework to correctly include and build this new type.


⚠️ Breaking because of the change of type in `VisualMesh`.

Companion PR for the GUI: https://github.com/sofa-framework/SofaGLFW/pull/292


https://github.com/user-attachments/assets/464b4a3c-e3fe-408c-a023-59c54d9ae801

Local gemma-4-e4b used for documentation and unit tests.

[with-all-tests]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
