### PR TITLE
[Simulation] Mapping graph: restrict construction of edges between groups and mappings

### DIFF
--- a/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolverImpl.h
+++ b/Sofa/Component/LinearSolver/Direct/src/sofa/component/linearsolver/direct/SparseLDLSolverImpl.h
@@ -109,7 +109,9 @@ inline void CSPARSE_numeric(int n,int * M_colptr,int * M_rowind,Real * M_values,
         kk = perm[k];  // kth original, or permuted, column 
         for (p = M_colptr[kk] ; p < M_colptr[kk+1] ; p++)
         {
-            i = invperm[M_rowind[p]];	// get A(i,k) 
+            const auto r = M_rowind[p] ;
+            assert(r < n && r >= 0);
+            i = invperm[r];	// get A(i,k)
             if (i <= k)
             {
                 Y[i] += M_values[p] ;  // scatter A(i,k) into Y (sum duplicates) 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.cpp
@@ -320,15 +320,19 @@ void MappingGraph::build(const InputLists& input)
     for (size_t i = 0; i < input.mappings.size(); ++i)
     {
         BaseMappingGraphNode* mappingNode = mappingNodePtrs[i];
-        for (auto& s : input.mappings[i]->getMechFrom())
+        const auto mappingInputs = input.mappings[i]->getMechFrom();
+        if (auto groupNode = findInGroupNodes(std::set(mappingInputs.begin(), mappingInputs.end())))
         {
-            if (auto groupNode = findInGroupNodes(s))
+            addEdge(groupNode.get(), mappingNode);
+        }
+        else
+        {
+            for (auto& s : input.mappings[i]->getMechFrom())
             {
-                addEdge(groupNode.get(), mappingNode);
-            }
-            else if (auto* sn = findStateNode(s))
-            {
-                addEdge(sn, mappingNode);
+                if (auto* sn = findStateNode(s))
+                {
+                    addEdge(sn, mappingNode);
+                }
             }
         }
 
@@ -387,12 +391,13 @@ ComponentGroupMappingGraphNode::SPtr MappingGraph::findGroupNode(
 }
 
 ComponentGroupMappingGraphNode::SPtr MappingGraph::findInGroupNodes(
-    const core::behavior::BaseMechanicalState::SPtr state)
+    const std::set<core::behavior::BaseMechanicalState*>& states)
 {
     auto it = std::find_if(m_groupIndex.begin(), m_groupIndex.end(),
-        [&state](auto& group)
+        [&states](auto& group)
         {
-            return std::find(group.first.begin(), group.first.end(), state) != group.first.end();
+            return group.first.size() == states.size() &&
+                std::equal(states.begin(), states.end(), group.first.begin());
         });
     if (it != m_groupIndex.end())
         return it->second;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/MappingGraph.h
@@ -255,7 +255,7 @@ private:
      * @param state The mechanical state defining the scope of the group.
      * @return A shared pointer to the found/created ComponentGroupMappingGraphNode.
      */
-    ComponentGroupMappingGraphNode::SPtr findInGroupNodes(const core::behavior::BaseMechanicalState::SPtr state);
+    ComponentGroupMappingGraphNode::SPtr findInGroupNodes(const std::set<core::behavior::BaseMechanicalState*>& states);
 
     /**
      * @brief Finds the graph node corresponding to a raw mechanical state pointer.

--- a/examples/Component/LinearSystem/MatrixLinearSystem.scn
+++ b/examples/Component/LinearSystem/MatrixLinearSystem.scn
@@ -132,8 +132,6 @@
             </Node>
 
             <Node name="springBetweenMappedAndNonMapped">
-                <BoxROI position="@red/FEM/DOFs.position" box="-1.6 -1.6 18.9 -1.4 -1.4 19.1" drawBoxes="true"/>
-                <BoxROI position="@green/DOFs.position" box="-1.6 -6.1 18.9 -1.4 -5.9 19.1" drawBoxes="true"/>
                 <SpringForceField object1="@red/FEM/DOFs" object2="@green/DOFs" spring="304 316 100 1 1" showArrowSize="0.05" drawMode="2"/>
             </Node>
         </Node>


### PR DESCRIPTION
This PR fixes a crash in `examples/Component/LinearSystem/MatrixLinearSystem.scn`.

<img width="780" height="901" alt="image" src="https://github.com/user-attachments/assets/363ecd19-db70-4c74-948f-503b001be402" />

This is complex scene showcasing the correct behavior of mappings in the matrix assembly.

This is the path to locate the bug:

1. The solver crashes because of a bad CSR matrix construction (which leads me to think that we don't have enough tools to analyze those matrices, and that this data structure is still fragile). 
⬇️ 
2. The matrix is not well constructed because of bad matrix projections (`MatrixProjectionMethod.inl`).
⬇️ 
3. The matrices are not well projected because `mappingGraph.getTopMostMechanicalStates` gives wrong inputs. For example, in the scene, it adds an unrelated input to `red/FEM/DOFs`. The unrelated input still contributes to the matrix, potentially to wrong locations.
⬇️ 
4. The wrong inputs are due to a wrong construction of the mapping graph. In the following screenshot, we can observe that the RigidMapping is a child of a group node, itself a child of the blue DoFs (which is unrelated to the mapping).

<img width="2097" height="340" alt="image" src="https://github.com/user-attachments/assets/ccd455e7-19d9-4b38-86dc-673e0ac4ce16" />

The fix:
Mappings must be child of a group only if all the mapping inputs are all equal to the group's states. Previously, only one common state was enough.

After the fix:

<img width="1879" height="325" alt="image" src="https://github.com/user-attachments/assets/add85a13-4adb-4a79-99d1-e29ee0c4a10e" />

The rigid mapping is no longer related to the blue DoFs.


This fix is in addition to https://github.com/sofa-framework/sofa/pull/6222 and https://github.com/sofa-framework/sofa/pull/6256

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
