### PR TITLE
[CI] Fix fetching in cmake configuration

### DIFF
--- a/.github/workflows/CI_build_and_test.yml
+++ b/.github/workflows/CI_build_and_test.yml
@@ -103,24 +103,6 @@ jobs:
 
             echo "Workspace folder for this build will be $WORKSPACE"
 
-            ## Setup github
-            # Git config (needed by CMake ExternalProject)
-            if ! git config --get user.name; then
-                git config --system user.name 'SOFA Bot' > /dev/null 2>&1 ||
-                    git config --global user.name 'SOFA Bot' > /dev/null 2>&1 ||
-                    git config user.name 'SOFA Bot' > /dev/null 2>&1 ||
-                    echo "WARNING: cannot setup git config"
-            fi
-            if ! git config --get user.email; then
-                git config --system user.email '<>' > /dev/null 2>&1 ||
-                    git config --global user.email '<>' > /dev/null 2>&1 ||
-                    git config user.email '<>' > /dev/null 2>&1 ||
-                    echo "WARNING: cannot setup git config"
-            fi
-
-            ##TODO (if required) fix path too long for windows (see main.sh:201)
-
-
       - name: Clone SOFA and CI
         id: clone
         shell: bash
@@ -128,6 +110,7 @@ jobs:
           cd $WORKSPACE
 
           ## Configure authentification for git to clone properly
+          echo "$GH_TOKEN" > gh auth login --with-token
           gh auth setup-git
 
           ## Clone sofa and merge origin master
@@ -315,7 +298,7 @@ jobs:
               docker run --rm --env XDG_CACHE_HOME --env GH_TOKEN="$GH_TOKEN" -v $BUILDER_CACHE_DIR:/cache\
                   --user $(id -u):$(id -g) --network=host -v $WORKSPACE:/workspace \
                   ${DOCKER_IMAGE} \
-                  /bin/bash -c "env; gh auth setup-git; cd /workspace; ccache -M 5; /bin/bash $DOCKER_CI_DIR/scripts/configure-and-build.sh $DOCKER_BUILD_DIR $DOCKER_SRC_DIR $DOCKER_CI_DIR/scripts/ $DOCKER_LOG_DIR \"${NODE_NAME}\" \"${BUILD_TYPE}\" \"${CONFIG}\" \"${{ inputs.python-version }}\" \"${{ inputs.preset }}\" \"${{ inputs.generate-binaries }}\" \"${CMAKE_OPTIONS}\""             
+                  /bin/bash -c "env; echo "$GH_TOKEN" > gh auth login --with-token; gh auth setup-git; cd /workspace; ccache -M 5; /bin/bash $DOCKER_CI_DIR/scripts/configure-and-build.sh $DOCKER_BUILD_DIR $DOCKER_SRC_DIR $DOCKER_CI_DIR/scripts/ $DOCKER_LOG_DIR \"${NODE_NAME}\" \"${BUILD_TYPE}\" \"${CONFIG}\" \"${{ inputs.python-version }}\" \"${{ inputs.preset }}\" \"${{ inputs.generate-binaries }}\" \"${CMAKE_OPTIONS}\""             
           else
               echo "Launching configuration and build"
 

--- a/.github/workflows/CI_build_and_test.yml
+++ b/.github/workflows/CI_build_and_test.yml
@@ -103,6 +103,23 @@ jobs:
 
             echo "Workspace folder for this build will be $WORKSPACE"
 
+
+            # TODO : Might not be useful anymore because of the use of gh
+            ## Setup github
+            # Git config (needed by CMake ExternalProject)
+            if ! git config --get user.name; then
+                git config --system user.name 'SOFA Bot' > /dev/null 2>&1 ||
+                    git config --global user.name 'SOFA Bot' > /dev/null 2>&1 ||
+                    git config user.name 'SOFA Bot' > /dev/null 2>&1 ||
+                    echo "WARNING: cannot setup git config"
+            fi
+            if ! git config --get user.email; then
+                git config --system user.email '<>' > /dev/null 2>&1 ||
+                    git config --global user.email '<>' > /dev/null 2>&1 ||
+                    git config user.email '<>' > /dev/null 2>&1 ||
+                    echo "WARNING: cannot setup git config"
+            fi
+
       - name: Clone SOFA and CI
         id: clone
         shell: bash

--- a/.github/workflows/CI_build_and_test.yml
+++ b/.github/workflows/CI_build_and_test.yml
@@ -298,7 +298,7 @@ jobs:
               docker run --rm --env XDG_CACHE_HOME --env GH_TOKEN="$GH_TOKEN" -v $BUILDER_CACHE_DIR:/cache\
                   --user $(id -u):$(id -g) --network=host -v $WORKSPACE:/workspace \
                   ${DOCKER_IMAGE} \
-                  /bin/bash -c "env; echo "$GH_TOKEN" > gh auth login --with-token; gh auth setup-git; cd /workspace; ccache -M 5; /bin/bash $DOCKER_CI_DIR/scripts/configure-and-build.sh $DOCKER_BUILD_DIR $DOCKER_SRC_DIR $DOCKER_CI_DIR/scripts/ $DOCKER_LOG_DIR \"${NODE_NAME}\" \"${BUILD_TYPE}\" \"${CONFIG}\" \"${{ inputs.python-version }}\" \"${{ inputs.preset }}\" \"${{ inputs.generate-binaries }}\" \"${CMAKE_OPTIONS}\""             
+                  /bin/bash -c "env; echo \"$GH_TOKEN\" > gh auth login --with-token; gh auth setup-git; cd /workspace; ccache -M 5; /bin/bash $DOCKER_CI_DIR/scripts/configure-and-build.sh $DOCKER_BUILD_DIR $DOCKER_SRC_DIR $DOCKER_CI_DIR/scripts/ $DOCKER_LOG_DIR \"${NODE_NAME}\" \"${BUILD_TYPE}\" \"${CONFIG}\" \"${{ inputs.python-version }}\" \"${{ inputs.preset }}\" \"${{ inputs.generate-binaries }}\" \"${CMAKE_OPTIONS}\""             
           else
               echo "Launching configuration and build"
 

--- a/.github/workflows/CI_build_and_test.yml
+++ b/.github/workflows/CI_build_and_test.yml
@@ -129,6 +129,7 @@ jobs:
           ## Configure authentification for git to clone properly
           echo "$GH_TOKEN" > gh auth login --with-token
           gh auth setup-git
+          gh auth status
 
           ## Clone sofa and merge origin master
           echo "Cloning SOFA at commit $GITHUB_WORKFLOW_SHA"
@@ -315,7 +316,7 @@ jobs:
               docker run --rm --env XDG_CACHE_HOME --env GH_TOKEN="$GH_TOKEN" -v $BUILDER_CACHE_DIR:/cache\
                   --user $(id -u):$(id -g) --network=host -v $WORKSPACE:/workspace \
                   ${DOCKER_IMAGE} \
-                  /bin/bash -c "env; echo \"$GH_TOKEN\" > gh auth login --with-token; gh auth setup-git; cd /workspace; ccache -M 5; /bin/bash $DOCKER_CI_DIR/scripts/configure-and-build.sh $DOCKER_BUILD_DIR $DOCKER_SRC_DIR $DOCKER_CI_DIR/scripts/ $DOCKER_LOG_DIR \"${NODE_NAME}\" \"${BUILD_TYPE}\" \"${CONFIG}\" \"${{ inputs.python-version }}\" \"${{ inputs.preset }}\" \"${{ inputs.generate-binaries }}\" \"${CMAKE_OPTIONS}\""             
+                  /bin/bash -c "env; echo \"$GH_TOKEN\" > gh auth login --with-token; gh auth setup-git; gh auth status; cd /workspace; ccache -M 5; /bin/bash $DOCKER_CI_DIR/scripts/configure-and-build.sh $DOCKER_BUILD_DIR $DOCKER_SRC_DIR $DOCKER_CI_DIR/scripts/ $DOCKER_LOG_DIR \"${NODE_NAME}\" \"${BUILD_TYPE}\" \"${CONFIG}\" \"${{ inputs.python-version }}\" \"${{ inputs.preset }}\" \"${{ inputs.generate-binaries }}\" \"${CMAKE_OPTIONS}\""             
           else
               echo "Launching configuration and build"
 


### PR DESCRIPTION
Add explicit authentication using gh before call to setup-git and remove old username configuration

So to make sure this call to docker works for cloning project inside of a cmake call I tried a minimal example using a simple cmake project cloning a private repository with the docker image used by the CI. The current master version of the call (only calling `gh auth setup-git`) was sufficient on my end. So this means that the builder is correctly authenticated but github still refuses the access to public repository.

Here I am trying to add a new level of authentication to make sure the builder is logged-in. Let's see how it goes. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
