### PR TITLE
[Constraint][Correction] Enable PrecomputedConstraintCorrection to operate with preconditioned systems

### DIFF
--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.h
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.h
@@ -23,7 +23,7 @@
 #include <sofa/component/constraint/lagrangian/correction/config.h>
 
 #include <sofa/core/behavior/ConstraintCorrection.h>
-#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/component/odesolver/backward/EulerImplicitSolver.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 
@@ -69,7 +69,7 @@ public:
     sofa::core::objectmodel::DataFileName d_fileCompliance; ///< Precomputed compliance matrix data file
     Data<std::string> d_fileDir; ///< If not empty, the compliance will be saved in this repertory
 
-    SingleLink<PrecomputedConstraintCorrection, sofa::core::behavior::OdeSolver, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_odeSolver; ///< Link towards the ODE solver used during the compliance precomputation. If unset, the first OdeSolver found in the current context is used.
+    SingleLink<PrecomputedConstraintCorrection, sofa::component::odesolver::backward::EulerImplicitSolver, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_odeSolver; ///< Link towards the EulerImplicit solver used during the compliance precomputation. If unset, the first OdeSolver found in the current context is used.
     SingleLink<PrecomputedConstraintCorrection, sofa::core::behavior::LinearSolver, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_linearSolver; ///< Link towards the linear solver used during the compliance precomputation. If unset, the first LinearSolver found in the current context is used.
 
 protected:

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.h
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.h
@@ -23,6 +23,8 @@
 #include <sofa/component/constraint/lagrangian/correction/config.h>
 
 #include <sofa/core/behavior/ConstraintCorrection.h>
+#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 
 #include <sofa/linearalgebra/FullMatrix.h>
@@ -66,7 +68,10 @@ public:
     Data<SReal> d_debugViewFrameScale; ///< Scale on computed node's frame
     sofa::core::objectmodel::DataFileName d_fileCompliance; ///< Precomputed compliance matrix data file
     Data<std::string> d_fileDir; ///< If not empty, the compliance will be saved in this repertory
-    
+
+    SingleLink<PrecomputedConstraintCorrection, sofa::core::behavior::OdeSolver, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_odeSolver; ///< Link towards the ODE solver used during the compliance precomputation. If unset, the first OdeSolver found in the current context is used.
+    SingleLink<PrecomputedConstraintCorrection, sofa::core::behavior::LinearSolver, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_linearSolver; ///< Link towards the linear solver used during the compliance precomputation. If unset, the first LinearSolver found in the current context is used.
+
 protected:
     PrecomputedConstraintCorrection(sofa::core::behavior::MechanicalState<DataTypes> *mm = nullptr);
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -294,7 +294,7 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
 
         // If a solver link was not set explicitly, fall back to the first one found in the context.
         if (l_odeSolver.empty())
-            l_odeSolver.set(this->getContext()->template get<sofa::core::behavior::OdeSolver>());
+            l_odeSolver.set(this->getContext()->template get<sofa::component::odesolver::backward::EulerImplicitSolver>());
         if (l_linearSolver.empty())
             l_linearSolver.set(this->getContext()->template get<core::behavior::LinearSolver>());
 

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -294,9 +294,9 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
 
         // If a solver link was not set explicitly, fall back to the first one found in the context.
         if (l_odeSolver.empty())
-            l_odeSolver.set(this->getContext()->template get<sofa::core::behavior::OdeSolver>(sofa::core::objectmodel::BaseContext::Local));
+            l_odeSolver.set(this->getContext()->template get<sofa::core::behavior::OdeSolver>());
         if (l_linearSolver.empty())
-            l_linearSolver.set(this->getContext()->template get<core::behavior::LinearSolver>(sofa::core::objectmodel::BaseContext::Local));
+            l_linearSolver.set(this->getContext()->template get<core::behavior::LinearSolver>());
 
         if (l_odeSolver && l_linearSolver)
         {

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -30,7 +30,9 @@
 #include <sofa/component/odesolver/backward/EulerImplicitSolver.h>
 
 #include <sofa/linearalgebra/SparseMatrix.h>
-#include <sofa/component/linearsolver/iterative/CGLinearSolver.h>
+#include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/objectmodel/BaseData.h>
+#include <sofa/core/ConstraintParams.h>
 
 #include <sofa/core/behavior/RotationFinder.h>
 
@@ -42,6 +44,7 @@
 #include <fstream>
 #include <sstream>
 #include <list>
+#include <vector>
 #include <iomanip>
 #include <limits>
 #include <sofa/helper/system/FileSystem.h>
@@ -288,44 +291,53 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         this->getContext()->setGravity(gravity_zero);
 
         sofa::component::odesolver::backward::EulerImplicitSolver* eulerSolver;
-        sofa::component::linearsolver::iterative::CGLinearSolver< sofa::component::linearsolver::GraphScatteredMatrix, sofa::component::linearsolver::GraphScatteredVector >* cgLinearSolver;
         core::behavior::LinearSolver* linearSolver;
 
         this->getContext()->get(eulerSolver);
-        this->getContext()->get(cgLinearSolver);
         this->getContext()->get(linearSolver);
 
-        if (eulerSolver && cgLinearSolver)
-        {
-            msg_info() << "use EulerImplicitSolver & CGLinearSolver" ;
-        }
-        else if (eulerSolver && linearSolver)
+        if (eulerSolver && linearSolver)
         {
             msg_info() << "use EulerImplicitSolver & LinearSolver";
         }
-        else if(eulerSolver)
+        else if (eulerSolver)
         {
             msg_info() << "use EulerImplicitSolver";
         }
         else
         {
-            msg_error() << "PrecomputedContactCorrection must be associated with EulerImplicitSolver+LinearSolver for the precomputation\nNo Precomputation" ;
+            msg_error() << "PrecomputedConstraintCorrection must be associated with EulerImplicitSolver+LinearSolver for the precomputation\nNo Precomputation" ;
             return;
         }
 
-        // Change the solver parameters
-        Real buf_tolerance = 0, buf_threshold = 0;
-        unsigned int	   buf_maxIter = 0;
+        // Tighten the linear solver accuracy so the compliance is computed as accurately as
+        // possible during precomputation and restore the original values afterwards.
+        core::objectmodel::BaseData* toleranceData  = linearSolver ? linearSolver->findData("tolerance")  : nullptr;
+        core::objectmodel::BaseData* iterationsData = linearSolver ? linearSolver->findData("iterations") : nullptr;
+        core::objectmodel::BaseData* thresholdData  = linearSolver ? linearSolver->findData("threshold")  : nullptr;
 
-        if (cgLinearSolver)
+        std::string buf_tolerance, buf_iterations, buf_threshold;
+
+        if (toleranceData)
         {
-            buf_tolerance = cgLinearSolver->d_tolerance.getValue();
-            buf_maxIter   = cgLinearSolver->d_maxIter.getValue();
-            buf_threshold = cgLinearSolver->d_smallDenominatorThreshold.getValue();
-
-            cgLinearSolver->d_tolerance.setValue(Real(1e-20));
-            cgLinearSolver->d_maxIter.setValue(5000u);
-            cgLinearSolver->d_smallDenominatorThreshold.setValue(Real(1e-35));
+            buf_tolerance = toleranceData->getValueString();
+            toleranceData->read("1e-20");
+            msg_info() << "Precomputation: temporarily setting '" << linearSolver->getName()
+                       << "' tolerance from " << buf_tolerance << " to 1e-20";
+        }
+        if (iterationsData)
+        {
+            buf_iterations = iterationsData->getValueString();
+            iterationsData->read("5000");
+            msg_info() << "Precomputation: temporarily setting '" << linearSolver->getName()
+                       << "' iterations from " << buf_iterations << " to 5000";
+        }
+        if (thresholdData)
+        {
+            buf_threshold = thresholdData->getValueString();
+            thresholdData->read("1e-35");
+            msg_info() << "Precomputation: temporarily setting '" << linearSolver->getName()
+                       << "' threshold from " << buf_threshold << " to 1e-35";
         }
 
 
@@ -403,12 +415,9 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         this->getContext()->setGravity(gravity);
 
         // Restore linear solver parameters
-        if (cgLinearSolver)
-        {
-            cgLinearSolver->d_tolerance.setValue(buf_tolerance);
-            cgLinearSolver->d_maxIter.setValue(buf_maxIter);
-            cgLinearSolver->d_smallDenominatorThreshold.setValue(buf_threshold);
-        }
+        if (toleranceData)  toleranceData->read(buf_tolerance);
+        if (iterationsData) iterationsData->read(buf_iterations);
+        if (thresholdData)  thresholdData->read(buf_threshold);
 
         // Restore velocity
         for (unsigned int i = 0; i < velocity.size(); i++)

--- a/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
+++ b/Sofa/Component/Constraint/Lagrangian/Correction/src/sofa/component/constraint/lagrangian/correction/PrecomputedConstraintCorrection.inl
@@ -73,6 +73,8 @@ PrecomputedConstraintCorrection<DataTypes>::PrecomputedConstraintCorrection(sofa
     , d_debugViewFrameScale(initData(&d_debugViewFrameScale, 1.0_sreal, "debugViewFrameScale", "Scale on computed node's frame"))
     , d_fileCompliance(initData(&d_fileCompliance, "fileCompliance", "Precomputed compliance matrix data file"))
     , d_fileDir(initData(&d_fileDir, "fileDir", "If not empty, the compliance will be saved in this repertory"))
+    , l_odeSolver(initLink("ODESolver", "Link towards the ODE solver used during the compliance precomputation. If unset, the first OdeSolver in the current context is used."))
+    , l_linearSolver(initLink("linearSolver", "Link towards the linear solver used during the compliance precomputation. If unset, the first LinearSolver in the current context is used."))
     , invM(nullptr)
     , appCompliance(nullptr)
     , nbRows(0), nbCols(0), dof_on_node(0), nbNodes(0)
@@ -290,17 +292,17 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         static constexpr sofa::type::Vec3 gravity_zero(0_sreal, 0_sreal, 0_sreal);
         this->getContext()->setGravity(gravity_zero);
 
-        sofa::component::odesolver::backward::EulerImplicitSolver* eulerSolver;
-        core::behavior::LinearSolver* linearSolver;
+        // If a solver link was not set explicitly, fall back to the first one found in the context.
+        if (l_odeSolver.empty())
+            l_odeSolver.set(this->getContext()->template get<sofa::core::behavior::OdeSolver>(sofa::core::objectmodel::BaseContext::Local));
+        if (l_linearSolver.empty())
+            l_linearSolver.set(this->getContext()->template get<core::behavior::LinearSolver>(sofa::core::objectmodel::BaseContext::Local));
 
-        this->getContext()->get(eulerSolver);
-        this->getContext()->get(linearSolver);
-
-        if (eulerSolver && linearSolver)
+        if (l_odeSolver && l_linearSolver)
         {
             msg_info() << "use EulerImplicitSolver & LinearSolver";
         }
-        else if (eulerSolver)
+        else if (l_odeSolver)
         {
             msg_info() << "use EulerImplicitSolver";
         }
@@ -312,9 +314,9 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
 
         // Tighten the linear solver accuracy so the compliance is computed as accurately as
         // possible during precomputation and restore the original values afterwards.
-        core::objectmodel::BaseData* toleranceData  = linearSolver ? linearSolver->findData("tolerance")  : nullptr;
-        core::objectmodel::BaseData* iterationsData = linearSolver ? linearSolver->findData("iterations") : nullptr;
-        core::objectmodel::BaseData* thresholdData  = linearSolver ? linearSolver->findData("threshold")  : nullptr;
+        core::objectmodel::BaseData* toleranceData  = l_linearSolver ? l_linearSolver->findData("tolerance")  : nullptr;
+        core::objectmodel::BaseData* iterationsData = l_linearSolver ? l_linearSolver->findData("iterations") : nullptr;
+        core::objectmodel::BaseData* thresholdData  = l_linearSolver ? l_linearSolver->findData("threshold")  : nullptr;
 
         std::string buf_tolerance, buf_iterations, buf_threshold;
 
@@ -322,21 +324,21 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         {
             buf_tolerance = toleranceData->getValueString();
             toleranceData->read("1e-20");
-            msg_info() << "Precomputation: temporarily setting '" << linearSolver->getName()
+            msg_info() << "Precomputation: temporarily setting '" << l_linearSolver->getName()
                        << "' tolerance from " << buf_tolerance << " to 1e-20";
         }
         if (iterationsData)
         {
             buf_iterations = iterationsData->getValueString();
             iterationsData->read("5000");
-            msg_info() << "Precomputation: temporarily setting '" << linearSolver->getName()
+            msg_info() << "Precomputation: temporarily setting '" << l_linearSolver->getName()
                        << "' iterations from " << buf_iterations << " to 5000";
         }
         if (thresholdData)
         {
             buf_threshold = thresholdData->getValueString();
             thresholdData->read("1e-35");
-            msg_info() << "Precomputation: temporarily setting '" << linearSolver->getName()
+            msg_info() << "Precomputation: temporarily setting '" << l_linearSolver->getName()
                        << "' threshold from " << buf_threshold << " to 1e-35";
         }
 
@@ -355,9 +357,9 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
 
         /// christian : it seems necessary to called the integration one time for initialization
         /// (avoid to have a line of 0 at the top of the matrix)
-        if (eulerSolver)
+        if (l_odeSolver)
         {
-            eulerSolver->solve(core::execparams::defaultInstance(), dt, core::vec_id::write_access::position, core::vec_id::write_access::velocity);
+            l_odeSolver->solve(core::execparams::defaultInstance(), dt, core::vec_id::write_access::position, core::vec_id::write_access::velocity);
         }
 
         Deriv unitary_force;
@@ -379,7 +381,7 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
                 velocity.clear();
                 velocity.resize(nbNodes);
 
-                // Actualize ref to the position vector ; it seems it is changed at every eulerSolver->solve()
+                // Actualize ref to the position vector ; it seems it is changed at every l_odeSolver->solve()
                 helper::WriteOnlyAccessor< Data< VecCoord > > wposData = *this->mstate->write(core::vec_id::write_access::position);
                 VecCoord& pos = wposData.wref();
 
@@ -388,11 +390,11 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
 
                 SReal fact = 1.0_sreal / dt; // christian : it is not a compliance... but an admittance that is computed !
 
-                if (eulerSolver)
+                if (l_odeSolver)
                 {
-                    fact *= eulerSolver->getPositionIntegrationFactor(); // here, we compute a compliance
+                    fact *= l_odeSolver->getPositionIntegrationFactor(); // here, we compute a compliance
 
-                    eulerSolver->solve(core::execparams::defaultInstance(), dt, core::vec_id::write_access::position, core::vec_id::write_access::velocity);
+                    l_odeSolver->solve(core::execparams::defaultInstance(), dt, core::vec_id::write_access::position, core::vec_id::write_access::velocity);
                 }
 
                 for (unsigned int v = 0; v < nbNodes; v++)

--- a/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
+++ b/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
@@ -35,8 +35,10 @@
 
         <RegularGridTopology name="grid" n="10 3 3" min="0 0 5" max="10 2 7" />
         <MechanicalObject name="dofs" />
-        <MeshMatrixMass massDensity="1" />
-        <HexahedronFEMForceField name="FEM" youngModulus="1e4" poissonRatio="0.45" method="large" />
+
+        <NodalMassDensity name="rho" property="1"/>
+        <FEMMass template="Vec3,Hexahedron" nodalMassDensity="@rho" />
+        <CorotationalFEMForceField template="Vec3,Hexahedron" name="FEM" youngModulus="1e4" poissonRatio="0.3" />
 
         <BoxROI name="boxFixed" box="-0.1 -0.1 4.9  0.1 2.1 7.1" drawBoxes="true" />
         <FixedProjectiveConstraint indices="@boxFixed.indices" />

--- a/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
+++ b/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
@@ -46,4 +46,27 @@
         <PrecomputedConstraintCorrection recompute="true" printLog="true" ODESolver="@odeSolver" linearSolver="@linearSolver"/>
     </Node>
 
+    <Node name="BeamLinearSolver">
+        <Visual3DText text="LinearSolverConstraintCorrection" position="0 3 12" scale="0.4" color="0.3 0.7 1 1" />
+        <EulerImplicitSolver name="odeSolver" rayleighStiffness="0.01" rayleighMass="0.01" linearSolver="@linearSolver"/>
+
+        <MatrixLinearSystem name="precondSystem" template="CompressedRowSparseMatrixd"/>
+        <SSORPreconditioner name="precond" linearSystem="@precondSystem"/>
+
+        <PreconditionedMatrixFreeSystem name="solverSystem" preconditionerSystem="@precondSystem"/>
+        <PCGLinearSolver name="linearSolver" iterations="200" tolerance="1e-6" linearSystem="@solverSystem" preconditioner="@precond"/>
+
+        <RegularGridTopology name="grid" n="10 3 3" min="0 0 9" max="10 2 11" />
+        <MechanicalObject name="dofs" />
+
+        <NodalMassDensity name="rho" property="1"/>
+        <FEMMass template="Vec3,Hexahedron" nodalMassDensity="@rho" />
+        <CorotationalFEMForceField template="Vec3,Hexahedron" name="FEM" youngModulus="1e4" poissonRatio="0.3" />
+
+        <BoxROI name="boxFixed" box="-0.1 -0.1 8.9  0.1 2.1 11.1" drawBoxes="true" />
+        <FixedProjectiveConstraint indices="@boxFixed.indices" />
+
+        <LinearSolverConstraintCorrection ODESolver="@odeSolver" linearSolver="@precond"/>
+    </Node>
+
 </Node>

--- a/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
+++ b/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
@@ -25,7 +25,7 @@
 
     <Node name="BeamPrecomputed">
         <Visual3DText text="PrecomputedConstraintCorrection" position="0 3 6" scale="0.4" color="0.3 0.7 1 1" />
-        <EulerImplicitSolver rayleighStiffness="0.01" rayleighMass="0.01" linearSolver="@linearSolver"/>
+        <EulerImplicitSolver name="odeSolver" rayleighStiffness="0.01" rayleighMass="0.01" linearSolver="@linearSolver"/>
 
         <MatrixLinearSystem name="precondSystem" template="CompressedRowSparseMatrixd"/>
         <SSORPreconditioner name="precond" linearSystem="@precondSystem"/>
@@ -41,7 +41,7 @@
         <BoxROI name="boxFixed" box="-0.1 -0.1 4.9  0.1 2.1 7.1" drawBoxes="true" />
         <FixedProjectiveConstraint indices="@boxFixed.indices" />
 
-        <PrecomputedConstraintCorrection recompute="true" printLog="true"/>
+        <PrecomputedConstraintCorrection recompute="true" printLog="true" ODESolver="@odeSolver" linearSolver="@linearSolver"/>
     </Node>
 
 </Node>

--- a/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
+++ b/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<Node name="root" dt="0.001" gravity="0 -10 0">
+    <Node name="RequiredPlugins">
+        <RequiredPlugin pluginName="Sofa.Component.AnimationLoop"/>
+        <RequiredPlugin pluginName="Sofa.Component.Constraint.Lagrangian.Correction"/>
+        <RequiredPlugin pluginName="Sofa.Component.Constraint.Lagrangian.Solver"/>
+        <RequiredPlugin pluginName="Sofa.Component.Constraint.Projective"/>
+        <RequiredPlugin pluginName="Sofa.Component.Engine.Select"/>
+        <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Iterative"/>
+        <RequiredPlugin pluginName="Sofa.Component.Mass"/>
+        <RequiredPlugin pluginName="Sofa.Component.MechanicalLoad"/>
+        <RequiredPlugin pluginName="Sofa.Component.ODESolver.Backward"/>
+        <RequiredPlugin pluginName="Sofa.Component.SolidMechanics.FEM.Elastic"/>
+        <RequiredPlugin pluginName="Sofa.Component.StateContainer"/>
+        <RequiredPlugin pluginName="Sofa.Component.Topology.Container.Grid"/>
+        <RequiredPlugin pluginName="Sofa.Component.Visual"/>
+        <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Preconditioner"/>
+        <RequiredPlugin pluginName="Sofa.Component.LinearSystem"/>
+    </Node>
+
+    <VisualStyle displayFlags="showBehaviorModels showForceFields showVisualModels" />
+
+    <FreeMotionAnimationLoop />
+    <BlockGaussSeidelConstraintSolver tolerance="1e-6" maxIterations="1000" />
+
+    <Node name="BeamPrecomputed">
+        <Visual3DText text="PrecomputedConstraintCorrection" position="0 3 6" scale="0.4" color="0.3 0.7 1 1" />
+        <EulerImplicitSolver rayleighStiffness="0.01" rayleighMass="0.01" linearSolver="@linearSolver"/>
+
+        <MatrixLinearSystem name="precondSystem" template="CompressedRowSparseMatrixd"/>
+        <SSORPreconditioner name="precond" linearSystem="@precondSystem"/>
+
+        <PreconditionedMatrixFreeSystem name="solverSystem" preconditionerSystem="@precondSystem"/>
+        <PCGLinearSolver name="linearSolver" iterations="200" tolerance="1e-6" linearSystem="@solverSystem" preconditioner="@precond"/>
+
+        <RegularGridTopology name="grid" n="10 3 3" min="0 0 5" max="10 2 7" />
+        <MechanicalObject name="dofs" />
+        <MeshMatrixMass massDensity="1" />
+        <HexahedronFEMForceField name="FEM" youngModulus="1e4" poissonRatio="0.45" method="large" />
+
+        <BoxROI name="boxFixed" box="-0.1 -0.1 4.9  0.1 2.1 7.1" drawBoxes="true" />
+        <FixedProjectiveConstraint indices="@boxFixed.indices" />
+
+        <PrecomputedConstraintCorrection recompute="true" printLog="true"/>
+    </Node>
+
+</Node>

--- a/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
+++ b/examples/Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn
@@ -1,7 +1,11 @@
 <?xml version="1.0" ?>
-<Node name="root" dt="0.001" gravity="0 -10 0">
+<Node name="root" dt="0.010" gravity="0 -10 0">
     <Node name="RequiredPlugins">
         <RequiredPlugin pluginName="Sofa.Component.AnimationLoop"/>
+        <RequiredPlugin pluginName="Sofa.Component.Collision.Detection.Algorithm"/>
+        <RequiredPlugin pluginName="Sofa.Component.Collision.Detection.Intersection"/>
+        <RequiredPlugin pluginName="Sofa.Component.Collision.Geometry"/>
+        <RequiredPlugin pluginName="Sofa.Component.Collision.Response.Contact"/>
         <RequiredPlugin pluginName="Sofa.Component.Constraint.Lagrangian.Correction"/>
         <RequiredPlugin pluginName="Sofa.Component.Constraint.Lagrangian.Solver"/>
         <RequiredPlugin pluginName="Sofa.Component.Constraint.Projective"/>
@@ -18,10 +22,16 @@
         <RequiredPlugin pluginName="Sofa.Component.LinearSystem"/>
     </Node>
 
-    <VisualStyle displayFlags="showBehaviorModels showForceFields showVisualModels" />
+    <VisualStyle displayFlags="showBehaviorModels showForceFields showVisualModels showCollisionModels" />
 
     <FreeMotionAnimationLoop />
     <BlockGaussSeidelConstraintSolver tolerance="1e-6" maxIterations="1000" />
+
+    <CollisionPipeline/>
+    <BruteForceBroadPhase />
+    <BVHNarrowPhase />
+    <NewProximityIntersection name="proximity" alarmDistance="0.3" contactDistance="0.1"/>
+    <CollisionResponse name="response" response="FrictionContactConstraint"/>
 
     <Node name="BeamPrecomputed">
         <Visual3DText text="PrecomputedConstraintCorrection" position="0 3 6" scale="0.4" color="0.3 0.7 1 1" />
@@ -42,6 +52,8 @@
 
         <BoxROI name="boxFixed" box="-0.1 -0.1 4.9  0.1 2.1 7.1" drawBoxes="true" />
         <FixedProjectiveConstraint indices="@boxFixed.indices" />
+
+        <PointCollisionModel />
 
         <PrecomputedConstraintCorrection recompute="true" printLog="true" ODESolver="@odeSolver" linearSolver="@linearSolver"/>
     </Node>
@@ -66,7 +78,15 @@
         <BoxROI name="boxFixed" box="-0.1 -0.1 8.9  0.1 2.1 11.1" drawBoxes="true" />
         <FixedProjectiveConstraint indices="@boxFixed.indices" />
 
+        <PointCollisionModel />
+
         <LinearSolverConstraintCorrection ODESolver="@odeSolver" linearSolver="@precond"/>
+    </Node>
+
+    <Node name="Floor">
+        <RegularGridTopology name="floor" n="5 1 5" min="5 -3 3.5" max="13 -3 11.5" />
+        <MechanicalObject name="dofs" />
+        <TriangleCollisionModel simulated="0" moving="0" />
     </Node>
 
 </Node>

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -44,6 +44,7 @@ Component/Constraint/Lagrangian/BilateralLagrangianConstraint_PGS.scn 100 1e-4 0
 Component/Constraint/Lagrangian/BilateralLagrangianConstraint_UGS.scn 100 1e-4 0 1
 Component/Constraint/Lagrangian/FrictionContact_LCP_with_friction.scn 500 1e-4 0 1
 Component/Constraint/Lagrangian/FrictionContact_LCP_without_friction.scn 500 1e-4 0 1
+Component/Constraint/Lagrangian/PrecomputedConstraintCorrection.scn 120 1e-4 0 1
 Component/Constraint/Projective/FixedProjectiveConstraint.scn 100 1e-4 0 1
 Component/Constraint/Projective/LinearVelocityProjectiveConstraint.scn 100 1e-4 0 1
 Component/LinearSolver/Direct/FEMBAR_EigenSimplicialLDLT.scn 100 1e-8 0 1


### PR DESCRIPTION
This is a component that can be very useful for real-time simulations, however it has been neglected. 

It pre-computes the compliance matrix by perturbing the dofs with a unit force. 

Problems:
- For accurate computations, when using an iterative solver, stricter tolerances must be set during the perturbations. This was only done with `CGLinearSolver` during the perturbations. It now covers any solver that has `tolerance` and `iterations` as Data. Still fragile. A common API for iterative solvers could be useful. 
- With preconditioned solvers (such as PCG) the precomputation might break because it relies on finding the linearSolver through `getContext`. This can return either the preconditioner or the actual solver, depending on how the user set them up in the scene graph. I added a link instead to explicit this and a scene to demonstrate it.

[with-all-tests]
[ci-depends-on https://github.com/sofa-framework/Regression/pull/127]