### PR TITLE
[Mass] Support matrix lumping in FEMMass

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.h
@@ -80,6 +80,8 @@ protected:
 
 public:
 
+    sofa::Data<bool> d_lumping;
+
     /**
      * @brief Link to the nodal mass density component.
      *
@@ -102,9 +104,10 @@ public:
 
     /**
      * @brief Indicates whether the mass matrix is diagonal.
-     * @return Always returns false, as FEM mass matrices are generally not diagonal (unless lumped).
+     * @return Returns false in general as FEM mass matrices are generally not diagonal unless
+     * lumped. In that case, it returns true.
      */
-    bool isDiagonal() const override { return false; }
+    bool isDiagonal() const override { return d_lumping.getValue(); }
 
     /**
      * @brief Adds the gravity force (f = M * g) to the force vector.
@@ -147,7 +150,7 @@ public:
 
     using Inherit1::accFromF;
     /**
-     * @brief Supposed to compute $ a = M^{-1} f $, but triggers an error in this implementation.
+     * @brief Compute $ a = M^{-1} f $ if the mass matrix is lumped. Triggers an error otherwise.
      *
      * @param mparams Mechanical parameters for the computation.
      * @param a The result vector of $M^{-1} f$.

--- a/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.inl
@@ -199,7 +199,13 @@ void FEMMass<TDataTypes, TElementType>::initializeGlobalMassMatrix(
                           for (sofa::Size j = 0; j < NumberOfNodesInElement; ++j)
                           {
                               const auto node_j = element[j];
-                              m_globalMassMatrix.add(node_i, node_j, elementMassMatrix(i, j));
+
+                              const auto& value = elementMassMatrix(i, j);
+                              constexpr Real_t<DataTypes> tolerance { 1e-12 };
+                              if (std::abs(value) > tolerance)
+                              {
+                                  m_globalMassMatrix.add(node_i, node_j, value);
+                              }
                           }
                       }
                   });

--- a/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/FEMMass.inl
@@ -30,8 +30,15 @@ namespace sofa::component::mass
 
 template <class TDataTypes, class TElementType>
 FEMMass<TDataTypes, TElementType>::FEMMass()
-    : l_nodalMassDensity(initLink("nodalMassDensity", "Link to nodal mass density"))
+    : d_lumping(initData(&d_lumping, "lumping","If true, the mass matrix is lumped, meaning the mass matrix is approximated to a diagonal matrix (summing all mass values of a line on the diagonal)"))
+    , l_nodalMassDensity(initLink("nodalMassDensity", "Link to nodal mass density"))
 {
+    this->addUpdateCallback("recomputeMass", {&this->d_lumping},
+    [this](const sofa::core::DataTracker& )
+    {
+        elementFEMMass_init();
+        return this->getComponentState();
+    }, {});
 }
 
 
@@ -78,6 +85,9 @@ void FEMMass<TDataTypes, TElementType>::validateNodalMassDensity()
 template <class TDataTypes, class TElementType>
 void FEMMass<TDataTypes, TElementType>::elementFEMMass_init()
 {
+    if (!this->l_topology)
+        return;
+
     const auto& elements = FiniteElement::getElementSequence(*this->l_topology);
     sofa::type::vector<ElementMassMatrix> elementMassMatrices;
 
@@ -97,6 +107,8 @@ void FEMMass<TDataTypes, TElementType>::calculateElementMassMatrix(
 
     sofa::helper::ReadAccessor nodalMassDensityAccessor { l_nodalMassDensity->d_property };
     auto restPositionAccessor = this->mstate->readRestPositions();
+
+    const bool lumping = d_lumping.getValue();
 
     SCOPED_TIMER("elementMassMatrix");
     helper::IotaView indices{static_cast<decltype(nbElements)>(0ul), nbElements};
@@ -145,6 +157,19 @@ void FEMMass<TDataTypes, TElementType>::calculateElementMassMatrix(
 
                 elementMassMatrix += (weight * density * detJ) * NT_N;
             }
+
+            if (lumping)
+            {
+                ElementMassMatrix lumped{};
+                for (sofa::Size i = 0; i < NumberOfNodesInElement; ++i)
+                {
+                    Real_t<DataTypes> rowSum = 0;
+                    for (sofa::Size j = 0; j < NumberOfNodesInElement; ++j)
+                        rowSum += elementMassMatrix(i, j);
+                    lumped(i, i) = rowSum;
+                }
+                elementMassMatrix = lumped;
+            }
         });
 }
 
@@ -192,6 +217,9 @@ void FEMMass<TDataTypes, TElementType>::addForce(const core::MechanicalParams* m
     SOFA_UNUSED(x);
     SOFA_UNUSED(v);
 
+    if (this->isComponentStateInvalid())
+        return;
+
     auto forceAccessor = sofa::helper::getWriteAccessor(f);
 
     const auto g = getContext()->getGravity();
@@ -216,6 +244,9 @@ template <class TDataTypes, class TElementType>
 void FEMMass<TDataTypes, TElementType>::buildMassMatrix(
     sofa::core::behavior::MassMatrixAccumulator* matrices)
 {
+    if (this->isComponentStateInvalid())
+        return;
+
     for (std::size_t xi = 0; xi < m_globalMassMatrix.rowIndex.size(); ++xi)
     {
         const auto rowId = m_globalMassMatrix.rowIndex[xi];
@@ -241,6 +272,9 @@ void FEMMass<TDataTypes, TElementType>::addMDx(const core::MechanicalParams* mpa
 {
     SOFA_UNUSED(mparams);
 
+    if (this->isComponentStateInvalid())
+        return;
+
     auto result = sofa::helper::getWriteAccessor(f);
     const auto dxAccessor = sofa::helper::getReadAccessor(dx);
 
@@ -264,10 +298,36 @@ void FEMMass<TDataTypes, TElementType>::accFromF(const core::MechanicalParams* m
                                                         const DataVecDeriv_t<DataTypes>& f)
 {
     SOFA_UNUSED(mparams);
-    SOFA_UNUSED(a);
-    SOFA_UNUSED(f);
 
-    msg_error() << "the method 'accFromF' can't be used with this component as this SPARSE mass matrix can't be inversed easily.";
+    if (this->isComponentStateInvalid())
+        return;
+
+    if (!d_lumping.getValue())
+    {
+        msg_error() << "the method 'accFromF' can't be used with this component as this "
+                        "SPARSE mass matrix can't be inversed easily. Enable 'lumping' instead.";
+        return;
+    }
+
+    auto accAccessor = sofa::helper::getWriteAccessor(a);
+    const auto fAccessor = sofa::helper::getReadAccessor(f);
+
+    for (std::size_t xi = 0; xi < m_globalMassMatrix.rowIndex.size(); ++xi)
+    {
+        const auto rowId = m_globalMassMatrix.rowIndex[xi];
+        typename GlobalMassMatrixType::Range rowRange(
+            m_globalMassMatrix.rowBegin[xi], m_globalMassMatrix.rowBegin[xi + 1]);
+
+        for (typename GlobalMassMatrixType::Index xj = rowRange.begin(); xj < rowRange.end(); ++xj)
+        {
+            const auto columnId = m_globalMassMatrix.colsIndex[xj];
+            if (columnId == rowId) // diagonal is guaranteed to exist when lumped
+            {
+                const auto& value = m_globalMassMatrix.colsValue[xj];
+                accAccessor[rowId] = fAccessor[rowId] / value;
+            }
+        }
+    }
 }
 
 template <class TDataTypes, class TElementType>
@@ -276,6 +336,9 @@ SReal FEMMass<TDataTypes, TElementType>::getKineticEnergy(
     const DataVecDeriv_t<DataTypes>& v) const
 {
     SOFA_UNUSED(mparams);
+
+    if (this->isComponentStateInvalid())
+        return 0_sreal;
 
     SReal kineticEnergy = 0.0;
     auto vAccessor = sofa::helper::getReadAccessor(v);
@@ -302,6 +365,9 @@ SReal FEMMass<TDataTypes, TElementType>::getPotentialEnergy(
     const DataVecCoord_t<DataTypes>& x) const
 {
     SOFA_UNUSED(mparams);
+
+    if (this->isComponentStateInvalid())
+        return 0_sreal;
 
     SReal potentialEnergy = 0.0;
     auto xAccessor = sofa::helper::getReadAccessor(x);

--- a/Sofa/Component/Mass/tests/CMakeLists.txt
+++ b/Sofa/Component/Mass/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Sofa.Component.Mass_test)
 
 set(SOURCE_FILES
     DiagonalMass_test.cpp
+    FEMMass_test.cpp
     MassTestCreation[FEMMass].cpp
     MassTestCreation[MeshMatrixMass].cpp
     MassTestCreation[UniformMass].cpp

--- a/Sofa/Component/Mass/tests/FEMMass_test.cpp
+++ b/Sofa/Component/Mass/tests/FEMMass_test.cpp
@@ -1,0 +1,181 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <gtest/gtest.h>
+#include <sofa/component/mass/FEMMass.h>
+#include <sofa/component/statecontainer/MechanicalObject.h>
+#include <sofa/component/topology/container/constant/MeshTopology.h>
+#include <sofa/core/behavior/BaseLocalMassMatrix.h>
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/simulation/Simulation.h>
+#include <sofa/testing/BaseSimulationTest.h>
+#include <sofa/testing/LinearCongruentialRandomGenerator.h>
+
+namespace sofa::component::mass::testing
+{
+
+using MeshTopology = sofa::component::topology::container::constant::MeshTopology;
+
+namespace
+{
+struct MatrixDiagonalCheckerAccumulator : public sofa::core::behavior::MassMatrixAccumulator
+{
+    bool hasOffDiagonalNonZero { false };
+    bool hasDiagonalNonZero { false };
+    double tolerance { 1e-12 };
+
+    void checkEntry(sofa::SignedIndex row, sofa::SignedIndex col, double value)
+    {
+        if (std::abs(value) > tolerance)
+        {
+            if (row == col)
+            {
+                hasDiagonalNonZero = true;
+            }
+            else
+            {
+                hasOffDiagonalNonZero = true;
+            }
+        }
+    }
+
+    void add(sofa::SignedIndex row, sofa::SignedIndex col, float value) override
+    {
+        checkEntry(row, col, static_cast<double>(value));
+    }
+
+    void add(sofa::SignedIndex row, sofa::SignedIndex col, double value) override
+    {
+        checkEntry(row, col, value);
+    }
+
+    void clear() override
+    {
+        hasOffDiagonalNonZero = false;
+        hasDiagonalNonZero = false;
+    }
+};
+} // namespace
+
+template <typename MassParam>
+struct FEMMassLumpingTest : public sofa::testing::BaseSimulationTest
+{
+    using DataTypes = typename MassParam::DataTypes;
+    using ElementType = typename MassParam::ElementType;
+    using FEMMassType = FEMMass<DataTypes, ElementType>;
+    using DOF = sofa::component::statecontainer::MechanicalObject<DataTypes>;
+
+    typename simulation::Node::SPtr m_node;
+    typename DOF::SPtr m_dof;
+    typename FEMMassType::SPtr m_mass;
+    typename MeshTopology::SPtr m_topology;
+    typename NodalMassDensity<sofa::Real_t<DataTypes>>::SPtr m_nodalDensity;
+
+    void doSetUp() override
+    {
+        sofa::simulation::Simulation* simu = sofa::simulation::getSimulation();
+        ASSERT_NE(simu, nullptr);
+
+        m_node = simu->createNewGraph("root");
+        m_dof = sofa::core::objectmodel::New<DOF>();
+        m_node->addObject(m_dof);
+
+        m_topology = sofa::core::objectmodel::New<MeshTopology>();
+        m_node->addObject(m_topology);
+
+        // Define a simple mesh element with distinct connected vertices
+        m_topology->addEdge(0, 1);
+        m_topology->addTriangle(0, 1, 2);
+        m_topology->addQuad(0, 1, 2, 3);
+        m_topology->addTetra(0, 1, 2, 3);
+        m_topology->addHexa(0, 1, 2, 3, 4, 5, 6, 7);
+
+        m_nodalDensity = sofa::core::objectmodel::New<NodalMassDensity<sofa::Real_t<DataTypes>>>();
+        m_node->addObject(m_nodalDensity);
+
+        m_mass = sofa::core::objectmodel::New<FEMMassType>();
+        m_node->addObject(m_mass);
+
+        m_dof->resize(8);
+        typename DOF::WriteVecCoord x = m_dof->writePositions();
+        sofa::testing::LinearCongruentialRandomGenerator lcg(96547);
+        for (std::size_t i = 0; i < 8; ++i)
+        {
+            DataTypes::set(x[i],
+                           lcg.generateInUnitRange<sofa::Real_t<DataTypes>>(),
+                           lcg.generateInUnitRange<sofa::Real_t<DataTypes>>(),
+                           lcg.generateInUnitRange<sofa::Real_t<DataTypes>>());
+        }
+    }
+};
+
+template<class TDataTypes, class TElementType>
+struct MassParam
+{
+    using DataTypes = TDataTypes;
+    using ElementType = TElementType;
+};
+
+using ElementMassTypes = ::testing::Types<
+    MassParam<defaulttype::Vec1Types, sofa::geometry::Edge>,
+    MassParam<defaulttype::Vec2Types, sofa::geometry::Edge>,
+    MassParam<defaulttype::Vec3Types, sofa::geometry::Edge>,
+    MassParam<defaulttype::Vec2Types, sofa::geometry::Triangle>,
+    MassParam<defaulttype::Vec3Types, sofa::geometry::Triangle>,
+    MassParam<defaulttype::Vec2Types, sofa::geometry::Quad>,
+    MassParam<defaulttype::Vec3Types, sofa::geometry::Quad>,
+    MassParam<defaulttype::Vec3Types, sofa::geometry::Tetrahedron>,
+    MassParam<defaulttype::Vec3Types, sofa::geometry::Hexahedron>
+    // MassParam<defaulttype::Vec3Types, sofa::geometry::Prism>,
+    // MassParam<defaulttype::Vec3Types, sofa::geometry::Pyramid>
+>;
+
+TYPED_TEST_SUITE(FEMMassLumpingTest, ElementMassTypes);
+
+TYPED_TEST(FEMMassLumpingTest, ConsistentMassMatrixIsNotDiagonal)
+{
+    this->m_mass->d_lumping.setValue(false);
+    sofa::simulation::node::initRoot(this->m_node.get());
+
+    EXPECT_FALSE(this->m_mass->isDiagonal());
+
+    MatrixDiagonalCheckerAccumulator accumulator;
+    this->m_mass->buildMassMatrix(&accumulator);
+
+    EXPECT_TRUE(accumulator.hasDiagonalNonZero) << "Consistent mass matrix should contain diagonal entries.";
+    EXPECT_TRUE(accumulator.hasOffDiagonalNonZero) << "Consistent mass matrix must have non-zero off-diagonal entries.";
+}
+
+TYPED_TEST(FEMMassLumpingTest, LumpedMassMatrixIsDiagonal)
+{
+    this->m_mass->d_lumping.setValue(true);
+    sofa::simulation::node::initRoot(this->m_node.get());
+
+    EXPECT_TRUE(this->m_mass->isDiagonal());
+
+    MatrixDiagonalCheckerAccumulator accumulator;
+    this->m_mass->buildMassMatrix(&accumulator);
+
+    EXPECT_TRUE(accumulator.hasDiagonalNonZero) << "Lumped mass matrix must contain diagonal entries.";
+    EXPECT_FALSE(accumulator.hasOffDiagonalNonZero) << "Lumped mass matrix must not contain any off-diagonal entries.";
+}
+
+} // namespace sofa::component::mass::testing

--- a/examples/Component/Mass/FEMMass_lumping.scn
+++ b/examples/Component/Mass/FEMMass_lumping.scn
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<Node name="root" dt="0.01" gravity="0 -9.81 0">
+
+    <Node name="plugins">
+        <RequiredPlugin pluginName="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->
+        <RequiredPlugin pluginName="Sofa.Component.Engine.Select"/> <!-- Needed to use components [BoxROI] -->
+        <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [SparseLDLSolver] -->
+        <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->
+        <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Ordering"/> <!-- Needed to use components [NaturalOrderingMethod] -->
+        <RequiredPlugin pluginName="Sofa.Component.LinearSystem"/> <!-- Needed to use components [ConstantSparsityPatternSystem] -->
+        <RequiredPlugin pluginName="Sofa.Component.Mass"/> <!-- Needed to use components [MeshMatrixMass] -->
+        <RequiredPlugin pluginName="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->
+        <RequiredPlugin pluginName="Sofa.Component.SolidMechanics.FEM.Elastic"/>
+        <RequiredPlugin pluginName="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->
+        <RequiredPlugin pluginName="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TetrahedronSetGeometryAlgorithms,TetrahedronSetTopologyContainer,TetrahedronSetTopologyModifier] -->
+        <RequiredPlugin pluginName="Sofa.Component.Topology.Container.Grid"/> <!-- Needed to use components [RegularGridTopology] -->
+        <RequiredPlugin pluginName="Sofa.Component.Topology.Mapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping] -->
+        <RequiredPlugin pluginName="Sofa.Component.Visual"/> <!-- Needed to use components [LineAxis,VisualGrid,VisualStyle] -->
+        <RequiredPlugin pluginName="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglSceneFrame] -->
+    </Node>
+
+    <DefaultAnimationLoop parallelODESolving="true"/>
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <VisualGrid size="0.1"/>
+    <LineAxis size="0.1"/>
+    <OglSceneFrame/>
+
+    <Node name="consistent">
+        <Visual3DText text="consistent mass" position="-0.09 0.03 0" scale="0.01" color="teal"/>
+        <EulerImplicitSolver name="backward_Euler" rayleighStiffness="0.1" rayleighMass="0.1" />
+
+        <ConstantSparsityPatternSystem template="CompressedRowSparseMatrix" name="A" checkIndices="false"/>
+        <NaturalOrderingMethod/>
+        <SparseLDLSolver name="linear_solver" template="CompressedRowSparseMatrix"/>
+
+        <RegularGridTopology name="grid" min="-0.03 -0.01 0" max="-0.01 0.01 0.2" n="5 5 30"/>
+        <MechanicalObject template="Vec3" name="state" showObject="true"/>
+
+        <NodalMassDensity property="1100"/>
+        <FEMMass template="Vec3,Hexahedron" lumping="false"/>
+
+        <CorotationalFEMForceField name="FEM" template="Vec3,Hexahedron"
+                                   youngModulus="1e5" poissonRatio="0.45" topology="@grid"
+                                   computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+
+        <BoxROI template="Vec3" name="box_roi" box="-0.031 -0.011 -0.0001   -0.009 0.011 0.0001" drawBoxes="1" />
+        <FixedProjectiveConstraint template="Vec3" indices="@box_roi.indices" />
+    </Node>
+
+    <Node name="lumped">
+        <Visual3DText text="lumped mass" position="0.01 0.03 0" scale="0.01" color="orange"/>
+        <EulerImplicitSolver name="backward_Euler" rayleighStiffness="0.1" rayleighMass="0.1" />
+
+        <ConstantSparsityPatternSystem template="CompressedRowSparseMatrix" name="A" checkIndices="false"/>
+        <NaturalOrderingMethod/>
+        <SparseLDLSolver name="linear_solver" template="CompressedRowSparseMatrix"/>
+
+        <RegularGridTopology name="grid" min="0.01 -0.01 0" max="0.03 0.01 0.2" n="5 5 30"/>
+        <MechanicalObject template="Vec3" name="state" showObject="true"/>
+
+        <NodalMassDensity property="1100"/>
+        <FEMMass template="Vec3,Hexahedron" lumping="true"/>
+
+        <CorotationalFEMForceField name="FEM" template="Vec3,Hexahedron"
+                                   youngModulus="1e5" poissonRatio="0.45" topology="@grid"
+                                   computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+
+        <BoxROI template="Vec3" name="box_roi" box="0.009 -0.011 -0.0001   0.031 0.011 0.0001" drawBoxes="1" />
+        <FixedProjectiveConstraint template="Vec3" indices="@box_roi.indices" />
+    </Node>
+</Node>


### PR DESCRIPTION
Mass matrix lumping = diagonal matrix.
If the matrix is diagonal, it can be inverted trivially, and that's what we need in `accFromF`.

Mass lumping is most useful in explicit dynamics. I tried to make an example, but it's always unstable. So, I made a comparison between consistent and lumped masses using an implicit solver. I don't see any difference visually.

<img width="787" height="1015" alt="image" src="https://github.com/user-attachments/assets/13751e02-4229-4c1d-aaea-e2974e5592d7" />

[with-all-tests]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
