### PR TITLE
[FEM] Implement getPotentialEnergy for Linear & Corotational FEMForceField

### DIFF
--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseElementLinearFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseElementLinearFEMForceField.h
@@ -53,6 +53,7 @@ private:
     using trait = sofa::component::solidmechanics::fem::elastic::trait<DataTypes, ElementType>;
     using ElementHessian = typename trait::ElementHessian;
     using StrainDisplacement = typename trait::StrainDisplacement;
+    using ElementDisplacement = typename trait::ElementDisplacement;
     using Real = typename trait::Real;
 
 protected:
@@ -63,6 +64,12 @@ protected:
      * With linear small strain, the element stiffness matrix is constant, so it can be precomputed.
      */
     void precomputeElementStiffness();
+
+    /// Displacement of the element nodes relative to their rest position. Returns a flat vector.
+    ElementDisplacement computeElementDisplacement(
+        const typename trait::TopologyElement& element,
+        const sofa::VecCoord_t<DataTypes>& nodePositions,
+        const sofa::VecCoord_t<DataTypes>& nodeRestPositions) const;
 
 public:
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseElementLinearFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/BaseElementLinearFEMForceField.inl
@@ -103,4 +103,24 @@ void BaseElementLinearFEMForceField<DataTypes, ElementType>::precomputeElementSt
         });
 }
 
+template <class DataTypes, class ElementType>
+auto BaseElementLinearFEMForceField<DataTypes, ElementType>::computeElementDisplacement(
+    const typename trait::TopologyElement& element,
+    const sofa::VecCoord_t<DataTypes>& nodePositions,
+    const sofa::VecCoord_t<DataTypes>& nodeRestPositions) const -> ElementDisplacement
+{
+    ElementDisplacement displacement{ sofa::type::NOINIT };
+
+    for (sofa::Size j = 0; j < trait::NumberOfNodesInElement; ++j)
+    {
+        const auto nodeId = element[j];
+        for (sofa::Size dim = 0; dim < trait::spatial_dimensions; ++dim)
+        {
+            displacement[j * trait::spatial_dimensions + dim] = nodePositions[nodeId][dim] - nodeRestPositions[nodeId][dim];
+        }
+    }
+
+    return displacement;
+}
+
 }

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
@@ -124,6 +124,7 @@ public:
 private:
     using trait = sofa::component::solidmechanics::fem::elastic::trait<DataTypes, ElementType>;
     using ElementGradient = typename trait::ElementGradient;
+    using ElementDisplacement = typename trait::ElementDisplacement;
     using RotationMatrix = sofa::type::Mat<trait::spatial_dimensions, trait::spatial_dimensions, sofa::Real_t<DataTypes>>;
 
 
@@ -160,6 +161,12 @@ protected:
 
     sofa::type::vector<RotationMatrix> m_rotations;
     sofa::type::vector<RotationMatrix> m_initialRotationsTransposed;
+
+    /// Displacement of the element nodes in the element's own rotated frame. Returns a flat vector.
+    ElementDisplacement computeElementLocalDisplacement(
+        const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& nodes,
+        const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& restNodes,
+        const RotationMatrix& rotation) const;
 
     sofa::Coord_t<DataTypes> translation(const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& nodes) const;
     static sofa::Coord_t<DataTypes> computeCentroid(const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& nodes);

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.h
@@ -162,7 +162,7 @@ protected:
     sofa::type::vector<RotationMatrix> m_rotations;
     sofa::type::vector<RotationMatrix> m_initialRotationsTransposed;
 
-    /// Displacement of the element nodes in the element's own rotated frame. Returns a flat vector.
+    /// Local displacement of the element nodes in the element's own rotated frame. Flat vector.
     ElementDisplacement computeElementLocalDisplacement(
         const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& nodes,
         const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& restNodes,

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.inl
@@ -225,8 +225,6 @@ SReal CorotationalFEMForceField<DataTypes, ElementType>::getPotentialEnergy(
     const auto& elements = trait::FiniteElement::getElementSequence(*this->l_topology);
     const auto elementStiffness = sofa::helper::getReadAccessor(this->d_elementStiffness);
 
-    // The element rotations are those of the last force computation: they are filled while the forces
-    // are computed, so there are none to read before the first one has run.
     if (m_rotations.size() < elements.size())
         return 0;
 
@@ -239,16 +237,13 @@ SReal CorotationalFEMForceField<DataTypes, ElementType>::getPotentialEnergy(
     {
         const auto& element = elements[elementId];
 
-        const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement> elementNodesCoordinates =
-            extractNodesVectorFromGlobalVector(element, positionAccessor.ref());
-        const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement> restElementNodesCoordinates =
-            extractNodesVectorFromGlobalVector(element, restPositionAccessor.ref());
+        const auto elementNodesCoordinates = extractNodesVectorFromGlobalVector(element, positionAccessor.ref());
+        const auto restElementNodesCoordinates = extractNodesVectorFromGlobalVector(element, restPositionAccessor.ref());
 
         const auto displacement = computeElementLocalDisplacement(
             elementNodesCoordinates, restElementNodesCoordinates, m_rotations[elementId]);
 
-        // the element stiffness matrix is the quadratic form of the strain energy: 1/2 d^T K d, taken
-        // on the co-rotated displacement, so a rigid motion of the element contributes nothing
+        // Quadratic form of strain energy: 1/2 d^T K d
         energy += displacement * (elementStiffness[elementId] * displacement);
     }
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/CorotationalFEMForceField.inl
@@ -79,6 +79,26 @@ void CorotationalFEMForceField<DataTypes, ElementType>::beforeElementForce(
 }
 
 template <class DataTypes, class ElementType>
+auto CorotationalFEMForceField<DataTypes, ElementType>::computeElementLocalDisplacement(
+    const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& nodes,
+    const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement>& restNodes,
+    const RotationMatrix& rotation) const -> ElementDisplacement
+{
+    const auto t = translation(nodes);
+    const auto t0 = translation(restNodes);
+
+    ElementDisplacement displacement{ sofa::type::NOINIT };
+
+    for (sofa::Size j = 0; j < trait::NumberOfNodesInElement; ++j)
+    {
+        displacement.setsub(j * trait::spatial_dimensions,
+            rotation.multTranspose(nodes[j] - t) - (restNodes[j] - t0));
+    }
+
+    return displacement;
+}
+
+template <class DataTypes, class ElementType>
 void CorotationalFEMForceField<DataTypes, ElementType>::computeElementsForces(
     const sofa::simulation::Range<std::size_t>& range, const sofa::core::MechanicalParams* mparams,
     sofa::type::vector<ElementGradient>& elementForces, const sofa::VecCoord_t<DataTypes>& nodePositions)
@@ -102,15 +122,8 @@ void CorotationalFEMForceField<DataTypes, ElementType>::computeElementsForces(
 
         m_rotationMethods.computeRotation(elementRotation, elementInitialRotationTransposed, elementNodesCoordinates, restElementNodesCoordinates);
 
-        const auto t = translation(elementNodesCoordinates);
-        const auto t0 = translation(restElementNodesCoordinates);
-
-        typename trait::ElementDisplacement displacement(sofa::type::NOINIT);
-        for (sofa::Size j = 0; j < trait::NumberOfNodesInElement; ++j)
-        {
-            displacement.setsub(j * DIM,
-                elementRotation.multTranspose(elementNodesCoordinates[j] - t) - (restElementNodesCoordinates[j] - t0));
-        }
+        const auto displacement = computeElementLocalDisplacement(
+            elementNodesCoordinates, restElementNodesCoordinates, elementRotation);
 
         const auto& stiffnessMatrix = elementStiffness[elementId];
 
@@ -206,7 +219,40 @@ SReal CorotationalFEMForceField<DataTypes, ElementType>::getPotentialEnergy(
     const sofa::core::MechanicalParams*,
     const sofa::DataVecCoord_t<DataTypes>& x) const
 {
-    return 0;
+    if (this->isComponentStateInvalid())
+        return 0;
+
+    const auto& elements = trait::FiniteElement::getElementSequence(*this->l_topology);
+    const auto elementStiffness = sofa::helper::getReadAccessor(this->d_elementStiffness);
+
+    // The element rotations are those of the last force computation: they are filled while the forces
+    // are computed, so there are none to read before the first one has run.
+    if (m_rotations.size() < elements.size())
+        return 0;
+
+    const auto positionAccessor = sofa::helper::getReadAccessor(x);
+    const auto restPositionAccessor = this->mstate->readRestPositions();
+
+    sofa::Real_t<DataTypes> energy {};
+
+    for (std::size_t elementId = 0; elementId < elements.size(); ++elementId)
+    {
+        const auto& element = elements[elementId];
+
+        const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement> elementNodesCoordinates =
+            extractNodesVectorFromGlobalVector(element, positionAccessor.ref());
+        const std::array<sofa::Coord_t<DataTypes>, trait::NumberOfNodesInElement> restElementNodesCoordinates =
+            extractNodesVectorFromGlobalVector(element, restPositionAccessor.ref());
+
+        const auto displacement = computeElementLocalDisplacement(
+            elementNodesCoordinates, restElementNodesCoordinates, m_rotations[elementId]);
+
+        // the element stiffness matrix is the quadratic form of the strain energy: 1/2 d^T K d, taken
+        // on the co-rotated displacement, so a rigid motion of the element contributes nothing
+        energy += displacement * (elementStiffness[elementId] * displacement);
+    }
+
+    return static_cast<SReal>(0.5 * energy);
 }
 
 template <class DataTypes, class ElementType>

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
@@ -52,6 +52,12 @@ private:
     using StrainDisplacement = typename trait::StrainDisplacement;
     using ElementGradient = typename trait::ElementGradient;
 
+    /// Displacement of the element nodes relative to their rest position. Returns a flat vector.
+    ElementDisplacement computeElementDisplacement(
+        const typename trait::TopologyElement& element,
+        const sofa::VecCoord_t<DataTypes>& nodePositions,
+        const sofa::VecCoord_t<DataTypes>& nodeRestPositions) const;
+
 public:
     void init() override;
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.h
@@ -52,12 +52,6 @@ private:
     using StrainDisplacement = typename trait::StrainDisplacement;
     using ElementGradient = typename trait::ElementGradient;
 
-    /// Displacement of the element nodes relative to their rest position. Returns a flat vector.
-    ElementDisplacement computeElementDisplacement(
-        const typename trait::TopologyElement& element,
-        const sofa::VecCoord_t<DataTypes>& nodePositions,
-        const sofa::VecCoord_t<DataTypes>& nodeRestPositions) const;
-
 public:
     void init() override;
 

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.inl
@@ -41,26 +41,6 @@ void LinearSmallStrainFEMForceField<DataTypes, ElementType>::init()
 
 
 template <class DataTypes, class ElementType>
-auto LinearSmallStrainFEMForceField<DataTypes, ElementType>::computeElementDisplacement(
-    const typename trait::TopologyElement& element,
-    const sofa::VecCoord_t<DataTypes>& nodePositions,
-    const sofa::VecCoord_t<DataTypes>& nodeRestPositions) const -> ElementDisplacement
-{
-    ElementDisplacement displacement{ sofa::type::NOINIT };
-
-    for (sofa::Size j = 0; j < trait::NumberOfNodesInElement; ++j)
-    {
-        const auto nodeId = element[j];
-        for (sofa::Size dim = 0; dim < trait::spatial_dimensions; ++dim)
-        {
-            displacement[j * trait::spatial_dimensions + dim] = nodePositions[nodeId][dim] - nodeRestPositions[nodeId][dim];
-        }
-    }
-
-    return displacement;
-}
-
-template <class DataTypes, class ElementType>
 void LinearSmallStrainFEMForceField<DataTypes, ElementType>::computeElementsForces(
     const sofa::simulation::Range<std::size_t>& range,
     const sofa::core::MechanicalParams* mparams,
@@ -75,7 +55,7 @@ void LinearSmallStrainFEMForceField<DataTypes, ElementType>::computeElementsForc
     {
         const auto& stiffnessMatrix = elementStiffness[elementId];
 
-        const auto displacement = computeElementDisplacement(
+        const auto displacement = this->computeElementDisplacement(
             elements[elementId], nodePositions, restPositionAccessor.ref());
 
         elementForces[elementId] = stiffnessMatrix * displacement;
@@ -169,7 +149,7 @@ SReal LinearSmallStrainFEMForceField<DataTypes, ElementType>::getPotentialEnergy
 
     for (std::size_t elementId = 0; elementId < elements.size(); ++elementId)
     {
-        const auto displacement = computeElementDisplacement(
+        const auto displacement = this->computeElementDisplacement(
             elements[elementId], positionAccessor.ref(), restPositionAccessor.ref());
 
         // the element stiffness matrix is the quadratic form of the strain energy: 1/2 d^T K d

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.inl
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/LinearSmallStrainFEMForceField.inl
@@ -41,6 +41,26 @@ void LinearSmallStrainFEMForceField<DataTypes, ElementType>::init()
 
 
 template <class DataTypes, class ElementType>
+auto LinearSmallStrainFEMForceField<DataTypes, ElementType>::computeElementDisplacement(
+    const typename trait::TopologyElement& element,
+    const sofa::VecCoord_t<DataTypes>& nodePositions,
+    const sofa::VecCoord_t<DataTypes>& nodeRestPositions) const -> ElementDisplacement
+{
+    ElementDisplacement displacement{ sofa::type::NOINIT };
+
+    for (sofa::Size j = 0; j < trait::NumberOfNodesInElement; ++j)
+    {
+        const auto nodeId = element[j];
+        for (sofa::Size dim = 0; dim < trait::spatial_dimensions; ++dim)
+        {
+            displacement[j * trait::spatial_dimensions + dim] = nodePositions[nodeId][dim] - nodeRestPositions[nodeId][dim];
+        }
+    }
+
+    return displacement;
+}
+
+template <class DataTypes, class ElementType>
 void LinearSmallStrainFEMForceField<DataTypes, ElementType>::computeElementsForces(
     const sofa::simulation::Range<std::size_t>& range,
     const sofa::core::MechanicalParams* mparams,
@@ -53,19 +73,10 @@ void LinearSmallStrainFEMForceField<DataTypes, ElementType>::computeElementsForc
 
     for (std::size_t elementId = range.start; elementId < range.end; ++elementId)
     {
-        const auto& element = elements[elementId];
         const auto& stiffnessMatrix = elementStiffness[elementId];
 
-        typename trait::ElementDisplacement displacement{ sofa::type::NOINIT };
-
-        for (sofa::Size j = 0; j < trait::NumberOfNodesInElement; ++j)
-        {
-            const auto nodeId = element[j];
-            for (sofa::Size dim = 0; dim < trait::spatial_dimensions; ++dim)
-            {
-                displacement[j * trait::spatial_dimensions + dim] = nodePositions[nodeId][dim] - restPositionAccessor[nodeId][dim];
-            }
-        }
+        const auto displacement = computeElementDisplacement(
+            elements[elementId], nodePositions, restPositionAccessor.ref());
 
         elementForces[elementId] = stiffnessMatrix * displacement;
     }
@@ -145,7 +156,27 @@ SReal LinearSmallStrainFEMForceField<DataTypes, ElementType>::getPotentialEnergy
     const sofa::core::MechanicalParams*,
     const sofa::DataVecCoord_t<DataTypes>& x) const
 {
-    return 0;
+    if (this->isComponentStateInvalid())
+        return 0;
+
+    const auto& elements = trait::FiniteElement::getElementSequence(*this->l_topology);
+    const auto elementStiffness = sofa::helper::getReadAccessor(this->d_elementStiffness);
+
+    const auto positionAccessor = sofa::helper::getReadAccessor(x);
+    const auto restPositionAccessor = this->mstate->readRestPositions();
+
+    sofa::Real_t<DataTypes> energy {};
+
+    for (std::size_t elementId = 0; elementId < elements.size(); ++elementId)
+    {
+        const auto displacement = computeElementDisplacement(
+            elements[elementId], positionAccessor.ref(), restPositionAccessor.ref());
+
+        // the element stiffness matrix is the quadratic form of the strain energy: 1/2 d^T K d
+        energy += displacement * (elementStiffness[elementId] * displacement);
+    }
+
+    return static_cast<SReal>(0.5 * energy);
 }
 
 template <class DataTypes, class ElementType>


### PR DESCRIPTION
Implements `getPotentialEnergy()` for `CorotationalFEMForceField` and `LinearSmallStrainFEMForceField` components. Both now compute elastic strain energy using the form: 
```math
E = \sum_e \frac{1}{2}\mathbf{u_e}^T\mathbf{K_e}\mathbf{u_e} 
```
- $\mathbf{u_e}$: element displacement of DOFs
- $\mathbf{K_e}$: element stiffness matrix

The corotational form uses the local displacements and so gives the energy due to local deformations.

[with-all-tests]