### PR TITLE
[examples] Add Von Mises stress in Validation/cantilever_beam examples

### DIFF
--- a/examples/Validation/cantilever_beam/hexahedron/corotational/parallel/assembled/HexahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/corotational/parallel/assembled/HexahedronCorotationalFEMForceField.scn
@@ -9,5 +9,7 @@
     <CorotationalFEMForceField name="FEM" template="Vec3,Hexahedron"
                                       youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                       computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 
 </Node>

--- a/examples/Validation/cantilever_beam/hexahedron/corotational/parallel/matrixfree/HexahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/corotational/parallel/matrixfree/HexahedronCorotationalFEMForceField.scn
@@ -7,5 +7,7 @@
     <CorotationalFEMForceField name="FEM" template="Vec3,Hexahedron"
                                       youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                       computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 
 </Node>

--- a/examples/Validation/cantilever_beam/hexahedron/corotational/sequential/assembled/HexahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/corotational/sequential/assembled/HexahedronCorotationalFEMForceField.scn
@@ -9,5 +9,6 @@
     <CorotationalFEMForceField name="FEM" template="Vec3,Hexahedron"
                                       youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                       computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
-
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 </Node>

--- a/examples/Validation/cantilever_beam/hexahedron/corotational/sequential/matrixfree/HexahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/corotational/sequential/matrixfree/HexahedronCorotationalFEMForceField.scn
@@ -7,5 +7,7 @@
     <CorotationalFEMForceField name="FEM" template="Vec3,Hexahedron"
                                       youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                       computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 
 </Node>

--- a/examples/Validation/cantilever_beam/hexahedron/linear/parallel/assembled/HexahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/linear/parallel/assembled/HexahedronLinearSmallStrainFEMForceField.scn
@@ -9,5 +9,7 @@
     <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Hexahedron"
                                            youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                            computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 
 </Node>

--- a/examples/Validation/cantilever_beam/hexahedron/linear/parallel/matrixfree/HexahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/linear/parallel/matrixfree/HexahedronLinearSmallStrainFEMForceField.scn
@@ -7,5 +7,7 @@
     <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Hexahedron"
                                            youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                            computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 
 </Node>

--- a/examples/Validation/cantilever_beam/hexahedron/linear/sequential/assembled/HexahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/linear/sequential/assembled/HexahedronLinearSmallStrainFEMForceField.scn
@@ -9,5 +9,7 @@
     <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Hexahedron"
                                            youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                            computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 
 </Node>

--- a/examples/Validation/cantilever_beam/hexahedron/linear/sequential/matrixfree/HexahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/hexahedron/linear/sequential/matrixfree/HexahedronLinearSmallStrainFEMForceField.scn
@@ -7,5 +7,7 @@
     <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Hexahedron"
                                            youngModulus="2e6" poissonRatio="0.45" topology="@grid"
                                            computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+    <VonMisesStress template="Vec3,Hexahedron" name="stress" topology="@grid" stressEvaluator="@FEM"
+                    colorMap="green yellow orange red purple #221C35"/>
 
 </Node>

--- a/examples/Validation/cantilever_beam/tetrahedron/corotational/parallel/assembled/TetrahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/corotational/parallel/assembled/TetrahedronCorotationalFEMForceField.scn
@@ -15,6 +15,9 @@
         <CorotationalFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                               youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                               computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 </Node>

--- a/examples/Validation/cantilever_beam/tetrahedron/corotational/parallel/matrixfree/TetrahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/corotational/parallel/matrixfree/TetrahedronCorotationalFEMForceField.scn
@@ -13,6 +13,9 @@
         <CorotationalFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                           youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                           computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 </Node>

--- a/examples/Validation/cantilever_beam/tetrahedron/corotational/sequential/assembled/TetrahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/corotational/sequential/assembled/TetrahedronCorotationalFEMForceField.scn
@@ -15,6 +15,9 @@
         <CorotationalFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                           youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                           computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 

--- a/examples/Validation/cantilever_beam/tetrahedron/corotational/sequential/matrixfree/TetrahedronCorotationalFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/corotational/sequential/matrixfree/TetrahedronCorotationalFEMForceField.scn
@@ -13,6 +13,9 @@
         <CorotationalFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                           youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                           computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 </Node>

--- a/examples/Validation/cantilever_beam/tetrahedron/linear/parallel/assembled/TetrahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/linear/parallel/assembled/TetrahedronLinearSmallStrainFEMForceField.scn
@@ -15,6 +15,9 @@
         <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                                youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                                computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 </Node>

--- a/examples/Validation/cantilever_beam/tetrahedron/linear/parallel/matrixfree/TetrahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/linear/parallel/matrixfree/TetrahedronLinearSmallStrainFEMForceField.scn
@@ -13,6 +13,9 @@
         <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                                youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                                computeForceStrategy="parallel" computeForceDerivStrategy="parallel"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 </Node>

--- a/examples/Validation/cantilever_beam/tetrahedron/linear/sequential/assembled/TetrahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/linear/sequential/assembled/TetrahedronLinearSmallStrainFEMForceField.scn
@@ -15,6 +15,9 @@
         <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                                youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                                computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 </Node>

--- a/examples/Validation/cantilever_beam/tetrahedron/linear/sequential/matrixfree/TetrahedronLinearSmallStrainFEMForceField.scn
+++ b/examples/Validation/cantilever_beam/tetrahedron/linear/sequential/matrixfree/TetrahedronLinearSmallStrainFEMForceField.scn
@@ -13,6 +13,9 @@
         <LinearSmallStrainFEMForceField name="FEM" template="Vec3,Tetrahedron"
                                                youngModulus="2e6" poissonRatio="0.45" topology="@Tetra_topo"
                                                computeForceStrategy="sequenced" computeForceDerivStrategy="sequenced"/>
+        <VonMisesStress template="Vec3,Tetrahedron" name="stress" topology="@Tetra_topo" stressEvaluator="@FEM"
+                        colorMap="green yellow orange red purple #221C35"/>
+
     </Node>
 
 </Node>


### PR DESCRIPTION
The PR adds Von Mises stress computation and visualization in the cantiliver beam scenes.

To merge after https://github.com/sofa-framework/sofa/pull/6216.


[with-all-tests]


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
