### PR TITLE
[LinearSystem] MatrixProjectionMethod: Fix out-of-bounds matrix writes

### DIFF
--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixProjectionMethod.inl
@@ -103,14 +103,10 @@ void MatrixProjectionMethod<TMatrix>::addMappedMatrixToGlobalMatrixEigen(
     const auto inputs1 = mappingGraph.getTopMostMechanicalStates(mstatePair[0]);
     const auto inputs2 = mappingGraph.getTopMostMechanicalStates(mstatePair[1]);
 
-    std::set<core::behavior::BaseMechanicalState*> inputs;
-    inputs.insert(inputs1.begin(), inputs1.end());
-    inputs.insert(inputs2.begin(), inputs2.end());
-
     std::set< std::pair<core::behavior::BaseMechanicalState*, core::behavior::BaseMechanicalState*> > uniquePairs;
-    for (auto* a : inputs)
+    for (auto* a : inputs1)
     {
-        for (auto* b : inputs)
+        for (auto* b : inputs2)
         {
             uniquePairs.insert({a, b});
         }


### PR DESCRIPTION
`MatrixProjectionMethod::addMappedMatrixToGlobalMatrixEigen` iterated over the cartesian product of the union of both mechanical states' top-most ancestors, instead of inputs1 x inputs2. 
For the resulting spurious pairs no Jacobian exists, and computeProjection silently falls back to an unprojected block whose dimensions belong to the mapped state, written at the global offsets of an unrelated state.

[with-all-tests]

[ci-depends-on https://github.com/sofa-framework/Regression/pull/126]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
