### PR TITLE
[SofaMatrix.imgui] Custom style for the rendered matrix

### DIFF
--- a/applications/plugins/SofaMatrix/extensions/imgui/src/SofaMatrix/imgui/BaseMatrixImageProxyWidget.cpp
+++ b/applications/plugins/SofaMatrix/extensions/imgui/src/SofaMatrix/imgui/BaseMatrixImageProxyWidget.cpp
@@ -24,6 +24,10 @@
 #include <SofaMatrix/BaseMatrixImageProxy.h>
 #include <imgui.h>
 #include <sofa/core/objectmodel/Base.h>
+#include <sofa/helper/Utils.h>
+#include <sofa/helper/io/STBImage.h>
+#include <sofa/helper/system/FileRepository.h>
+#include <sofa/helper/system/FileSystem.h>
 
 #include <optional>
 
@@ -225,22 +229,70 @@ void DataWidget<sofa::type::BaseMatrixImageProxy>::showWidget(MyData& data)
             *lastCounter = counter;
         }
 
-        if (ImGui::ColorEdit3(("Color non-zero##" + data.getOwner()->getPathName() + data.getName()).c_str(), (float*)&sofamatrix::imgui::getColorNonZero(), ImGuiColorEditFlags_DisplayRGB)
+        if (ImGui::ColorEdit3(("Color non-zero##" + data.getOwner()->getPathName() + data.getName()).c_str(), (float*)&sofamatrix::imgui::getColorNonZero())
             ||
-            ImGui::ColorEdit3(("Color zero##" + data.getOwner()->getPathName() + data.getName()).c_str(), (float*)&sofamatrix::imgui::getColorZero(), ImGuiColorEditFlags_DisplayRGB))
+            ImGui::ColorEdit3(("Color zero##" + data.getOwner()->getPathName() + data.getName()).c_str(), (float*)&sofamatrix::imgui::getColorZero()))
         {
             auto textureID = sofamatrix::imgui::textureID(matrix);
-            if (textureID.has_value() == false)
-                return;
+            if (textureID.has_value() == true)
+            {
+                auto imageData = sofamatrix::imgui::imageData(matrix);
+                if (imageData.has_value() == true)
+                {
+                    auto& textureIDRef = textureID.value();
+                    auto& imageDataRef = imageData.value();
 
-            auto imageData = sofamatrix::imgui::imageData(matrix);
-            if (imageData.has_value() == false)
-                return;
+                    sofamatrix::imgui::updateTexture(matrix, textureIDRef, imageDataRef);
+                }
+            }
+        }
 
-            auto& textureIDRef = textureID.value();
-            auto& imageDataRef = imageData.value();
+        ImGui::NewLine();
+        if (ImGui::Button(("Save image##" + data.getOwner()->getPathName() + data.getName()).c_str()))
+        {
+            sofa::helper::io::STBImage image;
+            image.init(matrix->rows(), matrix->cols(), 1, 1,
+                sofa::helper::io::Image::DataType::UNORM8, sofa::helper::io::Image::ChannelFormat::RGB);
 
-            sofamatrix::imgui::updateTexture(matrix, textureIDRef, imageDataRef);
+            auto textureID = sofamatrix::imgui::textureID(matrix);
+            if (textureID.has_value() == true)
+            {
+                auto imageData = sofamatrix::imgui::imageData(matrix);
+                if (imageData.has_value() == true)
+                {
+                    auto& imageDataRef = imageData.value();
+                    auto& textureIDRef = textureID.value();
+                    sofamatrix::imgui::updateTexture(matrix, textureIDRef, imageDataRef);
+
+                    if (!imageDataRef.empty())
+                    {
+                        unsigned char* pixels = image.getPixels();
+                        for (sofa::SignedIndex y = 0; y < matrix->cols(); ++y)
+                        {
+                            for (sofa::SignedIndex x = 0; x < matrix->rows(); ++x)
+                            {
+                                for (std::size_t i = 0; i < 3; ++i)
+                                {
+                                    pixels[y * matrix->rows() * 3 + x * 3 + i] = imageDataRef[(matrix->rows() - y) * matrix->rows() * 3 + x * 3 + i];
+                                }
+                            }
+                        }
+                        const auto filename = sofa::helper::system::FileSystem::append(sofa::helper::Utils::getExecutableDirectory(), "matrix.bmp");
+                        if (image.save(filename))
+                        {
+                            msg_info("Matrix") << "Saved matrix file in '" << filename << "'";
+                        }
+                        else
+                        {
+                            msg_error(data.getOwner()) << "Error while saving matrix to file '" << filename << "'";
+                        }
+                    }
+                    else
+                    {
+                        msg_error(data.getOwner()) << "Cannot save matrix to file";
+                    }
+                }
+            }
         }
     }
     else

--- a/applications/plugins/SofaMatrix/extensions/imgui/src/SofaMatrix/imgui/BaseMatrixImageProxyWidget.cpp
+++ b/applications/plugins/SofaMatrix/extensions/imgui/src/SofaMatrix/imgui/BaseMatrixImageProxyWidget.cpp
@@ -82,20 +82,48 @@ void updateTexture(sofa::linearalgebra::BaseMatrix* matrix, unsigned& textureIDR
     const auto width = matrix->rows();
     const auto height = matrix->cols();
 
-    imageDataRef.resize(width * height, 255);
+    imageDataRef.resize(width * height * 3, 255);
+
+    const ImVec4 colorTrue = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+    const ImVec4 colorFalse = ImGui::GetStyleColorVec4(ImGuiCol_WindowBg);
+
+    // Extract R, G, B components
+    const unsigned char rTrue = static_cast<unsigned char>(255.f * colorTrue.x);
+    const unsigned char gTrue = static_cast<unsigned char>(255.f * colorTrue.y);
+    const unsigned char bTrue = static_cast<unsigned char>(255.f * colorTrue.z);
+
+    const unsigned char rFalse = static_cast<unsigned char>(255.f * colorFalse.x);
+    const unsigned char gFalse = static_cast<unsigned char>(255.f * colorFalse.y);
+    const unsigned char bFalse = static_cast<unsigned char>(255.f * colorFalse.z);
 
     // write the data
     for (sofa::SignedIndex y = 0; y < height; ++y)
     {
         for (sofa::SignedIndex x = 0; x < width; ++x)
         {
-            imageDataRef[y * width + x] = !static_cast<bool>(matrix->element(x, y)) * std::numeric_limits<unsigned char>::max();
+            size_t index = (y * width + x) * 3;
+
+            // Determine the color based on matrix element value
+            if (matrix->element(x, y))
+            {
+                // Element is TRUE: Use Window Background Color
+                imageDataRef[index]     = rTrue; // R
+                imageDataRef[index + 1] = gTrue; // G
+                imageDataRef[index + 2] = bTrue; // B
+            }
+            else
+            {
+                // Element is FALSE: Use Text Color
+                imageDataRef[index]     = rFalse; // R
+                imageDataRef[index + 1] = gFalse; // G
+                imageDataRef[index + 2] = bFalse; // B
+            }
         }
     }
 
     // Update the texture
     glBindTexture(GL_TEXTURE_2D, textureIDRef);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE,
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE,
                  imageDataRef.data());
 }
 

--- a/applications/plugins/SofaMatrix/extensions/imgui/src/SofaMatrix/imgui/BaseMatrixImageProxyWidget.cpp
+++ b/applications/plugins/SofaMatrix/extensions/imgui/src/SofaMatrix/imgui/BaseMatrixImageProxyWidget.cpp
@@ -19,10 +19,11 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaImGui/ImGuiDataWidget.h>
-#include <imgui.h>
 #include <GL/glew.h>
+#include <SofaImGui/ImGuiDataWidget.h>
 #include <SofaMatrix/BaseMatrixImageProxy.h>
+#include <imgui.h>
+#include <sofa/core/objectmodel/Base.h>
 
 #include <optional>
 
@@ -76,6 +77,18 @@ std::optional<GLuint> textureID(sofa::linearalgebra::BaseMatrix* ptr)
     return mapIt->second;
 }
 
+ImVec4& getColorNonZero()
+{
+    static ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+    return color;
+}
+
+ImVec4& getColorZero()
+{
+    static ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_WindowBg);
+    return color;
+}
+
 void updateTexture(sofa::linearalgebra::BaseMatrix* matrix, unsigned& textureIDRef,
                    std::vector<unsigned char>& imageDataRef)
 {
@@ -84,8 +97,8 @@ void updateTexture(sofa::linearalgebra::BaseMatrix* matrix, unsigned& textureIDR
 
     imageDataRef.resize(width * height * 3, 255);
 
-    const ImVec4 colorTrue = ImGui::GetStyleColorVec4(ImGuiCol_Text);
-    const ImVec4 colorFalse = ImGui::GetStyleColorVec4(ImGuiCol_WindowBg);
+    const ImVec4 colorTrue = getColorNonZero();
+    const ImVec4 colorFalse = getColorZero();
 
     // Extract R, G, B components
     const unsigned char rTrue = static_cast<unsigned char>(255.f * colorTrue.x);
@@ -210,6 +223,24 @@ void DataWidget<sofa::type::BaseMatrixImageProxy>::showWidget(MyData& data)
         if (lastCounter)
         {
             *lastCounter = counter;
+        }
+
+        if (ImGui::ColorEdit3(("Color non-zero##" + data.getOwner()->getPathName() + data.getName()).c_str(), (float*)&sofamatrix::imgui::getColorNonZero(), ImGuiColorEditFlags_DisplayRGB)
+            ||
+            ImGui::ColorEdit3(("Color zero##" + data.getOwner()->getPathName() + data.getName()).c_str(), (float*)&sofamatrix::imgui::getColorZero(), ImGuiColorEditFlags_DisplayRGB))
+        {
+            auto textureID = sofamatrix::imgui::textureID(matrix);
+            if (textureID.has_value() == false)
+                return;
+
+            auto imageData = sofamatrix::imgui::imageData(matrix);
+            if (imageData.has_value() == false)
+                return;
+
+            auto& textureIDRef = textureID.value();
+            auto& imageDataRef = imageData.value();
+
+            sofamatrix::imgui::updateTexture(matrix, textureIDRef, imageDataRef);
         }
     }
     else


### PR DESCRIPTION
Additional features when visualizing a matrix in the GUI:

- **Custom colors**: By default, it takes the colors `ImGuiCol_Text` for non-zero values and `ImGuiCol_WindowBg` for zero values. The image is more seamlessly integrated into the GUI.
- **Color picking**: colors can be changed by the user (for now they are not saved persistently).
- **Save button**: A button save the image along the executable file.

https://github.com/user-attachments/assets/fb741e8a-bd54-41e9-9e4b-97858a0477e5


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
