### PR TITLE
[Sofa.Simulation.Core] MappingGraph: fix memory leak in from parent/child shared_ptr cycle

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
@@ -91,11 +91,14 @@ MappingGraph::MappingInputs MappingGraph::getTopMostMechanicalStates(
                 current->accept(visitor);
             }
 
-            for (auto& parent : current->m_parents)
+            for (auto& weakParent : current->m_parents)
             {
-                if (parent->m_pendingCount == 0)
+                if (const auto parent = weakParent.lock())
                 {
-                    nodes.push(parent.get());
+                    if (parent->m_pendingCount == 0)
+                    {
+                        nodes.push(parent.get());
+                    }
                 }
             }
         }
@@ -230,11 +233,14 @@ sofa::type::vector<core::BaseMapping*> MappingGraph::getBottomUpMappingsFrom(
 
             current->accept(visitor);
 
-            for (auto& parent : current->m_parents)
+            for (auto& weakParent : current->m_parents)
             {
-                if (parent->m_pendingCount == 0)
+                if (const auto parent = weakParent.lock())
                 {
-                    nodes.push(parent.get());
+                    if (parent->m_pendingCount == 0)
+                    {
+                        nodes.push(parent.get());
+                    }
                 }
             }
         }
@@ -402,7 +408,7 @@ BaseMappingGraphNode* MappingGraph::findStateNode(core::behavior::BaseMechanical
 void MappingGraph::addEdge(BaseMappingGraphNode* from, BaseMappingGraphNode* to)
 {
     from->m_children.push_back(to->shared_from_this());
-    to->m_parents.push_back(from->shared_from_this());
+    to->m_parents.push_back(from->weak_from_this());
 }
 
 }  // namespace sofa::simulation

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/BaseMappingGraphNode.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/BaseMappingGraphNode.cpp
@@ -31,9 +31,10 @@ bool BaseMappingGraphNode::isMapped() const
         return m_isMapped.value();
     }
 
-    const auto isMapped = std::any_of(m_parents.begin(), m_parents.end(), [](const SPtr& node)
+    const auto isMapped = std::any_of(m_parents.begin(), m_parents.end(), [](const std::weak_ptr<BaseMappingGraphNode>& weakNode)
     {
-        return node->getType() == NodeType::Mapping || node->isMapped();
+        const auto node = weakNode.lock();
+        return node && (node->getType() == NodeType::Mapping || node->isMapped());
     });
 
     m_isMapped = isMapped;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/BaseMappingGraphNode.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mappinggraph/BaseMappingGraphNode.h
@@ -70,11 +70,15 @@ public:
      */
     bool isMapped() const;
 
-    const sofa::type::vector<SPtr>& getParents() const { return m_parents; }
+    const sofa::type::vector<std::weak_ptr<BaseMappingGraphNode>>& getParents() const { return m_parents; }
     const sofa::type::vector<SPtr>& getChildren() const { return m_children; }
 
 private:
-    sofa::type::vector<SPtr> m_parents;   ///< prerequisite nodes (nodes pointing to this one)
+    /// Prerequisite nodes (nodes pointing to this one). Held as weak_ptr: ownership of every
+    /// node belongs to MappingGraph::m_allNodes and to the owning parent's m_children; a strong
+    /// back-reference here would form a parent<->child reference cycle that keeps the whole
+    /// graph alive forever across rebuilds (MappingGraph::clear() only releases m_allNodes).
+    sofa::type::vector<std::weak_ptr<BaseMappingGraphNode>> m_parents;
     sofa::type::vector<SPtr> m_children;  ///< dependent nodes (nodes pointed from this one)
 
     // Mutable counter used during traversal (reset before each traversal).


### PR DESCRIPTION
From Claude (sonnet 😅):


`BaseMappingGraphNode` stored both `m_parents` and `m_children` as owning `shared_ptr`s. `MappingGraph::addEdge()` linked every connected pair in both directions, creating a reference cycle between each parent and child node.
`MappingGraph::clear()` (called at the start of every `build()`) only drops the graph's own `m_allNodes` vector; it never breaks these cycles. Since `EulerExplicitSolver::solve()` and `EulerImplicitSolver::solve()` call
`m_mappingGraph.build()` unconditionally on every timestep, the entire previous graph leaked on every single animation step for as long as the solver was active.
Fix: store `m_parents` as `std::weak_ptr` instead of `shared_ptr`. Node ownership already belongs to `MappingGraph::m_allNodes` (and to each node's owning parent via `m_children`), so the back-reference doesn't need to be owning.

| Solver step | Live nodes (before fix) | Live nodes (after fix) |
|---:|---:|---:|
| 1 | 0 | 0 |
| 101 | 1200 | 24 |
| 1001 | 12000 | 24 |
| 1901 | 22800 | 24 |

--- 

Basically the shared_ptr retained a ref so the parents/childs were owning each other, so the shared_ptr/gc mechanism were effectively dismissed.

Fix #6230 

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
