### PR TITLE
[Type] Fix cross-size operator = in Mat

### DIFF
--- a/Sofa/framework/Type/src/sofa/type/Mat.h
+++ b/Sofa/framework/Type/src/sofa/type/Mat.h
@@ -238,7 +238,9 @@ public:
     template<Size L2, Size C2> 
     constexpr void operator=(const Mat<L2,C2,real>& m) noexcept
     {
-        std::copy(m.begin(), m.begin()+(L>L2?L2:L), this->begin());
+        constexpr Size minL = (L>L2?L2:L);
+        for (Size i = 0; i < minL; i++)
+            (*this)[i].set(m[i]);
     }
 
     template<Size L2, Size C2> 


### PR DESCRIPTION
Linked to the lifecycle, the cross-size Mat::operator=(const Mat<L2,C2,real>&) was implemented via std::copy over rows, which internally needed Vec's now-disabled cross-dimension operator=.

It is here replaced with an explicit loop calling Vec::set() per row. The problem was initially arising from some code in SofaGLFW (see [code triggering the error here version from Vec4 to Vec3](https://github.com/sofa-framework/SofaGLFW/blob/2ba92f1eaa466d52eccb688155ecdc6404bafb10/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp#L919-L926)), but this core framework code shoud be used far beyond this single plugin.

[ci-build][with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
