### PR TITLE
[Simulation.Core] RequiredPlugin: Clarify "no component registered" warning

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
@@ -157,7 +157,7 @@ bool RequiredPlugin::loadPlugin()
                         << " - the entrypoint registerObjects() has not been implemented;\n"
                         << " - SOFA_TARGET has not been defined in the plugin;\n"
                         << " - (deprecated since v24.12) no sofa::core::RegisterObject() has been called;\n"
-                        << " - your plugin does not add any component (i.e BaseObject) into the factory. In that case, RequiredPlugin is not useful for this kind of plugin.";
+                        << " - your plugin does not add any component (i.e BaseComponent) into the factory. In that case, RequiredPlugin is not useful for this kind of plugin.";
                 }
 
                 if (d_stopAfterFirstSuffixFound.getValue()) break;

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/RequiredPlugin.cpp
@@ -152,9 +152,10 @@ bool RequiredPlugin::loadPlugin()
 
                 if (entries.empty())
                 {
-                    msg_warning() << "No component has been registered from " << name << ".\n"
+                    msg_warning() << "No component has been registered from " << pluginFilePath << ".\n"
                         << "It could be because: \n"
                         << " - the entrypoint registerObjects() has not been implemented;\n"
+                        << " - SOFA_TARGET has not been defined in the plugin;\n"
                         << " - (deprecated since v24.12) no sofa::core::RegisterObject() has been called;\n"
                         << " - your plugin does not add any component (i.e BaseObject) into the factory. In that case, RequiredPlugin is not useful for this kind of plugin.";
                 }


### PR DESCRIPTION
Having forgotten to define the infamous SOFA_TARGET in a plugin, I got the message which did not make sense in my case.

And it displays the pluginPath (which is `pluginName` data) instead of name as pluginName is the one to set in the scene.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
