### PR TITLE
[LinearSystem] Fix projection of InteractionForceFields on out-of-subtree states

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.inl
@@ -103,6 +103,11 @@ void MatrixProjectionMethod<TMatrix>::addMappedMatrixToGlobalMatrixEigen(
     const auto inputs1 = mappingGraph.getTopMostMechanicalStates(mstatePair[0]);
     const auto inputs2 = mappingGraph.getTopMostMechanicalStates(mstatePair[1]);
 
+    // A state outside this solver's subtree has no representation in the global
+    // matrix: its contribution cannot be projected and must not be accumulated.
+    if (inputs1.empty() || inputs2.empty())
+        return;
+
     std::set<core::behavior::BaseMechanicalState*> inputs;
     inputs.insert(inputs1.begin(), inputs1.end());
     inputs.insert(inputs2.begin(), inputs2.end());


### PR DESCRIPTION
It took me quite a long time before finding this bug in the assembled-matrix path (MatrixLinearSystem) when interacting with the mouse. This has been noticed by updating training materials using a direct solver (SparseLDLSolver).

I used the following two scenes to work on the problem:

<details>
  <summary>(1) Basic scene working</summary>
  <code>
def createScene(rootNode):

	from Sofa.Units.Definitions import s, m, mm, N, g, kg, kPa
	from Sofa.Units.UnitSystem import MechanicalUnitSystem

	scene_unit = MechanicalUnitSystem(s, mm, kg)

	rootNode.name = "RootNode"
	rootNode.dt = scene_unit(0.01, s)
	rootNode.gravity = [0, scene_unit(-9.81, N/kg), 0] # Defining gravity along -Y

	rootNode.addObject("DefaultAnimationLoop", name="animation_loop", computeBoundingBox=False)
	
	rootNode.addObject("RequiredPlugin", pluginName=["Sofa.Component.StateContainer","Sofa.Component.Mass","Sofa.Component.MechanicalLoad",
												     "Sofa.Component.LinearSolver.Direct","Sofa.Component.ODESolver.Backward",
													 "Sofa.Component.IO.Mesh","Sofa.Component.Topology.Container.Dynamic",
													 "Sofa.Component.SolidMechanics.FEM.Elastic","Sofa.Component.Topology.Container.Constant",
													 "Sofa.Component.Visual"])
	
	rootNode.addObject("MeshVTKLoader", name="mesh_loader_coarse", filename="../PneuNets_remeshed.vtk") # Using a VTK file format, thus using MeshVTKLoader
	
	mechanicalModel = rootNode.addChild("Finger")
	
	mechanicalModel.addObject("EulerImplicitSolver", name="integration_scheme")
	mechanicalModel.addObject("SparseLDLSolver", name="linear_solver", template="CompressedRowSparseMatrixMat3x3d")
	
	mechanicalModel.addObject("MeshTopology", name="topology_container", src="@../mesh_loader_coarse" )

	mechanicalModel.addObject("MechanicalObject", template="Vec3", name="state_container", showObject=True) # Define the template as Vec3 for 3D deformable bodies
	
	mechanicalModel.addObject("TetrahedronFEMForceField", name="elastic_material_law", template="Vec3", poissonRatio=0.3, youngModulus=scene_unit(5000, kPa)) # Define an elastic constitutive law
	mechanicalModel.addObject("MeshMatrixMass", name="mass", template="Vec3,Vec3", massDensity=scene_unit(3e3, kg/m**3)) # Use a mass integrated over the volume
	################################################

  </code>
</details>

<details>
  <summary>(2) Same scene - just adding a mapped OglModel using IdentityMapping</summary>
  <code>
def createScene(rootNode):

	from Sofa.Units.Definitions import s, m, mm, N, g, kg, kPa  
	from Sofa.Units.UnitSystem import MechanicalUnitSystem

	scene_unit = MechanicalUnitSystem(s, mm, kg)

	rootNode.name = "RootNode"
	rootNode.dt = scene_unit(0.01, s)
	rootNode.gravity = [0, scene_unit(-9.81, N/kg), 0]

	rootNode.addObject("DefaultAnimationLoop", name="animation_loop", computeBoundingBox=False)
	
	rootNode.addObject('RequiredPlugin', pluginName=['Sofa.Component.StateContainer','Sofa.Component.Mass','Sofa.Component.MechanicalLoad',
												     'Sofa.Component.LinearSolver.Direct','Sofa.Component.ODESolver.Backward',
													 'Sofa.Component.IO.Mesh','Sofa.Component.Topology.Container.Dynamic',
													 'Sofa.Component.SolidMechanics.FEM.Elastic','Sofa.Component.Topology.Container.Constant',
													 'Sofa.Component.Visual','Sofa.Component.Mapping.Linear','Sofa.GL.Component.Rendering3D'])
	
	rootNode.addObject("MeshVTKLoader", name="mesh_loader_coarse", filename="../PneuNets_remeshed.vtk")
	
	mechanicalModel = rootNode.addChild("Finger")
	
	mechanicalModel.addObject("EulerImplicitSolver", name="integration_scheme")
	mechanicalModel.addObject("SparseLDLSolver", name="linear_solver", template="CompressedRowSparseMatrixMat3x3d")
	
	mechanicalModel.addObject("MeshTopology", name="topology_container", src="@../mesh_loader_coarse" )

	mechanicalModel.addObject("MechanicalObject", template="Vec3", name="state_container", showObject=True)
	
	mechanicalModel.addObject("TetrahedronFEMForceField", name="elastic_material_law", template="Vec3", poissonRatio=0.3, youngModulus=scene_unit(5000, kPa))
	mechanicalModel.addObject("MeshMatrixMass", name="mass", template="Vec3,Vec3", massDensity=scene_unit(3e3, kg/m**3))

	
    # Adding a rendering model using the same mesh as for the mechanics
    # in a dedicated node connected to the mechanical model using a Mapping
	visualModel = mechanicalModel.addChild("Visual")
	visualModel.addObject('OglModel', name="visual_model", topology="@../topology_container", color="1 0.8 0.2 0.5") # Orange color with transparency
	visualModel.addObject('IdentityMapping', name="visual_mapping", input="@../state_container", output="@visual_model") # Identity mapping connecting the identic topology

  </code>
</details>


## Explanation

1. AttachBodyPerformer adds the SpringForceField into the picked node (Finger), but its first state is MappedMousePosition, which lives in the mouse node under the root — outside the
solver's subtree (AttachBodyPerformer.inl:104).
2. MappingGraph is built with SearchDown from the solver's context only (TypedMatrixLinearSystem.inl:74), so the mouse DOF is simply absent from the graph. But hasAnyMappingInput()
is implemented as !m_positionInGlobalMatrix.contains(mstate) (MappingGraph.cpp:147) — it conflates "mapped" with "unknown to the graph". The mouse DOF is therefore misclassified as
mapped, so the spring's df1_dx2 / df2_dx1 blocks are routed into a mapped local matrix instead of the global one (MatrixLinearSystem.inl:806-808, 892).
3. Whether those mapped matrices are ever projected is gated by hasAnyMapping() (MatrixLinearSystem.inl:210), and m_hasAnyMapping = input.mappings.size() > 0 (MappingGraph.cpp:260)
counts all BaseMappings — unfiltered. Your IdentityMapping → OglModel is isMechanical() == false (Mapping.inl:105 calls setNonMechanical() because OglModel is not a MechanicalState),
yet it still trips this flag.
- Scene 1: no mapping → flag false → the bogus mapped blocks are silently dropped. Matrix is correct.
- Scene 2: visual mapping → flag true → projection runs.
4. The projection then fails silently. computeJacobiansFrom finds no graph node for the mouse DOF, so it returns an empty Jacobian set (MatrixProjectionMethod.inl:275, 303);
computeProjection falls into its else branch JT_K_J = KMap (:189), i.e. identity Jacobian; and addToGlobalMatrix writes the raw block at getPositionInGlobalMatrix(fingerDofs, 
fingerDofs) = the object's own global offset, which is row/col 0.

Net effect: a spurious stiffness coupling between mesh node 0 and the picked node, of the same magnitude as the mouse spring. No warning, no error.

CG is immune exactly as you observed: GraphScattered is matrix-free, so addDForce is propagated through the real mapping graph and never goes near MatrixLinearSystem. A mapped MechanicalObject child instead of OglModel gives bit-identical wrong results to the visual case — it really is the mapping's mere presence.



## Possible additional fix to be discussed

- MappingGraph.cpp:260 — restrict m_hasAnyMapping to isMechanical() mappings or better distinguish any mapping and mechanical mappings
- MappingGraph.cpp:147 — hasAnyMappingInput() returning true for a state it has never seen is the root ambiguity. Splitting it into isKnown() / isMapped() would prevent this class of bug, but it's a more significant API change







______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
